### PR TITLE
fix(python): get_multilevel_modules should return the path

### DIFF
--- a/interfaces/python/infomap.py
+++ b/interfaces/python/infomap.py
@@ -1127,6 +1127,52 @@ class Infomap(InfomapWrapper):
     def get_multilevel_modules(self, states=False):
         """Get all the modules.
 
+        Examples
+        --------
+
+        >>> from infomap import Infomap
+        >>> im = Infomap(silent=True)
+        >>> im.read_file("ninetriangles.net")
+        >>> im.run()
+        >>> for node, modules in im.get_multilevel_modules().items():
+        ...     print(node, modules)
+        1 (6,)
+        2 (6,)
+        3 (6,)
+        4 (2,)
+        5 (2,)
+        6 (2,)
+        7 (3,)
+        8 (3,)
+        9 (3,)
+        10 (4,)
+        11 (4,)
+        12 (4,)
+        13 (7,)
+        14 (7,)
+        15 (7,)
+        16 (5,)
+        17 (5,)
+        18 (5,)
+        19 (1, 1)
+        20 (1, 1)
+        21 (1, 1)
+        22 (1, 2)
+        23 (1, 2)
+        24 (1, 2)
+        25 (1, 3)
+        26 (1, 3)
+        27 (1, 3)
+
+
+        Notes
+        -----
+        In a higher-order network, a physical node (defined by ``node_id``)
+        may partially exist in multiple modules. However, the ``node_id``
+        can not exist multiple times as a key in the node-to-module map,
+        so only one occurrence of a physical node will be retrieved.
+        To get all states, use ``get_multilevel_modules(states=True)``.
+
         Parameters
         ----------
         states : bool, optional

--- a/src/Infomap.cpp
+++ b/src/Infomap.cpp
@@ -62,24 +62,21 @@ std::map<unsigned int, unsigned int> InfomapWrapper::getModules(int level, bool 
 
 std::map<unsigned int, std::vector<unsigned int>> InfomapWrapper::getMultilevelModules(bool states)
 {
-  unsigned int maxDepth = maxTreeDepth();
-  unsigned int numModuleLevels = maxDepth - 1;
   std::map<unsigned int, std::vector<unsigned int>> modules;
-  for (unsigned int level = 1; level <= numModuleLevels; ++level) {
-    if (haveMemory() && !states) {
-      for (auto it(iterTreePhysical(level)); !it.isEnd(); ++it) {
-        auto& node = *it;
-        if (node.isLeaf()) {
-          modules[node.physicalId].push_back(it.moduleId());
-        }
+  if (haveMemory() && !states) {
+    for (auto it(iterTreePhysical()); !it.isEnd(); ++it) {
+      auto& node = *it;
+      if (node.isLeaf()) {
+        const auto& path = it.path();
+        modules[node.physicalId] = {path.begin(), path.end() - 1};
       }
-    } else {
-      for (auto it(iterTree(level)); !it.isEnd(); ++it) {
-        auto& node = *it;
-        if (node.isLeaf()) {
-          auto nodeId = states ? node.stateId : node.physicalId;
-          modules[nodeId].push_back(it.moduleId());
-        }
+    }
+  } else {
+    for (auto it(iterTree()); !it.isEnd(); ++it) {
+      auto& node = *it;
+      if (node.isLeaf()) {
+        const auto& path = it.path();
+        modules[states ? node.stateId : node.physicalId] = {path.begin(), path.end() - 1};
       }
     }
   }


### PR DESCRIPTION
Closes #214 

Before, the `moduleId` was the same for all nodes lacking assignments on that level:
```python
In [1]: from infomap import Infomap; im = Infomap(silent=True); im.read_file("examples/networks/ninetriangles.net"); im.run()

In [2]: im.get_multilevel_modules()
Out[2]:
{1: (6, 4),
 2: (6, 4),
 3: (6, 4),
 4: (2, 4),
 5: (2, 4),
 6: (2, 4),
 7: (3, 4),
 8: (3, 4),
 9: (3, 4),
 10: (4, 4),
 11: (4, 4),
 12: (4, 4),
 13: (7, 4),
 14: (7, 4),
 15: (7, 4),
 16: (5, 4),
 17: (5, 4),
 18: (5, 4),
 19: (1, 1),
 20: (1, 1),
 21: (1, 1),
 22: (1, 2),
 23: (1, 2),
 24: (1, 2),
 25: (1, 3),
 26: (1, 3),
 27: (1, 3)}
```

After, we use `path - 1`:
```python
In [9]: from infomap import Infomap; im = Infomap(silent=True); im.read_file("examples/networks/ninetriangles.net"); im.run()

In [10]: im.get_multilevel_modules()
Out[10]:
{1: (6,),
 2: (6,),
 3: (6,),
 4: (2,),
 5: (2,),
 6: (2,),
 7: (3,),
 8: (3,),
 9: (3,),
 10: (4,),
 11: (4,),
 12: (4,),
 13: (7,),
 14: (7,),
 15: (7,),
 16: (5,),
 17: (5,),
 18: (5,),
 19: (1, 1),
 20: (1, 1),
 21: (1, 1),
 22: (1, 2),
 23: (1, 2),
 24: (1, 2),
 25: (1, 3),
 26: (1, 3),
 27: (1, 3)}
```