### PR TITLE
Use python3 to setup python3 interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ python: py-build Makefile
 
 python3: py3-build Makefile
 	@cp -a interfaces/python/setup.py $(PY3_BUILD_DIR)/
-	cd $(PY3_BUILD_DIR) && python setup.py build_ext --inplace
+	cd $(PY3_BUILD_DIR) && python3 setup.py build_ext --inplace
 	@true
 
 # Generate wrapper files from source and interface files


### PR DESCRIPTION
To make sure, that indeed python3 is used to run setup.py, python3 should be called explicitly.

When using the unedited version, python2 is called if it is installed too (tested under debian jessie). With the previous setting I got an error on import:
```
> from infomap import infomap
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "…/src/infomap-repo/examples/python/infomap/infomap.py", line 28, in <module>
    _infomap = swig_import_helper()
  File "…/infomap-repo/examples/python/infomap/infomap.py", line 24, in swig_import_helper
    _mod = imp.load_module('_infomap', fp, pathname, description)
  File "/usr/lib/python3.4/imp.py", line 243, in load_module
    return load_dynamic(name, filename, file)
ImportError: …/infomap-repo/examples/python/infomap/_infomap.so: undefined symbol: PyClass_Type
```

This change fixed this.