### PR TITLE
fix: Scale variable Markov time logarithmic as default

### DIFF
--- a/interfaces/js/src/arguments.ts
+++ b/interfaces/js/src/arguments.ts
@@ -50,7 +50,7 @@ export interface Arguments
     entropyCorrectionStrength: number;
     markovTime: number;
     variableMarkovTime: boolean;
-    variableMarkovTimeStrength: number;
+    variableMarkovDamping: number;
     preferredNumberOfModules: number;
     multilayerRelaxRate: number;
     multilayerRelaxLimit: number;
@@ -71,7 +71,7 @@ export interface Arguments
     // about
     help: boolean | "advanced";
     version: boolean;
-  }> {}
+  }> { }
 
 export default function argumentsToString(args: Arguments) {
   let result = "";
@@ -159,9 +159,9 @@ export default function argumentsToString(args: Arguments) {
 
   if (args.variableMarkovTime) result += " --variable-markov-time";
 
-  if (args.variableMarkovTimeStrength != null)
+  if (args.variableMarkovDamping != null)
     result +=
-      " --variable-markov-time-strength " + args.variableMarkovTimeStrength;
+      " --variable-markov-damping " + args.variableMarkovDamping;
 
   if (args.preferredNumberOfModules != null)
     result += " --preferred-number-of-modules " + args.preferredNumberOfModules;

--- a/interfaces/python/infomap.py
+++ b/interfaces/python/infomap.py
@@ -77,7 +77,7 @@ def _construct_args(
     entropy_correction_strength=1.0,
     markov_time=1.0,
     variable_markov_time=False,
-    variable_markov_time_strength=1.0,
+    variable_markov_damping=1.0,
     preferred_number_of_modules=None,
     multilayer_relax_rate=_DEFAULT_MULTILAYER_RELAX_RATE,
     multilayer_relax_limit=-1,
@@ -214,9 +214,9 @@ def _construct_args(
         args += " --markov-time {}".format(markov_time)
     if variable_markov_time:
         args += " --variable-markov-time"
-    if variable_markov_time_strength != 1.0:
-        args += " --variable-markov-time-strength {}".format(
-            variable_markov_time_strength
+    if variable_markov_damping != 1.0:
+        args += " --variable-markov-damping {}".format(
+            variable_markov_damping
         )
 
     if preferred_number_of_modules is not None:
@@ -351,7 +351,7 @@ class Infomap(InfomapWrapper):
         entropy_correction_strength=1.0,
         markov_time=1.0,
         variable_markov_time=False,
-        variable_markov_time_strength=1.0,
+        variable_markov_damping=1.0,
         preferred_number_of_modules=None,
         multilayer_relax_rate=_DEFAULT_MULTILAYER_RELAX_RATE,
         multilayer_relax_limit=-1,
@@ -473,9 +473,9 @@ class Infomap(InfomapWrapper):
         variable_markov_time : bool, optional
             Increase Markov time locally to level out link flow. Reduces risk of
             overpartitioning sparse areas while keeping high resolution in dense areas.
-        variable_markov_time_strength : float, optional
-            Exponent for variable Markov time scale. 0 means no rescaling and 1 means
-            full rescaling to constant transition flow rate.
+        variable_markov_damping : float, optional
+            Damping parameter for variable Markov time, to scale with local effective 
+            degree (0) or local entropy (1).
         preferred_number_of_modules : int, optional
             Penalize solutions the more they differ from this number.
         multilayer_relax_rate : float, optional
@@ -563,7 +563,7 @@ class Infomap(InfomapWrapper):
                 entropy_correction_strength=entropy_correction_strength,
                 markov_time=markov_time,
                 variable_markov_time=variable_markov_time,
-                variable_markov_time_strength=variable_markov_time_strength,
+                variable_markov_damping=variable_markov_damping,
                 preferred_number_of_modules=preferred_number_of_modules,
                 multilayer_relax_rate=multilayer_relax_rate,
                 multilayer_relax_limit=multilayer_relax_limit,
@@ -1370,7 +1370,7 @@ If you want to set node names, use set_name."""
         entropy_correction_strength=1.0,
         markov_time=1.0,
         variable_markov_time=False,
-        variable_markov_time_strength=1.0,
+        variable_markov_damping=1.0,
         preferred_number_of_modules=None,
         multilayer_relax_rate=_DEFAULT_MULTILAYER_RELAX_RATE,
         multilayer_relax_limit=-1,
@@ -1495,7 +1495,7 @@ If you want to set node names, use set_name."""
         variable_markov_time : bool, optional
             Increase Markov time locally to level out link flow. Reduces risk of
             overpartitioning sparse areas while keeping high resolution in dense areas.
-        variable_markov_time_strength : float, optional
+        variable_markov_damping : float, optional
             Exponent for variable Markov time scale. 0 means no rescaling and 1 means
             full rescaling to constant transition flow rate.
         preferred_number_of_modules : int, optional
@@ -1588,7 +1588,7 @@ If you want to set node names, use set_name."""
             entropy_correction_strength=entropy_correction_strength,
             markov_time=markov_time,
             variable_markov_time=False,
-            variable_markov_time_strength=1.0,
+            variable_markov_damping=1.0,
             preferred_number_of_modules=preferred_number_of_modules,
             multilayer_relax_rate=multilayer_relax_rate,
             multilayer_relax_limit=multilayer_relax_limit,

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -808,7 +808,7 @@ void InfomapBase::generateSubNetwork(Network& network)
   m_maxEntropy = maxEntropy;
   m_maxFlow = maxFlow;
 
-  double minLocalScale = 1e-9;
+  double minLocalScale = variableMarkovTimeMinLocalScale;
   double damping = variableMarkovTimeDamping;
 
   double maxScale = infomath::linlog(pow(2.0, maxEntropy), damping);

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -808,28 +808,26 @@ void InfomapBase::generateSubNetwork(Network& network)
   m_maxEntropy = maxEntropy;
   m_maxFlow = maxFlow;
 
-  double eps = 1e-9;
+  double minLocalScale = 1e-9;
   double damping = variableMarkovTimeDamping;
 
-  double maxScale = infomath::linlog(pow(2.0, maxEntropy) + eps, damping);
+  double maxScale = infomath::linlog(pow(2.0, maxEntropy), damping);
 
   if (variableMarkovTime) {
     if (damping < 0) {
-      maxScale = infomath::linlog(maxFlow * totDegree, damping);
+      maxScale = infomath::linlog(maxFlow * totDegree, -damping);
     }
     for (unsigned i = 0; i < numNodes; ++i) {
       InfoNode& node = *m_leafNodes[i];
-      double localScale = damping >= 0 ? infomath::linlog(pow(2.0, entropies[i]) + eps, damping) : infomath::linlog(std::max(2.0, node.data.flow * totDegree), damping);
+      double localScale = damping >= 0 ? infomath::linlog(pow(2.0, entropies[i]), damping) : infomath::linlog(std::max(1.0, node.data.flow * totDegree), -damping);
       for (InfoEdge* e : node.outEdges()) {
         if (isUndirectedFlow()) {
-          double oppositeLocalScale = damping >= 0 ? infomath::linlog(pow(2., entropies[nodeIndexMap[e->target->stateId]]) + eps, damping) : infomath::linlog(std::max(2.0, e->target->data.flow * totDegree), damping);
+          double oppositeLocalScale = damping >= 0 ? infomath::linlog(pow(2.0, entropies[nodeIndexMap[e->target->stateId]]), damping) : infomath::linlog(std::max(1.0, e->target->data.flow * totDegree), -damping);
           localScale = std::max(localScale, oppositeLocalScale);
         }
-        // double localMarkovTimeScale = pow(std::log(std::max(1e-9, localScale)) / std::log(maxFlow), std::abs(damping));
-        // double localMarkovTimeScale = pow(maxScale / std::max(1.0, localScale), std::abs(damping));
-        // double localMarkovTimeScale = damping >= 0 ? maxScale / localScale : pow(maxScale / std::max(1.0, localScale), std::abs(damping));
-        double localMarkovTimeScale = maxScale / localScale;
+        double localMarkovTimeScale = maxScale / std::max(minLocalScale, localScale);
         e->data.flow *= localMarkovTimeScale;
+        network.nodeLinkMap()[e->source->stateId][e->target->stateId].flow = e->data.flow;
       }
     }
   }

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -218,6 +218,15 @@ void InfomapBase::run(Network& network)
 
   calculateFlow(network, *this);
 
+  if (network.isBipartite()) {
+    bipartite = true;
+  }
+
+  initNetwork(network);
+
+  if (numLeafNodes() == 0)
+    throw std::domain_error("No nodes to partition");
+
   if (printFlowNetwork) {
     std::string filename;
     if (printStates()) {
@@ -231,15 +240,6 @@ void InfomapBase::run(Network& network)
     network.writePajekNetwork(filename, true);
     Log() << "done!\n";
   }
-
-  if (network.isBipartite()) {
-    bipartite = true;
-  }
-
-  initNetwork(network);
-
-  if (numLeafNodes() == 0)
-    throw std::domain_error("No nodes to partition");
 
   // If used as a library, we may want to reuse the network instance, else clear to use less memory
   // TODO: May have to use some meta data for output?

--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -115,7 +115,7 @@ Config::Config(const std::string& flags, bool isCLI) : isCLI(isCLI)
 
   api.addOptionArgument(variableMarkovTime, "variable-markov-time", "Increase Markov time locally to level out link flow. Reduces risk of overpartitioning sparse areas while keeping high resolution in dense areas.", "Algorithm", true);
 
-  api.addOptionArgument(variableMarkovTimeStrength, "variable-markov-time-strength", "Exponent for variable Markov time scale. 0 means no rescaling and 1 means full rescaling to constant transition flow rate.", ArgType::number, "Algorithm", true);
+  api.addOptionArgument(variableMarkovTimeDamping, "variable-markov-damping", "Damping parameter for variable Markov time, to scale with local effective degree (0) or local entropy (1).", ArgType::number, "Algorithm", true);
 
   // api.addOptionArgument(markovTimeNoSelfLinks, "markov-time-no-self-links", "For testing.", "Algorithm", true);
 

--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -117,6 +117,8 @@ Config::Config(const std::string& flags, bool isCLI) : isCLI(isCLI)
 
   api.addOptionArgument(variableMarkovTimeDamping, "variable-markov-damping", "Damping parameter for variable Markov time, to scale with local effective degree (0) or local entropy (1).", ArgType::number, "Algorithm", true);
 
+  api.addOptionArgument(variableMarkovTimeMinLocalScale, "variable-markov-min-scale", "Minimum local scale for nodes with zero entropy to avoid division by zero. Local Markov time is max scale divided by local scale.", ArgType::number, "Algorithm", true);
+
   // api.addOptionArgument(markovTimeNoSelfLinks, "markov-time-no-self-links", "For testing.", "Algorithm", true);
 
   api.addOptionArgument(preferredNumberOfModules, "preferred-number-of-modules", "Penalize solutions the more they differ from this number.", ArgType::integer, "Algorithm", 1u, true);

--- a/src/io/Config.h
+++ b/src/io/Config.h
@@ -95,6 +95,7 @@ struct Config {
   double markovTime = 1.0;
   bool variableMarkovTime = false;
   double variableMarkovTimeDamping = 1.0; // 0 for linear scaling, 1 for log scaled.
+  double variableMarkovTimeMinLocalScale = 1e-9;
   bool markovTimeNoSelfLinks = false;
   double multilayerRelaxRate = 0.15;
   int multilayerRelaxLimit = -1; // Amount of layers allowed to jump up or down

--- a/src/io/Config.h
+++ b/src/io/Config.h
@@ -94,7 +94,7 @@ struct Config {
   bool teleportToNodes = false;
   double markovTime = 1.0;
   bool variableMarkovTime = false;
-  double variableMarkovTimeStrength = 1.0;
+  double variableMarkovTimeDamping = 1.0; // 0 for linear scaling, 1 for log scaled.
   bool markovTimeNoSelfLinks = false;
   double multilayerRelaxRate = 0.15;
   int multilayerRelaxLimit = -1; // Amount of layers allowed to jump up or down
@@ -188,7 +188,7 @@ struct Config {
     teleportToNodes = other.teleportToNodes;
     markovTime = other.markovTime;
     variableMarkovTime = other.variableMarkovTime;
-    variableMarkovTimeStrength = other.variableMarkovTimeStrength;
+    variableMarkovTimeDamping = other.variableMarkovTimeDamping;
     markovTimeNoSelfLinks = other.markovTimeNoSelfLinks;
     multilayerRelaxRate = other.multilayerRelaxRate;
     multilayerRelaxLimit = other.multilayerRelaxLimit;

--- a/src/io/Config.h
+++ b/src/io/Config.h
@@ -95,7 +95,7 @@ struct Config {
   double markovTime = 1.0;
   bool variableMarkovTime = false;
   double variableMarkovTimeDamping = 1.0; // 0 for linear scaling, 1 for log scaled.
-  double variableMarkovTimeMinLocalScale = 1e-9;
+  double variableMarkovTimeMinLocalScale = 1; // Correspond to two links in undirected unweighted networks. Avoids division by zero.
   bool markovTimeNoSelfLinks = false;
   double multilayerRelaxRate = 0.15;
   int multilayerRelaxLimit = -1; // Amount of layers allowed to jump up or down

--- a/src/utils/infomath.h
+++ b/src/utils/infomath.h
@@ -34,19 +34,21 @@ namespace infomath {
   inline double tsallisEntropyUniform(double n, double q = 1)
   {
     if (isEqual(q, 1)) {
-      return std::log(n);
+      return std::log2(n);
     }
-    return 1 / (q - 1) * (1 - pow(n, (1 - q)));
+    return 1 / (q - 1) * (1 - pow(n, (1 - q))) / std::log(2);
   }
 
   /**
    * Interpolate from linear (q = 0) to log (q = 1)
-   * linlog(k, 0) = k - 1
-   * linlog(k, 1) = log(k)
+   * linlog(k, 0) = k
+   * linlog(k, 1) = log2(k)
    */
   inline double linlog(double k, double q = 1)
   {
-    return tsallisEntropyUniform(k, q);
+    double baseCorrection = q <= 1 ? (1 - q) * std::log(2) + q : 1;
+    double offsetCorrection = q <= 1 ? 1 - q : 0;
+    return tsallisEntropyUniform(k, q) * baseCorrection + offsetCorrection;
   }
 
 } // namespace infomath

--- a/src/utils/infomath.h
+++ b/src/utils/infomath.h
@@ -11,6 +11,7 @@
 #define INFOMATH_H_
 
 #include <cmath>
+#include <cstdlib>
 
 namespace infomap {
 namespace infomath {
@@ -20,6 +21,32 @@ namespace infomath {
   inline double plogp(double p)
   {
     return p > 0.0 ? p * log2(p) : 0.0;
+  }
+
+  inline double isEqual(double a, double b, double tol = 1e-8)
+  {
+    return std::abs(a - b) <= tol;
+  }
+
+  /**
+   * Tsallis entropy S_q of a uniform probability distribution of length n
+   */
+  inline double tsallisEntropyUniform(double n, double q = 1)
+  {
+    if (isEqual(q, 1)) {
+      return std::log(n);
+    }
+    return 1 / (q - 1) * (1 - pow(n, (1 - q)));
+  }
+
+  /**
+   * Interpolate from linear (q = 0) to log (q = 1)
+   * linlog(k, 0) = k - 1
+   * linlog(k, 1) = log(k)
+   */
+  inline double linlog(double k, double q = 1)
+  {
+    return tsallisEntropyUniform(k, q);
   }
 
 } // namespace infomath


### PR DESCRIPTION
- Continuous interpolation between linear and logarithmic scaling
- Use damping parameter with default 1 for log2 scale, zero for linear
- Fix apply Markov time before print flow network