### PR TITLE
fix: Print states output if states input is first order

### DIFF
--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -289,7 +289,7 @@ void InfomapBase::run(Network& network)
 
   if (printPajekNetwork) {
     std::string filename;
-    if (network.haveMemoryInput()) {
+    if (printStates()) {
       filename = outDirectory + outName + "_states_as_physical.net";
       Log() << "Writing state network as first order Pajek network to '" << filename << "'... ";
     } else {
@@ -303,15 +303,17 @@ void InfomapBase::run(Network& network)
 
   if (network.haveMemoryInput()) {
     Log() << "  -> Found higher order network input, using the Map Equation for higher order network flows\n";
-    if (!haveMemory()) {
-      setMemoryInput();
-    }
+    setStateInput();
+    setStateOutput();
+
     if (network.isMultilayerNetwork() && !isMultilayerNetwork()) {
       setMultilayerInput();
     }
   } else {
-    if (haveMemory()) {
+    if (haveMemory() || network.higherOrderInputMethodCalled()) {
       Log() << "  -> Warning: Higher order network specified but no higher order input found.\n";
+      // Use state output anyway for consistency even in the special case when input is first order
+      setStateOutput();
     }
     Log() << "  -> Ordinary network input, using the Map Equation for first order network flows\n";
   }
@@ -326,7 +328,7 @@ void InfomapBase::run(Network& network)
 
   if (printFlowNetwork) {
     std::string filename;
-    if (network.haveMemoryInput()) {
+    if (printStates()) {
       filename = outDirectory + outName + "_states_as_physical_flow.net";
       Log() << "Writing flow state network as first order Pajek network to '" << filename << "'... ";
     } else {
@@ -2081,7 +2083,7 @@ void InfomapBase::writeResult()
   if (printTree) {
     std::string filename = outDirectory + outName + ".tree";
 
-    if (!haveMemory()) {
+    if (!printStates()) {
       Log() << "Write tree to " << filename << "... ";
       writeTree(filename);
       Log() << "done!\n";
@@ -2101,7 +2103,7 @@ void InfomapBase::writeResult()
   if (printFlowTree) {
     std::string filename = outDirectory + outName + ".ftree";
 
-    if (!haveMemory()) {
+    if (!printStates()) {
       Log() << "Write flow tree to " << filename << "... ";
       writeFlowTree(filename);
       Log() << "done!\n";
@@ -2121,7 +2123,7 @@ void InfomapBase::writeResult()
   if (printNewick) {
     std::string filename = outDirectory + outName + ".nwk";
 
-    if (!haveMemory()) {
+    if (!printStates()) {
       Log() << "Write Newick tree to " << filename << "... ";
       writeNewickTree(filename);
       Log() << "done!\n";
@@ -2141,7 +2143,7 @@ void InfomapBase::writeResult()
     std::string filename = outDirectory + outName + ".json";
     const bool writeLinks = false;
 
-    if (!haveMemory()) {
+    if (!printStates()) {
       Log() << "Write JSON tree to " << filename << "... ";
       writeJsonTree(filename, false, writeLinks);
       Log() << "done!\n";
@@ -2160,7 +2162,7 @@ void InfomapBase::writeResult()
   if (printCsv) {
     std::string filename = outDirectory + outName + ".csv";
 
-    if (!haveMemory()) {
+    if (!printStates()) {
       Log() << "Write CSV tree to " << filename << "... ";
       writeCsvTree(filename);
       Log() << "done!\n";
@@ -2178,7 +2180,7 @@ void InfomapBase::writeResult()
 
   if (printClu) {
     std::string filename = outDirectory + outName + ".clu";
-    if (!haveMemory()) {
+    if (!printStates()) {
       Log() << "Write node modules to " << filename << "... ";
       writeClu(filename, false, cluLevel);
       Log() << "done!\n";

--- a/src/core/InfomapIterator.cpp
+++ b/src/core/InfomapIterator.cpp
@@ -53,7 +53,7 @@ InfomapIterator& InfomapIterator::operator++()
 
     current = current->next;
 
-    if (!current->isLeaf() && (m_moduleIndex < 0 || static_cast<unsigned int>(m_moduleIndexLevel) >= m_depth)) {
+    if (!current->isLeaf() && (static_cast<unsigned int>(m_moduleIndexLevel) >= m_depth)) {
       ++m_moduleIndex;
     }
 

--- a/src/core/StateNetwork.cpp
+++ b/src/core/StateNetwork.cpp
@@ -48,6 +48,7 @@ std::pair<StateNetwork::NodeMap::iterator, bool> StateNetwork::addStateNode(Stat
 
 std::pair<StateNetwork::NodeMap::iterator, bool> StateNetwork::addStateNode(unsigned int id, unsigned int physId)
 {
+  m_higherOrderInputMethodCalled = true;
   return addStateNode(StateNode(id, physId));
 }
 

--- a/src/core/StateNetwork.h
+++ b/src/core/StateNetwork.h
@@ -107,6 +107,7 @@ protected:
   // Network
   bool m_haveDirectedInput = false;
   bool m_haveMemoryInput = false;
+  bool m_higherOrderInputMethodCalled = false;
   NodeMap m_nodes; // Nodes indexed by state id (equal physical id for first-order networks)
   NodeLinkMap m_nodeLinkMap;
   unsigned int m_numNodesFound = 0;
@@ -194,6 +195,7 @@ public:
 
   bool haveDirectedInput() const { return m_haveDirectedInput; }
   bool haveMemoryInput() const { return m_haveMemoryInput; }
+  bool higherOrderInputMethodCalled() const { return m_higherOrderInputMethodCalled; }
   // Bipartite
   bool isBipartite() const { return m_bipartiteStartId > 0; }
   unsigned int bipartiteStartId() const { return m_bipartiteStartId; }

--- a/src/io/Config.h
+++ b/src/io/Config.h
@@ -83,7 +83,8 @@ struct Config {
   std::string networkFile;
   std::vector<std::string> additionalInput;
   std::string inputFormat;
-  bool memoryInput = false;
+  bool stateInput = false;
+  bool stateOutput = false;
   bool multilayerInput = false;
   //bool withMemory = false; // unused
   double weightThreshold = 0.0;
@@ -203,7 +204,8 @@ struct Config {
     networkFile = other.networkFile;
     additionalInput = other.additionalInput;
     inputFormat = other.inputFormat;
-    memoryInput = other.memoryInput;
+    stateInput = other.stateInput;
+    stateOutput = other.stateOutput;
     multilayerInput = other.multilayerInput;
     //withMemory = other.withMemory;
     weightThreshold = other.weightThreshold;
@@ -349,7 +351,9 @@ struct Config {
 
   void adaptDefaults();
 
-  void setMemoryInput() { memoryInput = true; }
+  void setStateInput() { stateInput = true; }
+
+  void setStateOutput() { stateOutput = true; }
 
   void setMultilayerInput() { multilayerInput = true; }
 
@@ -371,7 +375,8 @@ struct Config {
   bool isStateNetwork() const { return inputFormat == "states"; }
   bool isBipartite() const { return inputFormat == "bipartite" || bipartite; }
 
-  bool haveMemory() const { return memoryInput; }
+  bool haveMemory() const { return stateInput; }
+  bool printStates() const { return stateOutput; }
 
   bool haveMetaData() const { return !metaDataFile.empty() || numMetaDataDimensions != 0; }
 

--- a/src/io/Network.cpp
+++ b/src/io/Network.cpp
@@ -338,6 +338,7 @@ std::string Network::parseVertices(std::ifstream& file, std::string heading)
 
 std::string Network::parseStateNodes(std::ifstream& file, /* [[maybe_unused]] */ std::string heading)
 {
+  m_higherOrderInputMethodCalled = true;
   Log() << "  Parsing state nodes...\n"
         << std::flush;
   std::string line;
@@ -590,6 +591,7 @@ void Network::printSummary()
 
 void Network::addMultilayerLink(unsigned int layer1, unsigned int n1, unsigned int layer2, unsigned int n2, double weight)
 {
+  m_higherOrderInputMethodCalled = true;
   if (weight < m_config.weightThreshold) {
     ++m_numLinksIgnoredByWeightThreshold;
     m_totalLinkWeightIgnored += weight;
@@ -955,7 +957,7 @@ double Network::calculateJensenShannonDivergence(bool& intersect, const OutLinkM
   auto layer1OutLinkItEnd = layer1OutLinks.end();
   auto layer2OutLinkItEnd = layer2OutLinks.end();
   while (layer1OutLinkIt != layer1OutLinkItEnd && layer2OutLinkIt != layer2OutLinkItEnd) {
-    auto diff = layer1OutLinkIt->first.id - layer2OutLinkIt->first.id;
+    int diff = layer1OutLinkIt->first.id - layer2OutLinkIt->first.id;
     if (diff < 0) {
       // If the first state node has a link that the second has not
       double p1 = layer1OutLinkIt->second.weight / ow1;
@@ -1021,6 +1023,7 @@ void Network::simulateInterLayerLinks()
 
 void Network::addMultilayerIntraLink(unsigned int layer, unsigned int n1, unsigned int n2, double weight)
 {
+  m_higherOrderInputMethodCalled = true;
   bool added = m_networks[layer].addLink(n1, n2, weight);
   if (added) {
     ++m_numIntraLayerLinks;
@@ -1034,6 +1037,7 @@ void Network::addMultilayerInterLink(unsigned int layer1, unsigned int n, unsign
   if (layer1 == layer2) {
     throw InputDomainError(io::Str() << "Inter-layer link (layer1, node, layer2): " << layer1 << ", " << n << ", " << layer2 << " must have layer1 != layer2");
   }
+  m_higherOrderInputMethodCalled = true;
 
   // m_interLinks[LayerNode(layer1, n)][layer2] += interWeight;
 
@@ -1067,6 +1071,7 @@ void Network::addMultilayerInterLink(unsigned int layer1, unsigned int n, unsign
 
 unsigned int Network::addMultilayerNode(unsigned int layerId, unsigned int physicalId, double weight)
 {
+  m_higherOrderInputMethodCalled = true;
   // auto layerNode = LayerNode(layerId, physicalId);
   // auto it = m_layerNodeToStateId.find(layerNode);
   // if (it != m_layerNodeToStateId.end()) {


### PR DESCRIPTION
In the case when higher-order input methods are used but states input happen to be a special case of a first-order network, print `_states` output files anyway for consistency.