### PR TITLE
Add beginning of C API and corresponding example

### DIFF
--- a/examples/c/Makefile
+++ b/examples/c/Makefile
@@ -1,0 +1,33 @@
+CXXFLAGS = -Wall
+
+CXX_CLANG := $(shell $(CXX) --version 2>/dev/null | grep clang)
+ifeq "$(CXX_CLANG)" ""
+	CXXFLAGS += -O4
+	ifneq "$(findstring noomp, $(MAKECMDGOALS))" "noomp"
+		CXXFLAGS += -fopenmp
+		LDFLAGS += -fopenmp
+	endif
+else
+	CXXFLAGS += -O3
+endif
+
+# Set INFOMAP_DIR to your Infomap directory
+INFOMAP_DIR = ../..
+INFOMAP_LIB = $(INFOMAP_DIR)/lib/libInfomap.a
+
+.PHONY: clean distclean
+
+example: example.o $(INFOMAP_LIB) Makefile
+	$(CXX) $(CXXFLAGS) -DNS_INFOMAP $< -o $@ -I$(INFOMAP_DIR)/include -L$(INFOMAP_DIR)/lib -lInfomap
+
+example.o: example.c $(INFOMAP_LIB) Makefile
+	$(CC) -c $< -o $@ -I$(INFOMAP_DIR)/include
+
+$(INFOMAP_LIB):
+	$(MAKE) -C $(INFOMAP_DIR) lib
+
+clean:
+	$(RM) example
+
+distclean:
+	$(MAKE) -C $(INFOMAP_DIR) clean

--- a/examples/c/example.c
+++ b/examples/c/example.c
@@ -1,0 +1,27 @@
+#include <Infomap.h>
+#include <stdio.h>
+
+int main(int argc, char** argv)
+{
+    struct Infomap* im = NewInfomap("--two-level -N2");
+
+    InfomapAddLink(im, 0, 2, 1.0);
+    InfomapAddLink(im, 0, 3, 1.0);
+    InfomapAddLink(im, 1, 0, 1.0);
+    InfomapAddLink(im, 1, 2, 1.0);
+    InfomapAddLink(im, 2, 1, 1.0);
+    InfomapAddLink(im, 2, 0, 1.0);
+    InfomapAddLink(im, 3, 0, 1.0);
+    InfomapAddLink(im, 3, 4, 1.0);
+    InfomapAddLink(im, 3, 5, 1.0);
+    InfomapAddLink(im, 4, 3, 1.0);
+    InfomapAddLink(im, 4, 5, 1.0);
+    InfomapAddLink(im, 5, 4, 1.0);
+    InfomapAddLink(im, 5, 3, 1.0);
+
+    InfomapRun(im);
+
+    printf("TODO: Show results.\n");
+
+    DestroyInfomap(im);
+}

--- a/src/CApi.cpp
+++ b/src/CApi.cpp
@@ -1,0 +1,15 @@
+#include "Infomap.h"
+
+namespace infomap {
+
+    Infomap *NewInfomap(const char *flags) { return new Infomap(flags); };
+
+    void DestroyInfomap(Infomap *im) { im->~Infomap(); };
+
+    void InfomapAddLink(Infomap *im, unsigned int sourceId, unsigned int targetId, double weight) {
+        im->addLink(sourceId, targetId, weight);
+    };
+
+    void InfomapRun(struct Infomap* im) { im->run(); };
+
+}

--- a/src/Infomap.h
+++ b/src/Infomap.h
@@ -28,6 +28,8 @@
 #ifndef SRC_INFOMAP_H_
 #define SRC_INFOMAP_H_
 
+#ifdef __cplusplus
+
 #include <string>
 #include "io/Config.h"
 #include "infomap/InfomapContext.h"
@@ -152,10 +154,25 @@ class MemInfomap {
     HierarchicalNetwork tree;
 };
 
+extern "C" {
+#else
+#include <stdint.h>
+struct Infomap;
+#endif
 
+struct Infomap *NewInfomap(const char *flags);
 
+void DestroyInfomap(struct Infomap *im);
+
+void InfomapAddLink(struct Infomap *im, unsigned int sourceId,  unsigned int targetId, double weight);
+
+void InfomapRun(struct Infomap *im);
+
+#ifdef __cplusplus
+}
 #ifdef NS_INFOMAP
 }
+#endif
 #endif
 
 #endif /* SRC_INFOMAP_H_ */


### PR DESCRIPTION
This adds just enough of a C api to use run(). I ignored the beta branch, because for the C API master works just fine with minimally intrusive changes. Your normal .a file and Infomap.h will be both C and C++ compatible in any build now.
The functions are in the `infomap` namespace, so there is no harm in including the C API by default. The symbols are unmangled, so they won't conflict with other C++ symbols either, unless someone uses the same `extern "C" fname` as we do. 

Compared to beta, I'm skipping the extra type wrapping `void*`. Declaring `struct Infomap` is sufficient in C and doesn't do any harm in C++. There is no problem having a pointer to an undefined C++ struct, as long as you don't dereference it. Let me know if I should rebase on something else.