### PR TITLE
feat: Write tree to CSV file

### DIFF
--- a/interfaces/js/pre-worker-module.js
+++ b/interfaces/js/pre-worker-module.js
@@ -42,6 +42,8 @@ var Module = {
       newick_states: readFile(`${outName}_states.nwk`), // -o newick (for state networks)
       json: readFile(`${outName}.json`), // -o json
       json_states: readFile(`${outName}_states.json`), // -o json (for state networks)
+      csv: readFile(`${outName}.csv`), // -o csv
+      csv_states: readFile(`${outName}_states.csv`), // -o csv (for state networks)
       net: readFile(`${outName}.net`), // -o network (for state networks)
       states_as_physical: readFile(`${outName}_states_as_physical.net`), // -o network (for state networks)
       states: readFile(`${outName}_states.net`), // -o states

--- a/interfaces/python/infomap.py
+++ b/interfaces/python/infomap.py
@@ -313,7 +313,7 @@ class Infomap(InfomapWrapper):
         clu_level : int, optional
             For clu output, print modules at specified depth from root. Use -1 for bottom level modules.
         output : list(str), optional
-            Comma-separated output formats without spaces, e.g. -o clu,tree,ftree. Options: clu, tree, ftree, newick, json, network, states.
+            Comma-separated output formats without spaces, e.g. -o clu,tree,ftree. Options: clu, tree, ftree, newick, json, csv, network, states.
         hide_bipartite_nodes : bool, optional
             Project bipartite solution to unipartite.
         two_level : bool, optional
@@ -1619,6 +1619,22 @@ class Infomap(InfomapWrapper):
             If the state nodes should be included (default False).
         """
         return self.writeJsonTree(filename, states)
+
+    def write_csv(self, filename, states=False):
+        """Write result to a CSV file.
+
+        See Also
+        --------
+        write_clu
+        write_tree
+
+        Parameters
+        ----------
+        filename : str
+        states : bool, optional
+            If the state nodes should be included (default False).
+        """
+        return self.writeCsvTree(filename, states)
 
     def get_effective_num_modules(self, depth_level=1):
         """The flow weighted effective number of modules.

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -430,6 +430,8 @@ public:
 
   std::string writeJsonTree(std::string filename = "", bool states = false);
 
+  std::string writeCsvTree(std::string filename = "", bool states = false);
+
   /**
    * Write tree to a .clu file.
    * @param filename the filename for the output file. If empty, use default
@@ -487,6 +489,12 @@ protected:
    * @param states, write state-level tree, else aggregate physical nodes within modules
    */
   void writeJsonTree(std::ostream& outStream, bool states = false);
+
+  /**
+   * Write CSV tree to output stream
+   * @param states, write state-level tree, else aggregate physical nodes within modules
+   */
+  void writeCsvTree(std::ostream& outStream, bool states = false);
 
   InfoNode m_root;
   std::vector<InfoNode*> m_leafNodes;

--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -75,7 +75,7 @@ Config::Config(std::string flags, bool isCLI) : isCLI(isCLI)
   // 		"Print the network with calculated flow values.", "Output", true);
 
   // -o network,states,clu,ftree
-  api.addOptionArgument(outputFormats, 'o', "output", "Comma-separated output formats without spaces, e.g. -o clu,tree,ftree. Options: clu, tree, ftree, newick, json, network, states, flow.", ArgType::list, "Output", true);
+  api.addOptionArgument(outputFormats, 'o', "output", "Comma-separated output formats without spaces, e.g. -o clu,tree,ftree. Options: clu, tree, ftree, newick, json, csv, network, states, flow.", ArgType::list, "Output", true);
 
   api.addOptionArgument(hideBipartiteNodes, "hide-bipartite-nodes", "Project bipartite solution to unipartite.", "Output", true);
 
@@ -252,6 +252,8 @@ void Config::adaptDefaults()
       printNewick = true;
     } else if (o == "json") {
       printJson = true;
+    } else if (o == "csv") {
+      printCsv = true;
     } else if (o == "network") {
       printPajekNetwork = true;
     } else if (o == "flow") {

--- a/src/io/Config.h
+++ b/src/io/Config.h
@@ -165,6 +165,7 @@ struct Config {
   bool printFlowTree = false;
   bool printNewick = false;
   bool printJson = false;
+  bool printCsv = false;
   bool printMap = false;
   bool printClu = false;
   int cluLevel = 1; // Write modules at specified depth from root. 1, 2, ... or -1 for bottom level
@@ -370,7 +371,7 @@ struct Config {
 
   bool haveModularResultOutput() const
   {
-    return printTree || printFlowTree || printNewick || printJson || printMap || printClu || printBinaryTree || printBinaryFlowTree;
+    return printTree || printFlowTree || printNewick || printJson || printCsv || printMap || printClu || printBinaryTree || printBinaryFlowTree;
   }
 };
 


### PR DESCRIPTION
Write CSV trees. This is useful for quick import into pandas data frames.

I don't know what to do about the header.

Example output:

`ninetriangles.csv`
```csv
path,flow,name,node_id
1:1:1,0.0384615,"10",10
1:1:2,0.0384615,"11",11
1:1:3,0.0384615,"12",12
1:2:1,0.0384615,"16",16
1:2:2,0.0384615,"17",17
1:2:3,0.0384615,"18",18
1:3:1,0.0384615,"13",13
1:3:2,0.0384615,"15",15
1:3:3,0.025641,"14",14
2:1,0.0384615,"7",7
2:2,0.0384615,"8",8
2:3,0.0384615,"9",9
2:4,0.0384615,"19",19
2:5,0.0384615,"20",20
2:6,0.0384615,"21",21
3:1,0.0384615,"4",4
3:2,0.0384615,"5",5
3:3,0.0384615,"6",6
4:1,0.0384615,"22",22
4:2,0.0384615,"23",23
4:3,0.0384615,"24",24
5:1,0.0384615,"1",1
5:2,0.0384615,"3",3
5:3,0.025641,"2",2
6:1,0.0384615,"25",25
6:2,0.0384615,"26",26
6:3,0.025641,"27",27
```

`multilayer_states.csv`
```csv
path,flow,name,state_id,layer_id,node_id
1:1,0.166667,"i",3,2,1
1:2,0.166667,"j",4,2,2
1:3,0.166667,"k",5,2,3
2:1,0.166667,"i",0,1,1
2:2,0.166667,"l",1,1,4
2:3,0.166667,"m",2,1,5
```

`states_states.csv`
```csv
path,flow,name,state_id,node_id
1:1,0.166667,"i",1,1
1:2,0.166667,"j",2,2
1:3,0.166667,"k",3,3
2:1,0.166667,"i",4,1
2:2,0.166667,"l",5,4
2:3,0.166667,"m",6,5
```