### PR TITLE
feat: Write node metadata to json

### DIFF
--- a/src/core/StateNetwork.h
+++ b/src/core/StateNetwork.h
@@ -176,6 +176,8 @@ public:
   std::map<unsigned int, std::string>& names() { return m_names; }
   const std::map<unsigned int, std::string>& names() const { return m_names; }
 
+  virtual const std::map<unsigned int, std::vector<int>>& metaData() const = 0;
+
   bool haveDirectedInput() const { return m_haveDirectedInput; }
   bool haveMemoryInput() const { return m_haveMemoryInput; }
   bool higherOrderInputMethodCalled() const { return m_higherOrderInputMethodCalled; }

--- a/src/io/Network.h
+++ b/src/io/Network.h
@@ -92,7 +92,7 @@ public:
   virtual void readMetaData(const std::string& filename);
 
   unsigned int numMetaDataColumns() const { return m_numMetaDataColumns; }
-  const std::map<unsigned int, std::vector<int>>& metaData() const { return m_metaData; }
+  const std::map<unsigned int, std::vector<int>>& metaData() const override { return m_metaData; }
 
   bool isMultilayerNetwork() const { return !m_layerNodeToStateId.empty(); }
   const std::map<unsigned int, std::map<unsigned int, unsigned int>>& layerNodeToStateId() const { return m_layerNodeToStateId; }

--- a/src/io/Output.cpp
+++ b/src/io/Output.cpp
@@ -382,6 +382,19 @@ void writeJsonTree(InfomapBase& im, const StateNetwork& network, std::ostream& o
 
   const auto multilevelModules = im.getMultilevelModules(states);
 
+  auto metaData = network.metaData();
+  auto writeMeta = [&metaData](auto& outStream, auto nodeId) {
+    outStream << "\"metadata\":{";
+    auto meta = metaData[nodeId];
+    for (unsigned int i = 0; i < meta.size(); ++i) {
+      outStream << '"' << i << "\":"
+                << '"' << meta[i] << '"'; // metadata class as string to highlight that this is a categorical variable
+      if (i < meta.size() - 1)
+        outStream << ',';
+    }
+    outStream << "},";
+  };
+
   // don't append a comma after the last entry
   auto first = true;
 
@@ -434,6 +447,11 @@ void writeJsonTree(InfomapBase& im, const StateNetwork& network, std::ostream& o
                   << "\"name\":\"" << getNodeName(network.names(), node) << "\","
                   << "\"flow\":" << node.data.flow << ","
                   << "\"mec\":" << it.modularCentrality() << ",";
+
+        // can't currently use both memory and meta map equation
+        if (im.haveMetaData() && !states) {
+          writeMeta(outStream, node.physicalId);
+        }
 
         if (states) {
           outStream << "\"stateId\":" << node.stateId << ",";


### PR DESCRIPTION
The `metadata` key is an object to enable multiple metadata dimensions, and add named metadata categories in post-processing.

The metadata value is a string to highlight that this is a categorical variable. In Alluvial, we also support numerical metadata (from e.g. color map equation) and we distinguish between categorical and numerical by the value types.

Metadata is only being written for memoryless networks as we don't support using both memory and meta map equation at the same time.

Output:
```json
"nodes": [{
      "path": [1, 1],
      "modules": [1],
      "name": "2",
      "flow": 0.214286,
      "mec": 0.230673,
      "metadata": {"0": "1"},
      "id": 2
    },
]
```