### PR TITLE
fix: handle regularized no-link networks

### DIFF
--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1109,7 +1109,8 @@ void InfomapBase::partition()
     Log() << " (" << m_numNonTrivialTopModules << " non-trivial)";
   Log() << " modules.\n";
 
-  if (!preferModularSolution && preferredNumberOfModules == 0 && haveNonTrivialModules() && getCodelength() > getOneLevelCodelength()) {
+  const bool regularizedPriorOnly = regularized && network().numLinks() == 0;
+  if (!preferModularSolution && preferredNumberOfModules == 0 && (haveNonTrivialModules() || regularizedPriorOnly) && getCodelength() > getOneLevelCodelength()) {
     Log() << "Worse codelength than one-level codelength, putting all nodes in one module... ";
 
     // Create new single module between modules and root

--- a/src/utils/FlowCalculator.cpp
+++ b/src/utils/FlowCalculator.cpp
@@ -421,6 +421,13 @@ void FlowCalculator::calcDirectedRegularizedFlow(const StateNetwork& network, co
   std::vector<double> s_in(N, 0);
   double sum_s = sumWeightedDegree;
   unsigned int sum_k = network.sumDegree();
+  if (sum_k == 0) {
+    const auto uniformFlow = 1.0 / N;
+    std::fill(nodeFlow.begin(), nodeFlow.end(), uniformFlow);
+    std::fill(nodeTeleportWeights.begin(), nodeTeleportWeights.end(), uniformFlow);
+    nodeTeleportFlow.assign(numNodes, uniformFlow);
+    return;
+  }
   double average_weight = sum_s / sum_k;
 
   for (auto& link : flowLinks) {
@@ -560,6 +567,13 @@ void FlowCalculator::calcUndirectedRegularizedFlow(const StateNetwork& network, 
   std::vector<double> s(N, 0);
   double sum_s = sumWeightedDegree;
   unsigned int sum_k = network.sumDegree();
+  if (sum_k == 0) {
+    const auto uniformFlow = 1.0 / N;
+    std::fill(nodeFlow.begin(), nodeFlow.end(), uniformFlow);
+    std::fill(nodeTeleportWeights.begin(), nodeTeleportWeights.end(), uniformFlow);
+    nodeTeleportFlow.assign(numNodes, uniformFlow);
+    return;
+  }
   double average_weight = sum_s / sum_k;
 
   for (auto& link : flowLinks) {


### PR DESCRIPTION
## Issue

Closes #360

## Risk

high

## Summary

- use a uniform prior in regularized flow calculation when the network has no links, instead of deriving prior weights from 0/0 degree statistics
- allow the existing one-level fallback to collapse prior-only regularized runs with zero links into a single top module
- add a Python regression covering both directed and undirected regularized no-link runs

## Verification

- `PATH="$PWD/.codex-bin:/opt/homebrew/bin:$PATH" CXXFLAGS="-I/opt/homebrew/opt/libomp/include" LDFLAGS="-L/opt/homebrew/opt/libomp/lib" make python`
- `PATH="$PWD/.codex-bin:/opt/homebrew/bin:$PATH" python -m pytest test/test_flow.py -k regularized_no_links`
- `PATH="/opt/homebrew/bin:$PATH" CXXFLAGS="-I/opt/homebrew/opt/libomp/include" LDFLAGS="-L/opt/homebrew/opt/libomp/lib" make -B`

## Residual Risk

- This changes regularized behavior in a core edge case, so other prior-only or zero-link paths should still be watched for unintended partition fallback changes.