### PR TITLE
Ensure cpp examples compile

### DIFF
--- a/examples/cpp/Infomap-igraph-interface-library/Makefile
+++ b/examples/cpp/Infomap-igraph-interface-library/Makefile
@@ -1,4 +1,15 @@
-CXXFLAGS = -Wall -O3
+CXXFLAGS = -Wall
+
+CXX_CLANG := $(shell $(CXX) --version 2>/dev/null | grep clang)
+ifeq "$(CXX_CLANG)" ""
+	CXXFLAGS += -O4
+	ifneq "$(findstring noomp, $(MAKECMDGOALS))" "noomp"
+		CXXFLAGS += -fopenmp
+		LDFLAGS += -fopenmp
+	endif
+else
+	CXXFLAGS += -O3
+endif
 
 # Set INFOMAP_DIR to your Infomap directory
 INFOMAP_DIR = ../../..

--- a/examples/cpp/igraph/Makefile
+++ b/examples/cpp/igraph/Makefile
@@ -1,4 +1,15 @@
-CXXFLAGS = -Wall -O3
+CXXFLAGS = -Wall
+
+CXX_CLANG := $(shell $(CXX) --version 2>/dev/null | grep clang)
+ifeq "$(CXX_CLANG)" ""
+	CXXFLAGS += -O4
+	ifneq "$(findstring noomp, $(MAKECMDGOALS))" "noomp"
+		CXXFLAGS += -fopenmp
+		LDFLAGS += -fopenmp
+	endif
+else
+	CXXFLAGS += -O3
+endif
 
 # Set INFOMAP_DIR to your Infomap directory
 INFOMAP_DIR = ../../..

--- a/examples/cpp/minimal/Makefile
+++ b/examples/cpp/minimal/Makefile
@@ -1,4 +1,15 @@
-CXXFLAGS = -Wall -O3
+CXXFLAGS = -Wall
+
+CXX_CLANG := $(shell $(CXX) --version 2>/dev/null | grep clang)
+ifeq "$(CXX_CLANG)" ""
+	CXXFLAGS += -O4
+	ifneq "$(findstring noomp, $(MAKECMDGOALS))" "noomp"
+		CXXFLAGS += -fopenmp
+		LDFLAGS += -fopenmp
+	endif
+else
+	CXXFLAGS += -O3
+endif
 
 # Set INFOMAP_DIR to your Infomap directory
 INFOMAP_DIR = ../../..


### PR DESCRIPTION
The examples don't compile if the infomap library was compiled with openmp enabled.

I added the same openmp logic to the examples' Makefiles, so they compile regardless of whether openmp was enabled for the infomap library compilation.