### PR TITLE
fix: sync matchable multilayer ids for python file input

### DIFF
--- a/src/io/Network.cpp
+++ b/src/io/Network.cpp
@@ -23,6 +23,11 @@ using std::make_pair;
 void Network::init()
 {
   initValidHeadings();
+  updateDerivedConfig();
+}
+
+void Network::updateDerivedConfig()
+{
   m_multilayerStateIdBitShift = static_cast<unsigned int>(std::ceil(std::log2(m_config.matchableMultilayerIds)));
 }
 

--- a/src/io/Network.h
+++ b/src/io/Network.h
@@ -70,6 +70,12 @@ public:
   Network(Network&&) = delete;
   Network& operator=(Network&&) = delete;
 
+  void setConfig(const Config& config)
+  {
+    StateNetwork::setConfig(config);
+    updateDerivedConfig();
+  }
+
   void clear() override;
 
   /**
@@ -132,6 +138,7 @@ public:
 
 private:
   void init();
+  void updateDerivedConfig();
   void initValidHeadings();
 
   void parseNetwork(const std::string& filename);

--- a/test/test_multilayer.py
+++ b/test/test_multilayer.py
@@ -1,0 +1,20 @@
+from infomap import Infomap
+
+
+def test_matchable_multilayer_ids_with_python_read_file():
+    im = Infomap(silent=True, no_infomap=True, matchable_multilayer_ids=3)
+    im.read_file("examples/networks/multilayer.net")
+    im.run()
+
+    nodes = sorted((node.state_id, node.node_id, node.layer_id) for node in im.nodes)
+
+    assert im.num_nodes == 6
+    assert im.num_physical_nodes == 5
+    assert nodes == [
+        (9, 1, 1),
+        (10, 1, 2),
+        (18, 2, 2),
+        (26, 3, 2),
+        (33, 4, 1),
+        (41, 5, 1),
+    ]


### PR DESCRIPTION
## Issue

Closes #311

## Risk

medium

## Summary

- recompute `Network`'s derived multilayer bit-shift whenever `setConfig()` updates `matchable_multilayer_ids`
- fix the Python `read_file()` path so matchable multilayer state ids use the configured deterministic encoding instead of a stale zero-bit shift
- add a regression test covering `Infomap(..., no_infomap=True, matchable_multilayer_ids=3).read_file(...).run()` on the example multilayer network

## Verification

- `PATH="$PWD/.codex-bin:/opt/homebrew/bin:$PATH" CXXFLAGS="-I/opt/homebrew/opt/libomp/include" LDFLAGS="-L/opt/homebrew/opt/libomp/lib" make python py-local-install`
- `PATH="$PWD/.codex-bin:/opt/homebrew/bin:$PATH" python -m pytest test/test_multilayer.py`
- `PATH="$PWD/.codex-bin:/opt/homebrew/bin:$PATH" CXXFLAGS="-I/opt/homebrew/opt/libomp/include" LDFLAGS="-L/opt/homebrew/opt/libomp/lib" make py-test`

## Residual Risk

- The fix is scoped to keeping derived multilayer config in sync on `Network`, but I only added explicit regression coverage for the Python file-input path discussed in #310/#311.
