### PR TITLE
Feat/variable markov time

### DIFF
--- a/interfaces/js/src/arguments.ts
+++ b/interfaces/js/src/arguments.ts
@@ -49,6 +49,8 @@ export interface Arguments
     entropyCorrected: boolean;
     entropyCorrectionStrength: number;
     markovTime: number;
+    variableMarkovTime: boolean;
+    variableMarkovTimeStrength: number;
     preferredNumberOfModules: number;
     multilayerRelaxRate: number;
     multilayerRelaxLimit: number;
@@ -154,6 +156,12 @@ export default function argumentsToString(args: Arguments) {
       " --entropy-correction-strength " + args.entropyCorrectionStrength;
 
   if (args.markovTime) result += " --markov-time " + args.markovTime;
+
+  if (args.variableMarkovTime) result += " --variable-markov-time";
+
+  if (args.variableMarkovTimeStrength != null)
+    result +=
+      " --variable-markov-time-strength " + args.variableMarkovTimeStrength;
 
   if (args.preferredNumberOfModules != null)
     result += " --preferred-number-of-modules " + args.preferredNumberOfModules;

--- a/interfaces/python/infomap.py
+++ b/interfaces/python/infomap.py
@@ -76,6 +76,8 @@ def _construct_args(
     entropy_corrected=False,
     entropy_correction_strength=1.0,
     markov_time=1.0,
+    variable_markov_time=False,
+    variable_markov_time_strength=1.0,
     preferred_number_of_modules=None,
     multilayer_relax_rate=_DEFAULT_MULTILAYER_RELAX_RATE,
     multilayer_relax_limit=-1,
@@ -210,6 +212,10 @@ def _construct_args(
 
     if markov_time != 1.0:
         args += " --markov-time {}".format(markov_time)
+    if variable_markov_time:
+        args += " --variable-markov-time"
+    if variable_markov_time_strength != 1.0:
+        args += " --variable-markov-time-strength {}".format(variable_markov_time_strength)
 
     if preferred_number_of_modules is not None:
         args += " --preferred-number-of-modules {}".format(preferred_number_of_modules)
@@ -342,6 +348,8 @@ class Infomap(InfomapWrapper):
         entropy_corrected=False,
         entropy_correction_strength=1.0,
         markov_time=1.0,
+        variable_markov_time=False,
+        variable_markov_time_strength=1.0,
         preferred_number_of_modules=None,
         multilayer_relax_rate=_DEFAULT_MULTILAYER_RELAX_RATE,
         multilayer_relax_limit=-1,
@@ -460,6 +468,12 @@ class Infomap(InfomapWrapper):
         markov_time : float, optional
             Scales link flow to change the cost of moving between modules.
             Higher values results in fewer modules.
+        variable_markov_time : bool, optional
+            Increase Markov time locally to level out link flow. Reduces risk of 
+            overpartitioning sparse areas while keeping high resolution in dense areas.
+        variable_markov_time_strength : float, optional
+            Exponent for variable Markov time scale. 0 means no rescaling and 1 means 
+            full rescaling to constant transition flow rate.
         preferred_number_of_modules : int, optional
             Penalize solutions the more they differ from this number.
         multilayer_relax_rate : float, optional
@@ -546,6 +560,8 @@ class Infomap(InfomapWrapper):
                 entropy_corrected=entropy_corrected,
                 entropy_correction_strength=entropy_correction_strength,
                 markov_time=markov_time,
+                variable_markov_time=False,
+                variable_markov_time_strength=1.0,
                 preferred_number_of_modules=preferred_number_of_modules,
                 multilayer_relax_rate=multilayer_relax_rate,
                 multilayer_relax_limit=multilayer_relax_limit,
@@ -1351,6 +1367,8 @@ If you want to set node names, use set_name."""
         entropy_corrected=False,
         entropy_correction_strength=1.0,
         markov_time=1.0,
+        variable_markov_time=False,
+        variable_markov_time_strength=1.0,
         preferred_number_of_modules=None,
         multilayer_relax_rate=_DEFAULT_MULTILAYER_RELAX_RATE,
         multilayer_relax_limit=-1,
@@ -1472,6 +1490,12 @@ If you want to set node names, use set_name."""
         markov_time : float, optional
             Scales link flow to change the cost of moving between modules.
             Higher values results in fewer modules.
+        variable_markov_time : bool, optional
+            Increase Markov time locally to level out link flow. Reduces risk of 
+            overpartitioning sparse areas while keeping high resolution in dense areas.
+        variable_markov_time_strength : float, optional
+            Exponent for variable Markov time scale. 0 means no rescaling and 1 means 
+            full rescaling to constant transition flow rate.
         preferred_number_of_modules : int, optional
             Penalize solutions the more they differ from this number.
         multilayer_relax_rate : float, optional
@@ -1561,6 +1585,8 @@ If you want to set node names, use set_name."""
             entropy_corrected=entropy_corrected,
             entropy_correction_strength=entropy_correction_strength,
             markov_time=markov_time,
+            variable_markov_time=False,
+            variable_markov_time_strength=1.0,
             preferred_number_of_modules=preferred_number_of_modules,
             multilayer_relax_rate=multilayer_relax_rate,
             multilayer_relax_limit=multilayer_relax_limit,

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -29,6 +29,7 @@
 #include <set>
 #include <cstdlib>
 #include <algorithm>
+#include <cmath>
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -743,6 +744,11 @@ void InfomapBase::generateSubNetwork(Network& network)
   if (std::abs(sumNodeFlow - 1.0) > 1e-10)
     Log() << "Warning, total flow on nodes differs from 1.0 by " << sumNodeFlow - 1.0 << ".\n";
 
+  bool changeMarkovTime = std::abs(markovTime - 1) > 1e-3;
+  if (changeMarkovTime) {
+    Log() << "  -> Rescale link flow with global Markov time " << markovTime << "\n";
+  }
+
   for (auto& linkIt : network.nodeLinkMap()) {
     unsigned int linkSourceId = linkIt.first.id;
     unsigned int sourceIndex = nodeIndexMap[linkSourceId];
@@ -754,6 +760,55 @@ void InfomapBase::generateSubNetwork(Network& network)
       if (sourceIndex != targetIndex) {
         auto& linkData = subIt.second;
         m_leafNodes[sourceIndex]->addOutEdge(*m_leafNodes[targetIndex], linkData.weight, linkData.flow * markovTime);
+      }
+    }
+  }
+  
+  if (variableMarkovTime) {
+    Log() << "  -> Rescale link flow with variable Markov time\n";
+    if (std::abs(variableMarkovTimeStrength - 1) > 1e-9) {
+      Log() << "  -> Use variable Markov time strength " << variableMarkovTimeStrength << "\n";
+    }
+  }
+
+  double maxEntropy = 0.0;
+  double entropyRate = 0.0;
+  std::vector<double> entropies(numNodes, 0);
+
+  for (unsigned i = 0; i < numNodes; ++i) {
+    InfoNode& node = *m_leafNodes[i];
+    double entropy = 0;
+    double sumOut = 0;
+    for (InfoEdge* e : node.outEdges()) {
+      entropy -= infomath::plogp(e->data.weight);
+      sumOut += e->data.weight;
+    }
+    if (isUndirectedFlow()) {
+      for (InfoEdge* e : node.inEdges()) {
+        entropy -= infomath::plogp(e->data.weight);
+        sumOut += e->data.weight;
+      }
+    }
+    entropy = sumOut > 1e-9 ? (entropy + infomath::plogp(sumOut)) / sumOut : 0;
+    maxEntropy = std::max(maxEntropy, entropy);
+    entropyRate += m_leafNodes[i]->data.flow * entropy;
+    entropies[i] = entropy; // Store for undirected networks
+  }
+  m_entropyRate = entropyRate;
+  m_maxEntropy = maxEntropy;
+  Log() << "  -> Max node entropy: " << io::toPrecision(maxEntropy) << '\n';
+  Log() << "  -> Entropy rate: " << io::toPrecision(entropyRate) << '\n';
+  if (variableMarkovTime) {
+    for (unsigned i = 0; i < numNodes; ++i) {
+      InfoNode& node = *m_leafNodes[i];
+      double localEntropy = std::max(1e-6, entropies[i]);
+      for (InfoEdge* e : node.outEdges()) {
+        if (isUndirectedFlow()) {
+          double hTarget = std::max(1e-6, entropies[nodeIndexMap[e->target->stateId]]);
+          localEntropy = std::max(localEntropy, hTarget);
+        }
+        double localMarkovTimeScale = pow(maxEntropy / localEntropy, variableMarkovTimeStrength);
+        e->data.flow *= localMarkovTimeScale;
       }
     }
   }
@@ -802,42 +857,8 @@ void InfomapBase::init()
 
   initNetwork();
 
-  Log() << "Calculating one-level codelength... " << std::flush;
   m_oneLevelCodelength = calcCodelength(m_root);
-  Log() << "done!\n -> One-level codelength: " << m_oneLevelCodelength << '\n';
-
-  Log() << "Calculating entropy rate... " << std::flush;
-
-  double entropyRate = calcEntropyRate();
-  Log() << "done!\n  -> Entropy rate: " << io::toPrecision(entropyRate) << '\n';
-}
-
-double InfomapBase::calcEntropyRate()
-{
-  double entropyRate = 0.0;
-  for (auto it(iterLeafNodes()); !it.isEnd(); ++it) {
-    InfoNode& node = *it;
-    double sumOutFlow = 0.0;
-    double entropy = 0.0;
-    for (InfoEdge* e : node.outEdges()) {
-      sumOutFlow += e->data.flow;
-    }
-    if (this->isUndirectedClustering()) {
-      for (InfoEdge* e : node.inEdges()) {
-        sumOutFlow += e->data.flow;
-      }
-    }
-    for (InfoEdge* e : node.outEdges()) {
-      entropy += -infomath::plogp(e->data.flow / sumOutFlow);
-    }
-    if (this->isUndirectedClustering()) {
-      for (InfoEdge* e : node.inEdges()) {
-        entropy += -infomath::plogp(e->data.flow / sumOutFlow);
-      }
-    }
-    entropyRate += node.data.flow * entropy;
-  }
-  return entropyRate;
+  Log() << "  -> One-level codelength: " << m_oneLevelCodelength << '\n';
 }
 
 // ===================================================

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -774,10 +774,16 @@ void InfomapBase::generateSubNetwork(Network& network)
   double maxEntropy = 0.0;
   double maxFlow = 0.0;
   double entropyRate = 0.0;
+  unsigned int maxDegree = 0;
+  unsigned int maxOutDegree = 0;
+  unsigned int maxInDegree = 0;
   std::vector<double> entropies(numNodes, 0);
 
   for (unsigned i = 0; i < numNodes; ++i) {
     InfoNode& node = *m_leafNodes[i];
+    maxDegree = std::max(maxDegree, node.degree());
+    maxOutDegree = std::max(maxOutDegree, node.outDegree());
+    maxInDegree = std::max(maxInDegree, node.inDegree());
     double entropy = 0;
     double sumOut = 0;
     for (InfoEdge* e : node.outEdges()) {
@@ -799,7 +805,11 @@ void InfomapBase::generateSubNetwork(Network& network)
   m_entropyRate = entropyRate;
   m_maxEntropy = maxEntropy;
   m_maxFlow = maxFlow;
-  Log() << "  -> Max node flow: " << io::toPrecision(maxFlow) << '\n';
+  Log() << "  -> Max node flow: " << io::toPrecision(maxFlow, 3) << '\n';
+  if (isUndirectedFlow())
+    Log() << "  -> Max node degree: " << io::toPrecision(maxDegree) << '\n';
+  else
+    Log() << "  -> Max node in/out degree: " << maxInDegree << "/" << maxOutDegree << '\n';
   Log() << "  -> Max node entropy: " << io::toPrecision(maxEntropy) << '\n';
   Log() << "  -> Entropy rate: " << io::toPrecision(entropyRate) << '\n';
   if (variableMarkovTime) {

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -137,6 +137,7 @@ public:
 
   double getEntropyRate() { return m_entropyRate; }
   double getMaxEntropy() { return m_maxEntropy; }
+  double getMaxFlow() { return m_maxFlow; }
 
   const Date& getStartDate() const { return m_startDate; }
   const Stopwatch& getElapsedTime() const { return m_elapsedTime; }
@@ -505,6 +506,7 @@ protected:
   std::vector<double> m_codelengths;
   double m_entropyRate = 0.0;
   double m_maxEntropy = 0.0;
+  double m_maxFlow = 0.0;
 
   double m_sumDanglingFlow = 0.0;
 

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -135,7 +135,8 @@ public:
     return oneLevelCodelength < 1e-16 ? 0 : 1.0 - codelength() / oneLevelCodelength;
   }
 
-  double getEntropyRate() { return calcEntropyRate(); }
+  double getEntropyRate() { return m_entropyRate; }
+  double getMaxEntropy() { return m_maxEntropy; }
 
   const Date& getStartDate() const { return m_startDate; }
   const Stopwatch& getElapsedTime() const { return m_elapsedTime; }
@@ -218,8 +219,6 @@ private:
   bool isMainInfomap() const { return m_isMain; }
 
   bool haveHardPartition() const { return !m_originalLeafNodes.empty(); }
-
-  double calcEntropyRate();
 
   // ===================================================
   // Run: *
@@ -504,6 +503,8 @@ protected:
 
   double m_hierarchicalCodelength = 0.0;
   std::vector<double> m_codelengths;
+  double m_entropyRate = 0.0;
+  double m_maxEntropy = 0.0;
 
   double m_sumDanglingFlow = 0.0;
 

--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -113,9 +113,9 @@ Config::Config(const std::string& flags, bool isCLI) : isCLI(isCLI)
 
   api.addOptionArgument(markovTime, "markov-time", "Scale link flow to change the cost of moving between modules. Higher values results in fewer modules.", ArgType::number, "Algorithm", 0.0, true);
   
-  api.addOptionArgument(variableMarkovTime, "variable-markov-time", "Increase link flow inversely proportional to local entropy to avoid overpartition sparse areas while keeping high resolution in dense areas.", "Algorithm", true);
+  api.addOptionArgument(variableMarkovTime, "variable-markov-time", "Increase Markov time locally to level out link flow. Reduces risk of overpartitioning sparse areas while keeping high resolution in dense areas.", "Algorithm", true);
   
-  api.addOptionArgument(variableMarkovTimeStrength, "variable-markov-time-strength", "Exponent for variable Markov time scale, 0 means no rescaling and 1 means full rescaling to constant bit rate.", ArgType::number, "Algorithm", true);
+  api.addOptionArgument(variableMarkovTimeStrength, "variable-markov-time-strength", "Exponent for variable Markov time scale. 0 means no rescaling and 1 means full rescaling to constant transition flow rate.", ArgType::number, "Algorithm", true);
   
   // api.addOptionArgument(markovTimeNoSelfLinks, "markov-time-no-self-links", "For testing.", "Algorithm", true);
 

--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -111,7 +111,13 @@ Config::Config(const std::string& flags, bool isCLI) : isCLI(isCLI)
 
   api.addOptionArgument(entropyBiasCorrectionMultiplier, "entropy-correction-strength", "Increase or decrease the default entropy correction with this factor.", ArgType::number, "Algorithm", true);
 
-  api.addOptionArgument(markovTime, "markov-time", "Scales link flow to change the cost of moving between modules. Higher values results in fewer modules.", ArgType::number, "Algorithm", 0.0, true);
+  api.addOptionArgument(markovTime, "markov-time", "Scale link flow to change the cost of moving between modules. Higher values results in fewer modules.", ArgType::number, "Algorithm", 0.0, true);
+  
+  api.addOptionArgument(variableMarkovTime, "variable-markov-time", "Increase link flow inversely proportional to local entropy to avoid overpartition sparse areas while keeping high resolution in dense areas.", "Algorithm", true);
+  
+  api.addOptionArgument(variableMarkovTimeStrength, "variable-markov-time-strength", "Exponent for variable Markov time scale, 0 means no rescaling and 1 means full rescaling to constant bit rate.", ArgType::number, "Algorithm", true);
+  
+  // api.addOptionArgument(markovTimeNoSelfLinks, "markov-time-no-self-links", "For testing.", "Algorithm", true);
 
   api.addOptionArgument(preferredNumberOfModules, "preferred-number-of-modules", "Penalize solutions the more they differ from this number.", ArgType::integer, "Algorithm", 1u, true);
 

--- a/src/io/Config.h
+++ b/src/io/Config.h
@@ -93,6 +93,9 @@ struct Config {
   bool useNodeWeightsAsFlow = false;
   bool teleportToNodes = false;
   double markovTime = 1.0;
+  bool variableMarkovTime = false;
+  double variableMarkovTimeStrength = 1.0;
+  bool markovTimeNoSelfLinks = false;
   double multilayerRelaxRate = 0.15;
   int multilayerRelaxLimit = -1; // Amount of layers allowed to jump up or down
   int multilayerRelaxLimitUp = -1; // One-sided limit to higher layers
@@ -184,6 +187,9 @@ struct Config {
     useNodeWeightsAsFlow = other.useNodeWeightsAsFlow;
     teleportToNodes = other.teleportToNodes;
     markovTime = other.markovTime;
+    variableMarkovTime = other.variableMarkovTime;
+    variableMarkovTimeStrength = other.variableMarkovTimeStrength;
+    markovTimeNoSelfLinks = other.markovTimeNoSelfLinks;
     multilayerRelaxRate = other.multilayerRelaxRate;
     multilayerRelaxLimit = other.multilayerRelaxLimit;
     multilayerRelaxLimitUp = other.multilayerRelaxLimitUp;


### PR DESCRIPTION
The map equation suffers from a field-of-view limit in that Infomap over-partition sparse enough areas. This can be avoided by increasing Markov time. However, that comes at a cost of losing resolution in dense areas.

Instead of a global resolution parameter, variable Markov time locally increases Markov time to level out transition flow rates. This increases the field-of-view limit without pushing dense areas below a resolution limit.

To enable it, use `--variable-markov-time`. Optionally set `--variable-markov-time-strength` between 0 and 1 to explore the effect.

Variable Markov time can be combined with the global Markov time rescaling using `--markov-time`.