### PR TITLE
refactor(core): execute phased InfoNode active-graph to CSR refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,7 @@ if(BUILD_TESTING)
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
         target_compile_options(infomap_cpp_lifecycle_tests PRIVATE -fno-access-control)
         target_compile_options(infomap_cpp_partition_tests PRIVATE -fno-access-control)
+        target_compile_options(infomap_cpp_flow_tests PRIVATE -fno-access-control)
     endif()
 
     add_custom_target(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,18 @@ target_link_libraries(infomap_cli PRIVATE infomap_core)
 set_target_properties(infomap_cli PROPERTIES OUTPUT_NAME "Infomap")
 
 if(BUILD_TESTING)
+    add_executable(
+        infomap_native_benchmark
+        test/bench/native_benchmark.cpp
+    )
+    target_include_directories(
+        infomap_native_benchmark
+        PRIVATE
+            "${CMAKE_CURRENT_SOURCE_DIR}/src"
+            "${CMAKE_CURRENT_SOURCE_DIR}/test"
+    )
+    target_link_libraries(infomap_native_benchmark PRIVATE infomap_core)
+
     function(add_infomap_cpp_test target_name source_file labels)
         add_executable(
             ${target_name}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,9 @@ if(BUILD_TESTING)
             "${CMAKE_CURRENT_SOURCE_DIR}/test"
     )
     target_link_libraries(infomap_native_benchmark PRIVATE infomap_core)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+        target_compile_options(infomap_native_benchmark PRIVATE -fno-access-control)
+    endif()
 
     function(add_infomap_cpp_test target_name source_file labels)
         add_executable(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,7 @@ if(BUILD_TESTING)
     add_infomap_cpp_test(infomap_cpp_flow_tests test/cpp/test_flow.cpp "fast;core;flow")
 
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+        target_compile_options(infomap_cpp_lifecycle_tests PRIVATE -fno-access-control)
         target_compile_options(infomap_cpp_partition_tests PRIVATE -fno-access-control)
     endif()
 

--- a/docs/automation/verification-matrix.md
+++ b/docs/automation/verification-matrix.md
@@ -6,6 +6,7 @@ Default rule: run the smallest sufficient verification for the changed surface. 
 | --- | --- | --- |
 | `README.rst`, `docs/automation/`, other docs-only text | No code verification required | If the change affects generated docs behavior or committed Sphinx output freshness, run `make test-docs` instead of editing generated output blindly. |
 | `src/` C++ code | `make build-native` | Use this as the minimum binary build check. Add narrower reproduction checks if the issue provides them. |
+| `scripts/benchmarks/`, native benchmark harness, benchmark-only instrumentation | `make build-native` and the smallest relevant benchmark smoke path, usually `make bench-native NATIVE_BENCHMARK_PROFILE=smoke NATIVE_BENCHMARK_REPEATS=1` | Use when changing benchmark runners, benchmark-only core timing hooks, or native benchmark build integration. |
 | `interfaces/python/`, Python packaging, SWIG-facing Python surface | `make build-python` and `make test-python` | `make test-python` exercises pytest, doctest, and the Python examples. |
 | `interfaces/js/` TypeScript or npm package surface | `npm ci` and `make build-js` | Use for package or TypeScript-only JS changes. |
 | JS worker or Emscripten boundary | `npm ci` and `make test-js` | Use when the change touches worker generation, bundled worker files, or the C++ to JS boundary. |

--- a/docs/plans/2026-04-03-infonode-csr-refactor-plan.md
+++ b/docs/plans/2026-04-03-infonode-csr-refactor-plan.md
@@ -8,7 +8,7 @@ This change should proceed in stages:
 
 1. lock down current behavior with stronger conformance tests and measurement
 2. remove known coupling/precondition bugs that block a clean abstraction
-3. split active-graph payload/state from `InfoNode`
+3. split active-graph flow payload from `InfoNode`
 4. introduce CSR adjacency for the leaf-level active graph
 5. retain pointer-backed fallback for features that are not yet migrated
 
@@ -47,7 +47,7 @@ Internal concepts to introduce:
 
 - `ActiveNodeId`: stable dense integer id for the current active graph
 - `ActiveNodePayload`: read-mostly per-node values such as flow data, state/physical/layer ids, and any metadata needed by the current objective
-- `ActiveNodeState`: read-write optimization state such as module assignment and dirty flags
+- `ActiveNodeState`: optimization state for CSR-backed paths such as module assignment and dirty flags
 - `ActiveAdjacency`: backend-specific adjacency access
 - `ActiveGraphContext<Backend>`: the active graph object handed to the optimizer/objective layer
 
@@ -59,6 +59,28 @@ Backend policy:
 - the second backend is CSR
 
 This active-graph layer is the only new abstraction boundary that should be introduced in the first implementation.
+
+### 2b. Define the active-graph lifecycle explicitly
+
+Every migrated path must follow the same lifecycle:
+
+1. **materialize**
+   - build the active graph from the current hierarchy state
+   - establish dense active-node ids and any payload arrays
+2. **optimize**
+   - run the move loop and objective updates against the active graph backend
+   - treat backend-owned optimization state as authoritative during this phase
+3. **sync back**
+   - write any state needed by downstream tree logic back to hierarchy `InfoNode`s
+   - this must happen before consolidation, tuning, or output code reads tree state again
+
+Fields that may require sync-back once they are migrated off `InfoNode`:
+
+- module assignment
+- dirty state if any downstream logic depends on it
+- any payload values that the tree/objective/output code later expects to read directly from `InfoNode`
+
+This lifecycle is a correctness invariant. No later phase should rely on implicit aliasing between active-graph storage and `InfoNode`.
 
 ### 3. Treat consolidation as an explicit backend boundary
 
@@ -81,7 +103,11 @@ Before any storage refactor starts, fix current coupling that would invalidate t
 
 - `generateSubNetwork(InfoNode&)` must stop clobbering `node.index` as a side-channel for mapping cloned edges
 - replace that temporary mutation with a local pointer-to-index map or equivalent explicit lookup
-- document `node.index` and `node.dirty` semantics as optimization-state fields, not general scratch storage
+- audit current `node.index` usages and document each role by lifecycle phase:
+  - optimization-time module assignment
+  - tree-time scratch/indexing uses
+  - output- or traversal-related temporary uses
+- document `node.dirty` semantics as optimization-state, not general scratch storage
 - document OpenMP move-loop assumptions: adjacency is read-only during a move round; membership/state arrays are the only mutated hot-path storage
 
 These are prerequisites, not follow-up cleanup.
@@ -139,9 +165,9 @@ Required code cleanup before storage changes:
 - add regression coverage for sub-network edge cloning correctness
 - codify module-assignment semantics so later SoA arrays preserve current read/write ordering
 
-#### 0c. Expand the conformance suite
+#### 0c. Expand the conformance suite in two tiers
 
-Add missing tests before introducing CSR:
+##### Tier 1: must-have before Phase 1
 
 1. hierarchy mutation invariants
    - `replaceChildrenWithGrandChildren`
@@ -149,56 +175,72 @@ Add missing tests before introducing CSR:
    - `collapseChildren` / `expandChildren`
    - `releaseChildren`
    - repeated remove/rebuild cycles
-2. output parity
+2. first-order partition parity
+   - current C++/Python regressions remain green
+   - add direct regression for `generateSubNetwork(...)` edge cloning correctness
+3. OpenMP parity
+   - sequential and parallel move loops produce equivalent results for fixed seeds / deterministic fixtures
+4. consolidation bridge correctness
+   - module-level edge weights equal the sum of inter-module leaf-edge weights after `consolidateModules(...)`
+
+##### Tier 2: must-have before Phase 2
+
+1. output parity
    - `.tree`
    - `.clu`
    - JSON
    - Pajek / state-network output
    - state vs physical output for memory networks
-3. recursive hierarchy behavior
+2. recursive hierarchy behavior
    - fine tune
    - coarse tune
    - super-module search
    - repeated rerun after hierarchy reconstruction
-4. higher-order parity
+3. higher-order parity
    - `states.net`
    - `multilayer.net`
    - `matchableMultilayerIds`
    - `iterTreePhysical`
    - `iterLeafNodesPhysical`
    - `getModules(states=true/false)`
-5. hard partition behavior
+4. hard partition behavior
    - `.clu` hard/soft
    - `.tree` import
    - restore after optimization
-6. metadata behavior
+5. metadata behavior
    - minimal `MetaMapEquation` fixture
    - stable module-level metadata aggregation after moves/consolidation
-7. OpenMP parity
-   - sequential and parallel move loops produce equivalent results for fixed seeds / deterministic fixtures
+6. sync-back and rollback invariants
+   - post-optimization sync-back preserves downstream tree semantics
+   - `restoreConsolidatedOptimizationPointIfNoImprovement(...)` remains safe with split active-graph state
 
 Phase 0 exit criteria:
 
 - all current tests remain green
-- the new conformance suite is green
+- Tier 1 conformance tests are green
 - baseline benchmark JSON exists and is committed or archived for comparison
 
-### Phase 1: Split active payload/state from `InfoNode`
+### Phase 1: Split active flow payload from `InfoNode`
 
-Introduce a dense active-graph data model without changing adjacency yet.
+Introduce a dense active-graph data model for read-mostly flow/payload values without changing adjacency or moving module assignment off `InfoNode` yet.
 
 Add:
 
 - read-mostly arrays for flow/payload data
-- read-write arrays for optimization state:
-  - module assignment
-  - dirty flags
 - explicit mapping between active-node id and hierarchy `InfoNode*`
 
 Important design rule:
 
 - separate read-mostly payload from read-write optimization state
-- do not treat them as one generic “node payload” blob
+- Phase 1 only migrates the read-mostly payload part
+- `InfoNode.index` and `InfoNode.dirty` remain authoritative in Phase 1
+
+Objective/backend rule for Phase 1:
+
+- do **not** attempt to template the existing objective virtual hierarchy on backend yet
+- keep objective entry points compatible with the current `InfoNode&`-based design
+- introduce lightweight payload access helpers/views as needed, but do not force a CRTP/policy rewrite of the objective hierarchy in Phase 1
+- the explicit template-based backend dimension starts when adjacency moves in Phase 2
 
 At this phase:
 
@@ -211,17 +253,24 @@ Purpose:
 
 - prove the active-graph abstraction
 - de-risk backend templating
-- isolate optimizer/objective code from direct `InfoNode` field access
+- isolate optimizer/objective code from direct `InfoNode.data` dependence where feasible
+
+Performance expectation:
+
+- Phase 1 is primarily an architecture/de-risking step
+- it is not expected to deliver major speedups on its own
+- acceptable outcome is parity with baseline within a small regression budget
 
 Phase 1 exit criteria:
 
 - correctness parity with the pointer baseline
 - measurable storage/accounting visibility for active payload/state
-- no unacceptable regression in total runtime on the benchmark corpus
+- total runtime within roughly `+/-5%` of baseline on benchmark cases
+- no new correctness regressions in Tier 1 conformance tests
 
 ### Phase 2: Add CSR adjacency for leaf-level active graphs
 
-Implement a CSR backend for the initial leaf-level active graph only.
+Implement a CSR backend for the initial leaf-level active graph only. This is also the phase where optimization state can move off `InfoNode` because neighbor positions become directly available from CSR targets.
 
 Storage shape:
 
@@ -232,11 +281,14 @@ Storage shape:
 - in-edge support:
   - either transposed CSR
   - or an explicit incoming index structure
+- optimization-state arrays:
+  - module assignment
+  - dirty flags
 
 Backend behavior:
 
 - the leaf-level active graph can be materialized as CSR
-- the optimizer/objective layer uses template-based backend access
+- the optimizer/objective layer can now use template-based backend access for hot-path adjacency/state reads
 - the move loop mutates only active-node state arrays
 - CSR adjacency remains read-only during a move round
 
@@ -250,12 +302,14 @@ Deliberate scope limit:
 
 - after `consolidateModules`, the next module-level active graph stays pointer-backed by default
 - recursive sub-Infomap and special feature paths also stay pointer-backed unless explicitly migrated later
+- directed CSR support may be staged after undirected support if transpose/in-edge support makes the initial rollout too large
 
 Phase 2 exit criteria:
 
 - pointer and CSR backends produce identical partitions/codelengths on first-order fixtures
-- benchmark shows real benefit on large first-order sparse graphs
-- no correctness regressions in the conformance suite
+- benchmark shows at least a measurable win on large first-order sparse graphs
+- Tier 2 conformance tests are green for any migrated path
+- no more than roughly `3%` total-runtime regression on non-migrated or fallback paths
 
 ### Phase 3: Extend CSR to selected nontrivial active-graph cases
 
@@ -315,6 +369,7 @@ Add direct pointer-vs-CSR A/B tests in the C++ suite for:
 - repeated multi-trial reruns
 - sub-network generation where applicable
 - OpenMP vs sequential parity for migrated backends
+- active-graph sync-back invariants before downstream tree consumers run
 
 ### Sanitizer and stress requirements
 
@@ -349,7 +404,8 @@ Recommended interpretation:
 ### Measurement gates per phase
 
 - Phase 1 must not meaningfully regress large first-order graphs while introducing payload/state arrays
-- Phase 2 must show a measurable benefit on large first-order sparse graphs before CSR expands further
+- Phase 1 should be judged as an architectural milestone, not a performance milestone
+- Phase 2 must show at least about `10%` peak-RSS reduction and about `5%` partition-phase speedup on `100k+` first-order sparse graphs before CSR expands further
 - Phase 3 extensions must justify themselves case-by-case
 
 ## Current Blockers And High-Risk Features

--- a/docs/plans/2026-04-03-infonode-csr-refactor-plan.md
+++ b/docs/plans/2026-04-03-infonode-csr-refactor-plan.md
@@ -262,6 +262,7 @@ Performance expectation:
 - it is not expected to deliver major speedups on its own
 - hot-path performance is expected to remain effectively unchanged
 - acceptable outcome is parity with baseline within a small regression budget
+- the optimizer and objective hot path remain unchanged in Phase 1; the new lifecycle/payload infrastructure exists alongside the current hot-path consumers without replacing them yet
 
 Phase 1 exit criteria:
 
@@ -287,6 +288,12 @@ Storage shape:
   - module assignment
   - dirty flags
 
+Backend requirements:
+
+- a `CSRBackend` for migrated leaf-level active graphs
+- a `PointerBackend` compatibility adapter that wraps current `InfoNode*` / `InfoEdge*` access behind the same accessor concept
+- the inner templated optimizer methods must work against both backends so pointer-backed module-level graphs and fallback paths keep using the same logic
+
 Backend behavior:
 
 - the leaf-level active graph can be materialized as CSR
@@ -295,6 +302,11 @@ Backend behavior:
 - CSR adjacency remains read-only during a move round
 - for first-order and biased objectives, the objective interface can remain `InfoNode&`-based because the objective logic reads stable flow payload on `InfoNode`, while module-assignment and dirty-state changes stay inside the optimizer/backend layer until sync-back
 - the `recordedTeleportation` optimizer branch is an explicit Phase 2 change site because it currently reads `current.index`
+- `initPartition()` is also an explicit Phase 2 change site because it seeds module assignment and dirty state for the active graph
+- `moveNodeToPredefinedModule()` and `moveActiveNodesToPredefinedModules()` are part of the Phase 2 optimizer/backend scope because fine-tuning seeds optimization through the same neighbor-module access pattern as the main move loop
+- fine-tuning should be treated as split scope:
+  - hierarchy/module bookkeeping stays pointer-backed
+  - the leaf-level optimization portion is CSR-eligible when the active graph is leaf-level
 
 OpenMP design requirement:
 
@@ -378,6 +390,7 @@ Add direct pointer-vs-CSR A/B tests in the C++ suite for:
 - active-graph sync-back invariants before downstream tree consumers run
 - `recordedTeleportation` parity on migrated CSR paths
 - `BiasedMapEquation` parity if it rides along with the first-order CSR rollout
+- `moveActiveNodesToPredefinedModules()` parity on migrated CSR paths
 
 ### Sanitizer and stress requirements
 
@@ -398,6 +411,8 @@ Track:
 - total runtime
 - partition-only runtime
 - CSR materialization/rebuild time
+- fine-tune time
+- coarse-tune time
 - consolidation count per trial
 - module graph size distribution after each consolidation step
 - peak RSS

--- a/docs/plans/2026-04-03-infonode-csr-refactor-plan.md
+++ b/docs/plans/2026-04-03-infonode-csr-refactor-plan.md
@@ -2,350 +2,405 @@
 
 ## Summary
 
-Refactor the internal `InfoNode`-centric model into two explicit layers instead of trying to make one object do everything:
+Refactor the internal `InfoNode`-centric model by **keeping the hierarchy/tree pointer-backed** and introducing a separate abstraction only for the **active optimization graph**. The goal is still lower memory usage and better performance, but the first CSR-backed milestone should target the hot leaf-level optimization path, not the entire tree and not full backend parity across every feature combination on day one.
 
-1. a **hierarchy layer** for tree/module ownership, traversal, output, and sub-Infomap ownership
-2. a **hot active-graph layer** for optimization-time node state and adjacency, with a pointer-backed backend first and a CSR backend second
+This change should proceed in stages:
 
-This is the only realistic way to get full feature parity without touching the whole codebase repeatedly. Today `InfoNode` is simultaneously tree node, graph vertex, aggregation container, and owner for recursive sub-Infomaps; it is also large enough to matter materially for memory (`sizeof(InfoNode)=336`, `sizeof(InfoEdge)=32`, excluding allocator/vector overhead). The refactor should therefore **split storage concerns first**, then switch the hot active graph to CSR behind a compatibility layer.
+1. lock down current behavior with stronger conformance tests and measurement
+2. remove known coupling/precondition bugs that block a clean abstraction
+3. split active-graph payload/state from `InfoNode`
+4. introduce CSR adjacency for the leaf-level active graph
+5. retain pointer-backed fallback for features that are not yet migrated
 
-This plan assumes the target is **full feature parity directly**, not a first-order-only milestone.
+This plan intentionally narrows the abstraction boundary compared to the previous draft:
+
+- **do not** abstract the tree/output layer up front
+- **do** abstract the active graph used by `InfomapOptimizer` and the objective functions
+- **do not** assume module-level or recursive graphs should immediately move to CSR
 
 ## Architecture And Implementation Changes
 
-### 1. Introduce a storage abstraction boundary before changing storage
+### 1. Keep the tree pointer-backed
 
-Add an internal abstraction layer with stable handles, not raw `InfoNode*`, for the optimization hot path.
+The current tree is not just a presentation structure. It is mutated during:
 
-Internal types to introduce:
+- consolidation
+- hard partition restore
+- fine/coarse tuning
+- super-module discovery
+- recursive sub-Infomap construction
+- final output and iterator traversal
 
-- `NodeHandle` / `ModuleHandle`: stable integer handles
-- `NodePayload`: flow/index/state/physical/layer/meta fields needed by objectives and movement logic
-- `ActiveGraphView`: the flat optimization graph interface used by `InfomapOptimizer`, `MapEquation`, `MemMapEquation`, and `MetaMapEquation`
-- `HierarchyView`: parent/child/path/leaf/module traversal interface used by `InfomapBase`, iterators, and output
-- `AdjacencyRange`: iterable out/in-neighbor view that hides whether storage is pointer vectors or CSR arrays
+The refactor should therefore keep `InfoNode` and the parent/child/sibling linked structure as the hierarchy representation for now.
+
+Consequences:
+
+- output code and iterators stay pointer-based initially
+- `owner`, `setInfomap()`, `disposeInfomap()`, `physicalNodes`, `stateNodes`, and `metaCollection` remain on the hierarchy nodes
+- tree rewrite operations such as `collapseChildren`, `expandChildren`, `replaceWithChildren`, and `replaceChildrenWithGrandChildren` remain unchanged until after the active-graph refactor proves out
+
+### 2. Abstract only the active optimization graph
+
+Add a new internal active-graph layer used by the optimizer and objectives. This layer must be compile-time based, not runtime-polymorphic, to avoid virtual dispatch in the hot loop.
+
+Internal concepts to introduce:
+
+- `ActiveNodeId`: stable dense integer id for the current active graph
+- `ActiveNodePayload`: read-mostly per-node values such as flow data, state/physical/layer ids, and any metadata needed by the current objective
+- `ActiveNodeState`: read-write optimization state such as module assignment and dirty flags
+- `ActiveAdjacency`: backend-specific adjacency access
+- `ActiveGraphContext<Backend>`: the active graph object handed to the optimizer/objective layer
+
+Backend policy:
+
+- the optimizer/objective code is templated on the backend or on backend-provided accessors
+- no virtual dispatch in edge traversal or node-state access
+- the first backend is a pointer-backed compatibility backend over existing `InfoNode`/`InfoEdge`
+- the second backend is CSR
+
+This active-graph layer is the only new abstraction boundary that should be introduced in the first implementation.
+
+### 3. Treat consolidation as an explicit backend boundary
+
+`consolidateModules(...)` is both a tree mutation and a graph rebuild. The plan must treat it as the bridge point between hierarchy and active graph.
 
 Rules:
 
-- `InfomapOptimizer*` and objective code stop iterating raw `InfoNode::outEdges()/inEdges()` directly and instead consume `ActiveGraphView`
-- output and iterators stop depending on concrete sibling pointers directly and instead consume `HierarchyView`
-- `InfoNode` remains temporarily as the pointer-backed implementation of `HierarchyView`
-- the first backend behind `ActiveGraphView` is a compatibility backend over current `InfoNode`/`InfoEdge`
-- the second backend is CSR
+- consolidation continues to create pointer-backed module `InfoNode`s and attach children exactly as today
+- after consolidation, the next active graph is materialized from the new top-level hierarchy state
+- backend choice is made at active-graph materialization time, not inside the hierarchy rewrite itself
 
-This is the key scope control mechanism: once those call sites depend on views/handles, the CSR work is localized to the new store plus a few bridge files instead of re-editing the entire tree every time.
+Default behavior for the first CSR rollout:
 
-### 2. Separate tree storage from hot graph storage
+- leaf-level active graphs may use CSR
+- module-level graphs created after consolidation remain pointer-backed unless measurement proves CSR is worth the rebuild cost
 
-Do **not** make the whole Infomap tree CSR in the first real cutover. Instead:
+### 4. Make the prerequisite cleanup explicit
 
-- keep a logical tree/hierarchy store for:
-  - parent/child/module relationships
-  - `calculatePath()`
-  - iterators
-  - output
-  - `owner` / sub-Infomap recursion
-  - hard-partition restore
-- move the hot active network to a compact store:
-  - dense node arrays for payload
-  - CSR adjacency arrays for out-edges
-  - either transposed CSR or computed in-edge index for in-neighbor iteration
-  - explicit module-membership arrays instead of walking sibling lists during optimization
+Before any storage refactor starts, fix current coupling that would invalidate the abstraction work:
 
-The bridge between them is:
+- `generateSubNetwork(InfoNode&)` must stop clobbering `node.index` as a side-channel for mapping cloned edges
+- replace that temporary mutation with a local pointer-to-index map or equivalent explicit lookup
+- document `node.index` and `node.dirty` semantics as optimization-state fields, not general scratch storage
+- document OpenMP move-loop assumptions: adjacency is read-only during a move round; membership/state arrays are the only mutated hot-path storage
 
-- leaf/module handles map back to hierarchy nodes
-- hierarchy operations can materialize the next active graph view when `setActiveNetworkFromLeafs()` or `setActiveNetworkFromChildrenOfRoot()` is called
-- subtree/subnetwork generation builds an `ActiveGraphView` from the hierarchy layer instead of cloning linked nodes/edges directly
+These are prerequisites, not follow-up cleanup.
 
-This makes the first meaningful performance win land in the real hot path while preserving current feature semantics.
+## Implementation Phases
 
-### 3. Refactor in four implementation phases
+### Phase 0: Baseline, prerequisites, and parity net
 
-#### Phase A: Baseline, parity harness, and abstraction scaffolding
+#### 0a. Measure current baseline
 
-- Add `ActiveGraphView` and `HierarchyView` interfaces plus a pointer-backed adapter over current `InfoNode`
-- Convert optimizer/objective code to read through the views without changing behavior
-- Keep all runtime behavior pointer-backed at this phase
-- Add backend-selection plumbing that is internal-only:
-  - default backend = current pointer backend
-  - CSR backend selectable only from tests/benchmarks or a non-public build-time/internal hook
+Add a native benchmark/memory harness before changing storage.
 
-#### Phase B: Build a full conformance test net before CSR
-
-Add missing regression tests first so the storage swap has a safety cage.
-
-Required new coverage:
-
-- tree rewrite invariants
-  - `replaceChildrenWithGrandChildren`
-  - `replaceWithChildren`
-  - `collapseChildren` / `expandChildren`
-  - `releaseChildren`
-  - sanity after repeated remove/rebuild cycles
-- output parity
-  - `.tree`
-  - `.clu`
-  - JSON/network-link output
-  - state vs physical output for higher-order input
-- recursive/sub-Infomap parity
-  - coarse tune
-  - fine tune
-  - super-module search
-  - repeated multi-trial reruns after hierarchy rebuilds
-- higher-order parity
-  - `states.net`
-  - `multilayer.net`
-  - `matchableMultilayerIds`
-  - physical aggregation and `iterTreePhysical`
-  - `getModules(states=true/false)` correctness
-- hard partition parity
-  - `.clu` hard/soft
-  - `.tree` import
-  - restore after optimization and after repeated trials
-- meta-data parity
-  - minimal meta-data fixture with `MetaMapEquation`
-  - stable module-level meta aggregation after moves/consolidation
-- determinism/parity checks
-  - same top modules
-  - same hierarchy depth
-  - same codelength/index codelength within tolerance
-  - same output files after normalization where appropriate
-
-Also add backend A/B tests:
-
-- pointer backend and CSR backend must produce identical results on the same fixture set
-- these tests must run inside the C++ suite, not only through Python
-
-#### Phase C: Implement the CSR backend for the active graph
-
-Implement a CSR-backed `ActiveGraphView` for:
-
-- first-order networks
-- state networks
-- module-level aggregated active networks
-- regenerated subnetwork views
-
-Storage requirements:
-
-- dense arrays for payload
-- CSR for out-neighbors
-- efficient in-neighbor access, either:
-  - second CSR transpose, or
-  - a separate incoming index structure
-- explicit module-membership arrays and flow aggregates replacing pointer chasing in the hot loop
-
-The optimizer/objective layer must not know which backend it is using.
-
-#### Phase D: Complete full feature parity and remove accidental pointer coupling
-
-Finish parity for the features most likely to block the rollout:
-
-- hard partition restore path
-- recursive sub-Infomap ownership/coarse tune/super modules
-- higher-order physical aggregation
-- meta-data aggregation
-- output/iterator traversal over the abstract hierarchy interface
-
-Only once the full parity suite passes against CSR should CSR be allowed as the default backend.
-
-### 4. Define the file boundary up front
-
-The refactor should concentrate changes primarily in:
-
-- the new storage/view layer
-- `InfomapBase`
-- `InfomapOptimizer*` and objective classes
-- iterator/output adapters
-
-The rest of the code should see:
-
-- handles/views instead of concrete `InfoNode` storage details
-- no direct knowledge of CSR layout
-
-Explicit non-goal:
-
-- no second pass of sweeping edits across the whole repo after the abstraction phase
-
-## Test Plan And Required New Coverage
-
-### C++ correctness additions required before cutover
-
-Extend the current C++ suite with these new groups:
-
-1. **Hierarchy mutation invariants**
-   - child/sibling counts remain correct after every tree rewrite
-   - path/depth/module numbering remain stable
-   - leaf coverage is preserved after collapse/expand/replace cycles
-   - no orphan nodes or parent mismatches after hard-partition restore
-
-2. **Output parity tests**
-   - golden or normalized comparisons for `.tree`, `.clu`, JSON, and Pajek/state-network outputs
-   - first-order and higher-order fixtures
-   - physical-vs-state outputs for memory networks
-
-3. **Higher-order and physical-node behavior**
-   - `iterTreePhysical`
-   - `iterLeafNodesPhysical`
-   - `getModules(states=true/false)`
-   - `states.net` and `multilayer.net` parity
-   - deterministic state-id behavior with `matchableMultilayerIds`
-
-4. **Recursive hierarchy behavior**
-   - coarse tune / fine tune / super-module passes produce stable trees
-   - repeated `run()` on the same instance after hierarchy reconstruction
-   - multi-trial best-tree restore still works with the abstraction
-
-5. **Meta-data behavior**
-   - module meta aggregation stays identical before/after moves and consolidation
-   - meta codelength parity on a minimal fixture
-
-6. **Backend conformance**
-   - identical partitions, level counts, and codelengths for pointer vs CSR backends on the same fixtures
-   - same failure behavior on malformed parser inputs
-
-### Acceptance criteria for test readiness
-
-Before CSR becomes default:
-
-- all existing C++ and Python regression suites remain green
-- new backend-conformance C++ tests are green
-- output parity tests are green
-- sanitizer runs are green for the CSR backend
-- pointer backend remains available until CSR parity is complete
-
-## Performance And Memory Measurement
-
-### Add a native benchmark/memory harness
-
-The current repo only has a small Python timing harness. That is not enough for this refactor.
-
-Add a native benchmark path that reports:
+Metrics:
 
 - total wall time for `readInputData + initNetwork + run`
-- partition-only wall time for the optimization phase
+- partition-only wall time
+- per-phase time where possible:
+  - initial leaf optimization
+  - consolidation/materialization
+  - module-level optimization
+  - recursive/sub-Infomap work
 - peak RSS / peak resident memory
 - internal storage accounting:
-  - bytes in node payload arrays
-  - bytes in adjacency arrays
-  - bytes in hierarchy storage
+  - bytes in hierarchy nodes
+  - bytes in edge storage
+  - bytes in active payload/state storage
   - bytes per node
   - bytes per edge
 
-Implementation shape:
+Benchmark corpus:
 
-- one native benchmark executable or script-driven native harness
-- JSON output committed as CI artifact
-- same cases run against pointer backend and CSR backend
+- repo fixtures:
+  - `examples/networks/twotriangles.net`
+  - `examples/networks/ninetriangles.net`
+  - `examples/networks/modular_w.net`
+  - `examples/networks/modular_wd.net`
+  - `examples/networks/states.net`
+  - `examples/networks/multilayer.net`
+  - `examples/networks/bipartite.net`
+- generated graphs:
+  - sparse first-order graphs at roughly `10k`, `100k`, and `1M` nodes with average degree around `10`
+  - clustered ring-of-cliques or planted-partition graphs at the same scales
+  - one deterministic larger higher-order/state-network workload
 
-### Benchmark corpus
+Also record:
 
-Use both real repo fixtures and deterministic generated graphs.
+- measured `sizeof(InfoNode)` and `sizeof(InfoEdge)` in the benchmark/diagnostic harness
+- edge-traversal throughput and, where feasible, cache-miss counters on Linux
 
-Repo fixtures:
+#### 0b. Fix prerequisites
 
-- `examples/networks/twotriangles.net`
-- `examples/networks/ninetriangles.net`
-- `examples/networks/modular_w.net`
-- `examples/networks/modular_wd.net`
-- `examples/networks/states.net`
-- `examples/networks/multilayer.net`
+Required code cleanup before storage changes:
 
-Generated workloads:
+- replace the `generateSubNetwork(...)` `node.index = childIndex` side-channel with explicit mapping
+- add regression coverage for sub-network edge cloning correctness
+- codify module-assignment semantics so later SoA arrays preserve current read/write ordering
 
-- large sparse first-order graph
-- ring-of-cliques / SBM-style clustered graph
-- larger deterministic state/higher-order graph
+#### 0c. Expand the conformance suite
 
-### Success metrics
+Add missing tests before introducing CSR:
 
-Track both absolute and relative deltas:
+1. hierarchy mutation invariants
+   - `replaceChildrenWithGrandChildren`
+   - `replaceWithChildren`
+   - `collapseChildren` / `expandChildren`
+   - `releaseChildren`
+   - repeated remove/rebuild cycles
+2. output parity
+   - `.tree`
+   - `.clu`
+   - JSON
+   - Pajek / state-network output
+   - state vs physical output for memory networks
+3. recursive hierarchy behavior
+   - fine tune
+   - coarse tune
+   - super-module search
+   - repeated rerun after hierarchy reconstruction
+4. higher-order parity
+   - `states.net`
+   - `multilayer.net`
+   - `matchableMultilayerIds`
+   - `iterTreePhysical`
+   - `iterLeafNodesPhysical`
+   - `getModules(states=true/false)`
+5. hard partition behavior
+   - `.clu` hard/soft
+   - `.tree` import
+   - restore after optimization
+6. metadata behavior
+   - minimal `MetaMapEquation` fixture
+   - stable module-level metadata aggregation after moves/consolidation
+7. OpenMP parity
+   - sequential and parallel move loops produce equivalent results for fixed seeds / deterministic fixtures
 
-- wall time
-- partition-only wall time
+Phase 0 exit criteria:
+
+- all current tests remain green
+- the new conformance suite is green
+- baseline benchmark JSON exists and is committed or archived for comparison
+
+### Phase 1: Split active payload/state from `InfoNode`
+
+Introduce a dense active-graph data model without changing adjacency yet.
+
+Add:
+
+- read-mostly arrays for flow/payload data
+- read-write arrays for optimization state:
+  - module assignment
+  - dirty flags
+- explicit mapping between active-node id and hierarchy `InfoNode*`
+
+Important design rule:
+
+- separate read-mostly payload from read-write optimization state
+- do not treat them as one generic “node payload” blob
+
+At this phase:
+
+- edge traversal still uses current `InfoEdge*` adjacency
+- consolidation still builds pointer-backed module nodes
+- module-level active graphs remain pointer-backed
+- higher-order/meta/hard-partition all stay on the current pointer backend
+
+Purpose:
+
+- prove the active-graph abstraction
+- de-risk backend templating
+- isolate optimizer/objective code from direct `InfoNode` field access
+
+Phase 1 exit criteria:
+
+- correctness parity with the pointer baseline
+- measurable storage/accounting visibility for active payload/state
+- no unacceptable regression in total runtime on the benchmark corpus
+
+### Phase 2: Add CSR adjacency for leaf-level active graphs
+
+Implement a CSR backend for the initial leaf-level active graph only.
+
+Storage shape:
+
+- out-edge CSR:
+  - offsets
+  - targets
+  - edge weights/flows
+- in-edge support:
+  - either transposed CSR
+  - or an explicit incoming index structure
+
+Backend behavior:
+
+- the leaf-level active graph can be materialized as CSR
+- the optimizer/objective layer uses template-based backend access
+- the move loop mutates only active-node state arrays
+- CSR adjacency remains read-only during a move round
+
+OpenMP design requirement:
+
+- document exactly which arrays are shared read-only
+- document how module-assignment state is updated in the parallel path
+- preserve current critical-section/validation semantics
+
+Deliberate scope limit:
+
+- after `consolidateModules`, the next module-level active graph stays pointer-backed by default
+- recursive sub-Infomap and special feature paths also stay pointer-backed unless explicitly migrated later
+
+Phase 2 exit criteria:
+
+- pointer and CSR backends produce identical partitions/codelengths on first-order fixtures
+- benchmark shows real benefit on large first-order sparse graphs
+- no correctness regressions in the conformance suite
+
+### Phase 3: Extend CSR to selected nontrivial active-graph cases
+
+Only after Phase 2 is proven useful, evaluate and selectively extend CSR to:
+
+- higher-order/state-network active graphs
+- recursive sub-Infomap leaf-level active graphs
+- possibly some module-level active graphs, but only if measured rebuild cost is justified
+
+Do not assume all of these are worth migrating.
+
+Explicit policy:
+
+- if a feature path has poor ROI or high complexity, keep it on the pointer backend behind the active-graph abstraction
+- supported fallback is acceptable as long as user-visible behavior does not change
+
+Features most likely to remain pointer-backed longest:
+
+- hard partition restore
+- metadata objective
+- physical aggregation on hierarchy nodes
+- super/coarse tune paths that constantly rebuild hierarchy state
+
+Phase 3 exit criteria:
+
+- selected extensions are benchmarked and justified individually
+- fallback matrix is documented explicitly
+
+### Phase 4: Re-evaluate broader migration or permanent hybrid design
+
+After measurements and parity results, decide whether to:
+
+- keep a permanent hybrid architecture:
+  - pointer-backed hierarchy
+  - CSR for selected active graphs
+- or expand CSR further where it pays off
+
+This phase is decision-oriented, not assumed.
+
+## Test Plan And Acceptance Criteria
+
+### Backend parity requirements
+
+For any path migrated to CSR:
+
+- same top-module partition
+- same number of levels
+- same `codelength` / `index codelength` within tolerance
+- same normalized output artifacts where output is part of the contract
+- same failure behavior on malformed input
+
+### Required backend comparison tests
+
+Add direct pointer-vs-CSR A/B tests in the C++ suite for:
+
+- first-order leaf-level optimization
+- repeated multi-trial reruns
+- sub-network generation where applicable
+- OpenMP vs sequential parity for migrated backends
+
+### Sanitizer and stress requirements
+
+For every migrated path:
+
+- normal C++ suite green
+- sanitizer suite green
+- at least one repeated stress/rerun case under sanitizers
+
+## Performance And Memory Goals
+
+### What success looks like
+
+Do not judge success by a single wall-time number.
+
+Track:
+
+- total runtime
+- partition-only runtime
+- CSR materialization/rebuild time
 - peak RSS
 - bytes per node
 - bytes per edge
+- edge-traversal throughput
 
-Recommended success thresholds for calling the refactor worthwhile:
+Recommended interpretation:
 
-- first-order sparse graphs: at least `20%` lower peak RSS and `15%` lower partition-phase runtime
-- no more than `5%` total-runtime regression on higher-order/meta/hard-partition cases while parity is being preserved
-- zero correctness regressions in partitions, hierarchy depth, outputs, or codelength tolerance
+- first-order large sparse graphs should show a clear memory win and a measurable partition-phase speedup
+- if CSR improves leaf-level partition time but total runtime barely moves, report that honestly rather than calling it a universal speedup
+- module-level CSR is only justified if rebuild cost is amortized by subsequent optimization rounds
 
-If CSR improves partition time but not total runtime, report both numbers explicitly rather than claiming an overall win.
+### Measurement gates per phase
+
+- Phase 1 must not meaningfully regress large first-order graphs while introducing payload/state arrays
+- Phase 2 must show a measurable benefit on large first-order sparse graphs before CSR expands further
+- Phase 3 extensions must justify themselves case-by-case
 
 ## Current Blockers And High-Risk Features
 
-These are the current features that are genuine blockers or likely to force temporary fallback to the pointer backend:
+### Explicit blockers for the first CSR milestone
 
-### Hard blockers for a clean CSR rollout
-
-- higher-order/state-network handling:
-  - `haveMemory()`
-  - `physicalNodes`
-  - `stateNodes`
-  - physical-node iterators/output
 - hard partition restore:
   - `clusterDataIsHard`
   - `restoreHardPartition`
-  - `collapseChildren` / `expandChildren` / `replaceWithChildren`
-- recursive sub-Infomap ownership:
-  - `owner`
-  - `setInfomap()` / `disposeInfomap()`
-  - coarse tune / super-module hierarchy rebuilds
-- meta-data aggregation:
+  - collapsed/expanded children rewrites
+- recursive hierarchy rebuilding:
+  - `coarseTune`
+  - `fineTune`
+  - super-module search
+  - `owner` / `setInfomap()` / `disposeInfomap()`
+- metadata aggregation:
   - `metaCollection`
   - `MetaMapEquation`
-- output and iterator contracts that assume pointer-linked siblings and parent chains
+- higher-order physical aggregation:
+  - `physicalNodes`
+  - `stateNodes`
+  - physical iterators and outputs
 
-### Not blockers, but correctness-sensitive during the refactor
+These should remain pointer-backed until explicitly migrated.
+
+### Correctness-sensitive but not first-class blockers
 
 - `recordedTeleportation`
 - `regularized`
 - `variableMarkovTime*`
 - precomputed flow input
 - `matchableMultilayerIds`
+- bipartite handling
 
-Policy for these:
-
-- they must be parity-tested
-- they should not be used to justify pointer-only escape hatches unless a real storage-coupling issue is proven
-
-### Features that may need temporary backend fallback
-
-If full parity cannot be achieved immediately, the only acceptable temporary fallback is:
-
-- keep the abstraction in place
-- route the affected feature through the pointer-backed implementation internally
-- do not remove public support or change user-visible semantics
-
-That fallback is acceptable for:
-
-- hard partition restore
-- higher-order physical aggregation
-- meta-data objective
-- recursive super/coarse tune passes
-
-It is **not** acceptable to silently drop feature support.
+These must be parity-tested for any migrated backend.
 
 ## Public/Internal Interface Changes
 
-No intended public CLI/Python/JS behavior changes.
+No intended public CLI, Python, or JS behavior changes.
 
-Internal changes that should exist in the final design:
+Internal changes that should exist after the first successful milestone:
 
-- `NodeHandle`-style stable identifiers
-- `ActiveGraphView` and `HierarchyView`
-- backend-selectable active graph store
-- internal benchmark hook for pointer-vs-CSR A/B runs
-
-The backend selector should remain internal until CSR is proven correct and beneficial.
+- active-node ids and explicit active-graph materialization
+- dense payload/state arrays for the active graph
+- template-based backend selection for optimizer/objective code
+- CSR adjacency for the leaf-level active graph
+- explicit pointer-backed fallback for non-migrated feature paths
 
 ## Assumptions And Defaults
 
-- This is a high-risk internal refactor and should be executed as a staged effort, with frequent checkpoints.
-- Full feature parity is required before CSR becomes the default backend.
-- The first real performance win should come from CSR in the active optimization graph, not from rewriting the entire hierarchy tree into CSR immediately.
-- `InfoNode` can remain as a compatibility-backed hierarchy implementation during the transition; the goal is to stop it from being the only storage model, not necessarily to delete it on day one.
-- The refactor is not considered successful without native runtime and memory measurements proving the gain.
+- This remains a high-risk internal refactor and should be executed behind tight parity and measurement gates.
+- The pointer-backed tree is not the primary performance problem; the hot active graph is.
+- A permanent hybrid design is acceptable if it gives the desired speed/memory improvements with lower risk.
+- Full user-visible feature support remains the goal, but full CSR coverage across all internal paths is **not** required for the first successful milestone.

--- a/docs/plans/2026-04-03-infonode-csr-refactor-plan.md
+++ b/docs/plans/2026-04-03-infonode-csr-refactor-plan.md
@@ -229,8 +229,10 @@ Required code cleanup before storage changes:
 2. first-order partition parity
    - current C++/Python regressions remain green
    - add direct regression for `generateSubNetwork(...)` edge cloning correctness
-3. OpenMP parity
-   - sequential and parallel move loops produce equivalent results for fixed seeds / deterministic fixtures
+3. OpenMP / inner-parallelization contract
+   - sequential and parallel move loops are both runnable and numerically sane on deterministic fixtures
+   - measure and document any current partition/codelength divergence under `--inner-parallelization`
+   - do not treat exact serial-vs-parallel parity as a Phase 1 gate unless the product contract is tightened first
 4. consolidation bridge correctness
    - module-level edge weights equal the sum of inter-module leaf-edge weights after `consolidateModules(...)`
 

--- a/docs/plans/2026-04-03-infonode-csr-refactor-plan.md
+++ b/docs/plans/2026-04-03-infonode-csr-refactor-plan.md
@@ -220,9 +220,9 @@ Phase 0 exit criteria:
 - Tier 1 conformance tests are green
 - baseline benchmark JSON exists and is committed or archived for comparison
 
-### Phase 1: Split active flow payload from `InfoNode`
+### Phase 1: Introduce active-graph lifecycle and payload infrastructure
 
-Introduce a dense active-graph data model for read-mostly flow/payload values without changing adjacency or moving module assignment off `InfoNode` yet.
+Introduce the active-graph lifecycle, active-node id mapping, and read-mostly payload infrastructure without changing adjacency or moving module assignment off `InfoNode` yet.
 
 Add:
 
@@ -251,14 +251,16 @@ At this phase:
 
 Purpose:
 
-- prove the active-graph abstraction
-- de-risk backend templating
-- isolate optimizer/objective code from direct `InfoNode.data` dependence where feasible
+- prove the materialize -> optimize -> sync-back lifecycle
+- establish active-node id <-> `InfoNode*` mapping
+- build payload arrays as structural proof that active-graph materialization works
+- de-risk later backend work without changing the hot-path consumer contract yet
 
 Performance expectation:
 
 - Phase 1 is primarily an architecture/de-risking step
 - it is not expected to deliver major speedups on its own
+- hot-path performance is expected to remain effectively unchanged
 - acceptable outcome is parity with baseline within a small regression budget
 
 Phase 1 exit criteria:
@@ -288,9 +290,11 @@ Storage shape:
 Backend behavior:
 
 - the leaf-level active graph can be materialized as CSR
-- the optimizer/objective layer can now use template-based backend access for hot-path adjacency/state reads
+- the optimizer hot path can now use template-based backend access for adjacency/state reads
 - the move loop mutates only active-node state arrays
 - CSR adjacency remains read-only during a move round
+- for first-order and biased objectives, the objective interface can remain `InfoNode&`-based because the objective logic reads stable flow payload on `InfoNode`, while module-assignment and dirty-state changes stay inside the optimizer/backend layer until sync-back
+- the `recordedTeleportation` optimizer branch is an explicit Phase 2 change site because it currently reads `current.index`
 
 OpenMP design requirement:
 
@@ -302,13 +306,15 @@ Deliberate scope limit:
 
 - after `consolidateModules`, the next module-level active graph stays pointer-backed by default
 - recursive sub-Infomap and special feature paths also stay pointer-backed unless explicitly migrated later
-- directed CSR support may be staged after undirected support if transpose/in-edge support makes the initial rollout too large
+- Phase 2 should start undirected-first if that materially reduces implementation size
+- directed CSR support can follow within Phase 2 once transpose/in-edge support is validated
 
 Phase 2 exit criteria:
 
 - pointer and CSR backends produce identical partitions/codelengths on first-order fixtures
 - benchmark shows at least a measurable win on large first-order sparse graphs
-- Tier 2 conformance tests are green for any migrated path
+- first-order Tier 2 conformance tests are green on both pointer and CSR backends for migrated paths
+- non-first-order Tier 2 tests remain green on the unchanged pointer-backed paths
 - no more than roughly `3%` total-runtime regression on non-migrated or fallback paths
 
 ### Phase 3: Extend CSR to selected nontrivial active-graph cases
@@ -370,6 +376,8 @@ Add direct pointer-vs-CSR A/B tests in the C++ suite for:
 - sub-network generation where applicable
 - OpenMP vs sequential parity for migrated backends
 - active-graph sync-back invariants before downstream tree consumers run
+- `recordedTeleportation` parity on migrated CSR paths
+- `BiasedMapEquation` parity if it rides along with the first-order CSR rollout
 
 ### Sanitizer and stress requirements
 
@@ -390,6 +398,8 @@ Track:
 - total runtime
 - partition-only runtime
 - CSR materialization/rebuild time
+- consolidation count per trial
+- module graph size distribution after each consolidation step
 - peak RSS
 - bytes per node
 - bytes per edge
@@ -407,6 +417,16 @@ Recommended interpretation:
 - Phase 1 should be judged as an architectural milestone, not a performance milestone
 - Phase 2 must show at least about `10%` peak-RSS reduction and about `5%` partition-phase speedup on `100k+` first-order sparse graphs before CSR expands further
 - Phase 3 extensions must justify themselves case-by-case
+
+### Backend templating default
+
+Preferred implementation strategy:
+
+- keep the outer optimizer type as `InfomapOptimizer<Objective>`
+- template only the hot inner methods on the backend/accessor type
+- select the backend once per call, then run the inner templated move loop
+
+This keeps runtime selection logic and binary growth more contained than templating the entire optimizer class on both objective and backend.
 
 ## Current Blockers And High-Risk Features
 

--- a/docs/plans/2026-04-03-infonode-csr-refactor-plan.md
+++ b/docs/plans/2026-04-03-infonode-csr-refactor-plan.md
@@ -1,0 +1,351 @@
+# InfoNode/CSR Refactor Plan
+
+## Summary
+
+Refactor the internal `InfoNode`-centric model into two explicit layers instead of trying to make one object do everything:
+
+1. a **hierarchy layer** for tree/module ownership, traversal, output, and sub-Infomap ownership
+2. a **hot active-graph layer** for optimization-time node state and adjacency, with a pointer-backed backend first and a CSR backend second
+
+This is the only realistic way to get full feature parity without touching the whole codebase repeatedly. Today `InfoNode` is simultaneously tree node, graph vertex, aggregation container, and owner for recursive sub-Infomaps; it is also large enough to matter materially for memory (`sizeof(InfoNode)=336`, `sizeof(InfoEdge)=32`, excluding allocator/vector overhead). The refactor should therefore **split storage concerns first**, then switch the hot active graph to CSR behind a compatibility layer.
+
+This plan assumes the target is **full feature parity directly**, not a first-order-only milestone.
+
+## Architecture And Implementation Changes
+
+### 1. Introduce a storage abstraction boundary before changing storage
+
+Add an internal abstraction layer with stable handles, not raw `InfoNode*`, for the optimization hot path.
+
+Internal types to introduce:
+
+- `NodeHandle` / `ModuleHandle`: stable integer handles
+- `NodePayload`: flow/index/state/physical/layer/meta fields needed by objectives and movement logic
+- `ActiveGraphView`: the flat optimization graph interface used by `InfomapOptimizer`, `MapEquation`, `MemMapEquation`, and `MetaMapEquation`
+- `HierarchyView`: parent/child/path/leaf/module traversal interface used by `InfomapBase`, iterators, and output
+- `AdjacencyRange`: iterable out/in-neighbor view that hides whether storage is pointer vectors or CSR arrays
+
+Rules:
+
+- `InfomapOptimizer*` and objective code stop iterating raw `InfoNode::outEdges()/inEdges()` directly and instead consume `ActiveGraphView`
+- output and iterators stop depending on concrete sibling pointers directly and instead consume `HierarchyView`
+- `InfoNode` remains temporarily as the pointer-backed implementation of `HierarchyView`
+- the first backend behind `ActiveGraphView` is a compatibility backend over current `InfoNode`/`InfoEdge`
+- the second backend is CSR
+
+This is the key scope control mechanism: once those call sites depend on views/handles, the CSR work is localized to the new store plus a few bridge files instead of re-editing the entire tree every time.
+
+### 2. Separate tree storage from hot graph storage
+
+Do **not** make the whole Infomap tree CSR in the first real cutover. Instead:
+
+- keep a logical tree/hierarchy store for:
+  - parent/child/module relationships
+  - `calculatePath()`
+  - iterators
+  - output
+  - `owner` / sub-Infomap recursion
+  - hard-partition restore
+- move the hot active network to a compact store:
+  - dense node arrays for payload
+  - CSR adjacency arrays for out-edges
+  - either transposed CSR or computed in-edge index for in-neighbor iteration
+  - explicit module-membership arrays instead of walking sibling lists during optimization
+
+The bridge between them is:
+
+- leaf/module handles map back to hierarchy nodes
+- hierarchy operations can materialize the next active graph view when `setActiveNetworkFromLeafs()` or `setActiveNetworkFromChildrenOfRoot()` is called
+- subtree/subnetwork generation builds an `ActiveGraphView` from the hierarchy layer instead of cloning linked nodes/edges directly
+
+This makes the first meaningful performance win land in the real hot path while preserving current feature semantics.
+
+### 3. Refactor in four implementation phases
+
+#### Phase A: Baseline, parity harness, and abstraction scaffolding
+
+- Add `ActiveGraphView` and `HierarchyView` interfaces plus a pointer-backed adapter over current `InfoNode`
+- Convert optimizer/objective code to read through the views without changing behavior
+- Keep all runtime behavior pointer-backed at this phase
+- Add backend-selection plumbing that is internal-only:
+  - default backend = current pointer backend
+  - CSR backend selectable only from tests/benchmarks or a non-public build-time/internal hook
+
+#### Phase B: Build a full conformance test net before CSR
+
+Add missing regression tests first so the storage swap has a safety cage.
+
+Required new coverage:
+
+- tree rewrite invariants
+  - `replaceChildrenWithGrandChildren`
+  - `replaceWithChildren`
+  - `collapseChildren` / `expandChildren`
+  - `releaseChildren`
+  - sanity after repeated remove/rebuild cycles
+- output parity
+  - `.tree`
+  - `.clu`
+  - JSON/network-link output
+  - state vs physical output for higher-order input
+- recursive/sub-Infomap parity
+  - coarse tune
+  - fine tune
+  - super-module search
+  - repeated multi-trial reruns after hierarchy rebuilds
+- higher-order parity
+  - `states.net`
+  - `multilayer.net`
+  - `matchableMultilayerIds`
+  - physical aggregation and `iterTreePhysical`
+  - `getModules(states=true/false)` correctness
+- hard partition parity
+  - `.clu` hard/soft
+  - `.tree` import
+  - restore after optimization and after repeated trials
+- meta-data parity
+  - minimal meta-data fixture with `MetaMapEquation`
+  - stable module-level meta aggregation after moves/consolidation
+- determinism/parity checks
+  - same top modules
+  - same hierarchy depth
+  - same codelength/index codelength within tolerance
+  - same output files after normalization where appropriate
+
+Also add backend A/B tests:
+
+- pointer backend and CSR backend must produce identical results on the same fixture set
+- these tests must run inside the C++ suite, not only through Python
+
+#### Phase C: Implement the CSR backend for the active graph
+
+Implement a CSR-backed `ActiveGraphView` for:
+
+- first-order networks
+- state networks
+- module-level aggregated active networks
+- regenerated subnetwork views
+
+Storage requirements:
+
+- dense arrays for payload
+- CSR for out-neighbors
+- efficient in-neighbor access, either:
+  - second CSR transpose, or
+  - a separate incoming index structure
+- explicit module-membership arrays and flow aggregates replacing pointer chasing in the hot loop
+
+The optimizer/objective layer must not know which backend it is using.
+
+#### Phase D: Complete full feature parity and remove accidental pointer coupling
+
+Finish parity for the features most likely to block the rollout:
+
+- hard partition restore path
+- recursive sub-Infomap ownership/coarse tune/super modules
+- higher-order physical aggregation
+- meta-data aggregation
+- output/iterator traversal over the abstract hierarchy interface
+
+Only once the full parity suite passes against CSR should CSR be allowed as the default backend.
+
+### 4. Define the file boundary up front
+
+The refactor should concentrate changes primarily in:
+
+- the new storage/view layer
+- `InfomapBase`
+- `InfomapOptimizer*` and objective classes
+- iterator/output adapters
+
+The rest of the code should see:
+
+- handles/views instead of concrete `InfoNode` storage details
+- no direct knowledge of CSR layout
+
+Explicit non-goal:
+
+- no second pass of sweeping edits across the whole repo after the abstraction phase
+
+## Test Plan And Required New Coverage
+
+### C++ correctness additions required before cutover
+
+Extend the current C++ suite with these new groups:
+
+1. **Hierarchy mutation invariants**
+   - child/sibling counts remain correct after every tree rewrite
+   - path/depth/module numbering remain stable
+   - leaf coverage is preserved after collapse/expand/replace cycles
+   - no orphan nodes or parent mismatches after hard-partition restore
+
+2. **Output parity tests**
+   - golden or normalized comparisons for `.tree`, `.clu`, JSON, and Pajek/state-network outputs
+   - first-order and higher-order fixtures
+   - physical-vs-state outputs for memory networks
+
+3. **Higher-order and physical-node behavior**
+   - `iterTreePhysical`
+   - `iterLeafNodesPhysical`
+   - `getModules(states=true/false)`
+   - `states.net` and `multilayer.net` parity
+   - deterministic state-id behavior with `matchableMultilayerIds`
+
+4. **Recursive hierarchy behavior**
+   - coarse tune / fine tune / super-module passes produce stable trees
+   - repeated `run()` on the same instance after hierarchy reconstruction
+   - multi-trial best-tree restore still works with the abstraction
+
+5. **Meta-data behavior**
+   - module meta aggregation stays identical before/after moves and consolidation
+   - meta codelength parity on a minimal fixture
+
+6. **Backend conformance**
+   - identical partitions, level counts, and codelengths for pointer vs CSR backends on the same fixtures
+   - same failure behavior on malformed parser inputs
+
+### Acceptance criteria for test readiness
+
+Before CSR becomes default:
+
+- all existing C++ and Python regression suites remain green
+- new backend-conformance C++ tests are green
+- output parity tests are green
+- sanitizer runs are green for the CSR backend
+- pointer backend remains available until CSR parity is complete
+
+## Performance And Memory Measurement
+
+### Add a native benchmark/memory harness
+
+The current repo only has a small Python timing harness. That is not enough for this refactor.
+
+Add a native benchmark path that reports:
+
+- total wall time for `readInputData + initNetwork + run`
+- partition-only wall time for the optimization phase
+- peak RSS / peak resident memory
+- internal storage accounting:
+  - bytes in node payload arrays
+  - bytes in adjacency arrays
+  - bytes in hierarchy storage
+  - bytes per node
+  - bytes per edge
+
+Implementation shape:
+
+- one native benchmark executable or script-driven native harness
+- JSON output committed as CI artifact
+- same cases run against pointer backend and CSR backend
+
+### Benchmark corpus
+
+Use both real repo fixtures and deterministic generated graphs.
+
+Repo fixtures:
+
+- `examples/networks/twotriangles.net`
+- `examples/networks/ninetriangles.net`
+- `examples/networks/modular_w.net`
+- `examples/networks/modular_wd.net`
+- `examples/networks/states.net`
+- `examples/networks/multilayer.net`
+
+Generated workloads:
+
+- large sparse first-order graph
+- ring-of-cliques / SBM-style clustered graph
+- larger deterministic state/higher-order graph
+
+### Success metrics
+
+Track both absolute and relative deltas:
+
+- wall time
+- partition-only wall time
+- peak RSS
+- bytes per node
+- bytes per edge
+
+Recommended success thresholds for calling the refactor worthwhile:
+
+- first-order sparse graphs: at least `20%` lower peak RSS and `15%` lower partition-phase runtime
+- no more than `5%` total-runtime regression on higher-order/meta/hard-partition cases while parity is being preserved
+- zero correctness regressions in partitions, hierarchy depth, outputs, or codelength tolerance
+
+If CSR improves partition time but not total runtime, report both numbers explicitly rather than claiming an overall win.
+
+## Current Blockers And High-Risk Features
+
+These are the current features that are genuine blockers or likely to force temporary fallback to the pointer backend:
+
+### Hard blockers for a clean CSR rollout
+
+- higher-order/state-network handling:
+  - `haveMemory()`
+  - `physicalNodes`
+  - `stateNodes`
+  - physical-node iterators/output
+- hard partition restore:
+  - `clusterDataIsHard`
+  - `restoreHardPartition`
+  - `collapseChildren` / `expandChildren` / `replaceWithChildren`
+- recursive sub-Infomap ownership:
+  - `owner`
+  - `setInfomap()` / `disposeInfomap()`
+  - coarse tune / super-module hierarchy rebuilds
+- meta-data aggregation:
+  - `metaCollection`
+  - `MetaMapEquation`
+- output and iterator contracts that assume pointer-linked siblings and parent chains
+
+### Not blockers, but correctness-sensitive during the refactor
+
+- `recordedTeleportation`
+- `regularized`
+- `variableMarkovTime*`
+- precomputed flow input
+- `matchableMultilayerIds`
+
+Policy for these:
+
+- they must be parity-tested
+- they should not be used to justify pointer-only escape hatches unless a real storage-coupling issue is proven
+
+### Features that may need temporary backend fallback
+
+If full parity cannot be achieved immediately, the only acceptable temporary fallback is:
+
+- keep the abstraction in place
+- route the affected feature through the pointer-backed implementation internally
+- do not remove public support or change user-visible semantics
+
+That fallback is acceptable for:
+
+- hard partition restore
+- higher-order physical aggregation
+- meta-data objective
+- recursive super/coarse tune passes
+
+It is **not** acceptable to silently drop feature support.
+
+## Public/Internal Interface Changes
+
+No intended public CLI/Python/JS behavior changes.
+
+Internal changes that should exist in the final design:
+
+- `NodeHandle`-style stable identifiers
+- `ActiveGraphView` and `HierarchyView`
+- backend-selectable active graph store
+- internal benchmark hook for pointer-vs-CSR A/B runs
+
+The backend selector should remain internal until CSR is proven correct and beneficial.
+
+## Assumptions And Defaults
+
+- This is a high-risk internal refactor and should be executed as a staged effort, with frequent checkpoints.
+- Full feature parity is required before CSR becomes the default backend.
+- The first real performance win should come from CSR in the active optimization graph, not from rewriting the entire hierarchy tree into CSR immediately.
+- `InfoNode` can remain as a compatibility-backed hierarchy implementation during the transition; the goal is to stop it from being the only storage model, not necessarily to delete it on day one.
+- The refactor is not considered successful without native runtime and memory measurements proving the gain.

--- a/docs/plans/2026-04-03-infonode-csr-refactor-plan.md
+++ b/docs/plans/2026-04-03-infonode-csr-refactor-plan.md
@@ -18,6 +18,57 @@ This plan intentionally narrows the abstraction boundary compared to the previou
 - **do** abstract the active graph used by `InfomapOptimizer` and the objective functions
 - **do not** assume module-level or recursive graphs should immediately move to CSR
 
+## Execution Contract
+
+This plan should be executed incrementally on one long-lived refactor branch with explicit checkpoints. Do not treat it as a single uninterrupted implementation run.
+
+### Working rules
+
+- open and keep a draft PR for the refactor branch early
+- keep commits grouped by prerequisite, checkpoint, or one bounded refactor step
+- do not mix unrelated cleanup into the branch
+- update this plan file whenever scope, fallback policy, or success criteria materially change
+
+### Allowed local decisions
+
+The implementer may decide the following without rewriting the plan:
+
+- exact file/type names for active-graph structures
+- exact JSON schema for benchmark artifacts, as long as all required metrics are present
+- whether directed CSR lands in the first Phase 2 pass or as a short follow-up within Phase 2
+- whether a migrated path uses CSR or the pointer backend, as long as the documented fallback rules and verification gates are preserved
+
+### Changes that require a plan update first
+
+Do not continue implementation without updating the plan if any of these become necessary:
+
+- moving the hierarchy/tree itself away from pointer-backed storage
+- making CSR the default backend before pointer-vs-CSR parity is demonstrated
+- dropping supported feature behavior instead of routing through the pointer-backed fallback
+- widening scope to public API, packaging, release, or publishing changes
+
+### Checkpoints
+
+Stop and review after each checkpoint:
+
+1. **Checkpoint A**
+   - Phase 0a baseline harness
+   - Phase 0b prerequisite cleanup
+2. **Checkpoint B**
+   - Phase 0c Tier 1 conformance tests
+3. **Checkpoint C**
+   - Phase 1 lifecycle/payload infrastructure
+4. **Checkpoint D**
+   - first Phase 2 CSR leaf-level rollout
+5. **Checkpoint E**
+   - any Phase 3 extension beyond first-order leaf-level CSR
+
+Each checkpoint should end with:
+
+- a clean commit boundary
+- explicit verification output
+- a short note in the PR describing what is now proven and what still falls back to pointer-backed behavior
+
 ## Architecture And Implementation Changes
 
 ### 1. Keep the tree pointer-backed
@@ -220,6 +271,12 @@ Phase 0 exit criteria:
 - Tier 1 conformance tests are green
 - baseline benchmark JSON exists and is committed or archived for comparison
 
+Phase 0 verification should include at minimum:
+
+- `make test-native`
+- targeted reruns for new C++ suites with `CTEST_ARGS`
+- one successful baseline benchmark run producing machine-readable output
+
 ### Phase 1: Introduce active-graph lifecycle and payload infrastructure
 
 Introduce the active-graph lifecycle, active-node id mapping, and read-mostly payload infrastructure without changing adjacency or moving module assignment off `InfoNode` yet.
@@ -270,6 +327,13 @@ Phase 1 exit criteria:
 - measurable storage/accounting visibility for active payload/state
 - total runtime within roughly `+/-5%` of baseline on benchmark cases
 - no new correctness regressions in Tier 1 conformance tests
+
+Phase 1 verification should include at minimum:
+
+- `make test-native`
+- targeted lifecycle/sync-back test reruns
+- one benchmark comparison against the Phase 0 baseline
+- explicit PR note that optimizer/objective hot-path consumers remain unchanged
 
 ### Phase 2: Add CSR adjacency for leaf-level active graphs
 
@@ -329,6 +393,19 @@ Phase 2 exit criteria:
 - non-first-order Tier 2 tests remain green on the unchanged pointer-backed paths
 - no more than roughly `3%` total-runtime regression on non-migrated or fallback paths
 
+Phase 2 verification should include at minimum:
+
+- `make test-native`
+- targeted pointer-vs-CSR A/B tests
+- `make test-sanitizers`
+- at least one sanitizer rerun of a migrated leaf-level CSR case
+- benchmark comparison against Phase 0 and Phase 1 with:
+  - partition-only runtime
+  - peak RSS
+  - CSR materialization cost
+  - consolidation count
+  - module graph size distribution
+
 ### Phase 3: Extend CSR to selected nontrivial active-graph cases
 
 Only after Phase 2 is proven useful, evaluate and selectively extend CSR to:
@@ -355,6 +432,12 @@ Phase 3 exit criteria:
 
 - selected extensions are benchmarked and justified individually
 - fallback matrix is documented explicitly
+
+Phase 3 verification should include at minimum:
+
+- targeted tests for the newly migrated path
+- pointer-vs-CSR parity for that path
+- a short ROI note in the PR explaining whether the extension is kept or reverted
 
 ### Phase 4: Re-evaluate broader migration or permanent hybrid design
 
@@ -426,6 +509,12 @@ Recommended interpretation:
 - if CSR improves leaf-level partition time but total runtime barely moves, report that honestly rather than calling it a universal speedup
 - module-level CSR is only justified if rebuild cost is amortized by subsequent optimization rounds
 
+Artifact policy:
+
+- preserve one clear Phase 0 baseline comparison point
+- do not overwrite later benchmark summaries without preserving the prior comparison context in the PR discussion or artifacts
+- every benchmark artifact should include backend mode, graph name, node count, edge count, and per-phase timing breakdown
+
 ### Measurement gates per phase
 
 - Phase 1 must not meaningfully regress large first-order graphs while introducing payload/state arrays
@@ -495,3 +584,16 @@ Internal changes that should exist after the first successful milestone:
 - The pointer-backed tree is not the primary performance problem; the hot active graph is.
 - A permanent hybrid design is acceptable if it gives the desired speed/memory improvements with lower risk.
 - Full user-visible feature support remains the goal, but full CSR coverage across all internal paths is **not** required for the first successful milestone.
+
+## Implementation Start Point
+
+Implementation should start at **Phase 0a**, not at abstraction work.
+
+Recommended first sequence:
+
+1. add the native benchmark/memory harness and capture the baseline
+2. fix the `generateSubNetwork(...)` scratch-index coupling
+3. add Tier 1 conformance tests
+4. only then begin Phase 1 lifecycle infrastructure
+
+If any of those first three steps expose a larger-than-expected blast radius, stop there and revise the plan before entering Phase 1.

--- a/interfaces/swig/InfomapBase.i
+++ b/interfaces/swig/InfomapBase.i
@@ -21,5 +21,12 @@ namespace infomap {
     %template(InfomapConfigInfomapBase) InfomapConfig<InfomapBase>;
 }
 
+// Internal refactor helpers; not part of the supported Python API.
+%ignore infomap::InfomapBase::activeGraphMaterialization;
+%ignore infomap::InfomapBase::csrMaterialization;
+%ignore infomap::InfomapBase::pointerBackend;
+%ignore infomap::InfomapBase::pointerActiveGraph;
+%ignore infomap::InfomapBase::csrBackend;
+
 /* Parse the header file to generate wrappers */
 %include "src/core/InfomapBase.h"

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -15,7 +15,7 @@ endif
 
 CXX ?= c++
 AR ?= ar
-PYTHON ?= python
+PYTHON ?= $(shell command -v python 2>/dev/null || command -v python3 2>/dev/null || echo python3)
 PYTHON_FOR_BUILD_CONFIG ?= $(shell command -v $(PYTHON) 2>/dev/null || command -v python3 2>/dev/null || echo python3)
 PIP ?= $(PYTHON) -m pip
 PYTEST ?= $(PYTHON) -m pytest
@@ -90,6 +90,7 @@ help:
 		"  test-js               Pack the npm package and smoke-test the browser example." \
 		"  test-fast             Run the fast native + Python feedback suite." \
 		"  test-sanitizers       Run the C++ test suite under ASan/UBSan." \
+		"  bench-native          Run the native benchmark and memory baseline harness." \
 		"  bench-python          Run the nightly-style Python benchmark harness." \
 		"" \
 		"Dev" \

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -10,8 +10,13 @@ SANITIZER_CXX ?= clang++
 SANITIZER_CMAKE_ARGS ?=
 BENCHMARK_OUTPUT ?= build/benchmarks/python-benchmarks.json
 BENCHMARK_SUMMARY ?=
+NATIVE_BENCHMARK_TARGET ?= infomap_native_benchmark
+NATIVE_BENCHMARK_OUTPUT ?= build/benchmarks/native-benchmarks.json
+NATIVE_BENCHMARK_SUMMARY ?=
+NATIVE_BENCHMARK_PROFILE ?= baseline
+NATIVE_BENCHMARK_REPEATS ?= 3
 
-.PHONY: test-native test-fast test-sanitizers bench-python
+.PHONY: test-native test-fast test-sanitizers bench-python bench-native
 
 test-native:
 	@generator_args=""; \
@@ -58,3 +63,25 @@ test-sanitizers:
 bench-python:
 	@mkdir -p $(dir $(BENCHMARK_OUTPUT))
 	@$(PYTHON) scripts/benchmarks/run_python_benchmarks.py --output $(BENCHMARK_OUTPUT) $(if $(BENCHMARK_SUMMARY),--summary $(BENCHMARK_SUMMARY),)
+
+bench-native:
+	@generator_args=""; \
+	if [ -n "$(CMAKE_GENERATOR)" ]; then generator_args="-G $(CMAKE_GENERATOR)"; fi; \
+	$(CMAKE) -S . -B $(CMAKE_TEST_BUILD_DIR) $$generator_args \
+		-DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
+		$(if $(CMAKE_CXX_COMPILER),-DCMAKE_CXX_COMPILER=$(CMAKE_CXX_COMPILER),) \
+		$(if $(and $(filter 1,$(USE_CCACHE)),$(CCACHE_BIN)),-DCMAKE_CXX_COMPILER_LAUNCHER=$(CCACHE_BIN),) \
+		-DINFOMAP_MODE=$(MODE) \
+		-DINFOMAP_USE_OPENMP=$(if $(filter 1,$(OPENMP)),ON,OFF) \
+		-DINFOMAP_EXTRA_CPPFLAGS="$(CPPFLAGS)" \
+		-DINFOMAP_EXTRA_CXX_FLAGS="$(CXXFLAGS)" \
+		-DINFOMAP_EXTRA_LINK_FLAGS="$(LDFLAGS)" \
+		$(TEST_CMAKE_ARGS)
+	@$(CMAKE) --build $(CMAKE_TEST_BUILD_DIR) --target $(NATIVE_BENCHMARK_TARGET) --parallel $(JOBS)
+	@mkdir -p $(dir $(NATIVE_BENCHMARK_OUTPUT))
+	@$(PYTHON) scripts/benchmarks/run_native_benchmarks.py \
+		--binary $(CMAKE_TEST_BUILD_DIR)/$(NATIVE_BENCHMARK_TARGET) \
+		--output $(NATIVE_BENCHMARK_OUTPUT) \
+		--profile $(NATIVE_BENCHMARK_PROFILE) \
+		--repeats $(NATIVE_BENCHMARK_REPEATS) \
+		$(if $(NATIVE_BENCHMARK_SUMMARY),--summary $(NATIVE_BENCHMARK_SUMMARY),)

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -17,6 +17,7 @@ NATIVE_BENCHMARK_PROFILE ?= baseline
 NATIVE_BENCHMARK_REPEATS ?= 3
 NATIVE_BENCHMARK_WARMUP_REPEATS ?= 0
 NATIVE_BENCHMARK_FLAGS ?= --silent --no-file-output --num-trials 1 --seed 123
+NATIVE_BENCHMARK_BACKEND_MODE ?= auto
 
 .PHONY: test-native test-fast test-sanitizers bench-python bench-native
 
@@ -87,5 +88,6 @@ bench-native:
 		--profile $(NATIVE_BENCHMARK_PROFILE) \
 		--repeats $(NATIVE_BENCHMARK_REPEATS) \
 		--warmup-repeats $(NATIVE_BENCHMARK_WARMUP_REPEATS) \
+		--backend-mode $(NATIVE_BENCHMARK_BACKEND_MODE) \
 		--flags "$(NATIVE_BENCHMARK_FLAGS)" \
 		$(if $(NATIVE_BENCHMARK_SUMMARY),--summary $(NATIVE_BENCHMARK_SUMMARY),)

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -15,6 +15,8 @@ NATIVE_BENCHMARK_OUTPUT ?= build/benchmarks/native-benchmarks.json
 NATIVE_BENCHMARK_SUMMARY ?=
 NATIVE_BENCHMARK_PROFILE ?= baseline
 NATIVE_BENCHMARK_REPEATS ?= 3
+NATIVE_BENCHMARK_WARMUP_REPEATS ?= 0
+NATIVE_BENCHMARK_FLAGS ?= --silent --no-file-output --num-trials 1 --seed 123
 
 .PHONY: test-native test-fast test-sanitizers bench-python bench-native
 
@@ -84,4 +86,6 @@ bench-native:
 		--output $(NATIVE_BENCHMARK_OUTPUT) \
 		--profile $(NATIVE_BENCHMARK_PROFILE) \
 		--repeats $(NATIVE_BENCHMARK_REPEATS) \
+		--warmup-repeats $(NATIVE_BENCHMARK_WARMUP_REPEATS) \
+		--flags "$(NATIVE_BENCHMARK_FLAGS)" \
 		$(if $(NATIVE_BENCHMARK_SUMMARY),--summary $(NATIVE_BENCHMARK_SUMMARY),)

--- a/scripts/benchmarks/run_native_benchmarks.py
+++ b/scripts/benchmarks/run_native_benchmarks.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import statistics
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def write_pajek_edges(path: Path, num_nodes: int, edges: set[tuple[int, int]]) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        handle.write("*Vertices\n")
+        for node_id in range(num_nodes):
+            handle.write(f'{node_id} "{node_id}"\n')
+        handle.write("*Edges\n")
+        for source, target in sorted(edges):
+            handle.write(f"{source} {target}\n")
+
+
+def generate_sparse_graph(path: Path, num_nodes: int, avg_degree: int, seed: int) -> None:
+    rng = random.Random(seed)
+    edges: set[tuple[int, int]] = set()
+    ring_span = max(1, avg_degree // 4)
+    for node in range(num_nodes):
+        for step in range(1, ring_span + 1):
+            target = (node + step) % num_nodes
+            edge = (node, target) if node < target else (target, node)
+            edges.add(edge)
+
+    target_edges = max(num_nodes, num_nodes * avg_degree // 2)
+    while len(edges) < target_edges:
+        source = rng.randrange(num_nodes)
+        target = rng.randrange(num_nodes)
+        if source == target:
+            continue
+        edge = (source, target) if source < target else (target, source)
+        edges.add(edge)
+
+    write_pajek_edges(path, num_nodes, edges)
+
+
+def generate_ring_of_cliques(path: Path, clique_count: int, clique_size: int) -> None:
+    edges: set[tuple[int, int]] = set()
+    num_nodes = clique_count * clique_size
+    for clique in range(clique_count):
+        offset = clique * clique_size
+        nodes = [offset + index for index in range(clique_size)]
+        for i, source in enumerate(nodes):
+            for target in nodes[i + 1 :]:
+                edges.add((source, target))
+        next_offset = ((clique + 1) % clique_count) * clique_size
+        bridge = (offset, next_offset)
+        edges.add(bridge if bridge[0] < bridge[1] else (bridge[1], bridge[0]))
+
+    write_pajek_edges(path, num_nodes, edges)
+
+
+def generate_state_ring(path: Path, physical_nodes: int) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        handle.write(f"*Vertices {physical_nodes}\n")
+        for node_id in range(1, physical_nodes + 1):
+            handle.write(f'{node_id} "{node_id}"\n')
+        handle.write("*States\n")
+        for node_id in range(1, physical_nodes + 1):
+            handle.write(f'{2 * node_id - 1} {node_id} "{node_id}a"\n')
+            handle.write(f'{2 * node_id} {node_id} "{node_id}b"\n')
+        handle.write("*Links\n")
+        for node_id in range(physical_nodes):
+            current_a = 2 * node_id + 1
+            current_b = 2 * node_id + 2
+            next_a = (2 * ((node_id + 1) % physical_nodes)) + 1
+            next_b = next_a + 1
+            handle.write(f"{current_a} {next_a} 1\n")
+            handle.write(f"{current_a} {next_b} 1\n")
+            handle.write(f"{current_b} {next_a} 1\n")
+            handle.write(f"{current_b} {next_b} 1\n")
+
+
+def benchmark_case(binary: Path, name: str, network_path: Path, repeats: int, flags: str) -> dict[str, object]:
+    runs: list[dict[str, object]] = []
+    for _ in range(repeats):
+        completed = subprocess.run(
+            [str(binary), "--input", str(network_path), "--name", name, "--flags", flags],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        runs.append(json.loads(completed.stdout))
+
+    def median(key: str) -> float:
+        return statistics.median(float(run[key]) for run in runs)
+
+    def stats_median(key: str) -> float:
+        return statistics.median(float(run["benchmark_stats"][key]) for run in runs)
+
+    return {
+        "name": name,
+        "path": str(network_path),
+        "repeats": repeats,
+        "backend_mode": runs[0]["backend_mode"],
+        "flags": runs[0]["flags"],
+        "median_total_sec": median("total_sec"),
+        "median_read_input_sec": median("read_input_sec"),
+        "median_run_sec": median("run_sec"),
+        "peak_rss_bytes_max": max(int(run["peak_rss_bytes"]) for run in runs),
+        "num_nodes": runs[0]["num_nodes"],
+        "num_links": runs[0]["num_links"],
+        "num_top_modules": runs[0]["num_top_modules"],
+        "num_levels": runs[0]["num_levels"],
+        "codelength": runs[0]["codelength"],
+        "higher_order_input": runs[0]["higher_order_input"],
+        "directed_input": runs[0]["directed_input"],
+        "node_size_bytes": runs[0]["node_size_bytes"],
+        "edge_size_bytes": runs[0]["edge_size_bytes"],
+        "benchmark_stats_median": {
+            "calculate_flow_sec": stats_median("calculate_flow_sec"),
+            "init_network_sec": stats_median("init_network_sec"),
+            "run_partition_sec": stats_median("run_partition_sec"),
+            "find_top_modules_sec": stats_median("find_top_modules_sec"),
+            "fine_tune_sec": stats_median("fine_tune_sec"),
+            "coarse_tune_sec": stats_median("coarse_tune_sec"),
+            "recursive_partition_sec": stats_median("recursive_partition_sec"),
+            "super_modules_sec": stats_median("super_modules_sec"),
+            "super_modules_fast_sec": stats_median("super_modules_fast_sec"),
+            "find_top_modules_calls": runs[0]["benchmark_stats"]["find_top_modules_calls"],
+            "fine_tune_calls": runs[0]["benchmark_stats"]["fine_tune_calls"],
+            "coarse_tune_calls": runs[0]["benchmark_stats"]["coarse_tune_calls"],
+            "recursive_partition_calls": runs[0]["benchmark_stats"]["recursive_partition_calls"],
+            "super_modules_calls": runs[0]["benchmark_stats"]["super_modules_calls"],
+            "super_modules_fast_calls": runs[0]["benchmark_stats"]["super_modules_fast_calls"],
+            "consolidation_count": runs[0]["benchmark_stats"]["consolidation_count"],
+            "consolidations": runs[0]["benchmark_stats"]["consolidations"],
+        },
+    }
+
+
+def render_markdown(results: list[dict[str, object]]) -> str:
+    lines = [
+        "## Native Benchmark Summary",
+        "",
+        "| Case | Nodes | Links | Median total (s) | Median run (s) | Peak RSS (MiB) | Top Modules | Levels |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for result in results:
+        lines.append(
+            "| {name} | {num_nodes} | {num_links} | {median_total_sec:.6f} | {median_run_sec:.6f} | {peak_rss_mib:.2f} | {num_top_modules} | {num_levels} |".format(
+                peak_rss_mib=float(result["peak_rss_bytes_max"]) / (1024.0 * 1024.0),
+                **result,
+            )
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run native Infomap benchmarks and write a JSON report.")
+    parser.add_argument("--binary", type=Path, required=True, help="Path to the native benchmark executable.")
+    parser.add_argument("--output", type=Path, required=True, help="Path to write the JSON benchmark report.")
+    parser.add_argument("--summary", type=Path, default=None, help="Optional Markdown summary output.")
+    parser.add_argument("--repeats", type=int, default=3, help="Number of runs per case.")
+    parser.add_argument(
+        "--profile",
+        choices=("smoke", "baseline", "full"),
+        default="baseline",
+        help="Benchmark corpus size.",
+    )
+    parser.add_argument(
+        "--flags",
+        default="--silent --no-file-output --num-trials 1 --seed 123",
+        help="Infomap flags forwarded to the native benchmark executable.",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    if not args.binary.is_file():
+        raise FileNotFoundError(f"Benchmark binary not found: {args.binary}")
+
+    cases: list[tuple[str, Path]] = [
+        ("twotriangles", repo_root / "examples" / "networks" / "twotriangles.net"),
+        ("ninetriangles", repo_root / "examples" / "networks" / "ninetriangles.net"),
+        ("modular_w", repo_root / "examples" / "networks" / "modular_w.net"),
+        ("modular_wd", repo_root / "examples" / "networks" / "modular_wd.net"),
+        ("states", repo_root / "examples" / "networks" / "states.net"),
+        ("multilayer", repo_root / "examples" / "networks" / "multilayer.net"),
+        ("bipartite", repo_root / "examples" / "networks" / "bipartite.net"),
+    ]
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        generated_dir = Path(temp_dir)
+        sparse_10k = generated_dir / "sparse_10k.net"
+        ring_10k = generated_dir / "ring_of_cliques_10k.net"
+        state_5k = generated_dir / "state_ring_5k.net"
+        generate_sparse_graph(sparse_10k, num_nodes=10_000, avg_degree=10, seed=123)
+        generate_ring_of_cliques(ring_10k, clique_count=1_000, clique_size=10)
+        generate_state_ring(state_5k, physical_nodes=5_000)
+        cases.extend(
+            [
+                ("sparse_10k", sparse_10k),
+                ("ring_of_cliques_10k", ring_10k),
+                ("state_ring_5k", state_5k),
+            ]
+        )
+
+        if args.profile in {"baseline", "full"}:
+            sparse_100k = generated_dir / "sparse_100k.net"
+            ring_100k = generated_dir / "ring_of_cliques_100k.net"
+            generate_sparse_graph(sparse_100k, num_nodes=100_000, avg_degree=10, seed=456)
+            generate_ring_of_cliques(ring_100k, clique_count=10_000, clique_size=10)
+            cases.extend(
+                [
+                    ("sparse_100k", sparse_100k),
+                    ("ring_of_cliques_100k", ring_100k),
+                ]
+            )
+
+        if args.profile == "full":
+            sparse_1m = generated_dir / "sparse_1m.net"
+            generate_sparse_graph(sparse_1m, num_nodes=1_000_000, avg_degree=10, seed=789)
+            cases.append(("sparse_1m", sparse_1m))
+
+        results = [
+            benchmark_case(args.binary, name, path, args.repeats, args.flags)
+            for name, path in cases
+        ]
+
+    report = {
+        "profile": args.profile,
+        "repeats": args.repeats,
+        "binary": str(args.binary),
+        "benchmarks": results,
+    }
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+    markdown = render_markdown(results)
+    if args.summary is not None:
+        args.summary.parent.mkdir(parents=True, exist_ok=True)
+        args.summary.write_text(markdown, encoding="utf-8")
+
+    print(markdown)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmarks/run_native_benchmarks.py
+++ b/scripts/benchmarks/run_native_benchmarks.py
@@ -78,16 +78,23 @@ def generate_state_ring(path: Path, physical_nodes: int) -> None:
             handle.write(f"{current_b} {next_b} 1\n")
 
 
-def benchmark_case(binary: Path, name: str, network_path: Path, repeats: int, flags: str) -> dict[str, object]:
+def run_case(binary: Path, name: str, network_path: Path, flags: str) -> dict[str, object]:
+    completed = subprocess.run(
+        [str(binary), "--input", str(network_path), "--name", name, "--flags", flags],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def benchmark_case(binary: Path, name: str, network_path: Path, repeats: int, warmup_repeats: int, flags: str) -> dict[str, object]:
+    for _ in range(warmup_repeats):
+        run_case(binary, name, network_path, flags)
+
     runs: list[dict[str, object]] = []
     for _ in range(repeats):
-        completed = subprocess.run(
-            [str(binary), "--input", str(network_path), "--name", name, "--flags", flags],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-        runs.append(json.loads(completed.stdout))
+        runs.append(run_case(binary, name, network_path, flags))
 
     def median(key: str) -> float:
         return statistics.median(float(run[key]) for run in runs)
@@ -99,6 +106,7 @@ def benchmark_case(binary: Path, name: str, network_path: Path, repeats: int, fl
         "name": name,
         "path": str(network_path),
         "repeats": repeats,
+        "warmup_repeats": warmup_repeats,
         "backend_mode": runs[0]["backend_mode"],
         "flags": runs[0]["flags"],
         "median_total_sec": median("total_sec"),
@@ -114,8 +122,8 @@ def benchmark_case(binary: Path, name: str, network_path: Path, repeats: int, fl
         "directed_input": runs[0]["directed_input"],
         "node_size_bytes": runs[0]["node_size_bytes"],
         "edge_size_bytes": runs[0]["edge_size_bytes"],
-        "active_payload_nodes": runs[0]["active_payload_nodes"],
-        "active_payload_bytes": runs[0]["active_payload_bytes"],
+        "active_payload_nodes": runs[0].get("active_payload_nodes", 0),
+        "active_payload_bytes": runs[0].get("active_payload_bytes", 0),
         "benchmark_stats_median": {
             "calculate_flow_sec": stats_median("calculate_flow_sec"),
             "init_network_sec": stats_median("init_network_sec"),
@@ -162,6 +170,7 @@ def main() -> None:
     parser.add_argument("--output", type=Path, required=True, help="Path to write the JSON benchmark report.")
     parser.add_argument("--summary", type=Path, default=None, help="Optional Markdown summary output.")
     parser.add_argument("--repeats", type=int, default=3, help="Number of runs per case.")
+    parser.add_argument("--warmup-repeats", type=int, default=0, help="Number of warmup runs per case before recording.")
     parser.add_argument(
         "--profile",
         choices=("smoke", "baseline", "full"),
@@ -223,13 +232,14 @@ def main() -> None:
             cases.append(("sparse_1m", sparse_1m))
 
         results = [
-            benchmark_case(args.binary, name, path, args.repeats, args.flags)
+            benchmark_case(args.binary, name, path, args.repeats, args.warmup_repeats, args.flags)
             for name, path in cases
         ]
 
     report = {
         "profile": args.profile,
         "repeats": args.repeats,
+        "warmup_repeats": args.warmup_repeats,
         "binary": str(args.binary),
         "benchmarks": results,
     }

--- a/scripts/benchmarks/run_native_benchmarks.py
+++ b/scripts/benchmarks/run_native_benchmarks.py
@@ -124,6 +124,9 @@ def benchmark_case(binary: Path, name: str, network_path: Path, repeats: int, wa
         "edge_size_bytes": runs[0]["edge_size_bytes"],
         "active_payload_nodes": runs[0].get("active_payload_nodes", 0),
         "active_payload_bytes": runs[0].get("active_payload_bytes", 0),
+        "active_graph_storage": runs[0].get("active_graph_storage", {}),
+        "last_active_graph_storage": runs[0]["benchmark_stats"].get("last_active_graph_storage", {}),
+        "max_active_graph_storage": runs[0]["benchmark_stats"].get("max_active_graph_storage", {}),
         "benchmark_stats_median": {
             "calculate_flow_sec": stats_median("calculate_flow_sec"),
             "init_network_sec": stats_median("init_network_sec"),

--- a/scripts/benchmarks/run_native_benchmarks.py
+++ b/scripts/benchmarks/run_native_benchmarks.py
@@ -78,9 +78,9 @@ def generate_state_ring(path: Path, physical_nodes: int) -> None:
             handle.write(f"{current_b} {next_b} 1\n")
 
 
-def run_case(binary: Path, name: str, network_path: Path, flags: str) -> dict[str, object]:
+def run_case(binary: Path, name: str, network_path: Path, flags: str, backend_mode: str) -> dict[str, object]:
     completed = subprocess.run(
-        [str(binary), "--input", str(network_path), "--name", name, "--flags", flags],
+        [str(binary), "--input", str(network_path), "--name", name, "--flags", flags, "--backend-mode", backend_mode],
         check=True,
         capture_output=True,
         text=True,
@@ -88,13 +88,13 @@ def run_case(binary: Path, name: str, network_path: Path, flags: str) -> dict[st
     return json.loads(completed.stdout)
 
 
-def benchmark_case(binary: Path, name: str, network_path: Path, repeats: int, warmup_repeats: int, flags: str) -> dict[str, object]:
+def benchmark_case(binary: Path, name: str, network_path: Path, repeats: int, warmup_repeats: int, flags: str, backend_mode: str) -> dict[str, object]:
     for _ in range(warmup_repeats):
-        run_case(binary, name, network_path, flags)
+        run_case(binary, name, network_path, flags, backend_mode)
 
     runs: list[dict[str, object]] = []
     for _ in range(repeats):
-        runs.append(run_case(binary, name, network_path, flags))
+        runs.append(run_case(binary, name, network_path, flags, backend_mode))
 
     def median(key: str) -> float:
         return statistics.median(float(run[key]) for run in runs)
@@ -182,6 +182,12 @@ def main() -> None:
         default="--silent --no-file-output --num-trials 1 --seed 123",
         help="Infomap flags forwarded to the native benchmark executable.",
     )
+    parser.add_argument(
+        "--backend-mode",
+        choices=("auto", "pointer"),
+        default="auto",
+        help="Internal active-graph backend mode for the benchmark executable.",
+    )
     args = parser.parse_args()
 
     repo_root = Path(__file__).resolve().parents[2]
@@ -232,7 +238,7 @@ def main() -> None:
             cases.append(("sparse_1m", sparse_1m))
 
         results = [
-            benchmark_case(args.binary, name, path, args.repeats, args.warmup_repeats, args.flags)
+            benchmark_case(args.binary, name, path, args.repeats, args.warmup_repeats, args.flags, args.backend_mode)
             for name, path in cases
         ]
 
@@ -241,6 +247,7 @@ def main() -> None:
         "repeats": args.repeats,
         "warmup_repeats": args.warmup_repeats,
         "binary": str(args.binary),
+        "backend_mode": args.backend_mode,
         "benchmarks": results,
     }
 

--- a/scripts/benchmarks/run_native_benchmarks.py
+++ b/scripts/benchmarks/run_native_benchmarks.py
@@ -114,6 +114,8 @@ def benchmark_case(binary: Path, name: str, network_path: Path, repeats: int, fl
         "directed_input": runs[0]["directed_input"],
         "node_size_bytes": runs[0]["node_size_bytes"],
         "edge_size_bytes": runs[0]["edge_size_bytes"],
+        "active_payload_nodes": runs[0]["active_payload_nodes"],
+        "active_payload_bytes": runs[0]["active_payload_bytes"],
         "benchmark_stats_median": {
             "calculate_flow_sec": stats_median("calculate_flow_sec"),
             "init_network_sec": stats_median("init_network_sec"),

--- a/scripts/benchmarks/run_native_benchmarks.py
+++ b/scripts/benchmarks/run_native_benchmarks.py
@@ -130,6 +130,7 @@ def benchmark_case(binary: Path, name: str, network_path: Path, repeats: int, wa
         "benchmark_stats_median": {
             "calculate_flow_sec": stats_median("calculate_flow_sec"),
             "init_network_sec": stats_median("init_network_sec"),
+            "materialize_csr_sec": stats_median("materialize_csr_sec"),
             "run_partition_sec": stats_median("run_partition_sec"),
             "find_top_modules_sec": stats_median("find_top_modules_sec"),
             "fine_tune_sec": stats_median("fine_tune_sec"),

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -37,6 +37,28 @@
 
 namespace infomap {
 
+namespace {
+
+struct ScopedBenchmarkDuration {
+  double& field;
+  unsigned int* calls = nullptr;
+  Stopwatch timer{ true };
+
+  explicit ScopedBenchmarkDuration(double& field, unsigned int* calls = nullptr)
+      : field(field),
+        calls(calls) { }
+
+  ~ScopedBenchmarkDuration()
+  {
+    field += timer.getElapsedTimeInSec();
+    if (calls != nullptr) {
+      ++(*calls);
+    }
+  }
+};
+
+} // namespace
+
 std::map<unsigned int, std::vector<unsigned int>> InfomapBase::getMultilevelModules(bool states)
 {
   if (haveMemory() && !states) {
@@ -163,6 +185,8 @@ void InfomapBase::run(Network& network)
   if (!isMainInfomap())
     throw std::logic_error("Can't run a non-main Infomap with an input network");
 
+  resetBenchmarkStats();
+
   if (network.numNodes() == 0) {
     network.postProcessInputData();
     if (network.numNodes() == 0) {
@@ -214,13 +238,19 @@ void InfomapBase::run(Network& network)
   }
   network.setConfig(*this);
 
-  calculateFlow(network, *this);
+  {
+    ScopedBenchmarkDuration scopedDuration(m_benchmarkStats.calculateFlowSec);
+    calculateFlow(network, *this);
+  }
 
   if (network.isBipartite()) {
     bipartite = true;
   }
 
-  initNetwork(network);
+  {
+    ScopedBenchmarkDuration scopedDuration(m_benchmarkStats.initNetworkSec);
+    initNetwork(network);
+  }
 
   if (numLeafNodes() == 0)
     throw std::domain_error("No nodes to partition");
@@ -367,6 +397,15 @@ void InfomapBase::run(Network& network)
     Log() << "\n";
     Log() << bestSolutionStatistics.str() << '\n';
   }
+}
+
+void InfomapBase::runPartition()
+{
+  ScopedBenchmarkDuration scopedDuration(m_benchmarkStats.runPartitionSec);
+  if (twoLevel)
+    partition();
+  else
+    hierarchicalPartition();
 }
 
 // ===================================================
@@ -1340,6 +1379,7 @@ void InfomapBase::setActiveNetworkFromChildrenOfRoot()
 
 void InfomapBase::findTopModulesRepeatedly(unsigned int maxLevels)
 {
+  ScopedBenchmarkDuration scopedDuration(m_benchmarkStats.findTopModulesSec, &m_benchmarkStats.findTopModulesCalls);
   Log(1, 2) << "Iteration " << (m_tuneIterationIndex + 1) << ", moving ";
   Log(3) << "\nIteration " << (m_tuneIterationIndex + 1) << ":\n";
   m_aggregationLevel = 0;
@@ -1389,6 +1429,7 @@ void InfomapBase::findTopModulesRepeatedly(unsigned int maxLevels)
 
 unsigned int InfomapBase::fineTune()
 {
+  ScopedBenchmarkDuration scopedDuration(m_benchmarkStats.fineTuneSec, &m_benchmarkStats.fineTuneCalls);
   if (numLevels() != 2)
     throw std::logic_error("InfomapBase::fineTune() called but numLevels != 2");
 
@@ -1427,6 +1468,7 @@ unsigned int InfomapBase::fineTune()
 
 unsigned int InfomapBase::coarseTune()
 {
+  ScopedBenchmarkDuration scopedDuration(m_benchmarkStats.coarseTuneSec, &m_benchmarkStats.coarseTuneCalls);
   if (numLevels() != 2)
     throw std::logic_error("InfomapBase::coarseTune() called but numLevels != 2");
 
@@ -1533,6 +1575,7 @@ unsigned int InfomapBase::calculateMaxDepth() const
 
 unsigned int InfomapBase::findHierarchicalSuperModulesFast(unsigned int superLevelLimit)
 {
+  ScopedBenchmarkDuration scopedDuration(m_benchmarkStats.superModulesFastSec, &m_benchmarkStats.superModulesFastCalls);
   if (superLevelLimit == 0)
     return 0;
 
@@ -1608,6 +1651,7 @@ unsigned int InfomapBase::findHierarchicalSuperModulesFast(unsigned int superLev
 
 unsigned int InfomapBase::findHierarchicalSuperModules(unsigned int superLevelLimit)
 {
+  ScopedBenchmarkDuration scopedDuration(m_benchmarkStats.superModulesSec, &m_benchmarkStats.superModulesCalls);
   if (superLevelLimit == 0)
     return 0;
 
@@ -1759,6 +1803,7 @@ unsigned int InfomapBase::removeSubModules(bool recalculateCodelengthOnTree)
 
 unsigned int InfomapBase::recursivePartition()
 {
+  ScopedBenchmarkDuration scopedDuration(m_benchmarkStats.recursivePartitionSec, &m_benchmarkStats.recursivePartitionCalls);
   double indexCodelength = getIndexCodelength();
   double hierarchicalCodelength = m_hierarchicalCodelength;
 

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1392,6 +1392,7 @@ void InfomapBase::materializeActiveGraphPayload()
 
   const auto& network = *m_activeNetwork;
   m_activeGraphMaterialization.nodes = network;
+  m_activeGraphMaterialization.nodeToId.max_load_factor(4.0f);
   m_activeGraphMaterialization.nodeToId.reserve(network.size());
   for (std::size_t i = 0; i < network.size(); ++i) {
     const auto* node = network[i];

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1392,14 +1392,10 @@ void InfomapBase::materializeActiveGraphPayload()
 
   const auto& network = *m_activeNetwork;
   m_activeGraphMaterialization.nodes = network;
-  m_activeGraphMaterialization.payloads.reserve(network.size());
   m_activeGraphMaterialization.nodeToId.reserve(network.size());
   for (std::size_t i = 0; i < network.size(); ++i) {
     const auto* node = network[i];
     m_activeGraphMaterialization.nodeToId[const_cast<InfoNode*>(node)] = static_cast<ActiveGraphMaterialization::ActiveNodeId>(i);
-    m_activeGraphMaterialization.payloads.push_back({
-        node->data,
-    });
   }
 
   if (m_disableCsrMaterialization) {
@@ -1457,20 +1453,6 @@ void InfomapBase::materializeLeafLevelCsr()
   csr.available = true;
 }
 
-void InfomapBase::syncActiveGraphPayloadToHierarchy()
-{
-  auto& nodes = m_activeGraphMaterialization.nodes;
-  auto& payloads = m_activeGraphMaterialization.payloads;
-
-  if (nodes.size() != payloads.size()) {
-    throw std::logic_error("InfomapBase::syncActiveGraphPayloadToHierarchy() called with mismatched active payload state");
-  }
-
-  for (std::size_t i = 0; i < nodes.size(); ++i) {
-    nodes[i]->data = payloads[i].data;
-  }
-}
-
 void InfomapBase::syncActiveGraphStateToHierarchy()
 {
   if (!m_csrMaterialization.available) {
@@ -1495,14 +1477,12 @@ unsigned int InfomapBase::optimizeActiveNetwork()
 {
   const auto numEffectiveLoops = m_optimizer->optimizeActiveNetwork();
   syncActiveGraphStateToHierarchy();
-  syncActiveGraphPayloadToHierarchy();
   return numEffectiveLoops;
 }
 
 void InfomapBase::moveActiveNodesToPredefinedModules(std::vector<unsigned int>& modules)
 {
   syncActiveGraphStateToHierarchy();
-  syncActiveGraphPayloadToHierarchy();
   m_optimizer->moveActiveNodesToPredefinedModules(modules);
   syncActiveGraphStateToHierarchy();
   materializeActiveGraphPayload();
@@ -1511,7 +1491,6 @@ void InfomapBase::moveActiveNodesToPredefinedModules(std::vector<unsigned int>& 
 void InfomapBase::consolidateModules(bool replaceExistingModules)
 {
   syncActiveGraphStateToHierarchy();
-  syncActiveGraphPayloadToHierarchy();
   m_optimizer->consolidateModules(replaceExistingModules);
   materializeActiveGraphPayload();
 }

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1419,37 +1419,46 @@ void InfomapBase::materializeLeafLevelCsr()
   }
 
   const auto numNodes = m_activeGraphMaterialization.size();
+  const auto& nodes = m_activeGraphMaterialization.nodes;
   auto& csr = m_csrMaterialization;
-  csr.outOffsets.reserve(numNodes + 1);
-  csr.inOffsets.reserve(numNodes + 1);
-  csr.moduleIndices.reserve(numNodes);
-  csr.dirtyFlags.reserve(numNodes);
-  csr.outOffsets.push_back(0);
-  csr.inOffsets.push_back(0);
+
+  std::size_t totalOutEdges = 0;
+  std::size_t totalInEdges = 0;
+  for (const auto* node : nodes) {
+    totalOutEdges += node->outDegree();
+    totalInEdges += node->inDegree();
+  }
+
+  csr.outOffsets.resize(numNodes + 1);
+  csr.inOffsets.resize(numNodes + 1);
+  csr.moduleIndices.resize(numNodes);
+  csr.dirtyFlags.resize(numNodes);
+  csr.outTargets.reserve(totalOutEdges);
+  csr.outWeights.reserve(totalOutEdges);
+  csr.outFlows.reserve(totalOutEdges);
+  csr.inTargets.reserve(totalInEdges);
+  csr.inWeights.reserve(totalInEdges);
+  csr.inFlows.reserve(totalInEdges);
+  csr.outOffsets[0] = 0;
+  csr.inOffsets[0] = 0;
 
   for (std::size_t i = 0; i < numNodes; ++i) {
-    auto& node = m_activeGraphMaterialization.nodeFor(static_cast<ActiveGraphMaterialization::ActiveNodeId>(i));
-    csr.moduleIndices.push_back(node.index);
-    csr.dirtyFlags.push_back(node.dirty);
-    csr.outTargets.reserve(csr.outTargets.size() + node.outDegree());
-    csr.outWeights.reserve(csr.outWeights.size() + node.outDegree());
-    csr.outFlows.reserve(csr.outFlows.size() + node.outDegree());
+    auto& node = *nodes[i];
+    csr.moduleIndices[i] = node.index;
+    csr.dirtyFlags[i] = node.dirty ? 1u : 0u;
     for (auto* edge : node.outEdges()) {
       csr.outTargets.push_back(m_activeGraphMaterialization.idFor(*edge->target));
       csr.outWeights.push_back(edge->data.weight);
       csr.outFlows.push_back(edge->data.flow);
     }
-    csr.outOffsets.push_back(static_cast<unsigned int>(csr.outTargets.size()));
+    csr.outOffsets[i + 1] = static_cast<unsigned int>(csr.outTargets.size());
 
-    csr.inTargets.reserve(csr.inTargets.size() + node.inDegree());
-    csr.inWeights.reserve(csr.inWeights.size() + node.inDegree());
-    csr.inFlows.reserve(csr.inFlows.size() + node.inDegree());
     for (auto* edge : node.inEdges()) {
       csr.inTargets.push_back(m_activeGraphMaterialization.idFor(*edge->source));
       csr.inWeights.push_back(edge->data.weight);
       csr.inFlows.push_back(edge->data.flow);
     }
-    csr.inOffsets.push_back(static_cast<unsigned int>(csr.inTargets.size()));
+    csr.inOffsets[i + 1] = static_cast<unsigned int>(csr.inTargets.size());
   }
 
   csr.available = true;

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1407,7 +1407,7 @@ void InfomapBase::materializeActiveGraphPayload()
 
 void InfomapBase::materializeLeafLevelCsr()
 {
-  if (m_activeNetwork == nullptr || m_activeNetwork != &m_leafNodes || haveMemory() || !isMainInfomap()) {
+  if (m_activeNetwork == nullptr || m_activeNetwork != &m_leafNodes || haveMemory() || !isMainInfomap() || innerParallelization) {
     return;
   }
 

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1384,6 +1384,7 @@ void InfomapBase::setActiveNetworkFromChildrenOfRoot()
 void InfomapBase::materializeActiveGraphPayload()
 {
   m_activeGraphMaterialization.reset();
+  m_csrMaterialization.reset();
 
   if (m_activeNetwork == nullptr) {
     return;
@@ -1403,6 +1404,47 @@ void InfomapBase::materializeActiveGraphPayload()
         node->layerId,
     });
   }
+
+  materializeLeafLevelCsr();
+}
+
+void InfomapBase::materializeLeafLevelCsr()
+{
+  if (m_activeNetwork == nullptr || m_activeNetwork != &m_leafNodes || haveMemory()) {
+    return;
+  }
+
+  const auto numNodes = m_activeGraphMaterialization.size();
+  auto& csr = m_csrMaterialization;
+  csr.outOffsets.reserve(numNodes + 1);
+  csr.inOffsets.reserve(numNodes + 1);
+  csr.outOffsets.push_back(0);
+  csr.inOffsets.push_back(0);
+
+  for (std::size_t i = 0; i < numNodes; ++i) {
+    auto& node = m_activeGraphMaterialization.nodeFor(static_cast<ActiveGraphMaterialization::ActiveNodeId>(i));
+    csr.outTargets.reserve(csr.outTargets.size() + node.outDegree());
+    csr.outWeights.reserve(csr.outWeights.size() + node.outDegree());
+    csr.outFlows.reserve(csr.outFlows.size() + node.outDegree());
+    for (auto* edge : node.outEdges()) {
+      csr.outTargets.push_back(m_activeGraphMaterialization.idFor(*edge->target));
+      csr.outWeights.push_back(edge->data.weight);
+      csr.outFlows.push_back(edge->data.flow);
+    }
+    csr.outOffsets.push_back(static_cast<unsigned int>(csr.outTargets.size()));
+
+    csr.inTargets.reserve(csr.inTargets.size() + node.inDegree());
+    csr.inWeights.reserve(csr.inWeights.size() + node.inDegree());
+    csr.inFlows.reserve(csr.inFlows.size() + node.inDegree());
+    for (auto* edge : node.inEdges()) {
+      csr.inTargets.push_back(m_activeGraphMaterialization.idFor(*edge->source));
+      csr.inWeights.push_back(edge->data.weight);
+      csr.inFlows.push_back(edge->data.flow);
+    }
+    csr.inOffsets.push_back(static_cast<unsigned int>(csr.inTargets.size()));
+  }
+
+  csr.available = true;
 }
 
 void InfomapBase::syncActiveGraphPayloadToHierarchy()

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -27,6 +27,7 @@
 #include <limits>
 #include <map>
 #include <set>
+#include <unordered_map>
 #include <cstdlib>
 #include <algorithm>
 #include <cmath>
@@ -922,11 +923,13 @@ void InfomapBase::generateSubNetwork(InfoNode& parent)
   Log(1) << "Generate sub network with " << numNodes << " nodes...\n";
 
   unsigned int childIndex = 0;
+  std::unordered_map<InfoNode*, unsigned int> nodeIndexMap;
+  nodeIndexMap.reserve(numNodes);
   for (InfoNode& node : parent) {
     auto* clonedNode = new InfoNode(node);
     clonedNode->initClean();
     m_root.addChild(clonedNode);
-    node.index = childIndex; // Set index to its place in this subnetwork to be able to find edge target below
+    nodeIndexMap[&node] = childIndex;
     m_leafNodes[childIndex] = clonedNode;
     ++childIndex;
   }
@@ -938,7 +941,7 @@ void InfomapBase::generateSubNetwork(InfoNode& parent)
       InfoEdge& edge = *e;
       // If neighbour node is within the same module, add the link to this subnetwork.
       if (edge.target->parent == parentPtr) {
-        m_leafNodes[edge.source->index]->addOutEdge(*m_leafNodes[edge.target->index], edge.data.weight, edge.data.flow);
+        m_leafNodes[nodeIndexMap.at(edge.source)]->addOutEdge(*m_leafNodes[nodeIndexMap.at(edge.target)], edge.data.weight, edge.data.flow);
       }
     }
   }

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1399,9 +1399,6 @@ void InfomapBase::materializeActiveGraphPayload()
     m_activeGraphMaterialization.nodeToId[const_cast<InfoNode*>(node)] = static_cast<ActiveGraphMaterialization::ActiveNodeId>(i);
     m_activeGraphMaterialization.payloads.push_back({
         node->data,
-        node->stateId,
-        node->physicalId,
-        node->layerId,
     });
   }
 

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1428,9 +1428,12 @@ void InfomapBase::materializeLeafLevelCsr()
   csr.outTargets.reserve(totalOutEdges);
   csr.outFlows.reserve(totalOutEdges);
   csr.inTargets.reserve(totalInEdges);
-  csr.inFlows.reserve(totalInEdges);
+  csr.inFlowIndices.reserve(totalInEdges);
   csr.outOffsets[0] = 0;
   csr.inOffsets[0] = 0;
+
+  std::unordered_map<const InfoEdge*, unsigned int> outFlowIndexByEdge;
+  outFlowIndexByEdge.reserve(totalOutEdges);
 
   for (std::size_t i = 0; i < numNodes; ++i) {
     auto& node = *nodes[i];
@@ -1444,12 +1447,16 @@ void InfomapBase::materializeLeafLevelCsr()
     for (auto* edge : node.outEdges()) {
       csr.outTargets.push_back(csr.stateIdToActiveId.at(edge->target->stateId));
       csr.outFlows.push_back(edge->data.flow);
+      outFlowIndexByEdge.emplace(edge, static_cast<unsigned int>(csr.outFlows.size() - 1));
     }
     csr.outOffsets[i + 1] = static_cast<unsigned int>(csr.outTargets.size());
+  }
 
+  for (std::size_t i = 0; i < numNodes; ++i) {
+    auto& node = *nodes[i];
     for (auto* edge : node.inEdges()) {
       csr.inTargets.push_back(csr.stateIdToActiveId.at(edge->source->stateId));
-      csr.inFlows.push_back(edge->data.flow);
+      csr.inFlowIndices.push_back(outFlowIndexByEdge.at(edge));
     }
     csr.inOffsets[i + 1] = static_cast<unsigned int>(csr.inTargets.size());
   }

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1416,6 +1416,27 @@ void InfomapBase::syncActiveGraphPayloadToHierarchy()
   }
 }
 
+unsigned int InfomapBase::optimizeActiveNetwork()
+{
+  const auto numEffectiveLoops = m_optimizer->optimizeActiveNetwork();
+  syncActiveGraphPayloadToHierarchy();
+  return numEffectiveLoops;
+}
+
+void InfomapBase::moveActiveNodesToPredefinedModules(std::vector<unsigned int>& modules)
+{
+  syncActiveGraphPayloadToHierarchy();
+  m_optimizer->moveActiveNodesToPredefinedModules(modules);
+  materializeActiveGraphPayload();
+}
+
+void InfomapBase::consolidateModules(bool replaceExistingModules)
+{
+  syncActiveGraphPayloadToHierarchy();
+  m_optimizer->consolidateModules(replaceExistingModules);
+  materializeActiveGraphPayload();
+}
+
 void InfomapBase::findTopModulesRepeatedly(unsigned int maxLevels)
 {
   ScopedBenchmarkDuration scopedDuration(m_benchmarkStats.findTopModulesSec, &m_benchmarkStats.findTopModulesCalls);

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1405,6 +1405,10 @@ void InfomapBase::materializeActiveGraphPayload()
     });
   }
 
+  if (m_disableCsrMaterialization) {
+    return;
+  }
+
   materializeLeafLevelCsr();
 }
 

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1422,11 +1422,15 @@ void InfomapBase::materializeLeafLevelCsr()
   auto& csr = m_csrMaterialization;
   csr.outOffsets.reserve(numNodes + 1);
   csr.inOffsets.reserve(numNodes + 1);
+  csr.moduleIndices.reserve(numNodes);
+  csr.dirtyFlags.reserve(numNodes);
   csr.outOffsets.push_back(0);
   csr.inOffsets.push_back(0);
 
   for (std::size_t i = 0; i < numNodes; ++i) {
     auto& node = m_activeGraphMaterialization.nodeFor(static_cast<ActiveGraphMaterialization::ActiveNodeId>(i));
+    csr.moduleIndices.push_back(node.index);
+    csr.dirtyFlags.push_back(node.dirty);
     csr.outTargets.reserve(csr.outTargets.size() + node.outDegree());
     csr.outWeights.reserve(csr.outWeights.size() + node.outDegree());
     csr.outFlows.reserve(csr.outFlows.size() + node.outDegree());
@@ -1465,22 +1469,46 @@ void InfomapBase::syncActiveGraphPayloadToHierarchy()
   }
 }
 
+void InfomapBase::syncActiveGraphStateToHierarchy()
+{
+  if (!m_csrMaterialization.available) {
+    return;
+  }
+
+  auto& nodes = m_activeGraphMaterialization.nodes;
+  auto& moduleIndices = m_csrMaterialization.moduleIndices;
+  auto& dirtyFlags = m_csrMaterialization.dirtyFlags;
+
+  if (nodes.size() != moduleIndices.size() || nodes.size() != dirtyFlags.size()) {
+    throw std::logic_error("InfomapBase::syncActiveGraphStateToHierarchy() called with mismatched active state");
+  }
+
+  for (std::size_t i = 0; i < nodes.size(); ++i) {
+    nodes[i]->index = moduleIndices[i];
+    nodes[i]->dirty = dirtyFlags[i];
+  }
+}
+
 unsigned int InfomapBase::optimizeActiveNetwork()
 {
   const auto numEffectiveLoops = m_optimizer->optimizeActiveNetwork();
+  syncActiveGraphStateToHierarchy();
   syncActiveGraphPayloadToHierarchy();
   return numEffectiveLoops;
 }
 
 void InfomapBase::moveActiveNodesToPredefinedModules(std::vector<unsigned int>& modules)
 {
+  syncActiveGraphStateToHierarchy();
   syncActiveGraphPayloadToHierarchy();
   m_optimizer->moveActiveNodesToPredefinedModules(modules);
+  syncActiveGraphStateToHierarchy();
   materializeActiveGraphPayload();
 }
 
 void InfomapBase::consolidateModules(bool replaceExistingModules)
 {
+  syncActiveGraphStateToHierarchy();
   syncActiveGraphPayloadToHierarchy();
   m_optimizer->consolidateModules(replaceExistingModules);
   materializeActiveGraphPayload();

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1414,10 +1414,8 @@ void InfomapBase::materializeLeafLevelCsr()
   auto& csr = m_csrMaterialization;
 
   std::size_t totalOutEdges = 0;
-  std::size_t totalInEdges = 0;
   for (const auto* node : nodes) {
     totalOutEdges += node->outDegree();
-    totalInEdges += node->inDegree();
   }
 
   csr.outOffsets.resize(numNodes + 1);
@@ -1426,10 +1424,9 @@ void InfomapBase::materializeLeafLevelCsr()
   csr.dirtyFlags.resize(numNodes);
   csr.outTargets.reserve(totalOutEdges);
   csr.outFlows.reserve(totalOutEdges);
-  csr.inTargets.reserve(totalInEdges);
-  csr.inFlowIndices.reserve(totalInEdges);
+  csr.inTargets.resize(totalOutEdges);
+  csr.inFlowIndices.resize(totalOutEdges);
   csr.outOffsets[0] = 0;
-  csr.inOffsets[0] = 0;
 
   std::unordered_map<unsigned int, unsigned int> stateIdToActiveId;
   stateIdToActiveId.max_load_factor(4.0f);
@@ -1451,27 +1448,24 @@ void InfomapBase::materializeLeafLevelCsr()
     csr.outOffsets[i + 1] = static_cast<unsigned int>(csr.outTargets.size());
   }
 
+  std::vector<unsigned int> inCount(numNodes, 0);
+  for (auto targetId : csr.outTargets) {
+    ++inCount[targetId];
+  }
+
+  csr.inOffsets[0] = 0;
   for (std::size_t i = 0; i < numNodes; ++i) {
-    auto& node = *nodes[i];
-    for (auto* edge : node.inEdges()) {
-      const auto sourceId = stateIdToActiveId.at(edge->source->stateId);
-      const auto sourceOutOffset = csr.outOffsets[sourceId];
-      unsigned int localOutIndex = 0;
-      bool foundOutEdge = false;
-      for (auto* sourceEdge : edge->source->outEdges()) {
-        if (sourceEdge == edge) {
-          foundOutEdge = true;
-          break;
-        }
-        ++localOutIndex;
-      }
-      if (!foundOutEdge) {
-        throw std::logic_error("InfomapBase::materializeLeafLevelCsr() could not resolve inbound edge to source out-edge index");
-      }
-      csr.inTargets.push_back(sourceId);
-      csr.inFlowIndices.push_back(sourceOutOffset + localOutIndex);
+    csr.inOffsets[i + 1] = csr.inOffsets[i] + inCount[i];
+  }
+
+  std::vector<unsigned int> insertPos(csr.inOffsets.begin(), csr.inOffsets.begin() + numNodes);
+  for (unsigned int sourceId = 0; sourceId < numNodes; ++sourceId) {
+    for (unsigned int edgeIndex = csr.outOffsets[sourceId]; edgeIndex < csr.outOffsets[sourceId + 1]; ++edgeIndex) {
+      const auto targetId = csr.outTargets[edgeIndex];
+      const auto insertIndex = insertPos[targetId]++;
+      csr.inTargets[insertIndex] = sourceId;
+      csr.inFlowIndices[insertIndex] = edgeIndex;
     }
-    csr.inOffsets[i + 1] = static_cast<unsigned int>(csr.inTargets.size());
   }
 
   csr.available = true;

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1423,8 +1423,6 @@ void InfomapBase::materializeLeafLevelCsr()
   csr.inOffsets.resize(numNodes + 1);
   csr.moduleIndices.resize(numNodes);
   csr.dirtyFlags.resize(numNodes);
-  csr.stateIdToActiveId.max_load_factor(4.0f);
-  csr.stateIdToActiveId.reserve(numNodes);
   csr.outTargets.reserve(totalOutEdges);
   csr.outFlows.reserve(totalOutEdges);
   csr.inTargets.reserve(totalInEdges);
@@ -1432,12 +1430,15 @@ void InfomapBase::materializeLeafLevelCsr()
   csr.outOffsets[0] = 0;
   csr.inOffsets[0] = 0;
 
+  std::unordered_map<unsigned int, unsigned int> stateIdToActiveId;
+  stateIdToActiveId.max_load_factor(4.0f);
+  stateIdToActiveId.reserve(numNodes);
   std::unordered_map<const InfoEdge*, unsigned int> outFlowIndexByEdge;
   outFlowIndexByEdge.reserve(totalOutEdges);
 
   for (std::size_t i = 0; i < numNodes; ++i) {
     auto& node = *nodes[i];
-    csr.stateIdToActiveId[node.stateId] = static_cast<unsigned int>(i);
+    stateIdToActiveId[node.stateId] = static_cast<unsigned int>(i);
   }
 
   for (std::size_t i = 0; i < numNodes; ++i) {
@@ -1445,7 +1446,7 @@ void InfomapBase::materializeLeafLevelCsr()
     csr.moduleIndices[i] = node.index;
     csr.dirtyFlags[i] = node.dirty ? 1u : 0u;
     for (auto* edge : node.outEdges()) {
-      csr.outTargets.push_back(csr.stateIdToActiveId.at(edge->target->stateId));
+      csr.outTargets.push_back(stateIdToActiveId.at(edge->target->stateId));
       csr.outFlows.push_back(edge->data.flow);
       outFlowIndexByEdge.emplace(edge, static_cast<unsigned int>(csr.outFlows.size() - 1));
     }
@@ -1455,7 +1456,7 @@ void InfomapBase::materializeLeafLevelCsr()
   for (std::size_t i = 0; i < numNodes; ++i) {
     auto& node = *nodes[i];
     for (auto* edge : node.inEdges()) {
-      csr.inTargets.push_back(csr.stateIdToActiveId.at(edge->source->stateId));
+      csr.inTargets.push_back(stateIdToActiveId.at(edge->source->stateId));
       csr.inFlowIndices.push_back(outFlowIndexByEdge.at(edge));
     }
     csr.inOffsets[i + 1] = static_cast<unsigned int>(csr.inTargets.size());

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1392,12 +1392,6 @@ void InfomapBase::materializeActiveGraphPayload()
 
   const auto& network = *m_activeNetwork;
   m_activeGraphMaterialization.nodes = network;
-  m_activeGraphMaterialization.nodeToId.max_load_factor(4.0f);
-  m_activeGraphMaterialization.nodeToId.reserve(network.size());
-  for (std::size_t i = 0; i < network.size(); ++i) {
-    const auto* node = network[i];
-    m_activeGraphMaterialization.nodeToId[const_cast<InfoNode*>(node)] = static_cast<ActiveGraphMaterialization::ActiveNodeId>(i);
-  }
 
   if (m_disableCsrMaterialization) {
     m_benchmarkStats.lastActiveGraphStorage = activeGraphStorageBreakdown();
@@ -1431,6 +1425,8 @@ void InfomapBase::materializeLeafLevelCsr()
   csr.inOffsets.resize(numNodes + 1);
   csr.moduleIndices.resize(numNodes);
   csr.dirtyFlags.resize(numNodes);
+  csr.stateIdToActiveId.max_load_factor(4.0f);
+  csr.stateIdToActiveId.reserve(numNodes);
   csr.outTargets.reserve(totalOutEdges);
   csr.outFlows.reserve(totalOutEdges);
   csr.inTargets.reserve(totalInEdges);
@@ -1440,16 +1436,21 @@ void InfomapBase::materializeLeafLevelCsr()
 
   for (std::size_t i = 0; i < numNodes; ++i) {
     auto& node = *nodes[i];
+    csr.stateIdToActiveId[node.stateId] = static_cast<unsigned int>(i);
+  }
+
+  for (std::size_t i = 0; i < numNodes; ++i) {
+    auto& node = *nodes[i];
     csr.moduleIndices[i] = node.index;
     csr.dirtyFlags[i] = node.dirty ? 1u : 0u;
     for (auto* edge : node.outEdges()) {
-      csr.outTargets.push_back(m_activeGraphMaterialization.idFor(*edge->target));
+      csr.outTargets.push_back(csr.stateIdToActiveId.at(edge->target->stateId));
       csr.outFlows.push_back(edge->data.flow);
     }
     csr.outOffsets[i + 1] = static_cast<unsigned int>(csr.outTargets.size());
 
     for (auto* edge : node.inEdges()) {
-      csr.inTargets.push_back(m_activeGraphMaterialization.idFor(*edge->source));
+      csr.inTargets.push_back(csr.stateIdToActiveId.at(edge->source->stateId));
       csr.inFlows.push_back(edge->data.flow);
     }
     csr.inOffsets[i + 1] = static_cast<unsigned int>(csr.inTargets.size());

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1434,8 +1434,6 @@ void InfomapBase::materializeLeafLevelCsr()
   std::unordered_map<unsigned int, unsigned int> stateIdToActiveId;
   stateIdToActiveId.max_load_factor(4.0f);
   stateIdToActiveId.reserve(numNodes);
-  std::unordered_map<const InfoEdge*, unsigned int> outFlowIndexByEdge;
-  outFlowIndexByEdge.reserve(totalOutEdges);
 
   for (std::size_t i = 0; i < numNodes; ++i) {
     auto& node = *nodes[i];
@@ -1449,7 +1447,6 @@ void InfomapBase::materializeLeafLevelCsr()
     for (auto* edge : node.outEdges()) {
       csr.outTargets.push_back(stateIdToActiveId.at(edge->target->stateId));
       csr.outFlows.push_back(edge->data.flow);
-      outFlowIndexByEdge.emplace(edge, static_cast<unsigned int>(csr.outFlows.size() - 1));
     }
     csr.outOffsets[i + 1] = static_cast<unsigned int>(csr.outTargets.size());
   }
@@ -1457,8 +1454,22 @@ void InfomapBase::materializeLeafLevelCsr()
   for (std::size_t i = 0; i < numNodes; ++i) {
     auto& node = *nodes[i];
     for (auto* edge : node.inEdges()) {
-      csr.inTargets.push_back(stateIdToActiveId.at(edge->source->stateId));
-      csr.inFlowIndices.push_back(outFlowIndexByEdge.at(edge));
+      const auto sourceId = stateIdToActiveId.at(edge->source->stateId);
+      const auto sourceOutOffset = csr.outOffsets[sourceId];
+      unsigned int localOutIndex = 0;
+      bool foundOutEdge = false;
+      for (auto* sourceEdge : edge->source->outEdges()) {
+        if (sourceEdge == edge) {
+          foundOutEdge = true;
+          break;
+        }
+        ++localOutIndex;
+      }
+      if (!foundOutEdge) {
+        throw std::logic_error("InfomapBase::materializeLeafLevelCsr() could not resolve inbound edge to source out-edge index");
+      }
+      csr.inTargets.push_back(sourceId);
+      csr.inFlowIndices.push_back(sourceOutOffset + localOutIndex);
     }
     csr.inOffsets[i + 1] = static_cast<unsigned int>(csr.inTargets.size());
   }

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1404,6 +1404,7 @@ void InfomapBase::materializeActiveGraphPayload()
 
 void InfomapBase::materializeLeafLevelCsr()
 {
+  ScopedBenchmarkDuration scopedDuration(m_benchmarkStats.materializeCsrSec);
   if (m_activeNetwork == nullptr || m_activeNetwork != &m_leafNodes || haveMemory() || !isMainInfomap() || innerParallelization) {
     return;
   }

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1378,6 +1378,42 @@ void InfomapBase::setActiveNetworkFromChildrenOfRoot()
   for (auto& node : m_root)
     m_moduleNodes[i++] = &node;
   m_activeNetwork = &m_moduleNodes;
+  materializeActiveGraphPayload();
+}
+
+void InfomapBase::materializeActiveGraphPayload()
+{
+  m_activeGraphMaterialization.reset();
+
+  if (m_activeNetwork == nullptr) {
+    return;
+  }
+
+  const auto& network = *m_activeNetwork;
+  m_activeGraphMaterialization.nodes = network;
+  m_activeGraphMaterialization.payloads.reserve(network.size());
+  for (const auto* node : network) {
+    m_activeGraphMaterialization.payloads.push_back({
+        node->data,
+        node->stateId,
+        node->physicalId,
+        node->layerId,
+    });
+  }
+}
+
+void InfomapBase::syncActiveGraphPayloadToHierarchy()
+{
+  auto& nodes = m_activeGraphMaterialization.nodes;
+  auto& payloads = m_activeGraphMaterialization.payloads;
+
+  if (nodes.size() != payloads.size()) {
+    throw std::logic_error("InfomapBase::syncActiveGraphPayloadToHierarchy() called with mismatched active payload state");
+  }
+
+  for (std::size_t i = 0; i < nodes.size(); ++i) {
+    nodes[i]->data = payloads[i].data;
+  }
 }
 
 void InfomapBase::findTopModulesRepeatedly(unsigned int maxLevels)

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1392,7 +1392,10 @@ void InfomapBase::materializeActiveGraphPayload()
   const auto& network = *m_activeNetwork;
   m_activeGraphMaterialization.nodes = network;
   m_activeGraphMaterialization.payloads.reserve(network.size());
-  for (const auto* node : network) {
+  m_activeGraphMaterialization.nodeToId.reserve(network.size());
+  for (std::size_t i = 0; i < network.size(); ++i) {
+    const auto* node = network[i];
+    m_activeGraphMaterialization.nodeToId[const_cast<InfoNode*>(node)] = static_cast<ActiveGraphMaterialization::ActiveNodeId>(i);
     m_activeGraphMaterialization.payloads.push_back({
         node->data,
         node->stateId,

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1407,7 +1407,7 @@ void InfomapBase::materializeActiveGraphPayload()
 
 void InfomapBase::materializeLeafLevelCsr()
 {
-  if (m_activeNetwork == nullptr || m_activeNetwork != &m_leafNodes || haveMemory()) {
+  if (m_activeNetwork == nullptr || m_activeNetwork != &m_leafNodes || haveMemory() || !isMainInfomap()) {
     return;
   }
 

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1394,14 +1394,12 @@ void InfomapBase::materializeActiveGraphPayload()
   m_activeGraphMaterialization.nodes = network;
 
   if (m_disableCsrMaterialization) {
-    m_benchmarkStats.lastActiveGraphStorage = activeGraphStorageBreakdown();
-    m_benchmarkStats.maxActiveGraphStorage.maximize(m_benchmarkStats.lastActiveGraphStorage);
+    updateActiveGraphStorageBenchmarkStats();
     return;
   }
 
   materializeLeafLevelCsr();
-  m_benchmarkStats.lastActiveGraphStorage = activeGraphStorageBreakdown();
-  m_benchmarkStats.maxActiveGraphStorage.maximize(m_benchmarkStats.lastActiveGraphStorage);
+  updateActiveGraphStorageBenchmarkStats();
 }
 
 void InfomapBase::materializeLeafLevelCsr()
@@ -1457,6 +1455,21 @@ void InfomapBase::materializeLeafLevelCsr()
   }
 
   csr.available = true;
+}
+
+void InfomapBase::updateActiveGraphStorageBenchmarkStats()
+{
+  m_benchmarkStats.lastActiveGraphStorage = activeGraphStorageBreakdown();
+  m_benchmarkStats.maxActiveGraphStorage.maximize(m_benchmarkStats.lastActiveGraphStorage);
+}
+
+void InfomapBase::ensureActiveGraphNodeToId()
+{
+  const auto hadReverseLookup = !m_activeGraphMaterialization.nodeToId.empty();
+  m_activeGraphMaterialization.ensureNodeToId();
+  if (!hadReverseLookup && !m_activeGraphMaterialization.nodeToId.empty()) {
+    updateActiveGraphStorageBenchmarkStats();
+  }
 }
 
 void InfomapBase::syncActiveGraphStateToHierarchy()

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1399,10 +1399,14 @@ void InfomapBase::materializeActiveGraphPayload()
   }
 
   if (m_disableCsrMaterialization) {
+    m_benchmarkStats.lastActiveGraphStorage = activeGraphStorageBreakdown();
+    m_benchmarkStats.maxActiveGraphStorage.maximize(m_benchmarkStats.lastActiveGraphStorage);
     return;
   }
 
   materializeLeafLevelCsr();
+  m_benchmarkStats.lastActiveGraphStorage = activeGraphStorageBreakdown();
+  m_benchmarkStats.maxActiveGraphStorage.maximize(m_benchmarkStats.lastActiveGraphStorage);
 }
 
 void InfomapBase::materializeLeafLevelCsr()

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1434,10 +1434,8 @@ void InfomapBase::materializeLeafLevelCsr()
   csr.moduleIndices.resize(numNodes);
   csr.dirtyFlags.resize(numNodes);
   csr.outTargets.reserve(totalOutEdges);
-  csr.outWeights.reserve(totalOutEdges);
   csr.outFlows.reserve(totalOutEdges);
   csr.inTargets.reserve(totalInEdges);
-  csr.inWeights.reserve(totalInEdges);
   csr.inFlows.reserve(totalInEdges);
   csr.outOffsets[0] = 0;
   csr.inOffsets[0] = 0;
@@ -1448,14 +1446,12 @@ void InfomapBase::materializeLeafLevelCsr()
     csr.dirtyFlags[i] = node.dirty ? 1u : 0u;
     for (auto* edge : node.outEdges()) {
       csr.outTargets.push_back(m_activeGraphMaterialization.idFor(*edge->target));
-      csr.outWeights.push_back(edge->data.weight);
       csr.outFlows.push_back(edge->data.flow);
     }
     csr.outOffsets[i + 1] = static_cast<unsigned int>(csr.outTargets.size());
 
     for (auto* edge : node.inEdges()) {
       csr.inTargets.push_back(m_activeGraphMaterialization.idFor(*edge->source));
-      csr.inWeights.push_back(edge->data.weight);
       csr.inFlows.push_back(edge->data.flow);
     }
     csr.inOffsets[i + 1] = static_cast<unsigned int>(csr.inTargets.size());

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -60,7 +60,7 @@ public:
     std::size_t csrOutFlowBytes = 0;
     std::size_t csrInOffsetBytes = 0;
     std::size_t csrInTargetBytes = 0;
-    std::size_t csrInFlowBytes = 0;
+    std::size_t csrInFlowIndexBytes = 0;
     std::size_t csrModuleIndexBytes = 0;
     std::size_t csrDirtyFlagBytes = 0;
     bool csrAvailable = false;
@@ -77,7 +77,7 @@ public:
           + csrOutFlowBytes
           + csrInOffsetBytes
           + csrInTargetBytes
-          + csrInFlowBytes
+          + csrInFlowIndexBytes
           + csrModuleIndexBytes
           + csrDirtyFlagBytes;
     }
@@ -94,7 +94,7 @@ public:
       csrOutFlowBytes = std::max(csrOutFlowBytes, other.csrOutFlowBytes);
       csrInOffsetBytes = std::max(csrInOffsetBytes, other.csrInOffsetBytes);
       csrInTargetBytes = std::max(csrInTargetBytes, other.csrInTargetBytes);
-      csrInFlowBytes = std::max(csrInFlowBytes, other.csrInFlowBytes);
+      csrInFlowIndexBytes = std::max(csrInFlowIndexBytes, other.csrInFlowIndexBytes);
       csrModuleIndexBytes = std::max(csrModuleIndexBytes, other.csrModuleIndexBytes);
       csrDirtyFlagBytes = std::max(csrDirtyFlagBytes, other.csrDirtyFlagBytes);
       csrAvailable = csrAvailable || other.csrAvailable;
@@ -240,7 +240,7 @@ public:
     std::vector<double> outFlows;
     std::vector<unsigned int> inOffsets;
     std::vector<unsigned int> inTargets;
-    std::vector<double> inFlows;
+    std::vector<unsigned int> inFlowIndices;
     std::vector<unsigned int> moduleIndices;
     std::vector<unsigned char> dirtyFlags;
     bool available = false;
@@ -253,7 +253,7 @@ public:
       outFlows.clear();
       inOffsets.clear();
       inTargets.clear();
-      inFlows.clear();
+      inFlowIndices.clear();
       moduleIndices.clear();
       dirtyFlags.clear();
       available = false;
@@ -268,7 +268,7 @@ public:
           + outFlowBytes()
           + inOffsetBytes()
           + inTargetBytes()
-          + inFlowBytes()
+          + inFlowIndexBytes()
           + moduleIndexBytes()
           + dirtyFlagBytes();
     }
@@ -308,9 +308,9 @@ public:
       return inTargets.capacity() * sizeof(unsigned int);
     }
 
-    std::size_t inFlowBytes() const noexcept
+    std::size_t inFlowIndexBytes() const noexcept
     {
-      return inFlows.capacity() * sizeof(double);
+      return inFlowIndices.capacity() * sizeof(unsigned int);
     }
 
     std::size_t moduleIndexBytes() const noexcept
@@ -419,6 +419,18 @@ public:
       std::size_t size = 0;
     };
 
+    struct InEdgeSpan {
+      const unsigned int* targets = nullptr;
+      const unsigned int* flowIndices = nullptr;
+      const double* outFlows = nullptr;
+      std::size_t size = 0;
+
+      double flowAt(std::size_t index) const
+      {
+        return outFlows[flowIndices[index]];
+      }
+    };
+
     CsrBackend(ActiveGraphMaterialization& materialization, CsrMaterialization& csrMaterialization)
         : materialization(materialization),
           csrMaterialization(csrMaterialization) { }
@@ -493,7 +505,7 @@ public:
       for (std::size_t i = 0; i < edges.size; ++i) {
         EdgeView edge{
             edges.targets[i],
-            edges.flows[i],
+            edges.flowAt(i),
         };
         fn(edge.neighbourId, *materialization.nodes[edge.neighbourId], edge);
       }
@@ -512,7 +524,7 @@ public:
       };
     }
 
-    EdgeSpan inEdges(ActiveNodeId id) const
+    InEdgeSpan inEdges(ActiveNodeId id) const
     {
       if (!available()) return {};
       assert(id + 1 < csrMaterialization.inOffsets.size());
@@ -520,7 +532,8 @@ public:
       const auto end = csrMaterialization.inOffsets[id + 1];
       return {
           csrMaterialization.inTargets.data() + begin,
-          csrMaterialization.inFlows.data() + begin,
+          csrMaterialization.inFlowIndices.data() + begin,
+          csrMaterialization.outFlows.data(),
           end - begin,
       };
     }
@@ -636,7 +649,7 @@ public:
         m_csrMaterialization.outFlowBytes(),
         m_csrMaterialization.inOffsetBytes(),
         m_csrMaterialization.inTargetBytes(),
-        m_csrMaterialization.inFlowBytes(),
+        m_csrMaterialization.inFlowIndexBytes(),
         m_csrMaterialization.moduleIndexBytes(),
         m_csrMaterialization.dirtyFlagBytes(),
         m_csrMaterialization.available,

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -283,6 +283,12 @@ public:
   struct CsrBackend {
     using ActiveNodeId = ActiveGraphMaterialization::ActiveNodeId;
 
+    struct EdgeView {
+      ActiveNodeId neighbourId = 0;
+      double weight = 0.0;
+      double flow = 0.0;
+    };
+
     struct EdgeSpan {
       const unsigned int* targets = nullptr;
       const double* weights = nullptr;
@@ -302,6 +308,36 @@ public:
     InfoNode& nodeFor(ActiveNodeId id) const { return materialization.nodeFor(id); }
     ActiveNodePayload& payloadFor(ActiveNodeId id) { return materialization.payloadFor(id); }
     const ActiveNodePayload& payloadFor(ActiveNodeId id) const { return materialization.payloadFor(id); }
+    unsigned int& moduleIndex(ActiveNodeId id) const { return nodeFor(id).index; }
+    bool& dirty(ActiveNodeId id) const { return nodeFor(id).dirty; }
+
+    template <typename Fn>
+    void forEachOutEdge(ActiveNodeId id, Fn&& fn) const
+    {
+      const auto edges = outEdges(id);
+      for (std::size_t i = 0; i < edges.size; ++i) {
+        EdgeView edge{
+            edges.targets[i],
+            edges.weights[i],
+            edges.flows[i],
+        };
+        fn(edge.neighbourId, nodeFor(edge.neighbourId), edge);
+      }
+    }
+
+    template <typename Fn>
+    void forEachInEdge(ActiveNodeId id, Fn&& fn) const
+    {
+      const auto edges = inEdges(id);
+      for (std::size_t i = 0; i < edges.size; ++i) {
+        EdgeView edge{
+            edges.targets[i],
+            edges.weights[i],
+            edges.flows[i],
+        };
+        fn(edge.neighbourId, nodeFor(edge.neighbourId), edge);
+      }
+    }
 
     EdgeSpan outEdges(ActiveNodeId id) const
     {

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -46,6 +46,55 @@ class InfomapBase : public InfomapConfig<InfomapBase> {
 public:
   using PartitionQueue = detail::PartitionQueue;
 
+  struct ConsolidationSnapshot {
+    unsigned int level = 0;
+    unsigned int activeNodeCount = 0;
+    unsigned int moduleNodeCount = 0;
+    unsigned int moduleEdgeCount = 0;
+    bool replaceExistingModules = false;
+  };
+
+  struct BenchmarkStats {
+    double calculateFlowSec = 0.0;
+    double initNetworkSec = 0.0;
+    double runPartitionSec = 0.0;
+    double findTopModulesSec = 0.0;
+    double fineTuneSec = 0.0;
+    double coarseTuneSec = 0.0;
+    double recursivePartitionSec = 0.0;
+    double superModulesSec = 0.0;
+    double superModulesFastSec = 0.0;
+    unsigned int findTopModulesCalls = 0;
+    unsigned int fineTuneCalls = 0;
+    unsigned int coarseTuneCalls = 0;
+    unsigned int recursivePartitionCalls = 0;
+    unsigned int superModulesCalls = 0;
+    unsigned int superModulesFastCalls = 0;
+    unsigned int consolidationCount = 0;
+    std::vector<ConsolidationSnapshot> consolidations;
+
+    void reset()
+    {
+      calculateFlowSec = 0.0;
+      initNetworkSec = 0.0;
+      runPartitionSec = 0.0;
+      findTopModulesSec = 0.0;
+      fineTuneSec = 0.0;
+      coarseTuneSec = 0.0;
+      recursivePartitionSec = 0.0;
+      superModulesSec = 0.0;
+      superModulesFastSec = 0.0;
+      findTopModulesCalls = 0;
+      fineTuneCalls = 0;
+      coarseTuneCalls = 0;
+      recursivePartitionCalls = 0;
+      superModulesCalls = 0;
+      superModulesFastCalls = 0;
+      consolidationCount = 0;
+      consolidations.clear();
+    }
+  };
+
   InfomapBase() : InfomapConfig<InfomapBase>() { initOptimizer(); }
 
   explicit InfomapBase(const Config& conf) : InfomapConfig<InfomapBase>(conf), m_network(conf) { initOptimizer(); }
@@ -138,6 +187,7 @@ public:
   double getEntropyRate() { return m_entropyRate; }
   double getMaxEntropy() { return m_maxEntropy; }
   double getMaxFlow() { return m_maxFlow; }
+  const BenchmarkStats& benchmarkStats() const noexcept { return m_benchmarkStats; }
 
   const Date& getStartDate() const { return m_startDate; }
   const Stopwatch& getElapsedTime() const { return m_elapsedTime; }
@@ -289,13 +339,7 @@ private:
 
   void init();
 
-  void runPartition()
-  {
-    if (twoLevel)
-      partition();
-    else
-      hierarchicalPartition();
-  }
+  void runPartition();
 
   void restoreHardPartition();
 
@@ -418,6 +462,18 @@ private:
 
   bool processPartitionQueue(PartitionQueue& queue, PartitionQueue& nextLevel) const;
 
+  void resetBenchmarkStats() { m_benchmarkStats.reset(); }
+
+  void recordConsolidationSnapshot(unsigned int level,
+                                   unsigned int activeNodeCount,
+                                   unsigned int moduleNodeCount,
+                                   unsigned int moduleEdgeCount,
+                                   bool replaceExistingModules)
+  {
+    ++m_benchmarkStats.consolidationCount;
+    m_benchmarkStats.consolidations.push_back({ level, activeNodeCount, moduleNodeCount, moduleEdgeCount, replaceExistingModules });
+  }
+
 public:
   // ===================================================
   // Output: *
@@ -516,6 +572,7 @@ protected:
   Stopwatch m_elapsedTime = Stopwatch(false);
   std::string m_initialParameters;
   std::string m_currentParameters;
+  BenchmarkStats m_benchmarkStats;
 
   std::unique_ptr<InfomapOptimizerBase> m_optimizer;
 };

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -333,14 +333,19 @@ public:
       double flow = 0.0;
     };
 
-    explicit PointerBackend(ActiveGraphMaterialization& materialization)
-        : materialization(materialization) { }
+    PointerBackend(InfomapBase& owner, ActiveGraphMaterialization& materialization)
+        : owner(owner),
+          materialization(materialization) { }
 
     std::size_t size() const noexcept { return materialization.size(); }
     bool empty() const noexcept { return materialization.empty(); }
-    void ensureReverseLookup() const { materialization.ensureNodeToId(); }
+    void ensureReverseLookup() const { owner.ensureActiveGraphNodeToId(); }
 
-    ActiveNodeId idFor(const InfoNode& node) const { return materialization.idFor(node); }
+    ActiveNodeId idFor(const InfoNode& node) const
+    {
+      owner.ensureActiveGraphNodeToId();
+      return materialization.idFor(node);
+    }
     InfoNode& nodeFor(ActiveNodeId id) const { return materialization.nodeFor(id); }
     unsigned int& moduleIndex(ActiveNodeId id) const { return nodeFor(id).index; }
     bool& dirty(ActiveNodeId id) const { return nodeFor(id).dirty; }
@@ -394,6 +399,7 @@ public:
     }
 
   private:
+    InfomapBase& owner;
     ActiveGraphMaterialization& materialization;
   };
 
@@ -640,7 +646,7 @@ public:
   const ActiveGraphMaterialization& activeGraphMaterialization() const noexcept { return m_activeGraphMaterialization; }
   CsrMaterialization& csrMaterialization() noexcept { return m_csrMaterialization; }
   const CsrMaterialization& csrMaterialization() const noexcept { return m_csrMaterialization; }
-  PointerBackend pointerBackend() noexcept { return PointerBackend(m_activeGraphMaterialization); }
+  PointerBackend pointerBackend() noexcept { return PointerBackend(*this, m_activeGraphMaterialization); }
   PointerActiveGraph pointerActiveGraph() noexcept { return pointerBackend(); }
   CsrBackend csrBackend() noexcept { return CsrBackend(m_activeGraphMaterialization, m_csrMaterialization); }
 
@@ -849,6 +855,8 @@ private:
 
   void materializeActiveGraphPayload();
   void materializeLeafLevelCsr();
+  void updateActiveGraphStorageBenchmarkStats();
+  void ensureActiveGraphNodeToId();
   void syncActiveGraphStateToHierarchy();
 
   void initPartition() { return m_optimizer->initPartition(); }

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -25,6 +25,7 @@
 #include <vector>
 #include <deque>
 #include <map>
+#include <unordered_map>
 #include <limits>
 #include <string>
 #include <iostream>
@@ -103,18 +104,65 @@ public:
   };
 
   struct ActiveGraphMaterialization {
+    using ActiveNodeId = unsigned int;
+
     std::vector<InfoNode*> nodes;
     std::vector<ActiveNodePayload> payloads;
+    std::unordered_map<InfoNode*, ActiveNodeId> nodeToId;
 
     void reset()
     {
       nodes.clear();
       payloads.clear();
+      nodeToId.clear();
     }
 
     std::size_t payloadBytes() const noexcept
     {
       return payloads.size() * sizeof(ActiveNodePayload);
+    }
+
+    std::size_t size() const noexcept
+    {
+      return nodes.size();
+    }
+
+    bool empty() const noexcept
+    {
+      return nodes.empty();
+    }
+
+    ActiveNodeId idFor(const InfoNode& node) const
+    {
+      auto it = nodeToId.find(const_cast<InfoNode*>(&node));
+      if (it == nodeToId.end()) {
+        throw std::out_of_range("ActiveGraphMaterialization::idFor() called for non-materialized node");
+      }
+      return it->second;
+    }
+
+    InfoNode& nodeFor(ActiveNodeId id) const
+    {
+      if (id >= nodes.size()) {
+        throw std::out_of_range("ActiveGraphMaterialization::nodeFor() id out of range");
+      }
+      return *nodes[id];
+    }
+
+    ActiveNodePayload& payloadFor(ActiveNodeId id)
+    {
+      if (id >= payloads.size()) {
+        throw std::out_of_range("ActiveGraphMaterialization::payloadFor() id out of range");
+      }
+      return payloads[id];
+    }
+
+    const ActiveNodePayload& payloadFor(ActiveNodeId id) const
+    {
+      if (id >= payloads.size()) {
+        throw std::out_of_range("ActiveGraphMaterialization::payloadFor() id out of range");
+      }
+      return payloads[id];
     }
   };
 

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -166,6 +166,63 @@ public:
     }
   };
 
+  struct PointerActiveGraph {
+    using ActiveNodeId = ActiveGraphMaterialization::ActiveNodeId;
+
+    struct EdgeView {
+      ActiveNodeId neighbourId = 0;
+      double weight = 0.0;
+      double flow = 0.0;
+    };
+
+    explicit PointerActiveGraph(ActiveGraphMaterialization& materialization)
+        : materialization(materialization) { }
+
+    std::size_t size() const noexcept { return materialization.size(); }
+    bool empty() const noexcept { return materialization.empty(); }
+
+    ActiveNodeId idFor(const InfoNode& node) const { return materialization.idFor(node); }
+    InfoNode& nodeFor(ActiveNodeId id) const { return materialization.nodeFor(id); }
+    ActiveNodePayload& payloadFor(ActiveNodeId id) { return materialization.payloadFor(id); }
+    const ActiveNodePayload& payloadFor(ActiveNodeId id) const { return materialization.payloadFor(id); }
+
+    unsigned int& moduleIndex(ActiveNodeId id) const { return nodeFor(id).index; }
+    bool& dirty(ActiveNodeId id) const { return nodeFor(id).dirty; }
+
+    std::vector<EdgeView> outEdges(ActiveNodeId id) const
+    {
+      std::vector<EdgeView> edges;
+      auto& node = nodeFor(id);
+      edges.reserve(node.outDegree());
+      for (auto* edge : node.outEdges()) {
+        edges.push_back({
+            materialization.idFor(*edge->target),
+            edge->data.weight,
+            edge->data.flow,
+        });
+      }
+      return edges;
+    }
+
+    std::vector<EdgeView> inEdges(ActiveNodeId id) const
+    {
+      std::vector<EdgeView> edges;
+      auto& node = nodeFor(id);
+      edges.reserve(node.inDegree());
+      for (auto* edge : node.inEdges()) {
+        edges.push_back({
+            materialization.idFor(*edge->source),
+            edge->data.weight,
+            edge->data.flow,
+        });
+      }
+      return edges;
+    }
+
+  private:
+    ActiveGraphMaterialization& materialization;
+  };
+
   InfomapBase() : InfomapConfig<InfomapBase>() { initOptimizer(); }
 
   explicit InfomapBase(const Config& conf) : InfomapConfig<InfomapBase>(conf), m_network(conf) { initOptimizer(); }
@@ -261,6 +318,7 @@ public:
   const BenchmarkStats& benchmarkStats() const noexcept { return m_benchmarkStats; }
   ActiveGraphMaterialization& activeGraphMaterialization() noexcept { return m_activeGraphMaterialization; }
   const ActiveGraphMaterialization& activeGraphMaterialization() const noexcept { return m_activeGraphMaterialization; }
+  PointerActiveGraph pointerActiveGraph() noexcept { return PointerActiveGraph(m_activeGraphMaterialization); }
 
   const Date& getStartDate() const { return m_startDate; }
   const Stopwatch& getElapsedTime() const { return m_elapsedTime; }

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -163,7 +163,7 @@ public:
     void reset()
     {
       nodes.clear();
-      nodeToId.clear();
+      decltype(nodeToId){}.swap(nodeToId);
     }
 
     std::size_t payloadBytes() const noexcept
@@ -247,7 +247,7 @@ public:
 
     void reset()
     {
-      stateIdToActiveId.clear();
+      decltype(stateIdToActiveId){}.swap(stateIdToActiveId);
       outOffsets.clear();
       outTargets.clear();
       outFlows.clear();

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -30,6 +30,7 @@
 #include <string>
 #include <iostream>
 #include <sstream>
+#include <cassert>
 
 namespace infomap {
 
@@ -176,7 +177,7 @@ public:
     std::vector<double> inWeights;
     std::vector<double> inFlows;
     std::vector<unsigned int> moduleIndices;
-    std::vector<bool> dirtyFlags;
+    std::vector<unsigned char> dirtyFlags;
     bool available = false;
 
     void reset()
@@ -205,7 +206,7 @@ public:
           + inWeights.size() * sizeof(double)
           + inFlows.size() * sizeof(double)
           + moduleIndices.size() * sizeof(unsigned int)
-          + dirtyFlags.size() * sizeof(bool);
+          + dirtyFlags.size() * sizeof(unsigned char);
     }
   };
 
@@ -311,38 +312,46 @@ public:
     bool empty() const noexcept { return materialization.empty(); }
 
     ActiveNodeId idFor(const InfoNode& node) const { return materialization.idFor(node); }
-    InfoNode& nodeFor(ActiveNodeId id) const { return materialization.nodeFor(id); }
-    ActiveNodePayload& payloadFor(ActiveNodeId id) { return materialization.payloadFor(id); }
-    const ActiveNodePayload& payloadFor(ActiveNodeId id) const { return materialization.payloadFor(id); }
+    InfoNode& nodeFor(ActiveNodeId id) const
+    {
+      assert(id < materialization.nodes.size());
+      return *materialization.nodes[id];
+    }
+    ActiveNodePayload& payloadFor(ActiveNodeId id)
+    {
+      assert(id < materialization.payloads.size());
+      return materialization.payloads[id];
+    }
+    const ActiveNodePayload& payloadFor(ActiveNodeId id) const
+    {
+      assert(id < materialization.payloads.size());
+      return materialization.payloads[id];
+    }
     unsigned int& moduleIndex(ActiveNodeId id) const
     {
-      if (id >= csrMaterialization.moduleIndices.size()) {
-        throw std::out_of_range("CsrBackend::moduleIndex() id out of range");
-      }
+      assert(id < csrMaterialization.moduleIndices.size());
       return csrMaterialization.moduleIndices[id];
     }
 
     struct DirtyRef {
-      std::vector<bool>* flags = nullptr;
+      std::vector<unsigned char>* flags = nullptr;
       std::size_t index = 0;
 
       DirtyRef& operator=(bool value)
       {
-        (*flags)[index] = value;
+        (*flags)[index] = value ? 1u : 0u;
         return *this;
       }
 
       operator bool() const
       {
-        return (*flags)[index];
+        return (*flags)[index] != 0;
       }
     };
 
     DirtyRef dirty(ActiveNodeId id) const
     {
-      if (id >= csrMaterialization.dirtyFlags.size()) {
-        throw std::out_of_range("CsrBackend::dirty() id out of range");
-      }
+      assert(id < csrMaterialization.dirtyFlags.size());
       return DirtyRef{&csrMaterialization.dirtyFlags, id};
     }
 
@@ -356,7 +365,7 @@ public:
             edges.weights[i],
             edges.flows[i],
         };
-        fn(edge.neighbourId, nodeFor(edge.neighbourId), edge);
+        fn(edge.neighbourId, *materialization.nodes[edge.neighbourId], edge);
       }
     }
 
@@ -370,18 +379,14 @@ public:
             edges.weights[i],
             edges.flows[i],
         };
-        fn(edge.neighbourId, nodeFor(edge.neighbourId), edge);
+        fn(edge.neighbourId, *materialization.nodes[edge.neighbourId], edge);
       }
     }
 
     EdgeSpan outEdges(ActiveNodeId id) const
     {
-      if (!available()) {
-        return {};
-      }
-      if (id + 1 >= csrMaterialization.outOffsets.size()) {
-        throw std::out_of_range("CsrBackend::outEdges() id out of range");
-      }
+      if (!available()) return {};
+      assert(id + 1 < csrMaterialization.outOffsets.size());
       const auto begin = csrMaterialization.outOffsets[id];
       const auto end = csrMaterialization.outOffsets[id + 1];
       return {
@@ -394,12 +399,8 @@ public:
 
     EdgeSpan inEdges(ActiveNodeId id) const
     {
-      if (!available()) {
-        return {};
-      }
-      if (id + 1 >= csrMaterialization.inOffsets.size()) {
-        throw std::out_of_range("CsrBackend::inEdges() id out of range");
-      }
+      if (!available()) return {};
+      assert(id + 1 < csrMaterialization.inOffsets.size());
       const auto begin = csrMaterialization.inOffsets[id];
       const auto end = csrMaterialization.inOffsets[id + 1];
       return {

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -870,6 +870,7 @@ protected:
   BenchmarkStats m_benchmarkStats;
   ActiveGraphMaterialization m_activeGraphMaterialization;
   CsrMaterialization m_csrMaterialization;
+  bool m_disableCsrMaterialization = false;
 
   std::unique_ptr<InfomapOptimizerBase> m_optimizer;
 };

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -355,6 +355,11 @@ public:
       return DirtyRef{&csrMaterialization.dirtyFlags, id};
     }
 
+    unsigned int* moduleIndicesData() noexcept { return csrMaterialization.moduleIndices.data(); }
+    const unsigned int* moduleIndicesData() const noexcept { return csrMaterialization.moduleIndices.data(); }
+    unsigned char* dirtyFlagsData() noexcept { return csrMaterialization.dirtyFlags.data(); }
+    const unsigned char* dirtyFlagsData() const noexcept { return csrMaterialization.dirtyFlags.data(); }
+
     template <typename Fn>
     void forEachOutEdge(ActiveNodeId id, Fn&& fn) const
     {

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -166,7 +166,7 @@ public:
     }
   };
 
-  struct PointerActiveGraph {
+  struct PointerBackend {
     using ActiveNodeId = ActiveGraphMaterialization::ActiveNodeId;
 
     struct EdgeView {
@@ -175,7 +175,7 @@ public:
       double flow = 0.0;
     };
 
-    explicit PointerActiveGraph(ActiveGraphMaterialization& materialization)
+    explicit PointerBackend(ActiveGraphMaterialization& materialization)
         : materialization(materialization) { }
 
     std::size_t size() const noexcept { return materialization.size(); }
@@ -240,6 +240,8 @@ public:
   private:
     ActiveGraphMaterialization& materialization;
   };
+
+  using PointerActiveGraph = PointerBackend;
 
   InfomapBase() : InfomapConfig<InfomapBase>() { initOptimizer(); }
 
@@ -336,7 +338,8 @@ public:
   const BenchmarkStats& benchmarkStats() const noexcept { return m_benchmarkStats; }
   ActiveGraphMaterialization& activeGraphMaterialization() noexcept { return m_activeGraphMaterialization; }
   const ActiveGraphMaterialization& activeGraphMaterialization() const noexcept { return m_activeGraphMaterialization; }
-  PointerActiveGraph pointerActiveGraph() noexcept { return PointerActiveGraph(m_activeGraphMaterialization); }
+  PointerBackend pointerBackend() noexcept { return PointerBackend(m_activeGraphMaterialization); }
+  PointerActiveGraph pointerActiveGraph() noexcept { return pointerBackend(); }
 
   const Date& getStartDate() const { return m_startDate; }
   const Stopwatch& getElapsedTime() const { return m_elapsedTime; }

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -95,6 +95,29 @@ public:
     }
   };
 
+  struct ActiveNodePayload {
+    FlowData data;
+    unsigned int stateId = 0;
+    unsigned int physicalId = 0;
+    unsigned int layerId = 0;
+  };
+
+  struct ActiveGraphMaterialization {
+    std::vector<InfoNode*> nodes;
+    std::vector<ActiveNodePayload> payloads;
+
+    void reset()
+    {
+      nodes.clear();
+      payloads.clear();
+    }
+
+    std::size_t payloadBytes() const noexcept
+    {
+      return payloads.size() * sizeof(ActiveNodePayload);
+    }
+  };
+
   InfomapBase() : InfomapConfig<InfomapBase>() { initOptimizer(); }
 
   explicit InfomapBase(const Config& conf) : InfomapConfig<InfomapBase>(conf), m_network(conf) { initOptimizer(); }
@@ -188,6 +211,8 @@ public:
   double getMaxEntropy() { return m_maxEntropy; }
   double getMaxFlow() { return m_maxFlow; }
   const BenchmarkStats& benchmarkStats() const noexcept { return m_benchmarkStats; }
+  ActiveGraphMaterialization& activeGraphMaterialization() noexcept { return m_activeGraphMaterialization; }
+  const ActiveGraphMaterialization& activeGraphMaterialization() const noexcept { return m_activeGraphMaterialization; }
 
   const Date& getStartDate() const { return m_startDate; }
   const Stopwatch& getElapsedTime() const { return m_elapsedTime; }
@@ -384,9 +409,17 @@ private:
   // Run: Partition: *
   // ===================================================
 
-  void setActiveNetworkFromLeafs() { m_activeNetwork = &m_leafNodes; }
+  void setActiveNetworkFromLeafs()
+  {
+    m_activeNetwork = &m_leafNodes;
+    materializeActiveGraphPayload();
+  }
 
   void setActiveNetworkFromChildrenOfRoot();
+
+  void materializeActiveGraphPayload();
+
+  void syncActiveGraphPayloadToHierarchy();
 
   void initPartition() { return m_optimizer->initPartition(); }
 
@@ -573,6 +606,7 @@ protected:
   std::string m_initialParameters;
   std::string m_currentParameters;
   BenchmarkStats m_benchmarkStats;
+  ActiveGraphMaterialization m_activeGraphMaterialization;
 
   std::unique_ptr<InfomapOptimizerBase> m_optimizer;
 };

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -234,7 +234,6 @@ public:
   };
 
   struct CsrMaterialization {
-    std::unordered_map<unsigned int, unsigned int> stateIdToActiveId;
     std::vector<unsigned int> outOffsets;
     std::vector<unsigned int> outTargets;
     std::vector<double> outFlows;
@@ -247,7 +246,6 @@ public:
 
     void reset()
     {
-      decltype(stateIdToActiveId){}.swap(stateIdToActiveId);
       outOffsets.clear();
       outTargets.clear();
       outFlows.clear();
@@ -280,12 +278,12 @@ public:
 
     std::size_t stateIdEntryBytes() const noexcept
     {
-      return stateIdToActiveId.size() * sizeof(typename decltype(stateIdToActiveId)::value_type);
+      return 0;
     }
 
     std::size_t stateIdBucketBytes() const noexcept
     {
-      return stateIdToActiveId.bucket_count() * sizeof(void*);
+      return 0;
     }
 
     std::size_t outTargetBytes() const noexcept
@@ -441,11 +439,7 @@ public:
 
     ActiveNodeId idFor(const InfoNode& node) const
     {
-      auto it = csrMaterialization.stateIdToActiveId.find(node.stateId);
-      if (it == csrMaterialization.stateIdToActiveId.end()) {
-        throw std::out_of_range("CsrBackend::idFor() called for non-materialized node");
-      }
-      return it->second;
+      return materialization.idFor(node);
     }
     InfoNode& nodeFor(ActiveNodeId id) const
     {

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -170,11 +170,9 @@ public:
   struct CsrMaterialization {
     std::vector<unsigned int> outOffsets;
     std::vector<unsigned int> outTargets;
-    std::vector<double> outWeights;
     std::vector<double> outFlows;
     std::vector<unsigned int> inOffsets;
     std::vector<unsigned int> inTargets;
-    std::vector<double> inWeights;
     std::vector<double> inFlows;
     std::vector<unsigned int> moduleIndices;
     std::vector<unsigned char> dirtyFlags;
@@ -184,11 +182,9 @@ public:
     {
       outOffsets.clear();
       outTargets.clear();
-      outWeights.clear();
       outFlows.clear();
       inOffsets.clear();
       inTargets.clear();
-      inWeights.clear();
       inFlows.clear();
       moduleIndices.clear();
       dirtyFlags.clear();
@@ -199,11 +195,9 @@ public:
     {
       return outOffsets.size() * sizeof(unsigned int)
           + outTargets.size() * sizeof(unsigned int)
-          + outWeights.size() * sizeof(double)
           + outFlows.size() * sizeof(double)
           + inOffsets.size() * sizeof(unsigned int)
           + inTargets.size() * sizeof(unsigned int)
-          + inWeights.size() * sizeof(double)
           + inFlows.size() * sizeof(double)
           + moduleIndices.size() * sizeof(unsigned int)
           + dirtyFlags.size() * sizeof(unsigned char);
@@ -292,13 +286,11 @@ public:
 
     struct EdgeView {
       ActiveNodeId neighbourId = 0;
-      double weight = 0.0;
       double flow = 0.0;
     };
 
     struct EdgeSpan {
       const unsigned int* targets = nullptr;
-      const double* weights = nullptr;
       const double* flows = nullptr;
       std::size_t size = 0;
     };
@@ -367,7 +359,6 @@ public:
       for (std::size_t i = 0; i < edges.size; ++i) {
         EdgeView edge{
             edges.targets[i],
-            edges.weights[i],
             edges.flows[i],
         };
         fn(edge.neighbourId, *materialization.nodes[edge.neighbourId], edge);
@@ -381,7 +372,6 @@ public:
       for (std::size_t i = 0; i < edges.size; ++i) {
         EdgeView edge{
             edges.targets[i],
-            edges.weights[i],
             edges.flows[i],
         };
         fn(edge.neighbourId, *materialization.nodes[edge.neighbourId], edge);
@@ -396,7 +386,6 @@ public:
       const auto end = csrMaterialization.outOffsets[id + 1];
       return {
           csrMaterialization.outTargets.data() + begin,
-          csrMaterialization.outWeights.data() + begin,
           csrMaterialization.outFlows.data() + begin,
           end - begin,
       };
@@ -410,7 +399,6 @@ public:
       const auto end = csrMaterialization.inOffsets[id + 1];
       return {
           csrMaterialization.inTargets.data() + begin,
-          csrMaterialization.inWeights.data() + begin,
           csrMaterialization.inFlows.data() + begin,
           end - begin,
       };

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -189,6 +189,24 @@ public:
     unsigned int& moduleIndex(ActiveNodeId id) const { return nodeFor(id).index; }
     bool& dirty(ActiveNodeId id) const { return nodeFor(id).dirty; }
 
+    template <typename Fn>
+    void forEachOutEdge(ActiveNodeId id, Fn&& fn) const
+    {
+      auto& node = nodeFor(id);
+      for (auto* edge : node.outEdges()) {
+        fn(materialization.idFor(*edge->target), *edge->target, *edge);
+      }
+    }
+
+    template <typename Fn>
+    void forEachInEdge(ActiveNodeId id, Fn&& fn) const
+    {
+      auto& node = nodeFor(id);
+      for (auto* edge : node.inEdges()) {
+        fn(materialization.idFor(*edge->source), *edge->source, *edge);
+      }
+    }
+
     std::vector<EdgeView> outEdges(ActiveNodeId id) const
     {
       std::vector<EdgeView> edges;

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -53,6 +53,8 @@ public:
     std::size_t activeNodePointerBytes = 0;
     std::size_t activeNodeToIdEntryBytes = 0;
     std::size_t activeNodeToIdBucketBytes = 0;
+    std::size_t csrStateIdEntryBytes = 0;
+    std::size_t csrStateIdBucketBytes = 0;
     std::size_t csrOutOffsetBytes = 0;
     std::size_t csrOutTargetBytes = 0;
     std::size_t csrOutFlowBytes = 0;
@@ -68,6 +70,8 @@ public:
       return activeNodePointerBytes
           + activeNodeToIdEntryBytes
           + activeNodeToIdBucketBytes
+          + csrStateIdEntryBytes
+          + csrStateIdBucketBytes
           + csrOutOffsetBytes
           + csrOutTargetBytes
           + csrOutFlowBytes
@@ -83,6 +87,8 @@ public:
       activeNodePointerBytes = std::max(activeNodePointerBytes, other.activeNodePointerBytes);
       activeNodeToIdEntryBytes = std::max(activeNodeToIdEntryBytes, other.activeNodeToIdEntryBytes);
       activeNodeToIdBucketBytes = std::max(activeNodeToIdBucketBytes, other.activeNodeToIdBucketBytes);
+      csrStateIdEntryBytes = std::max(csrStateIdEntryBytes, other.csrStateIdEntryBytes);
+      csrStateIdBucketBytes = std::max(csrStateIdBucketBytes, other.csrStateIdBucketBytes);
       csrOutOffsetBytes = std::max(csrOutOffsetBytes, other.csrOutOffsetBytes);
       csrOutTargetBytes = std::max(csrOutTargetBytes, other.csrOutTargetBytes);
       csrOutFlowBytes = std::max(csrOutFlowBytes, other.csrOutFlowBytes);
@@ -152,7 +158,7 @@ public:
     using ActiveNodeId = unsigned int;
 
     std::vector<InfoNode*> nodes;
-    std::unordered_map<InfoNode*, ActiveNodeId> nodeToId;
+    mutable std::unordered_map<InfoNode*, ActiveNodeId> nodeToId;
 
     void reset()
     {
@@ -195,8 +201,21 @@ public:
       return nodes.empty();
     }
 
+    void ensureNodeToId() const
+    {
+      if (!nodeToId.empty() || nodes.empty()) {
+        return;
+      }
+      nodeToId.max_load_factor(4.0f);
+      nodeToId.reserve(nodes.size());
+      for (std::size_t i = 0; i < nodes.size(); ++i) {
+        nodeToId[const_cast<InfoNode*>(nodes[i])] = static_cast<ActiveNodeId>(i);
+      }
+    }
+
     ActiveNodeId idFor(const InfoNode& node) const
     {
+      ensureNodeToId();
       auto it = nodeToId.find(const_cast<InfoNode*>(&node));
       if (it == nodeToId.end()) {
         throw std::out_of_range("ActiveGraphMaterialization::idFor() called for non-materialized node");
@@ -215,6 +234,7 @@ public:
   };
 
   struct CsrMaterialization {
+    std::unordered_map<unsigned int, unsigned int> stateIdToActiveId;
     std::vector<unsigned int> outOffsets;
     std::vector<unsigned int> outTargets;
     std::vector<double> outFlows;
@@ -227,6 +247,7 @@ public:
 
     void reset()
     {
+      stateIdToActiveId.clear();
       outOffsets.clear();
       outTargets.clear();
       outFlows.clear();
@@ -240,7 +261,9 @@ public:
 
     std::size_t adjacencyBytes() const noexcept
     {
-      return outOffsetBytes()
+      return stateIdEntryBytes()
+          + stateIdBucketBytes()
+          + outOffsetBytes()
           + outTargetBytes()
           + outFlowBytes()
           + inOffsetBytes()
@@ -253,6 +276,16 @@ public:
     std::size_t outOffsetBytes() const noexcept
     {
       return outOffsets.capacity() * sizeof(unsigned int);
+    }
+
+    std::size_t stateIdEntryBytes() const noexcept
+    {
+      return stateIdToActiveId.size() * sizeof(typename decltype(stateIdToActiveId)::value_type);
+    }
+
+    std::size_t stateIdBucketBytes() const noexcept
+    {
+      return stateIdToActiveId.bucket_count() * sizeof(void*);
     }
 
     std::size_t outTargetBytes() const noexcept
@@ -305,6 +338,7 @@ public:
 
     std::size_t size() const noexcept { return materialization.size(); }
     bool empty() const noexcept { return materialization.empty(); }
+    void ensureReverseLookup() const { materialization.ensureNodeToId(); }
 
     ActiveNodeId idFor(const InfoNode& node) const { return materialization.idFor(node); }
     InfoNode& nodeFor(ActiveNodeId id) const { return materialization.nodeFor(id); }
@@ -387,7 +421,14 @@ public:
     std::size_t size() const noexcept { return materialization.size(); }
     bool empty() const noexcept { return materialization.empty(); }
 
-    ActiveNodeId idFor(const InfoNode& node) const { return materialization.idFor(node); }
+    ActiveNodeId idFor(const InfoNode& node) const
+    {
+      auto it = csrMaterialization.stateIdToActiveId.find(node.stateId);
+      if (it == csrMaterialization.stateIdToActiveId.end()) {
+        throw std::out_of_range("CsrBackend::idFor() called for non-materialized node");
+      }
+      return it->second;
+    }
     InfoNode& nodeFor(ActiveNodeId id) const
     {
       assert(id < materialization.nodes.size());
@@ -582,6 +623,8 @@ public:
         m_activeGraphMaterialization.nodePointerBytes(),
         m_activeGraphMaterialization.nodeToIdEntryBytes(),
         m_activeGraphMaterialization.nodeToIdBucketBytes(),
+        m_csrMaterialization.stateIdEntryBytes(),
+        m_csrMaterialization.stateIdBucketBytes(),
         m_csrMaterialization.outOffsetBytes(),
         m_csrMaterialization.outTargetBytes(),
         m_csrMaterialization.outFlowBytes(),

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -432,17 +432,11 @@ private:
   /**
    * Return the number of effective core loops, i.e. not the last if not at coreLoopLimit
    */
-  unsigned int optimizeActiveNetwork() { return m_optimizer->optimizeActiveNetwork(); }
+  unsigned int optimizeActiveNetwork();
 
-  void moveActiveNodesToPredefinedModules(std::vector<unsigned int>& modules)
-  {
-    return m_optimizer->moveActiveNodesToPredefinedModules(modules);
-  }
+  void moveActiveNodesToPredefinedModules(std::vector<unsigned int>& modules);
 
-  void consolidateModules(bool replaceExistingModules = true)
-  {
-    return m_optimizer->consolidateModules(replaceExistingModules);
-  }
+  void consolidateModules(bool replaceExistingModules = true);
 
   unsigned int calculateNumNonTrivialTopModules() const;
 

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -112,6 +112,7 @@ public:
   struct BenchmarkStats {
     double calculateFlowSec = 0.0;
     double initNetworkSec = 0.0;
+    double materializeCsrSec = 0.0;
     double runPartitionSec = 0.0;
     double findTopModulesSec = 0.0;
     double fineTuneSec = 0.0;
@@ -134,6 +135,7 @@ public:
     {
       calculateFlowSec = 0.0;
       initNetworkSec = 0.0;
+      materializeCsrSec = 0.0;
       runPartitionSec = 0.0;
       findTopModulesSec = 0.0;
       fineTuneSec = 0.0;

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -166,6 +166,43 @@ public:
     }
   };
 
+  struct CsrMaterialization {
+    std::vector<unsigned int> outOffsets;
+    std::vector<unsigned int> outTargets;
+    std::vector<double> outWeights;
+    std::vector<double> outFlows;
+    std::vector<unsigned int> inOffsets;
+    std::vector<unsigned int> inTargets;
+    std::vector<double> inWeights;
+    std::vector<double> inFlows;
+    bool available = false;
+
+    void reset()
+    {
+      outOffsets.clear();
+      outTargets.clear();
+      outWeights.clear();
+      outFlows.clear();
+      inOffsets.clear();
+      inTargets.clear();
+      inWeights.clear();
+      inFlows.clear();
+      available = false;
+    }
+
+    std::size_t adjacencyBytes() const noexcept
+    {
+      return outOffsets.size() * sizeof(unsigned int)
+          + outTargets.size() * sizeof(unsigned int)
+          + outWeights.size() * sizeof(double)
+          + outFlows.size() * sizeof(double)
+          + inOffsets.size() * sizeof(unsigned int)
+          + inTargets.size() * sizeof(unsigned int)
+          + inWeights.size() * sizeof(double)
+          + inFlows.size() * sizeof(double);
+    }
+  };
+
   struct PointerBackend {
     using ActiveNodeId = ActiveGraphMaterialization::ActiveNodeId;
 
@@ -242,6 +279,70 @@ public:
   };
 
   using PointerActiveGraph = PointerBackend;
+
+  struct CsrBackend {
+    using ActiveNodeId = ActiveGraphMaterialization::ActiveNodeId;
+
+    struct EdgeSpan {
+      const unsigned int* targets = nullptr;
+      const double* weights = nullptr;
+      const double* flows = nullptr;
+      std::size_t size = 0;
+    };
+
+    CsrBackend(ActiveGraphMaterialization& materialization, CsrMaterialization& csrMaterialization)
+        : materialization(materialization),
+          csrMaterialization(csrMaterialization) { }
+
+    bool available() const noexcept { return csrMaterialization.available; }
+    std::size_t size() const noexcept { return materialization.size(); }
+    bool empty() const noexcept { return materialization.empty(); }
+
+    ActiveNodeId idFor(const InfoNode& node) const { return materialization.idFor(node); }
+    InfoNode& nodeFor(ActiveNodeId id) const { return materialization.nodeFor(id); }
+    ActiveNodePayload& payloadFor(ActiveNodeId id) { return materialization.payloadFor(id); }
+    const ActiveNodePayload& payloadFor(ActiveNodeId id) const { return materialization.payloadFor(id); }
+
+    EdgeSpan outEdges(ActiveNodeId id) const
+    {
+      if (!available()) {
+        return {};
+      }
+      if (id + 1 >= csrMaterialization.outOffsets.size()) {
+        throw std::out_of_range("CsrBackend::outEdges() id out of range");
+      }
+      const auto begin = csrMaterialization.outOffsets[id];
+      const auto end = csrMaterialization.outOffsets[id + 1];
+      return {
+          csrMaterialization.outTargets.data() + begin,
+          csrMaterialization.outWeights.data() + begin,
+          csrMaterialization.outFlows.data() + begin,
+          end - begin,
+      };
+    }
+
+    EdgeSpan inEdges(ActiveNodeId id) const
+    {
+      if (!available()) {
+        return {};
+      }
+      if (id + 1 >= csrMaterialization.inOffsets.size()) {
+        throw std::out_of_range("CsrBackend::inEdges() id out of range");
+      }
+      const auto begin = csrMaterialization.inOffsets[id];
+      const auto end = csrMaterialization.inOffsets[id + 1];
+      return {
+          csrMaterialization.inTargets.data() + begin,
+          csrMaterialization.inWeights.data() + begin,
+          csrMaterialization.inFlows.data() + begin,
+          end - begin,
+      };
+    }
+
+  private:
+    ActiveGraphMaterialization& materialization;
+    CsrMaterialization& csrMaterialization;
+  };
 
   InfomapBase() : InfomapConfig<InfomapBase>() { initOptimizer(); }
 
@@ -338,8 +439,11 @@ public:
   const BenchmarkStats& benchmarkStats() const noexcept { return m_benchmarkStats; }
   ActiveGraphMaterialization& activeGraphMaterialization() noexcept { return m_activeGraphMaterialization; }
   const ActiveGraphMaterialization& activeGraphMaterialization() const noexcept { return m_activeGraphMaterialization; }
+  CsrMaterialization& csrMaterialization() noexcept { return m_csrMaterialization; }
+  const CsrMaterialization& csrMaterialization() const noexcept { return m_csrMaterialization; }
   PointerBackend pointerBackend() noexcept { return PointerBackend(m_activeGraphMaterialization); }
   PointerActiveGraph pointerActiveGraph() noexcept { return pointerBackend(); }
+  CsrBackend csrBackend() noexcept { return CsrBackend(m_activeGraphMaterialization, m_csrMaterialization); }
 
   const Date& getStartDate() const { return m_startDate; }
   const Stopwatch& getElapsedTime() const { return m_elapsedTime; }
@@ -545,6 +649,7 @@ private:
   void setActiveNetworkFromChildrenOfRoot();
 
   void materializeActiveGraphPayload();
+  void materializeLeafLevelCsr();
 
   void syncActiveGraphPayloadToHierarchy();
 
@@ -728,6 +833,7 @@ protected:
   std::string m_currentParameters;
   BenchmarkStats m_benchmarkStats;
   ActiveGraphMaterialization m_activeGraphMaterialization;
+  CsrMaterialization m_csrMaterialization;
 
   std::unique_ptr<InfomapOptimizerBase> m_optimizer;
 };

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -99,9 +99,6 @@ public:
 
   struct ActiveNodePayload {
     FlowData data;
-    unsigned int stateId = 0;
-    unsigned int physicalId = 0;
-    unsigned int layerId = 0;
   };
 
   struct ActiveGraphMaterialization {

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -97,27 +97,21 @@ public:
     }
   };
 
-  struct ActiveNodePayload {
-    FlowData data;
-  };
-
   struct ActiveGraphMaterialization {
     using ActiveNodeId = unsigned int;
 
     std::vector<InfoNode*> nodes;
-    std::vector<ActiveNodePayload> payloads;
     std::unordered_map<InfoNode*, ActiveNodeId> nodeToId;
 
     void reset()
     {
       nodes.clear();
-      payloads.clear();
       nodeToId.clear();
     }
 
     std::size_t payloadBytes() const noexcept
     {
-      return payloads.size() * sizeof(ActiveNodePayload);
+      return 0;
     }
 
     std::size_t size() const noexcept
@@ -147,21 +141,6 @@ public:
       return *nodes[id];
     }
 
-    ActiveNodePayload& payloadFor(ActiveNodeId id)
-    {
-      if (id >= payloads.size()) {
-        throw std::out_of_range("ActiveGraphMaterialization::payloadFor() id out of range");
-      }
-      return payloads[id];
-    }
-
-    const ActiveNodePayload& payloadFor(ActiveNodeId id) const
-    {
-      if (id >= payloads.size()) {
-        throw std::out_of_range("ActiveGraphMaterialization::payloadFor() id out of range");
-      }
-      return payloads[id];
-    }
   };
 
   struct CsrMaterialization {
@@ -218,9 +197,6 @@ public:
 
     ActiveNodeId idFor(const InfoNode& node) const { return materialization.idFor(node); }
     InfoNode& nodeFor(ActiveNodeId id) const { return materialization.nodeFor(id); }
-    ActiveNodePayload& payloadFor(ActiveNodeId id) { return materialization.payloadFor(id); }
-    const ActiveNodePayload& payloadFor(ActiveNodeId id) const { return materialization.payloadFor(id); }
-
     unsigned int& moduleIndex(ActiveNodeId id) const { return nodeFor(id).index; }
     bool& dirty(ActiveNodeId id) const { return nodeFor(id).dirty; }
 
@@ -305,16 +281,6 @@ public:
     {
       assert(id < materialization.nodes.size());
       return *materialization.nodes[id];
-    }
-    ActiveNodePayload& payloadFor(ActiveNodeId id)
-    {
-      assert(id < materialization.payloads.size());
-      return materialization.payloads[id];
-    }
-    const ActiveNodePayload& payloadFor(ActiveNodeId id) const
-    {
-      assert(id < materialization.payloads.size());
-      return materialization.payloads[id];
     }
     unsigned int& moduleIndex(ActiveNodeId id) const
     {
@@ -712,8 +678,6 @@ private:
 
   void materializeActiveGraphPayload();
   void materializeLeafLevelCsr();
-
-  void syncActiveGraphPayloadToHierarchy();
   void syncActiveGraphStateToHierarchy();
 
   void initPartition() { return m_optimizer->initPartition(); }

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -23,6 +23,7 @@
 #include "../utils/Stopwatch.h"
 
 #include <vector>
+#include <algorithm>
 #include <deque>
 #include <map>
 #include <unordered_map>
@@ -47,6 +48,52 @@ class InfomapBase : public InfomapConfig<InfomapBase> {
 
 public:
   using PartitionQueue = detail::PartitionQueue;
+
+  struct ActiveGraphStorageBreakdown {
+    std::size_t activeNodePointerBytes = 0;
+    std::size_t activeNodeToIdEntryBytes = 0;
+    std::size_t activeNodeToIdBucketBytes = 0;
+    std::size_t csrOutOffsetBytes = 0;
+    std::size_t csrOutTargetBytes = 0;
+    std::size_t csrOutFlowBytes = 0;
+    std::size_t csrInOffsetBytes = 0;
+    std::size_t csrInTargetBytes = 0;
+    std::size_t csrInFlowBytes = 0;
+    std::size_t csrModuleIndexBytes = 0;
+    std::size_t csrDirtyFlagBytes = 0;
+    bool csrAvailable = false;
+
+    std::size_t totalBytes() const noexcept
+    {
+      return activeNodePointerBytes
+          + activeNodeToIdEntryBytes
+          + activeNodeToIdBucketBytes
+          + csrOutOffsetBytes
+          + csrOutTargetBytes
+          + csrOutFlowBytes
+          + csrInOffsetBytes
+          + csrInTargetBytes
+          + csrInFlowBytes
+          + csrModuleIndexBytes
+          + csrDirtyFlagBytes;
+    }
+
+    void maximize(const ActiveGraphStorageBreakdown& other) noexcept
+    {
+      activeNodePointerBytes = std::max(activeNodePointerBytes, other.activeNodePointerBytes);
+      activeNodeToIdEntryBytes = std::max(activeNodeToIdEntryBytes, other.activeNodeToIdEntryBytes);
+      activeNodeToIdBucketBytes = std::max(activeNodeToIdBucketBytes, other.activeNodeToIdBucketBytes);
+      csrOutOffsetBytes = std::max(csrOutOffsetBytes, other.csrOutOffsetBytes);
+      csrOutTargetBytes = std::max(csrOutTargetBytes, other.csrOutTargetBytes);
+      csrOutFlowBytes = std::max(csrOutFlowBytes, other.csrOutFlowBytes);
+      csrInOffsetBytes = std::max(csrInOffsetBytes, other.csrInOffsetBytes);
+      csrInTargetBytes = std::max(csrInTargetBytes, other.csrInTargetBytes);
+      csrInFlowBytes = std::max(csrInFlowBytes, other.csrInFlowBytes);
+      csrModuleIndexBytes = std::max(csrModuleIndexBytes, other.csrModuleIndexBytes);
+      csrDirtyFlagBytes = std::max(csrDirtyFlagBytes, other.csrDirtyFlagBytes);
+      csrAvailable = csrAvailable || other.csrAvailable;
+    }
+  };
 
   struct ConsolidationSnapshot {
     unsigned int level = 0;
@@ -74,6 +121,8 @@ public:
     unsigned int superModulesFastCalls = 0;
     unsigned int consolidationCount = 0;
     std::vector<ConsolidationSnapshot> consolidations;
+    ActiveGraphStorageBreakdown lastActiveGraphStorage;
+    ActiveGraphStorageBreakdown maxActiveGraphStorage;
 
     void reset()
     {
@@ -94,6 +143,8 @@ public:
       superModulesFastCalls = 0;
       consolidationCount = 0;
       consolidations.clear();
+      lastActiveGraphStorage = {};
+      maxActiveGraphStorage = {};
     }
   };
 
@@ -112,6 +163,26 @@ public:
     std::size_t payloadBytes() const noexcept
     {
       return 0;
+    }
+
+    std::size_t nodePointerBytes() const noexcept
+    {
+      return nodes.capacity() * sizeof(InfoNode*);
+    }
+
+    std::size_t nodeToIdEntryBytes() const noexcept
+    {
+      return nodeToId.size() * sizeof(typename decltype(nodeToId)::value_type);
+    }
+
+    std::size_t nodeToIdBucketBytes() const noexcept
+    {
+      return nodeToId.bucket_count() * sizeof(void*);
+    }
+
+    std::size_t storageBytes() const noexcept
+    {
+      return nodePointerBytes() + nodeToIdEntryBytes() + nodeToIdBucketBytes();
     }
 
     std::size_t size() const noexcept
@@ -169,14 +240,54 @@ public:
 
     std::size_t adjacencyBytes() const noexcept
     {
-      return outOffsets.size() * sizeof(unsigned int)
-          + outTargets.size() * sizeof(unsigned int)
-          + outFlows.size() * sizeof(double)
-          + inOffsets.size() * sizeof(unsigned int)
-          + inTargets.size() * sizeof(unsigned int)
-          + inFlows.size() * sizeof(double)
-          + moduleIndices.size() * sizeof(unsigned int)
-          + dirtyFlags.size() * sizeof(unsigned char);
+      return outOffsetBytes()
+          + outTargetBytes()
+          + outFlowBytes()
+          + inOffsetBytes()
+          + inTargetBytes()
+          + inFlowBytes()
+          + moduleIndexBytes()
+          + dirtyFlagBytes();
+    }
+
+    std::size_t outOffsetBytes() const noexcept
+    {
+      return outOffsets.capacity() * sizeof(unsigned int);
+    }
+
+    std::size_t outTargetBytes() const noexcept
+    {
+      return outTargets.capacity() * sizeof(unsigned int);
+    }
+
+    std::size_t outFlowBytes() const noexcept
+    {
+      return outFlows.capacity() * sizeof(double);
+    }
+
+    std::size_t inOffsetBytes() const noexcept
+    {
+      return inOffsets.capacity() * sizeof(unsigned int);
+    }
+
+    std::size_t inTargetBytes() const noexcept
+    {
+      return inTargets.capacity() * sizeof(unsigned int);
+    }
+
+    std::size_t inFlowBytes() const noexcept
+    {
+      return inFlows.capacity() * sizeof(double);
+    }
+
+    std::size_t moduleIndexBytes() const noexcept
+    {
+      return moduleIndices.capacity() * sizeof(unsigned int);
+    }
+
+    std::size_t dirtyFlagBytes() const noexcept
+    {
+      return dirtyFlags.capacity() * sizeof(unsigned char);
     }
   };
 
@@ -465,6 +576,23 @@ public:
   double getMaxEntropy() { return m_maxEntropy; }
   double getMaxFlow() { return m_maxFlow; }
   const BenchmarkStats& benchmarkStats() const noexcept { return m_benchmarkStats; }
+  ActiveGraphStorageBreakdown activeGraphStorageBreakdown() const noexcept
+  {
+    return {
+        m_activeGraphMaterialization.nodePointerBytes(),
+        m_activeGraphMaterialization.nodeToIdEntryBytes(),
+        m_activeGraphMaterialization.nodeToIdBucketBytes(),
+        m_csrMaterialization.outOffsetBytes(),
+        m_csrMaterialization.outTargetBytes(),
+        m_csrMaterialization.outFlowBytes(),
+        m_csrMaterialization.inOffsetBytes(),
+        m_csrMaterialization.inTargetBytes(),
+        m_csrMaterialization.inFlowBytes(),
+        m_csrMaterialization.moduleIndexBytes(),
+        m_csrMaterialization.dirtyFlagBytes(),
+        m_csrMaterialization.available,
+    };
+  }
   ActiveGraphMaterialization& activeGraphMaterialization() noexcept { return m_activeGraphMaterialization; }
   const ActiveGraphMaterialization& activeGraphMaterialization() const noexcept { return m_activeGraphMaterialization; }
   CsrMaterialization& csrMaterialization() noexcept { return m_csrMaterialization; }

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -175,6 +175,8 @@ public:
     std::vector<unsigned int> inTargets;
     std::vector<double> inWeights;
     std::vector<double> inFlows;
+    std::vector<unsigned int> moduleIndices;
+    std::vector<bool> dirtyFlags;
     bool available = false;
 
     void reset()
@@ -187,6 +189,8 @@ public:
       inTargets.clear();
       inWeights.clear();
       inFlows.clear();
+      moduleIndices.clear();
+      dirtyFlags.clear();
       available = false;
     }
 
@@ -199,7 +203,9 @@ public:
           + inOffsets.size() * sizeof(unsigned int)
           + inTargets.size() * sizeof(unsigned int)
           + inWeights.size() * sizeof(double)
-          + inFlows.size() * sizeof(double);
+          + inFlows.size() * sizeof(double)
+          + moduleIndices.size() * sizeof(unsigned int)
+          + dirtyFlags.size() * sizeof(bool);
     }
   };
 
@@ -308,8 +314,37 @@ public:
     InfoNode& nodeFor(ActiveNodeId id) const { return materialization.nodeFor(id); }
     ActiveNodePayload& payloadFor(ActiveNodeId id) { return materialization.payloadFor(id); }
     const ActiveNodePayload& payloadFor(ActiveNodeId id) const { return materialization.payloadFor(id); }
-    unsigned int& moduleIndex(ActiveNodeId id) const { return nodeFor(id).index; }
-    bool& dirty(ActiveNodeId id) const { return nodeFor(id).dirty; }
+    unsigned int& moduleIndex(ActiveNodeId id) const
+    {
+      if (id >= csrMaterialization.moduleIndices.size()) {
+        throw std::out_of_range("CsrBackend::moduleIndex() id out of range");
+      }
+      return csrMaterialization.moduleIndices[id];
+    }
+
+    struct DirtyRef {
+      std::vector<bool>* flags = nullptr;
+      std::size_t index = 0;
+
+      DirtyRef& operator=(bool value)
+      {
+        (*flags)[index] = value;
+        return *this;
+      }
+
+      operator bool() const
+      {
+        return (*flags)[index];
+      }
+    };
+
+    DirtyRef dirty(ActiveNodeId id) const
+    {
+      if (id >= csrMaterialization.dirtyFlags.size()) {
+        throw std::out_of_range("CsrBackend::dirty() id out of range");
+      }
+      return DirtyRef{&csrMaterialization.dirtyFlags, id};
+    }
 
     template <typename Fn>
     void forEachOutEdge(ActiveNodeId id, Fn&& fn) const
@@ -688,6 +723,7 @@ private:
   void materializeLeafLevelCsr();
 
   void syncActiveGraphPayloadToHierarchy();
+  void syncActiveGraphStateToHierarchy();
 
   void initPartition() { return m_optimizer->initPartition(); }
 

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -903,153 +903,156 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleInParalle
 {
   auto graph = m_infomap->pointerBackend();
   // Get random enumeration of nodes
-  auto& network = m_infomap->activeNetwork();
-  std::vector<unsigned int> nodeEnumeration(network.size());
+  const auto numNodes = graph.size();
+  std::vector<unsigned int> nodeEnumeration(numNodes);
   m_infomap->m_rand.getRandomizedIndexVector(nodeEnumeration);
 
-  auto numNodes = nodeEnumeration.size();
   unsigned int numMoved = 0;
   unsigned int numInvalidMoves = 0;
 
-#pragma omp parallel for schedule(dynamic) // Use dynamic scheduling as some threads could end early
-  for (unsigned int i = 0; i < numNodes; ++i) {
-    // Pick nodes in random order
-    const auto currentId = nodeEnumeration[i];
-    InfoNode& current = graph.nodeFor(currentId);
-
-    if (!graph.dirty(currentId))
-      continue;
-
-    // If other nodes have moved here, don't move away on first loop
-    const auto currentModuleIndex = graph.moduleIndex(currentId);
-    if (m_moduleMembers[currentModuleIndex] > 1 && m_infomap->isFirstLoop() && m_infomap->tuneIterationLimit != 1)
-      continue;
-
-    // If no links connecting this node with other nodes, it won't move into others,
-    // and others won't move into this. TODO: Always best leave it alone?
-    // For memory networks, don't skip try move to same physical node!
-
-    // Create map with module links
+#pragma omp parallel
+  {
     VectorMap<DeltaFlowDataType> deltaFlow(numNodes);
 
-    addNeighbourModuleLinks(graph, currentId, deltaFlow);
+#pragma omp for schedule(dynamic) // Use dynamic scheduling as some threads could end early
+    for (unsigned int i = 0; i < numNodes; ++i) {
+    // Pick nodes in random order
+      const auto currentId = nodeEnumeration[i];
+      InfoNode& current = graph.nodeFor(currentId);
 
-    // For not moving
-    deltaFlow.add(currentModuleIndex, DeltaFlowDataType(currentModuleIndex, 0.0, 0.0));
-    DeltaFlowDataType& oldModuleDelta = deltaFlow[currentModuleIndex];
-    oldModuleDelta.module = currentModuleIndex; // Make sure index is correct if created new
+      if (!graph.dirty(currentId))
+        continue;
 
-    // Option to move to empty module (if node not already alone)
-    if (m_moduleMembers[currentModuleIndex] > 1 && !m_emptyModules.empty()) {
-      // deltaFlow[m_emptyModules.back()] += DeltaFlowDataType(m_emptyModules.back(), 0.0, 0.0);
-      deltaFlow.add(m_emptyModules.back(), DeltaFlowDataType(m_emptyModules.back(), 0.0, 0.0));
-    }
+      // If other nodes have moved here, don't move away on first loop
+      const auto currentModuleIndex = graph.moduleIndex(currentId);
+      if (m_moduleMembers[currentModuleIndex] > 1 && m_infomap->isFirstLoop() && m_infomap->tuneIterationLimit != 1)
+        continue;
 
-    // For memory networks
-    m_objective.addMemoryContributions(current, oldModuleDelta, deltaFlow);
+      // If no links connecting this node with other nodes, it won't move into others,
+      // and others won't move into this. TODO: Always best leave it alone?
+      // For memory networks, don't skip try move to same physical node!
 
-    auto& moduleDeltaEnterExit = deltaFlow.values();
-    unsigned int numModuleLinks = deltaFlow.size();
+      deltaFlow.startRound();
 
-    // Randomize link order for optimized search
-    if (numModuleLinks > 2) {
-      for (unsigned int j = 0; j < numModuleLinks - 2; ++j) {
-        unsigned int randPos = m_infomap->m_rand.randInt(j + 1, numModuleLinks - 1);
-        swap(moduleDeltaEnterExit[j], moduleDeltaEnterExit[randPos]);
+      addNeighbourModuleLinks(graph, currentId, deltaFlow);
+
+      // For not moving
+      deltaFlow.add(currentModuleIndex, DeltaFlowDataType(currentModuleIndex, 0.0, 0.0));
+      DeltaFlowDataType& oldModuleDelta = deltaFlow[currentModuleIndex];
+      oldModuleDelta.module = currentModuleIndex; // Make sure index is correct if created new
+
+      // Option to move to empty module (if node not already alone)
+      if (m_moduleMembers[currentModuleIndex] > 1 && !m_emptyModules.empty()) {
+        // deltaFlow[m_emptyModules.back()] += DeltaFlowDataType(m_emptyModules.back(), 0.0, 0.0);
+        deltaFlow.add(m_emptyModules.back(), DeltaFlowDataType(m_emptyModules.back(), 0.0, 0.0));
       }
-    }
 
-    DeltaFlowDataType bestDeltaModule(oldModuleDelta);
-    double bestDeltaCodelength = 0.0;
-    DeltaFlowDataType strongestConnectedModule(oldModuleDelta);
-    double deltaCodelengthOnStrongestConnectedModule = 0.0;
+      // For memory networks
+      m_objective.addMemoryContributions(current, oldModuleDelta, deltaFlow);
 
-    // Find the move that minimizes the description length
-    for (unsigned int j = 0; j < deltaFlow.size(); ++j) {
-      unsigned int otherModule = moduleDeltaEnterExit[j].module;
-      if (otherModule != currentModuleIndex) {
-        double deltaCodelength = m_objective.getDeltaCodelengthOnMovingNode(current,
-                                                                            oldModuleDelta,
-                                                                            moduleDeltaEnterExit[j],
-                                                                            m_moduleFlowData,
-                                                                            m_moduleMembers);
+      auto& moduleDeltaEnterExit = deltaFlow.values();
+      unsigned int numModuleLinks = deltaFlow.size();
 
-        if (deltaCodelength < bestDeltaCodelength - m_infomap->minimumSingleNodeCodelengthImprovement) {
-          bestDeltaModule = moduleDeltaEnterExit[j];
-          bestDeltaCodelength = deltaCodelength;
-        }
-
-        // Save strongest connected module to prefer if codelength improvement equal
-        if (moduleDeltaEnterExit[j].deltaExit > strongestConnectedModule.deltaExit) {
-          strongestConnectedModule = moduleDeltaEnterExit[j];
-          deltaCodelengthOnStrongestConnectedModule = deltaCodelength;
+      // Randomize link order for optimized search
+      if (numModuleLinks > 2) {
+        for (unsigned int j = 0; j < numModuleLinks - 2; ++j) {
+          unsigned int randPos = m_infomap->m_rand.randInt(j + 1, numModuleLinks - 1);
+          swap(moduleDeltaEnterExit[j], moduleDeltaEnterExit[randPos]);
         }
       }
-    }
 
-    // Prefer strongest connected module if equal delta codelength
-    if (strongestConnectedModule.module != bestDeltaModule.module && deltaCodelengthOnStrongestConnectedModule <= bestDeltaCodelength + m_infomap->minimumSingleNodeCodelengthImprovement) {
-      bestDeltaModule = strongestConnectedModule;
-    }
+      DeltaFlowDataType bestDeltaModule(oldModuleDelta);
+      double bestDeltaCodelength = 0.0;
+      DeltaFlowDataType strongestConnectedModule(oldModuleDelta);
+      double deltaCodelengthOnStrongestConnectedModule = 0.0;
 
-    // Make best possible move
-    if (bestDeltaModule.module == currentModuleIndex) {
-      graph.dirty(currentId) = false;
-      continue;
-    } else {
-#pragma omp critical(moveUpdate)
-      {
-        unsigned int bestModuleIndex = bestDeltaModule.module;
-        unsigned int oldModuleIndex = graph.moduleIndex(currentId);
-        const bool targetsCurrentEmptyModule = !m_emptyModules.empty() && bestModuleIndex == m_emptyModules.back();
-
-        bool validMove = targetsCurrentEmptyModule
-            // Check validity of move to empty target
-            ? m_moduleMembers[oldModuleIndex] > 1 && !m_emptyModules.empty()
-            // Not valid if the best module is empty now but not when decided
-            : m_moduleMembers[bestModuleIndex] > 0;
-
-        if (validMove) {
-          // Recalculate delta codelength for proposed move to see if still an improvement
-          oldModuleDelta = DeltaFlowDataType(oldModuleIndex, 0.0, 0.0);
-          DeltaFlowDataType newModuleDelta(bestModuleIndex, 0.0, 0.0);
-
-          accumulateMoveDelta(graph, currentId, oldModuleIndex, bestModuleIndex, oldModuleDelta, newModuleDelta);
-
-          // For memory networks
-          m_objective.addMemoryContributions(current, oldModuleDelta, deltaFlow);
-
+      // Find the move that minimizes the description length
+      for (unsigned int j = 0; j < deltaFlow.size(); ++j) {
+        unsigned int otherModule = moduleDeltaEnterExit[j].module;
+        if (otherModule != currentModuleIndex) {
           double deltaCodelength = m_objective.getDeltaCodelengthOnMovingNode(current,
                                                                               oldModuleDelta,
-                                                                              newModuleDelta,
+                                                                              moduleDeltaEnterExit[j],
                                                                               m_moduleFlowData,
                                                                               m_moduleMembers);
 
-          if (deltaCodelength < 0.0 - m_infomap->minimumSingleNodeCodelengthImprovement) {
-            // Update empty module vector
-            if (m_moduleMembers[bestModuleIndex] == 0) {
-              m_emptyModules.pop_back();
+          if (deltaCodelength < bestDeltaCodelength - m_infomap->minimumSingleNodeCodelengthImprovement) {
+            bestDeltaModule = moduleDeltaEnterExit[j];
+            bestDeltaCodelength = deltaCodelength;
+          }
+
+          // Save strongest connected module to prefer if codelength improvement equal
+          if (moduleDeltaEnterExit[j].deltaExit > strongestConnectedModule.deltaExit) {
+            strongestConnectedModule = moduleDeltaEnterExit[j];
+            deltaCodelengthOnStrongestConnectedModule = deltaCodelength;
+          }
+        }
+      }
+
+      // Prefer strongest connected module if equal delta codelength
+      if (strongestConnectedModule.module != bestDeltaModule.module && deltaCodelengthOnStrongestConnectedModule <= bestDeltaCodelength + m_infomap->minimumSingleNodeCodelengthImprovement) {
+        bestDeltaModule = strongestConnectedModule;
+      }
+
+      // Make best possible move
+      if (bestDeltaModule.module == currentModuleIndex) {
+        graph.dirty(currentId) = false;
+        continue;
+      } else {
+#pragma omp critical(moveUpdate)
+        {
+          unsigned int bestModuleIndex = bestDeltaModule.module;
+          unsigned int oldModuleIndex = graph.moduleIndex(currentId);
+          const bool targetsCurrentEmptyModule = !m_emptyModules.empty() && bestModuleIndex == m_emptyModules.back();
+
+          bool validMove = targetsCurrentEmptyModule
+              // Check validity of move to empty target
+              ? m_moduleMembers[oldModuleIndex] > 1 && !m_emptyModules.empty()
+              // Not valid if the best module is empty now but not when decided
+              : m_moduleMembers[bestModuleIndex] > 0;
+
+          if (validMove) {
+            // Recalculate delta codelength for proposed move to see if still an improvement
+            oldModuleDelta = DeltaFlowDataType(oldModuleIndex, 0.0, 0.0);
+            DeltaFlowDataType newModuleDelta(bestModuleIndex, 0.0, 0.0);
+
+            accumulateMoveDelta(graph, currentId, oldModuleIndex, bestModuleIndex, oldModuleDelta, newModuleDelta);
+
+            // For memory networks
+            m_objective.addMemoryContributions(current, oldModuleDelta, deltaFlow);
+
+            double deltaCodelength = m_objective.getDeltaCodelengthOnMovingNode(current,
+                                                                                oldModuleDelta,
+                                                                                newModuleDelta,
+                                                                                m_moduleFlowData,
+                                                                                m_moduleMembers);
+
+            if (deltaCodelength < 0.0 - m_infomap->minimumSingleNodeCodelengthImprovement) {
+              // Update empty module vector
+              if (m_moduleMembers[bestModuleIndex] == 0) {
+                m_emptyModules.pop_back();
+              }
+              if (m_moduleMembers[oldModuleIndex] == 1) {
+                m_emptyModules.push_back(oldModuleIndex);
+              }
+
+              m_objective.updateCodelengthOnMovingNode(current, oldModuleDelta, bestDeltaModule, m_moduleFlowData, m_moduleMembers);
+
+              m_moduleMembers[oldModuleIndex] -= 1;
+              m_moduleMembers[bestModuleIndex] += 1;
+
+              graph.moduleIndex(currentId) = bestModuleIndex;
+
+              ++numMoved;
+
+              // Mark neighbours as dirty
+              markNodeNeighboursDirty(graph, currentId);
+            } else {
+              ++numInvalidMoves;
             }
-            if (m_moduleMembers[oldModuleIndex] == 1) {
-              m_emptyModules.push_back(oldModuleIndex);
-            }
-
-            m_objective.updateCodelengthOnMovingNode(current, oldModuleDelta, bestDeltaModule, m_moduleFlowData, m_moduleMembers);
-
-            m_moduleMembers[oldModuleIndex] -= 1;
-            m_moduleMembers[bestModuleIndex] += 1;
-
-            graph.moduleIndex(currentId) = bestModuleIndex;
-
-            ++numMoved;
-
-            // Mark neighbours as dirty
-            markNodeNeighboursDirty(graph, currentId);
           } else {
             ++numInvalidMoves;
           }
-        } else {
-          ++numInvalidMoves;
         }
       }
     }

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -193,7 +193,9 @@ void InfomapOptimizer<Objective>::moveActiveNodesToPredefinedModules(std::vector
 template <typename Objective>
 bool InfomapOptimizer<Objective>::moveNodeToPredefinedModule(InfoNode& current, unsigned int newModule)
 {
-  unsigned int oldM = current.index;
+  auto graph = m_infomap->pointerActiveGraph();
+  auto currentId = graph.idFor(current);
+  unsigned int oldM = graph.moduleIndex(currentId);
   unsigned int newM = newModule;
 
   if (newM == oldM) {
@@ -204,25 +206,23 @@ bool InfomapOptimizer<Objective>::moveNodeToPredefinedModule(InfoNode& current, 
   DeltaFlowDataType newModuleDelta(newM, 0.0, 0.0);
 
   // For all outlinks
-  for (auto& e : current.outEdges()) {
-    auto& edge = *e;
-    unsigned int otherModule = edge.target->index;
+  graph.forEachOutEdge(currentId, [&](auto neighbourId, const InfoNode&, const InfoEdge& edge) {
+    unsigned int otherModule = graph.moduleIndex(neighbourId);
     if (otherModule == oldM) {
       oldModuleDelta.deltaExit += edge.data.flow;
     } else if (otherModule == newM) {
       newModuleDelta.deltaExit += edge.data.flow;
     }
-  }
+  });
   // For all inlinks
-  for (auto& e : current.inEdges()) {
-    auto& edge = *e;
-    unsigned int otherModule = edge.source->index;
+  graph.forEachInEdge(currentId, [&](auto neighbourId, const InfoNode&, const InfoEdge& edge) {
+    unsigned int otherModule = graph.moduleIndex(neighbourId);
     if (otherModule == oldM) {
       oldModuleDelta.deltaEnter += edge.data.flow;
     } else if (otherModule == newM) {
       newModuleDelta.deltaEnter += edge.data.flow;
     }
-  }
+  });
 
   // For recorded teleportation
   if (m_infomap->recordedTeleportation) {
@@ -242,7 +242,7 @@ bool InfomapOptimizer<Objective>::moveNodeToPredefinedModule(InfoNode& current, 
   if (m_moduleMembers[newM] == 0) {
     m_emptyModules.pop_back();
   }
-  if (m_moduleMembers[current.index] == 1) {
+  if (m_moduleMembers[oldM] == 1) {
     m_emptyModules.push_back(oldM);
   }
 
@@ -251,7 +251,7 @@ bool InfomapOptimizer<Objective>::moveNodeToPredefinedModule(InfoNode& current, 
   m_moduleMembers[oldM] -= 1;
   m_moduleMembers[newM] += 1;
 
-  current.index = newM;
+  graph.moduleIndex(currentId) = newM;
   return true;
 }
 
@@ -287,9 +287,9 @@ inline unsigned int InfomapOptimizer<Objective>::optimizeActiveNetwork()
 template <typename Objective>
 unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModule()
 {
+  auto graph = m_infomap->pointerActiveGraph();
   // Get random enumeration of nodes
-  auto& network = m_infomap->activeNetwork();
-  std::vector<unsigned int> nodeEnumeration(network.size());
+  std::vector<unsigned int> nodeEnumeration(graph.size());
   m_infomap->m_rand.getRandomizedIndexVector(nodeEnumeration);
 
   auto numNodes = nodeEnumeration.size();
@@ -299,13 +299,15 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModule()
   VectorMap<DeltaFlowDataType> deltaFlow(numNodes);
 
   for (unsigned int i = 0; i < numNodes; ++i) {
-    InfoNode& current = *network[nodeEnumeration[i]];
+    auto currentId = nodeEnumeration[i];
+    InfoNode& current = graph.nodeFor(currentId);
+    unsigned int currentModuleIndex = graph.moduleIndex(currentId);
 
-    if (!current.dirty)
+    if (!graph.dirty(currentId))
       continue;
 
     // If other nodes have moved here, don't move away on first loop
-    if (m_moduleMembers[current.index] > 1 && m_infomap->isFirstLoop() && m_infomap->tuneIterationLimit != 1)
+    if (m_moduleMembers[currentModuleIndex] > 1 && m_infomap->isFirstLoop() && m_infomap->tuneIterationLimit != 1)
       continue;
 
     // If no links connecting this node with other nodes, it won't move into others,
@@ -315,25 +317,23 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModule()
     deltaFlow.startRound();
 
     // For all outlinks
-    for (auto& e : current.outEdges()) {
-      auto& edge = *e;
-      InfoNode* neighbour = edge.target;
-      deltaFlow.add(neighbour->index, DeltaFlowDataType(neighbour->index, edge.data.flow, 0.0));
-    }
+    graph.forEachOutEdge(currentId, [&](auto neighbourId, const InfoNode&, const InfoEdge& edge) {
+      auto otherModule = graph.moduleIndex(neighbourId);
+      deltaFlow.add(otherModule, DeltaFlowDataType(otherModule, edge.data.flow, 0.0));
+    });
     // For all inlinks
-    for (auto& e : current.inEdges()) {
-      auto& edge = *e;
-      InfoNode* neighbour = edge.source;
-      deltaFlow.add(neighbour->index, DeltaFlowDataType(neighbour->index, 0.0, edge.data.flow));
-    }
+    graph.forEachInEdge(currentId, [&](auto neighbourId, const InfoNode&, const InfoEdge& edge) {
+      auto otherModule = graph.moduleIndex(neighbourId);
+      deltaFlow.add(otherModule, DeltaFlowDataType(otherModule, 0.0, edge.data.flow));
+    });
 
     // For not moving
-    deltaFlow.add(current.index, DeltaFlowDataType(current.index, 0.0, 0.0));
-    DeltaFlowDataType& oldModuleDelta = deltaFlow[current.index];
-    oldModuleDelta.module = current.index; // Make sure index is correct if created new
+    deltaFlow.add(currentModuleIndex, DeltaFlowDataType(currentModuleIndex, 0.0, 0.0));
+    DeltaFlowDataType& oldModuleDelta = deltaFlow[currentModuleIndex];
+    oldModuleDelta.module = currentModuleIndex; // Make sure index is correct if created new
 
     // Option to move to empty module (if node not already alone)
-    if (m_moduleMembers[current.index] > 1 && !m_emptyModules.empty()) {
+    if (m_moduleMembers[currentModuleIndex] > 1 && !m_emptyModules.empty()) {
       deltaFlow.add(m_emptyModules.back(), DeltaFlowDataType(m_emptyModules.back(), 0.0, 0.0));
     }
 
@@ -348,7 +348,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModule()
       for (unsigned int j = 0; j < numModuleLinks; ++j) {
         auto& deltaEnterExit = moduleDeltaEnterExit[j];
         auto moduleIndex = deltaEnterExit.module;
-        if (moduleIndex == current.index) {
+        if (moduleIndex == currentModuleIndex) {
           auto& oldModuleFlowData = m_moduleFlowData[moduleIndex];
           double deltaEnterOld = (oldModuleFlowData.teleportFlow - current.data.teleportFlow) * current.data.teleportWeight;
           double deltaExitOld = current.data.teleportFlow * (oldModuleFlowData.teleportWeight - current.data.teleportWeight);
@@ -375,7 +375,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModule()
     for (unsigned int k = 0; k < numModuleLinks; ++k) {
       auto j = moduleEnumeration[k];
       unsigned int otherModule = moduleDeltaEnterExit[j].module;
-      if (otherModule != current.index) {
+      if (otherModule != currentModuleIndex) {
         double deltaCodelength = m_objective.getDeltaCodelengthOnMovingNode(current,
                                                                             oldModuleDelta,
                                                                             moduleDeltaEnterExit[j],
@@ -401,43 +401,43 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModule()
     }
 
     // Make best possible move
-    if (bestDeltaModule.module != current.index) {
+    if (bestDeltaModule.module != currentModuleIndex) {
       unsigned int bestModuleIndex = bestDeltaModule.module;
       // Update empty module vector
       if (m_moduleMembers[bestModuleIndex] == 0) {
         m_emptyModules.pop_back();
       }
-      if (m_moduleMembers[current.index] == 1) {
-        m_emptyModules.push_back(current.index);
+      if (m_moduleMembers[currentModuleIndex] == 1) {
+        m_emptyModules.push_back(currentModuleIndex);
       }
 
       m_objective.updateCodelengthOnMovingNode(current, oldModuleDelta, bestDeltaModule, m_moduleFlowData, m_moduleMembers);
 
-      m_moduleMembers[current.index] -= 1;
+      m_moduleMembers[currentModuleIndex] -= 1;
       m_moduleMembers[bestModuleIndex] += 1;
 
-      unsigned int oldModuleIndex = current.index;
-      current.index = bestModuleIndex;
+      unsigned int oldModuleIndex = currentModuleIndex;
+      graph.moduleIndex(currentId) = bestModuleIndex;
 
       ++numMoved;
 
       InfoNode* nodeInOldModule = &current;
       unsigned int numLinkedNodesInOldModule = 0;
       // Mark neighbours as dirty
-      for (auto& e : current.outEdges()) {
-        e->target->dirty = true;
-        if (e->target->index == oldModuleIndex) {
-          nodeInOldModule = e->target;
+      graph.forEachOutEdge(currentId, [&](auto neighbourId, InfoNode& neighbour, const InfoEdge&) {
+        graph.dirty(neighbourId) = true;
+        if (graph.moduleIndex(neighbourId) == oldModuleIndex) {
+          nodeInOldModule = &neighbour;
           ++numLinkedNodesInOldModule;
         }
-      }
-      for (auto& e : current.inEdges()) {
-        e->source->dirty = true;
-        if (e->source->index == oldModuleIndex) {
-          nodeInOldModule = e->source;
+      });
+      graph.forEachInEdge(currentId, [&](auto neighbourId, InfoNode& neighbour, const InfoEdge&) {
+        graph.dirty(neighbourId) = true;
+        if (graph.moduleIndex(neighbourId) == oldModuleIndex) {
+          nodeInOldModule = &neighbour;
           ++numLinkedNodesInOldModule;
         }
-      }
+      });
 
       // Move single connected nodes to same module
       if (numLinkedNodesInOldModule == 1 && m_moduleMembers[oldModuleIndex] == 1) {
@@ -445,14 +445,17 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModule()
         ++numMoved;
         // Mark neighbours as dirty
         if (nodeInOldModule->degree() > 1) {
-          for (auto& e : nodeInOldModule->outEdges())
-            e->target->dirty = true;
-          for (auto& e : nodeInOldModule->inEdges())
-            e->source->dirty = true;
+          auto linkedNodeId = graph.idFor(*nodeInOldModule);
+          graph.forEachOutEdge(linkedNodeId, [&](auto neighbourId, InfoNode&, const InfoEdge&) {
+            graph.dirty(neighbourId) = true;
+          });
+          graph.forEachInEdge(linkedNodeId, [&](auto neighbourId, InfoNode&, const InfoEdge&) {
+            graph.dirty(neighbourId) = true;
+          });
         }
       }
     } else {
-      current.dirty = false;
+      graph.dirty(currentId) = false;
     }
   }
 

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -658,11 +658,11 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleInParalle
 template <typename Objective>
 inline void InfomapOptimizer<Objective>::consolidateModules(bool replaceExistingModules)
 {
-  auto& network = m_infomap->activeNetwork();
-  auto numNodes = network.size();
+  auto graph = m_infomap->pointerActiveGraph();
+  auto numNodes = graph.size();
   std::vector<InfoNode*> modules(numNodes, nullptr);
 
-  InfoNode& firstActiveNode = *network[0];
+  InfoNode& firstActiveNode = graph.nodeFor(0);
   auto level = firstActiveNode.depth();
   auto leafLevel = m_infomap->numLevels();
 
@@ -670,40 +670,39 @@ inline void InfomapOptimizer<Objective>::consolidateModules(bool replaceExisting
     replaceExistingModules = false;
 
   // Release children pointers on current parent(s) to put new modules between
-  for (auto& n : network) {
-    n->parent->releaseChildren(); // Safe to call multiple times
+  for (unsigned int i = 0; i < numNodes; ++i) {
+    graph.nodeFor(i).parent->releaseChildren(); // Safe to call multiple times
   }
 
   // Create the new module nodes and re-parent the active network from its common parent to the new module level
   for (unsigned int i = 0; i < numNodes; ++i) {
-    InfoNode* node = network[i];
-    unsigned int moduleIndex = node->index;
+    InfoNode& node = graph.nodeFor(i);
+    unsigned int moduleIndex = graph.moduleIndex(i);
     if (modules[moduleIndex] == nullptr) {
       modules[moduleIndex] = new InfoNode(m_moduleFlowData[moduleIndex]);
       modules[moduleIndex]->index = moduleIndex;
-      node->parent->addChild(modules[moduleIndex]);
+      node.parent->addChild(modules[moduleIndex]);
     }
-    modules[moduleIndex]->addChild(node);
+    modules[moduleIndex]->addChild(&node);
   }
 
   using NodePair = std::pair<unsigned int, unsigned int>;
   using EdgeMap = std::map<NodePair, double>;
   EdgeMap moduleLinks;
 
-  for (auto& node : network) {
-    unsigned int module1 = node->index;
-    for (auto& e : node->outEdges()) {
-      InfoEdge& edge = *e;
-      unsigned int module2 = edge.target->index;
+  for (unsigned int i = 0; i < numNodes; ++i) {
+    unsigned int module1 = graph.moduleIndex(i);
+    for (const auto& edge : graph.outEdges(i)) {
+      unsigned int module2 = graph.moduleIndex(edge.neighbourId);
       if (module1 != module2) {
         // Use new variables to not swap module1
         unsigned int m1 = module1, m2 = module2;
         // If undirected, the order may be swapped to aggregate the edge on an opposite one
         if (m_infomap->isUndirectedClustering() && m1 > m2)
           std::swap(m1, m2);
-        auto ret = moduleLinks.insert(std::make_pair(NodePair(m1, m2), edge.data.flow));
+        auto ret = moduleLinks.insert(std::make_pair(NodePair(m1, m2), edge.flow));
         if (!ret.second) {
-          ret.first->second += edge.data.flow;
+          ret.first->second += edge.flow;
         }
       }
     }
@@ -726,8 +725,8 @@ inline void InfomapOptimizer<Objective>::consolidateModules(bool replaceExisting
   if (replaceExistingModules) {
     if (level == 1) {
       Log(4) << "Consolidated super modules, removing old modules...\n";
-      for (auto& node : network)
-        node->replaceWithChildren();
+      for (unsigned int i = 0; i < numNodes; ++i)
+        graph.nodeFor(i).replaceWithChildren();
     } else if (level == 2) {
       Log(4) << "Consolidated sub-modules, removing modules...\n";
       unsigned int moduleIndex = 0;

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -1224,6 +1224,10 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleInParalle
   auto graph = m_infomap->pointerBackend();
   // Get random enumeration of nodes
   const auto numNodes = graph.size();
+  const bool lockFirstLoopMoves = m_infomap->isFirstLoop() && m_infomap->tuneIterationLimit != 1;
+  const double minimumSingleNodeImprovement = m_infomap->minimumSingleNodeCodelengthImprovement;
+  auto& moduleFlowData = m_moduleFlowData;
+  auto& moduleMembers = m_moduleMembers;
   std::vector<unsigned int> nodeEnumeration(numNodes);
   m_infomap->m_rand.getRandomizedIndexVector(nodeEnumeration);
 
@@ -1240,12 +1244,12 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleInParalle
       const auto currentId = nodeEnumeration[i];
       InfoNode& current = graph.nodeFor(currentId);
 
-      if (!graph.dirty(currentId))
+      if (!current.dirty)
         continue;
 
       // If other nodes have moved here, don't move away on first loop
-      const auto currentModuleIndex = graph.moduleIndex(currentId);
-      if (m_moduleMembers[currentModuleIndex] > 1 && m_infomap->isFirstLoop() && m_infomap->tuneIterationLimit != 1)
+      const auto currentModuleIndex = current.index;
+      if (moduleMembers[currentModuleIndex] > 1 && lockFirstLoopMoves)
         continue;
 
       // If no links connecting this node with other nodes, it won't move into others,
@@ -1262,7 +1266,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleInParalle
       oldModuleDelta.module = currentModuleIndex; // Make sure index is correct if created new
 
       // Option to move to empty module (if node not already alone)
-      if (m_moduleMembers[currentModuleIndex] > 1 && !m_emptyModules.empty()) {
+      if (moduleMembers[currentModuleIndex] > 1 && !m_emptyModules.empty()) {
         // deltaFlow[m_emptyModules.back()] += DeltaFlowDataType(m_emptyModules.back(), 0.0, 0.0);
         deltaFlow.add(m_emptyModules.back(), DeltaFlowDataType(m_emptyModules.back(), 0.0, 0.0));
       }
@@ -1293,10 +1297,10 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleInParalle
           double deltaCodelength = m_objective.getDeltaCodelengthOnMovingNode(current,
                                                                               oldModuleDelta,
                                                                               moduleDeltaEnterExit[j],
-                                                                              m_moduleFlowData,
-                                                                              m_moduleMembers);
+                                                                              moduleFlowData,
+                                                                              moduleMembers);
 
-          if (deltaCodelength < bestDeltaCodelength - m_infomap->minimumSingleNodeCodelengthImprovement) {
+          if (deltaCodelength < bestDeltaCodelength - minimumSingleNodeImprovement) {
             bestDeltaModule = moduleDeltaEnterExit[j];
             bestDeltaCodelength = deltaCodelength;
           }
@@ -1310,7 +1314,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleInParalle
       }
 
       // Prefer strongest connected module if equal delta codelength
-      if (strongestConnectedModule.module != bestDeltaModule.module && deltaCodelengthOnStrongestConnectedModule <= bestDeltaCodelength + m_infomap->minimumSingleNodeCodelengthImprovement) {
+      if (strongestConnectedModule.module != bestDeltaModule.module && deltaCodelengthOnStrongestConnectedModule <= bestDeltaCodelength + minimumSingleNodeImprovement) {
         bestDeltaModule = strongestConnectedModule;
       }
 
@@ -1322,14 +1326,14 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleInParalle
 #pragma omp critical(moveUpdate)
       {
         unsigned int bestModuleIndex = bestDeltaModule.module;
-        unsigned int oldModuleIndex = graph.moduleIndex(currentId);
+        unsigned int oldModuleIndex = current.index;
         const bool targetsCurrentEmptyModule = !m_emptyModules.empty() && bestModuleIndex == m_emptyModules.back();
 
         bool validMove = targetsCurrentEmptyModule
             // Check validity of move to empty target
-            ? m_moduleMembers[oldModuleIndex] > 1 && !m_emptyModules.empty()
+            ? moduleMembers[oldModuleIndex] > 1 && !m_emptyModules.empty()
             // Not valid if the best module is empty now but not when decided
-            : m_moduleMembers[bestModuleIndex] > 0;
+            : moduleMembers[bestModuleIndex] > 0;
 
         if (validMove) {
           // Recalculate delta codelength for proposed move to see if still an improvement
@@ -1344,24 +1348,24 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleInParalle
           double deltaCodelength = m_objective.getDeltaCodelengthOnMovingNode(current,
                                                                               oldModuleDelta,
                                                                               newModuleDelta,
-                                                                              m_moduleFlowData,
-                                                                              m_moduleMembers);
+                                                                              moduleFlowData,
+                                                                              moduleMembers);
 
-          if (deltaCodelength < 0.0 - m_infomap->minimumSingleNodeCodelengthImprovement) {
+          if (deltaCodelength < 0.0 - minimumSingleNodeImprovement) {
             // Update empty module vector
-            if (m_moduleMembers[bestModuleIndex] == 0) {
+            if (moduleMembers[bestModuleIndex] == 0) {
               m_emptyModules.pop_back();
             }
-            if (m_moduleMembers[oldModuleIndex] == 1) {
+            if (moduleMembers[oldModuleIndex] == 1) {
               m_emptyModules.push_back(oldModuleIndex);
             }
 
-            m_objective.updateCodelengthOnMovingNode(current, oldModuleDelta, bestDeltaModule, m_moduleFlowData, m_moduleMembers);
+            m_objective.updateCodelengthOnMovingNode(current, oldModuleDelta, bestDeltaModule, moduleFlowData, moduleMembers);
 
-            m_moduleMembers[oldModuleIndex] -= 1;
-            m_moduleMembers[bestModuleIndex] += 1;
+            moduleMembers[oldModuleIndex] -= 1;
+            moduleMembers[bestModuleIndex] += 1;
 
-            graph.moduleIndex(currentId) = bestModuleIndex;
+            current.index = bestModuleIndex;
 
             ++numMoved;
 

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -483,6 +483,9 @@ bool InfomapOptimizer<Objective>::moveNodeToPredefinedModuleImpl(InfomapBase::Cs
 {
   InfoNode& current = graph.nodeFor(currentId);
   auto* moduleIndices = graph.moduleIndicesData();
+  const bool recordedTeleportation = m_infomap->recordedTeleportation;
+  auto& moduleFlowData = m_moduleFlowData;
+  auto& moduleMembers = m_moduleMembers;
   unsigned int oldM = moduleIndices[currentId];
   unsigned int newM = newModule;
 
@@ -495,31 +498,31 @@ bool InfomapOptimizer<Objective>::moveNodeToPredefinedModuleImpl(InfomapBase::Cs
 
   accumulateMoveDelta(graph, currentId, oldM, newM, oldModuleDelta, newModuleDelta);
 
-  if (m_infomap->recordedTeleportation) {
-    auto& oldModuleFlowData = m_moduleFlowData[oldM];
+  if (recordedTeleportation) {
+    auto& oldModuleFlowData = moduleFlowData[oldM];
     double deltaEnterOld = (oldModuleFlowData.teleportFlow - current.data.teleportFlow) * current.data.teleportWeight;
     double deltaExitOld = current.data.teleportFlow * (oldModuleFlowData.teleportWeight - current.data.teleportWeight);
     oldModuleDelta.deltaEnter += deltaEnterOld;
     oldModuleDelta.deltaExit += deltaExitOld;
 
-    auto& newModuleFlowData = m_moduleFlowData[newM];
+    auto& newModuleFlowData = moduleFlowData[newM];
     double deltaEnterNew = current.data.teleportFlow * newModuleFlowData.teleportWeight;
     double deltaExitNew = newModuleFlowData.teleportFlow * current.data.teleportWeight;
     newModuleDelta.deltaEnter += deltaEnterNew;
     newModuleDelta.deltaExit += deltaExitNew;
   }
 
-  if (m_moduleMembers[newM] == 0) {
+  if (moduleMembers[newM] == 0) {
     m_emptyModules.pop_back();
   }
-  if (m_moduleMembers[oldM] == 1) {
+  if (moduleMembers[oldM] == 1) {
     m_emptyModules.push_back(oldM);
   }
 
-  m_objective.updateCodelengthOnMovingNode(current, oldModuleDelta, newModuleDelta, m_moduleFlowData, m_moduleMembers);
+  m_objective.updateCodelengthOnMovingNode(current, oldModuleDelta, newModuleDelta, moduleFlowData, moduleMembers);
 
-  m_moduleMembers[oldM] -= 1;
-  m_moduleMembers[newM] += 1;
+  moduleMembers[oldM] -= 1;
+  moduleMembers[newM] += 1;
 
   moduleIndices[currentId] = newM;
   return true;
@@ -530,6 +533,9 @@ template <typename Graph>
 bool InfomapOptimizer<Objective>::moveNodeToPredefinedModuleImpl(Graph& graph, typename Graph::ActiveNodeId currentId, unsigned int newModule)
 {
   InfoNode& current = graph.nodeFor(currentId);
+  const bool recordedTeleportation = m_infomap->recordedTeleportation;
+  auto& moduleFlowData = m_moduleFlowData;
+  auto& moduleMembers = m_moduleMembers;
   unsigned int oldM = graph.moduleIndex(currentId);
   unsigned int newM = newModule;
 
@@ -543,31 +549,31 @@ bool InfomapOptimizer<Objective>::moveNodeToPredefinedModuleImpl(Graph& graph, t
   accumulateMoveDelta(graph, currentId, oldM, newM, oldModuleDelta, newModuleDelta);
 
   // For recorded teleportation
-  if (m_infomap->recordedTeleportation) {
-    auto& oldModuleFlowData = m_moduleFlowData[oldM];
+  if (recordedTeleportation) {
+    auto& oldModuleFlowData = moduleFlowData[oldM];
     double deltaEnterOld = (oldModuleFlowData.teleportFlow - current.data.teleportFlow) * current.data.teleportWeight;
     double deltaExitOld = current.data.teleportFlow * (oldModuleFlowData.teleportWeight - current.data.teleportWeight);
     oldModuleDelta.deltaEnter += deltaEnterOld;
     oldModuleDelta.deltaExit += deltaExitOld;
 
-    auto& newModuleFlowData = m_moduleFlowData[newM];
+    auto& newModuleFlowData = moduleFlowData[newM];
     double deltaEnterNew = current.data.teleportFlow * newModuleFlowData.teleportWeight;
     double deltaExitNew = newModuleFlowData.teleportFlow * current.data.teleportWeight;
     newModuleDelta.deltaEnter += deltaEnterNew;
     newModuleDelta.deltaExit += deltaExitNew;
   }
   // Update empty module vector
-  if (m_moduleMembers[newM] == 0) {
+  if (moduleMembers[newM] == 0) {
     m_emptyModules.pop_back();
   }
-  if (m_moduleMembers[oldM] == 1) {
+  if (moduleMembers[oldM] == 1) {
     m_emptyModules.push_back(oldM);
   }
 
-  m_objective.updateCodelengthOnMovingNode(current, oldModuleDelta, newModuleDelta, m_moduleFlowData, m_moduleMembers);
+  m_objective.updateCodelengthOnMovingNode(current, oldModuleDelta, newModuleDelta, moduleFlowData, moduleMembers);
 
-  m_moduleMembers[oldM] -= 1;
-  m_moduleMembers[newM] += 1;
+  moduleMembers[oldM] -= 1;
+  moduleMembers[newM] += 1;
 
   graph.moduleIndex(currentId) = newM;
   return true;

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -417,7 +417,7 @@ void InfomapOptimizer<Objective>::initPartition()
 
     for (unsigned int i = 0; i < numNodes; ++i) {
       graph.moduleIndex(i) = i; // Unique module index for each node
-      m_moduleFlowData[i] = graph.payloadFor(i).data;
+      m_moduleFlowData[i] = graph.nodeFor(i).data;
       graph.dirty(i) = true;
     }
 

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -157,23 +157,21 @@ inline void InfomapOptimizer<Objective>::initSuperNetwork()
 template <typename Objective>
 void InfomapOptimizer<Objective>::initPartition()
 {
+  auto graph = m_infomap->pointerActiveGraph();
   auto& network = m_infomap->activeNetwork();
-  Log(4) << "InfomapOptimizer::initPartition() with " << network.size() << " nodes...\n";
+  Log(4) << "InfomapOptimizer::initPartition() with " << graph.size() << " nodes...\n";
 
   // Init one module for each node
-  auto numNodes = network.size();
+  auto numNodes = graph.size();
   m_moduleFlowData.resize(numNodes);
   m_moduleMembers.assign(numNodes, 1);
   m_emptyModules.clear();
   m_emptyModules.reserve(numNodes);
 
-  unsigned int i = 0;
-  for (auto& nodePtr : network) {
-    InfoNode& node = *nodePtr;
-    node.index = i; // Unique module index for each node
-    m_moduleFlowData[i] = node.data;
-    node.dirty = true;
-    ++i;
+  for (unsigned int i = 0; i < numNodes; ++i) {
+    graph.moduleIndex(i) = i; // Unique module index for each node
+    m_moduleFlowData[i] = graph.payloadFor(i).data;
+    graph.dirty(i) = true;
   }
 
   m_objective.initPartition(network);
@@ -182,13 +180,13 @@ void InfomapOptimizer<Objective>::initPartition()
 template <typename Objective>
 void InfomapOptimizer<Objective>::moveActiveNodesToPredefinedModules(std::vector<unsigned int>& modules)
 {
-  auto& network = m_infomap->activeNetwork();
-  auto numNodes = network.size();
+  auto graph = m_infomap->pointerActiveGraph();
+  auto numNodes = graph.size();
   if (modules.size() != numNodes)
     throw std::length_error("Size of predefined modules differ from size of active network.");
 
   for (unsigned int i = 0; i < numNodes; ++i) {
-    moveNodeToPredefinedModule(*network[i], modules[i]);
+    moveNodeToPredefinedModule(graph.nodeFor(i), modules[i]);
   }
 }
 

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -137,10 +137,16 @@ protected:
                                       InfomapBase::CsrBackend::ActiveNodeId currentId,
                                       unsigned int newModule);
 
+  bool moveNodeToPredefinedModuleImpl(InfomapBase::PointerBackend& graph,
+                                      InfomapBase::PointerBackend::ActiveNodeId currentId,
+                                      unsigned int newModule);
+
   template <typename Graph>
   bool moveNodeToPredefinedModuleImpl(Graph& graph, typename Graph::ActiveNodeId currentId, unsigned int newModule);
 
   unsigned int tryMoveEachNodeIntoBestModuleImpl(InfomapBase::CsrBackend& graph);
+
+  unsigned int tryMoveEachNodeIntoBestModuleImpl(InfomapBase::PointerBackend& graph);
 
   template <typename Graph>
   unsigned int tryMoveEachNodeIntoBestModuleImpl(Graph& graph);
@@ -629,6 +635,57 @@ bool InfomapOptimizer<Objective>::moveNodeToPredefinedModuleImpl(InfomapBase::Cs
 }
 
 template <typename Objective>
+bool InfomapOptimizer<Objective>::moveNodeToPredefinedModuleImpl(InfomapBase::PointerBackend& graph,
+                                                                 InfomapBase::PointerBackend::ActiveNodeId currentId,
+                                                                 unsigned int newModule)
+{
+  InfoNode& current = graph.nodeFor(currentId);
+  const bool recordedTeleportation = m_infomap->recordedTeleportation;
+  auto& moduleFlowData = m_moduleFlowData;
+  auto& moduleMembers = m_moduleMembers;
+  unsigned int oldM = current.index;
+  unsigned int newM = newModule;
+
+  if (newM == oldM) {
+    return false;
+  }
+
+  DeltaFlowDataType oldModuleDelta(oldM, 0.0, 0.0);
+  DeltaFlowDataType newModuleDelta(newM, 0.0, 0.0);
+
+  accumulateMoveDelta(graph, currentId, oldM, newM, oldModuleDelta, newModuleDelta);
+
+  if (recordedTeleportation) {
+    auto& oldModuleFlowData = moduleFlowData[oldM];
+    double deltaEnterOld = (oldModuleFlowData.teleportFlow - current.data.teleportFlow) * current.data.teleportWeight;
+    double deltaExitOld = current.data.teleportFlow * (oldModuleFlowData.teleportWeight - current.data.teleportWeight);
+    oldModuleDelta.deltaEnter += deltaEnterOld;
+    oldModuleDelta.deltaExit += deltaExitOld;
+
+    auto& newModuleFlowData = moduleFlowData[newM];
+    double deltaEnterNew = current.data.teleportFlow * newModuleFlowData.teleportWeight;
+    double deltaExitNew = newModuleFlowData.teleportFlow * current.data.teleportWeight;
+    newModuleDelta.deltaEnter += deltaEnterNew;
+    newModuleDelta.deltaExit += deltaExitNew;
+  }
+
+  if (moduleMembers[newM] == 0) {
+    m_emptyModules.pop_back();
+  }
+  if (moduleMembers[oldM] == 1) {
+    m_emptyModules.push_back(oldM);
+  }
+
+  m_objective.updateCodelengthOnMovingNode(current, oldModuleDelta, newModuleDelta, moduleFlowData, moduleMembers);
+
+  moduleMembers[oldM] -= 1;
+  moduleMembers[newM] += 1;
+
+  current.index = newM;
+  return true;
+}
+
+template <typename Objective>
 template <typename Graph>
 bool InfomapOptimizer<Objective>::moveNodeToPredefinedModuleImpl(Graph& graph, typename Graph::ActiveNodeId currentId, unsigned int newModule)
 {
@@ -852,6 +909,142 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Info
       }
     } else {
       dirtyFlags[currentId] = 0u;
+    }
+  }
+
+  return numMoved;
+}
+
+template <typename Objective>
+unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(InfomapBase::PointerBackend& graph)
+{
+  std::vector<unsigned int> nodeEnumeration(graph.size());
+  m_infomap->m_rand.getRandomizedIndexVector(nodeEnumeration);
+
+  const auto numNodes = nodeEnumeration.size();
+  const bool lockFirstLoopMoves = m_infomap->isFirstLoop() && m_infomap->tuneIterationLimit != 1;
+  const bool recordedTeleportation = m_infomap->recordedTeleportation;
+  const double minimumSingleNodeImprovement = m_infomap->minimumSingleNodeCodelengthImprovement;
+  auto& moduleFlowData = m_moduleFlowData;
+  auto& moduleMembers = m_moduleMembers;
+  unsigned int numMoved = 0;
+
+  VectorMap<DeltaFlowDataType> deltaFlow(numNodes);
+  std::vector<unsigned int> moduleEnumeration;
+
+  for (unsigned int i = 0; i < numNodes; ++i) {
+    const auto currentId = nodeEnumeration[i];
+    InfoNode& current = graph.nodeFor(currentId);
+    const unsigned int currentModuleIndex = current.index;
+
+    if (!current.dirty)
+      continue;
+
+    if (moduleMembers[currentModuleIndex] > 1 && lockFirstLoopMoves)
+      continue;
+
+    deltaFlow.startRound();
+
+    addNeighbourModuleLinks(graph, currentId, deltaFlow);
+
+    deltaFlow.add(currentModuleIndex, DeltaFlowDataType(currentModuleIndex, 0.0, 0.0));
+    DeltaFlowDataType& oldModuleDelta = deltaFlow[currentModuleIndex];
+    oldModuleDelta.module = currentModuleIndex;
+
+    if (moduleMembers[currentModuleIndex] > 1 && !m_emptyModules.empty()) {
+      deltaFlow.add(m_emptyModules.back(), DeltaFlowDataType(m_emptyModules.back(), 0.0, 0.0));
+    }
+
+    m_objective.addMemoryContributions(current, oldModuleDelta, deltaFlow);
+
+    auto& moduleDeltaEnterExit = deltaFlow.values();
+    const unsigned int numModuleLinks = deltaFlow.size();
+
+    if (recordedTeleportation) {
+      for (unsigned int j = 0; j < numModuleLinks; ++j) {
+        auto& deltaEnterExit = moduleDeltaEnterExit[j];
+        const auto moduleIndex = deltaEnterExit.module;
+        if (moduleIndex == currentModuleIndex) {
+          auto& oldModuleFlowData = moduleFlowData[moduleIndex];
+          const double deltaEnterOld = (oldModuleFlowData.teleportFlow - current.data.teleportFlow) * current.data.teleportWeight;
+          const double deltaExitOld = current.data.teleportFlow * (oldModuleFlowData.teleportWeight - current.data.teleportWeight);
+          deltaFlow.add(moduleIndex, DeltaFlowDataType(moduleIndex, deltaExitOld, deltaEnterOld));
+        } else {
+          auto& newModuleFlowData = moduleFlowData[moduleIndex];
+          const double deltaEnterNew = newModuleFlowData.teleportFlow * current.data.teleportWeight;
+          const double deltaExitNew = current.data.teleportFlow * newModuleFlowData.teleportWeight;
+          deltaFlow.add(moduleIndex, DeltaFlowDataType(moduleIndex, deltaExitNew, deltaEnterNew));
+        }
+      }
+    }
+
+    moduleEnumeration.resize(numModuleLinks);
+    m_infomap->m_rand.getRandomizedIndexVector(moduleEnumeration);
+
+    DeltaFlowDataType bestDeltaModule(oldModuleDelta);
+    double bestDeltaCodelength = 0.0;
+    DeltaFlowDataType strongestConnectedModule(oldModuleDelta);
+    double deltaCodelengthOnStrongestConnectedModule = 0.0;
+
+    for (unsigned int k = 0; k < numModuleLinks; ++k) {
+      const auto j = moduleEnumeration[k];
+      const unsigned int otherModule = moduleDeltaEnterExit[j].module;
+      if (otherModule != currentModuleIndex) {
+        const double deltaCodelength = m_objective.getDeltaCodelengthOnMovingNode(current,
+                                                                                   oldModuleDelta,
+                                                                                   moduleDeltaEnterExit[j],
+                                                                                   moduleFlowData,
+                                                                                   moduleMembers);
+
+        if (deltaCodelength < bestDeltaCodelength - minimumSingleNodeImprovement) {
+          bestDeltaModule = moduleDeltaEnterExit[j];
+          bestDeltaCodelength = deltaCodelength;
+        }
+
+        if (moduleDeltaEnterExit[j].deltaExit > strongestConnectedModule.deltaExit) {
+          strongestConnectedModule = moduleDeltaEnterExit[j];
+          deltaCodelengthOnStrongestConnectedModule = deltaCodelength;
+        }
+      }
+    }
+
+    if (strongestConnectedModule.module != bestDeltaModule.module && deltaCodelengthOnStrongestConnectedModule <= bestDeltaCodelength + minimumSingleNodeImprovement) {
+      bestDeltaModule = strongestConnectedModule;
+    }
+
+    if (bestDeltaModule.module != currentModuleIndex) {
+      const unsigned int bestModuleIndex = bestDeltaModule.module;
+      if (moduleMembers[bestModuleIndex] == 0) {
+        m_emptyModules.pop_back();
+      }
+      if (moduleMembers[currentModuleIndex] == 1) {
+        m_emptyModules.push_back(currentModuleIndex);
+      }
+
+      m_objective.updateCodelengthOnMovingNode(current, oldModuleDelta, bestDeltaModule, moduleFlowData, moduleMembers);
+
+      moduleMembers[currentModuleIndex] -= 1;
+      moduleMembers[bestModuleIndex] += 1;
+
+      const unsigned int oldModuleIndex = currentModuleIndex;
+      current.index = bestModuleIndex;
+
+      ++numMoved;
+
+      InfoNode* nodeInOldModule = &current;
+      auto nodeInOldModuleId = currentId;
+      unsigned int numLinkedNodesInOldModule = 0;
+      markNeighboursDirty(graph, currentId, oldModuleIndex, nodeInOldModule, nodeInOldModuleId, numLinkedNodesInOldModule);
+
+      if (numLinkedNodesInOldModule == 1 && moduleMembers[oldModuleIndex] == 1) {
+        moveNodeToPredefinedModuleImpl(graph, nodeInOldModuleId, bestModuleIndex);
+        ++numMoved;
+        if (nodeInOldModule->degree() > 1) {
+          markNodeNeighboursDirty(graph, nodeInOldModuleId);
+        }
+      }
+    } else {
+      current.dirty = false;
     }
   }
 

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -76,6 +76,15 @@ protected:
   template <typename Graph>
   void markNodeNeighboursDirty(Graph& graph, typename Graph::ActiveNodeId nodeId);
 
+  template <typename Graph>
+  void moveActiveNodesToPredefinedModulesImpl(Graph& graph, std::vector<unsigned int>& modules);
+
+  template <typename Graph>
+  bool moveNodeToPredefinedModuleImpl(Graph& graph, typename Graph::ActiveNodeId currentId, unsigned int newModule);
+
+  template <typename Graph>
+  unsigned int tryMoveEachNodeIntoBestModuleImpl(Graph& graph);
+
   // ===================================================
   // Run: Init: *
   // ===================================================
@@ -283,12 +292,19 @@ template <typename Objective>
 void InfomapOptimizer<Objective>::moveActiveNodesToPredefinedModules(std::vector<unsigned int>& modules)
 {
   auto graph = m_infomap->pointerActiveGraph();
+  moveActiveNodesToPredefinedModulesImpl(graph, modules);
+}
+
+template <typename Objective>
+template <typename Graph>
+void InfomapOptimizer<Objective>::moveActiveNodesToPredefinedModulesImpl(Graph& graph, std::vector<unsigned int>& modules)
+{
   auto numNodes = graph.size();
   if (modules.size() != numNodes)
     throw std::length_error("Size of predefined modules differ from size of active network.");
 
   for (unsigned int i = 0; i < numNodes; ++i) {
-    moveNodeToPredefinedModule(graph.nodeFor(i), modules[i]);
+    moveNodeToPredefinedModuleImpl(graph, i, modules[i]);
   }
 }
 
@@ -296,7 +312,14 @@ template <typename Objective>
 bool InfomapOptimizer<Objective>::moveNodeToPredefinedModule(InfoNode& current, unsigned int newModule)
 {
   auto graph = m_infomap->pointerActiveGraph();
-  auto currentId = graph.idFor(current);
+  return moveNodeToPredefinedModuleImpl(graph, graph.idFor(current), newModule);
+}
+
+template <typename Objective>
+template <typename Graph>
+bool InfomapOptimizer<Objective>::moveNodeToPredefinedModuleImpl(Graph& graph, typename Graph::ActiveNodeId currentId, unsigned int newModule)
+{
+  InfoNode& current = graph.nodeFor(currentId);
   unsigned int oldM = graph.moduleIndex(currentId);
   unsigned int newM = newModule;
 
@@ -373,6 +396,13 @@ template <typename Objective>
 unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModule()
 {
   auto graph = m_infomap->pointerActiveGraph();
+  return tryMoveEachNodeIntoBestModuleImpl(graph);
+}
+
+template <typename Objective>
+template <typename Graph>
+unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Graph& graph)
+{
   // Get random enumeration of nodes
   std::vector<unsigned int> nodeEnumeration(graph.size());
   m_infomap->m_rand.getRandomizedIndexVector(nodeEnumeration);
@@ -505,7 +535,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModule()
 
       // Move single connected nodes to same module
       if (numLinkedNodesInOldModule == 1 && m_moduleMembers[oldModuleIndex] == 1) {
-        moveNodeToPredefinedModule(*nodeInOldModule, bestModuleIndex);
+        moveNodeToPredefinedModuleImpl(graph, graph.idFor(*nodeInOldModule), bestModuleIndex);
         ++numMoved;
         // Mark neighbours as dirty
         if (nodeInOldModule->degree() > 1) {

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -283,24 +283,33 @@ void InfomapOptimizer<Objective>::markNodeNeighboursDirty(Graph& graph, typename
 template <typename Objective>
 void InfomapOptimizer<Objective>::initPartition()
 {
-  auto graph = m_infomap->pointerBackend();
-  auto& network = m_infomap->activeNetwork();
-  Log(4) << "InfomapOptimizer::initPartition() with " << graph.size() << " nodes...\n";
+  auto initPartitionImpl = [&](auto graph) {
+    auto& network = m_infomap->activeNetwork();
+    Log(4) << "InfomapOptimizer::initPartition() with " << graph.size() << " nodes...\n";
 
-  // Init one module for each node
-  auto numNodes = graph.size();
-  m_moduleFlowData.resize(numNodes);
-  m_moduleMembers.assign(numNodes, 1);
-  m_emptyModules.clear();
-  m_emptyModules.reserve(numNodes);
+    // Init one module for each node
+    auto numNodes = graph.size();
+    m_moduleFlowData.resize(numNodes);
+    m_moduleMembers.assign(numNodes, 1);
+    m_emptyModules.clear();
+    m_emptyModules.reserve(numNodes);
 
-  for (unsigned int i = 0; i < numNodes; ++i) {
-    graph.moduleIndex(i) = i; // Unique module index for each node
-    m_moduleFlowData[i] = graph.payloadFor(i).data;
-    graph.dirty(i) = true;
+    for (unsigned int i = 0; i < numNodes; ++i) {
+      graph.moduleIndex(i) = i; // Unique module index for each node
+      m_moduleFlowData[i] = graph.payloadFor(i).data;
+      graph.dirty(i) = true;
+    }
+
+    m_objective.initPartition(network);
+  };
+
+  auto csrGraph = m_infomap->csrBackend();
+  if (csrGraph.available()) {
+    return initPartitionImpl(csrGraph);
   }
 
-  m_objective.initPartition(network);
+  auto graph = m_infomap->pointerBackend();
+  initPartitionImpl(graph);
 }
 
 template <typename Objective>

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -72,11 +72,22 @@ protected:
 
   void addNeighbourModuleLinks(InfomapBase::CsrBackend& graph, InfomapBase::CsrBackend::ActiveNodeId currentId, VectorMap<DeltaFlowDataType>& deltaFlow);
 
+  void addNeighbourModuleLinks(InfomapBase::PointerBackend& graph,
+                               InfomapBase::PointerBackend::ActiveNodeId currentId,
+                               VectorMap<DeltaFlowDataType>& deltaFlow);
+
   template <typename Graph>
   void addNeighbourModuleLinks(Graph& graph, typename Graph::ActiveNodeId currentId, VectorMap<DeltaFlowDataType>& deltaFlow);
 
   void accumulateMoveDelta(InfomapBase::CsrBackend& graph,
                            InfomapBase::CsrBackend::ActiveNodeId currentId,
+                           unsigned int oldModule,
+                           unsigned int newModule,
+                           DeltaFlowDataType& oldModuleDelta,
+                           DeltaFlowDataType& newModuleDelta);
+
+  void accumulateMoveDelta(InfomapBase::PointerBackend& graph,
+                           InfomapBase::PointerBackend::ActiveNodeId currentId,
                            unsigned int oldModule,
                            unsigned int newModule,
                            DeltaFlowDataType& oldModuleDelta,
@@ -97,6 +108,13 @@ protected:
                            InfomapBase::CsrBackend::ActiveNodeId& nodeInOldModuleId,
                            unsigned int& numLinkedNodesInOldModule);
 
+  void markNeighboursDirty(InfomapBase::PointerBackend& graph,
+                           InfomapBase::PointerBackend::ActiveNodeId currentId,
+                           unsigned int oldModuleIndex,
+                           InfoNode*& nodeInOldModule,
+                           InfomapBase::PointerBackend::ActiveNodeId& nodeInOldModuleId,
+                           unsigned int& numLinkedNodesInOldModule);
+
   template <typename Graph>
   void markNeighboursDirty(Graph& graph,
                            typename Graph::ActiveNodeId currentId,
@@ -106,6 +124,8 @@ protected:
                            unsigned int& numLinkedNodesInOldModule);
 
   void markNodeNeighboursDirty(InfomapBase::CsrBackend& graph, InfomapBase::CsrBackend::ActiveNodeId nodeId);
+
+  void markNodeNeighboursDirty(InfomapBase::PointerBackend& graph, InfomapBase::PointerBackend::ActiveNodeId nodeId);
 
   template <typename Graph>
   void markNodeNeighboursDirty(Graph& graph, typename Graph::ActiveNodeId nodeId);
@@ -246,6 +266,20 @@ void InfomapOptimizer<Objective>::addNeighbourModuleLinks(InfomapBase::CsrBacken
 }
 
 template <typename Objective>
+void InfomapOptimizer<Objective>::addNeighbourModuleLinks(InfomapBase::PointerBackend& graph,
+                                                          InfomapBase::PointerBackend::ActiveNodeId currentId,
+                                                          VectorMap<DeltaFlowDataType>& deltaFlow)
+{
+  graph.forEachOutEdge(currentId, [&](auto, const InfoNode& neighbour, const auto& edge) {
+    deltaFlow.add(neighbour.index, DeltaFlowDataType(neighbour.index, detail::edgeFlow(edge), 0.0));
+  });
+
+  graph.forEachInEdge(currentId, [&](auto, const InfoNode& neighbour, const auto& edge) {
+    deltaFlow.add(neighbour.index, DeltaFlowDataType(neighbour.index, 0.0, detail::edgeFlow(edge)));
+  });
+}
+
+template <typename Objective>
 template <typename Graph>
 void InfomapOptimizer<Objective>::addNeighbourModuleLinks(Graph& graph, typename Graph::ActiveNodeId currentId, VectorMap<DeltaFlowDataType>& deltaFlow)
 {
@@ -288,6 +322,33 @@ void InfomapOptimizer<Objective>::accumulateMoveDelta(InfomapBase::CsrBackend& g
       newModuleDelta.deltaEnter += inEdges.flows[i];
     }
   }
+}
+
+template <typename Objective>
+void InfomapOptimizer<Objective>::accumulateMoveDelta(InfomapBase::PointerBackend& graph,
+                                                      InfomapBase::PointerBackend::ActiveNodeId currentId,
+                                                      unsigned int oldModule,
+                                                      unsigned int newModule,
+                                                      DeltaFlowDataType& oldModuleDelta,
+                                                      DeltaFlowDataType& newModuleDelta)
+{
+  graph.forEachOutEdge(currentId, [&](auto, const InfoNode& neighbour, const auto& edge) {
+    const unsigned int otherModule = neighbour.index;
+    if (otherModule == oldModule) {
+      oldModuleDelta.deltaExit += detail::edgeFlow(edge);
+    } else if (otherModule == newModule) {
+      newModuleDelta.deltaExit += detail::edgeFlow(edge);
+    }
+  });
+
+  graph.forEachInEdge(currentId, [&](auto, const InfoNode& neighbour, const auto& edge) {
+    const unsigned int otherModule = neighbour.index;
+    if (otherModule == oldModule) {
+      oldModuleDelta.deltaEnter += detail::edgeFlow(edge);
+    } else if (otherModule == newModule) {
+      newModuleDelta.deltaEnter += detail::edgeFlow(edge);
+    }
+  });
 }
 
 template <typename Objective>
@@ -353,6 +414,33 @@ void InfomapOptimizer<Objective>::markNeighboursDirty(InfomapBase::CsrBackend& g
 }
 
 template <typename Objective>
+void InfomapOptimizer<Objective>::markNeighboursDirty(InfomapBase::PointerBackend& graph,
+                                                      InfomapBase::PointerBackend::ActiveNodeId currentId,
+                                                      unsigned int oldModuleIndex,
+                                                      InfoNode*& nodeInOldModule,
+                                                      InfomapBase::PointerBackend::ActiveNodeId& nodeInOldModuleId,
+                                                      unsigned int& numLinkedNodesInOldModule)
+{
+  graph.forEachOutEdge(currentId, [&](auto neighbourId, InfoNode& neighbour, const auto&) {
+    neighbour.dirty = true;
+    if (neighbour.index == oldModuleIndex) {
+      nodeInOldModule = &neighbour;
+      nodeInOldModuleId = neighbourId;
+      ++numLinkedNodesInOldModule;
+    }
+  });
+
+  graph.forEachInEdge(currentId, [&](auto neighbourId, InfoNode& neighbour, const auto&) {
+    neighbour.dirty = true;
+    if (neighbour.index == oldModuleIndex) {
+      nodeInOldModule = &neighbour;
+      nodeInOldModuleId = neighbourId;
+      ++numLinkedNodesInOldModule;
+    }
+  });
+}
+
+template <typename Objective>
 template <typename Graph>
 void InfomapOptimizer<Objective>::markNeighboursDirty(Graph& graph,
                                                       typename Graph::ActiveNodeId currentId,
@@ -394,6 +482,18 @@ void InfomapOptimizer<Objective>::markNodeNeighboursDirty(InfomapBase::CsrBacken
   for (std::size_t i = 0; i < inEdges.size; ++i) {
     dirtyFlags[inEdges.targets[i]] = 1u;
   }
+}
+
+template <typename Objective>
+void InfomapOptimizer<Objective>::markNodeNeighboursDirty(InfomapBase::PointerBackend& graph, InfomapBase::PointerBackend::ActiveNodeId nodeId)
+{
+  graph.forEachOutEdge(nodeId, [&](auto, InfoNode& neighbour, const auto&) {
+    neighbour.dirty = true;
+  });
+
+  graph.forEachInEdge(nodeId, [&](auto, InfoNode& neighbour, const auto&) {
+    neighbour.dirty = true;
+  });
 }
 
 template <typename Objective>

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -55,6 +55,27 @@ public:
 protected:
   unsigned int numActiveModules() const override { return m_infomap->activeNetwork().size() - m_emptyModules.size(); }
 
+  template <typename Graph>
+  void addNeighbourModuleLinks(Graph& graph, typename Graph::ActiveNodeId currentId, VectorMap<DeltaFlowDataType>& deltaFlow);
+
+  template <typename Graph>
+  void accumulateMoveDelta(Graph& graph,
+                           typename Graph::ActiveNodeId currentId,
+                           unsigned int oldModule,
+                           unsigned int newModule,
+                           DeltaFlowDataType& oldModuleDelta,
+                           DeltaFlowDataType& newModuleDelta);
+
+  template <typename Graph>
+  void markNeighboursDirty(Graph& graph,
+                           typename Graph::ActiveNodeId currentId,
+                           unsigned int oldModuleIndex,
+                           InfoNode*& nodeInOldModule,
+                           unsigned int& numLinkedNodesInOldModule);
+
+  template <typename Graph>
+  void markNodeNeighboursDirty(Graph& graph, typename Graph::ActiveNodeId nodeId);
+
   // ===================================================
   // Run: Init: *
   // ===================================================
@@ -155,6 +176,87 @@ inline void InfomapOptimizer<Objective>::initSuperNetwork()
 // ===================================================
 
 template <typename Objective>
+template <typename Graph>
+void InfomapOptimizer<Objective>::addNeighbourModuleLinks(Graph& graph, typename Graph::ActiveNodeId currentId, VectorMap<DeltaFlowDataType>& deltaFlow)
+{
+  graph.forEachOutEdge(currentId, [&](auto neighbourId, const InfoNode&, const InfoEdge& edge) {
+    auto otherModule = graph.moduleIndex(neighbourId);
+    deltaFlow.add(otherModule, DeltaFlowDataType(otherModule, edge.data.flow, 0.0));
+  });
+
+  graph.forEachInEdge(currentId, [&](auto neighbourId, const InfoNode&, const InfoEdge& edge) {
+    auto otherModule = graph.moduleIndex(neighbourId);
+    deltaFlow.add(otherModule, DeltaFlowDataType(otherModule, 0.0, edge.data.flow));
+  });
+}
+
+template <typename Objective>
+template <typename Graph>
+void InfomapOptimizer<Objective>::accumulateMoveDelta(Graph& graph,
+                                                      typename Graph::ActiveNodeId currentId,
+                                                      unsigned int oldModule,
+                                                      unsigned int newModule,
+                                                      DeltaFlowDataType& oldModuleDelta,
+                                                      DeltaFlowDataType& newModuleDelta)
+{
+  graph.forEachOutEdge(currentId, [&](auto neighbourId, const InfoNode&, const InfoEdge& edge) {
+    unsigned int otherModule = graph.moduleIndex(neighbourId);
+    if (otherModule == oldModule) {
+      oldModuleDelta.deltaExit += edge.data.flow;
+    } else if (otherModule == newModule) {
+      newModuleDelta.deltaExit += edge.data.flow;
+    }
+  });
+
+  graph.forEachInEdge(currentId, [&](auto neighbourId, const InfoNode&, const InfoEdge& edge) {
+    unsigned int otherModule = graph.moduleIndex(neighbourId);
+    if (otherModule == oldModule) {
+      oldModuleDelta.deltaEnter += edge.data.flow;
+    } else if (otherModule == newModule) {
+      newModuleDelta.deltaEnter += edge.data.flow;
+    }
+  });
+}
+
+template <typename Objective>
+template <typename Graph>
+void InfomapOptimizer<Objective>::markNeighboursDirty(Graph& graph,
+                                                      typename Graph::ActiveNodeId currentId,
+                                                      unsigned int oldModuleIndex,
+                                                      InfoNode*& nodeInOldModule,
+                                                      unsigned int& numLinkedNodesInOldModule)
+{
+  graph.forEachOutEdge(currentId, [&](auto neighbourId, InfoNode& neighbour, const InfoEdge&) {
+    graph.dirty(neighbourId) = true;
+    if (graph.moduleIndex(neighbourId) == oldModuleIndex) {
+      nodeInOldModule = &neighbour;
+      ++numLinkedNodesInOldModule;
+    }
+  });
+
+  graph.forEachInEdge(currentId, [&](auto neighbourId, InfoNode& neighbour, const InfoEdge&) {
+    graph.dirty(neighbourId) = true;
+    if (graph.moduleIndex(neighbourId) == oldModuleIndex) {
+      nodeInOldModule = &neighbour;
+      ++numLinkedNodesInOldModule;
+    }
+  });
+}
+
+template <typename Objective>
+template <typename Graph>
+void InfomapOptimizer<Objective>::markNodeNeighboursDirty(Graph& graph, typename Graph::ActiveNodeId nodeId)
+{
+  graph.forEachOutEdge(nodeId, [&](auto neighbourId, InfoNode&, const InfoEdge&) {
+    graph.dirty(neighbourId) = true;
+  });
+
+  graph.forEachInEdge(nodeId, [&](auto neighbourId, InfoNode&, const InfoEdge&) {
+    graph.dirty(neighbourId) = true;
+  });
+}
+
+template <typename Objective>
 void InfomapOptimizer<Objective>::initPartition()
 {
   auto graph = m_infomap->pointerActiveGraph();
@@ -205,24 +307,7 @@ bool InfomapOptimizer<Objective>::moveNodeToPredefinedModule(InfoNode& current, 
   DeltaFlowDataType oldModuleDelta(oldM, 0.0, 0.0);
   DeltaFlowDataType newModuleDelta(newM, 0.0, 0.0);
 
-  // For all outlinks
-  graph.forEachOutEdge(currentId, [&](auto neighbourId, const InfoNode&, const InfoEdge& edge) {
-    unsigned int otherModule = graph.moduleIndex(neighbourId);
-    if (otherModule == oldM) {
-      oldModuleDelta.deltaExit += edge.data.flow;
-    } else if (otherModule == newM) {
-      newModuleDelta.deltaExit += edge.data.flow;
-    }
-  });
-  // For all inlinks
-  graph.forEachInEdge(currentId, [&](auto neighbourId, const InfoNode&, const InfoEdge& edge) {
-    unsigned int otherModule = graph.moduleIndex(neighbourId);
-    if (otherModule == oldM) {
-      oldModuleDelta.deltaEnter += edge.data.flow;
-    } else if (otherModule == newM) {
-      newModuleDelta.deltaEnter += edge.data.flow;
-    }
-  });
+  accumulateMoveDelta(graph, currentId, oldM, newM, oldModuleDelta, newModuleDelta);
 
   // For recorded teleportation
   if (m_infomap->recordedTeleportation) {
@@ -317,15 +402,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModule()
     deltaFlow.startRound();
 
     // For all outlinks
-    graph.forEachOutEdge(currentId, [&](auto neighbourId, const InfoNode&, const InfoEdge& edge) {
-      auto otherModule = graph.moduleIndex(neighbourId);
-      deltaFlow.add(otherModule, DeltaFlowDataType(otherModule, edge.data.flow, 0.0));
-    });
-    // For all inlinks
-    graph.forEachInEdge(currentId, [&](auto neighbourId, const InfoNode&, const InfoEdge& edge) {
-      auto otherModule = graph.moduleIndex(neighbourId);
-      deltaFlow.add(otherModule, DeltaFlowDataType(otherModule, 0.0, edge.data.flow));
-    });
+    addNeighbourModuleLinks(graph, currentId, deltaFlow);
 
     // For not moving
     deltaFlow.add(currentModuleIndex, DeltaFlowDataType(currentModuleIndex, 0.0, 0.0));
@@ -424,20 +501,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModule()
       InfoNode* nodeInOldModule = &current;
       unsigned int numLinkedNodesInOldModule = 0;
       // Mark neighbours as dirty
-      graph.forEachOutEdge(currentId, [&](auto neighbourId, InfoNode& neighbour, const InfoEdge&) {
-        graph.dirty(neighbourId) = true;
-        if (graph.moduleIndex(neighbourId) == oldModuleIndex) {
-          nodeInOldModule = &neighbour;
-          ++numLinkedNodesInOldModule;
-        }
-      });
-      graph.forEachInEdge(currentId, [&](auto neighbourId, InfoNode& neighbour, const InfoEdge&) {
-        graph.dirty(neighbourId) = true;
-        if (graph.moduleIndex(neighbourId) == oldModuleIndex) {
-          nodeInOldModule = &neighbour;
-          ++numLinkedNodesInOldModule;
-        }
-      });
+      markNeighboursDirty(graph, currentId, oldModuleIndex, nodeInOldModule, numLinkedNodesInOldModule);
 
       // Move single connected nodes to same module
       if (numLinkedNodesInOldModule == 1 && m_moduleMembers[oldModuleIndex] == 1) {
@@ -446,12 +510,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModule()
         // Mark neighbours as dirty
         if (nodeInOldModule->degree() > 1) {
           auto linkedNodeId = graph.idFor(*nodeInOldModule);
-          graph.forEachOutEdge(linkedNodeId, [&](auto neighbourId, InfoNode&, const InfoEdge&) {
-            graph.dirty(neighbourId) = true;
-          });
-          graph.forEachInEdge(linkedNodeId, [&](auto neighbourId, InfoNode&, const InfoEdge&) {
-            graph.dirty(neighbourId) = true;
-          });
+          markNodeNeighboursDirty(graph, linkedNodeId);
         }
       }
     } else {

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -269,7 +269,7 @@ void InfomapOptimizer<Objective>::addNeighbourModuleLinks(InfomapBase::CsrBacken
   for (std::size_t i = 0; i < inEdges.size; ++i) {
     const auto neighbourId = inEdges.targets[i];
     const auto otherModule = moduleIndices[neighbourId];
-    deltaFlow.add(otherModule, DeltaFlowDataType(otherModule, 0.0, inEdges.flows[i]));
+    deltaFlow.add(otherModule, DeltaFlowDataType(otherModule, 0.0, inEdges.flowAt(i)));
   }
 }
 
@@ -325,9 +325,9 @@ void InfomapOptimizer<Objective>::accumulateMoveDelta(InfomapBase::CsrBackend& g
   for (std::size_t i = 0; i < inEdges.size; ++i) {
     const auto otherModule = moduleIndices[inEdges.targets[i]];
     if (otherModule == oldModule) {
-      oldModuleDelta.deltaEnter += inEdges.flows[i];
+      oldModuleDelta.deltaEnter += inEdges.flowAt(i);
     } else if (otherModule == newModule) {
-      newModuleDelta.deltaEnter += inEdges.flows[i];
+      newModuleDelta.deltaEnter += inEdges.flowAt(i);
     }
   }
 }

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -1224,6 +1224,7 @@ template <typename Objective>
 unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleInParallel()
 {
   auto graph = m_infomap->pointerBackend();
+  graph.ensureReverseLookup();
   // Get random enumeration of nodes
   const auto numNodes = graph.size();
   const bool lockFirstLoopMoves = m_infomap->isFirstLoop() && m_infomap->tuneIterationLimit != 1;

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -620,6 +620,8 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Info
   m_infomap->m_rand.getRandomizedIndexVector(nodeEnumeration);
 
   const auto numNodes = nodeEnumeration.size();
+  const bool lockFirstLoopMoves = m_infomap->isFirstLoop() && m_infomap->tuneIterationLimit != 1;
+  const bool recordedTeleportation = m_infomap->recordedTeleportation;
   unsigned int numMoved = 0;
 
   auto* moduleIndices = graph.moduleIndicesData();
@@ -636,7 +638,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Info
     if (dirtyFlags[currentId] == 0u)
       continue;
 
-    if (m_moduleMembers[currentModuleIndex] > 1 && m_infomap->isFirstLoop() && m_infomap->tuneIterationLimit != 1)
+    if (m_moduleMembers[currentModuleIndex] > 1 && lockFirstLoopMoves)
       continue;
 
     deltaFlow.startRound();
@@ -656,7 +658,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Info
     auto& moduleDeltaEnterExit = deltaFlow.values();
     const unsigned int numModuleLinks = deltaFlow.size();
 
-    if (m_infomap->recordedTeleportation) {
+    if (recordedTeleportation) {
       for (unsigned int j = 0; j < numModuleLinks; ++j) {
         auto& deltaEnterExit = moduleDeltaEnterExit[j];
         const auto moduleIndex = deltaEnterExit.module;
@@ -756,6 +758,8 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Grap
   m_infomap->m_rand.getRandomizedIndexVector(nodeEnumeration);
 
   auto numNodes = nodeEnumeration.size();
+  const bool lockFirstLoopMoves = m_infomap->isFirstLoop() && m_infomap->tuneIterationLimit != 1;
+  const bool recordedTeleportation = m_infomap->recordedTeleportation;
   unsigned int numMoved = 0;
 
   // Create map with module links
@@ -771,7 +775,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Grap
       continue;
 
     // If other nodes have moved here, don't move away on first loop
-    if (m_moduleMembers[currentModuleIndex] > 1 && m_infomap->isFirstLoop() && m_infomap->tuneIterationLimit != 1)
+    if (m_moduleMembers[currentModuleIndex] > 1 && lockFirstLoopMoves)
       continue;
 
     // If no links connecting this node with other nodes, it won't move into others,
@@ -800,7 +804,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Grap
     unsigned int numModuleLinks = deltaFlow.size();
 
     // For recorded teleportation
-    if (m_infomap->recordedTeleportation) {
+    if (recordedTeleportation) {
       for (unsigned int j = 0; j < numModuleLinks; ++j) {
         auto& deltaEnterExit = moduleDeltaEnterExit[j];
         auto moduleIndex = deltaEnterExit.module;

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -717,6 +717,14 @@ inline void InfomapOptimizer<Objective>::consolidateModules(bool replaceExisting
     modules[nodePair.first]->addOutEdge(*modules[nodePair.second], 0.0, e.second);
   }
 
+  unsigned int moduleCount = 0;
+  for (const auto* module : modules) {
+    if (module != nullptr) {
+      ++moduleCount;
+    }
+  }
+  m_infomap->recordConsolidationSnapshot(level, numNodes, moduleCount, moduleLinks.size(), replaceExistingModules);
+
   if (replaceExistingModules) {
     if (level == 1) {
       Log(4) << "Consolidated super modules, removing old modules...\n";

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -1001,8 +1001,9 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleInParalle
       {
         unsigned int bestModuleIndex = bestDeltaModule.module;
         unsigned int oldModuleIndex = graph.moduleIndex(currentId);
+        const bool targetsCurrentEmptyModule = !m_emptyModules.empty() && bestModuleIndex == m_emptyModules.back();
 
-        bool validMove = bestModuleIndex == m_emptyModules.back()
+        bool validMove = targetsCurrentEmptyModule
             // Check validity of move to empty target
             ? m_moduleMembers[oldModuleIndex] > 1 && !m_emptyModules.empty()
             // Not valid if the best module is empty now but not when decided

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -182,6 +182,8 @@ protected:
 
   void consolidateModules(bool replaceExistingModules = true) override;
 
+  void consolidateModulesImpl(InfomapBase::PointerBackend& graph, bool replaceExistingModules);
+
   bool restoreConsolidatedOptimizationPointIfNoImprovement(bool forceRestore = false) override;
 
   // ===================================================
@@ -1388,25 +1390,33 @@ template <typename Objective>
 inline void InfomapOptimizer<Objective>::consolidateModules(bool replaceExistingModules)
 {
   auto graph = m_infomap->pointerBackend();
+  consolidateModulesImpl(graph, replaceExistingModules);
+}
+
+template <typename Objective>
+inline void InfomapOptimizer<Objective>::consolidateModulesImpl(InfomapBase::PointerBackend& graph, bool replaceExistingModules)
+{
   auto numNodes = graph.size();
   std::vector<InfoNode*> modules(numNodes, nullptr);
 
   InfoNode& firstActiveNode = graph.nodeFor(0);
   auto level = firstActiveNode.depth();
   auto leafLevel = m_infomap->numLevels();
+  const bool isUndirectedClustering = m_infomap->isUndirectedClustering();
 
   if (leafLevel == 1)
     replaceExistingModules = false;
 
   // Release children pointers on current parent(s) to put new modules between
   for (unsigned int i = 0; i < numNodes; ++i) {
-    graph.nodeFor(i).parent->releaseChildren(); // Safe to call multiple times
+    InfoNode& node = graph.nodeFor(i);
+    node.parent->releaseChildren(); // Safe to call multiple times
   }
 
   // Create the new module nodes and re-parent the active network from its common parent to the new module level
   for (unsigned int i = 0; i < numNodes; ++i) {
     InfoNode& node = graph.nodeFor(i);
-    unsigned int moduleIndex = graph.moduleIndex(i);
+    unsigned int moduleIndex = node.index;
     if (modules[moduleIndex] == nullptr) {
       modules[moduleIndex] = new InfoNode(m_moduleFlowData[moduleIndex]);
       modules[moduleIndex]->index = moduleIndex;
@@ -1420,18 +1430,19 @@ inline void InfomapOptimizer<Objective>::consolidateModules(bool replaceExisting
   EdgeMap moduleLinks;
 
   for (unsigned int i = 0; i < numNodes; ++i) {
-    unsigned int module1 = graph.moduleIndex(i);
-    for (const auto& edge : graph.outEdges(i)) {
-      unsigned int module2 = graph.moduleIndex(edge.neighbourId);
+    InfoNode& node = graph.nodeFor(i);
+    unsigned int module1 = node.index;
+    for (auto* edge : node.outEdges()) {
+      unsigned int module2 = edge->target->index;
       if (module1 != module2) {
         // Use new variables to not swap module1
         unsigned int m1 = module1, m2 = module2;
         // If undirected, the order may be swapped to aggregate the edge on an opposite one
-        if (m_infomap->isUndirectedClustering() && m1 > m2)
+        if (isUndirectedClustering && m1 > m2)
           std::swap(m1, m2);
-        auto ret = moduleLinks.insert(std::make_pair(NodePair(m1, m2), edge.flow));
+        auto ret = moduleLinks.insert(std::make_pair(NodePair(m1, m2), edge->data.flow));
         if (!ret.second) {
-          ret.first->second += edge.flow;
+          ret.first->second += edge->data.flow;
         }
       }
     }

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -22,6 +22,21 @@
 
 namespace infomap {
 
+namespace detail {
+
+inline double edgeFlow(const InfoEdge& edge)
+{
+  return edge.data.flow;
+}
+
+template <typename EdgeLike>
+inline double edgeFlow(const EdgeLike& edge)
+{
+  return edge.flow;
+}
+
+} // namespace detail
+
 template <typename Objective>
 class InfomapOptimizer : public InfomapOptimizerBase {
   using FlowDataType = FlowData;
@@ -188,14 +203,14 @@ template <typename Objective>
 template <typename Graph>
 void InfomapOptimizer<Objective>::addNeighbourModuleLinks(Graph& graph, typename Graph::ActiveNodeId currentId, VectorMap<DeltaFlowDataType>& deltaFlow)
 {
-  graph.forEachOutEdge(currentId, [&](auto neighbourId, const InfoNode&, const InfoEdge& edge) {
+  graph.forEachOutEdge(currentId, [&](auto neighbourId, const InfoNode&, const auto& edge) {
     auto otherModule = graph.moduleIndex(neighbourId);
-    deltaFlow.add(otherModule, DeltaFlowDataType(otherModule, edge.data.flow, 0.0));
+    deltaFlow.add(otherModule, DeltaFlowDataType(otherModule, detail::edgeFlow(edge), 0.0));
   });
 
-  graph.forEachInEdge(currentId, [&](auto neighbourId, const InfoNode&, const InfoEdge& edge) {
+  graph.forEachInEdge(currentId, [&](auto neighbourId, const InfoNode&, const auto& edge) {
     auto otherModule = graph.moduleIndex(neighbourId);
-    deltaFlow.add(otherModule, DeltaFlowDataType(otherModule, 0.0, edge.data.flow));
+    deltaFlow.add(otherModule, DeltaFlowDataType(otherModule, 0.0, detail::edgeFlow(edge)));
   });
 }
 
@@ -208,21 +223,21 @@ void InfomapOptimizer<Objective>::accumulateMoveDelta(Graph& graph,
                                                       DeltaFlowDataType& oldModuleDelta,
                                                       DeltaFlowDataType& newModuleDelta)
 {
-  graph.forEachOutEdge(currentId, [&](auto neighbourId, const InfoNode&, const InfoEdge& edge) {
+  graph.forEachOutEdge(currentId, [&](auto neighbourId, const InfoNode&, const auto& edge) {
     unsigned int otherModule = graph.moduleIndex(neighbourId);
     if (otherModule == oldModule) {
-      oldModuleDelta.deltaExit += edge.data.flow;
+      oldModuleDelta.deltaExit += detail::edgeFlow(edge);
     } else if (otherModule == newModule) {
-      newModuleDelta.deltaExit += edge.data.flow;
+      newModuleDelta.deltaExit += detail::edgeFlow(edge);
     }
   });
 
-  graph.forEachInEdge(currentId, [&](auto neighbourId, const InfoNode&, const InfoEdge& edge) {
+  graph.forEachInEdge(currentId, [&](auto neighbourId, const InfoNode&, const auto& edge) {
     unsigned int otherModule = graph.moduleIndex(neighbourId);
     if (otherModule == oldModule) {
-      oldModuleDelta.deltaEnter += edge.data.flow;
+      oldModuleDelta.deltaEnter += detail::edgeFlow(edge);
     } else if (otherModule == newModule) {
-      newModuleDelta.deltaEnter += edge.data.flow;
+      newModuleDelta.deltaEnter += detail::edgeFlow(edge);
     }
   });
 }
@@ -235,7 +250,7 @@ void InfomapOptimizer<Objective>::markNeighboursDirty(Graph& graph,
                                                       InfoNode*& nodeInOldModule,
                                                       unsigned int& numLinkedNodesInOldModule)
 {
-  graph.forEachOutEdge(currentId, [&](auto neighbourId, InfoNode& neighbour, const InfoEdge&) {
+  graph.forEachOutEdge(currentId, [&](auto neighbourId, InfoNode& neighbour, const auto&) {
     graph.dirty(neighbourId) = true;
     if (graph.moduleIndex(neighbourId) == oldModuleIndex) {
       nodeInOldModule = &neighbour;
@@ -243,7 +258,7 @@ void InfomapOptimizer<Objective>::markNeighboursDirty(Graph& graph,
     }
   });
 
-  graph.forEachInEdge(currentId, [&](auto neighbourId, InfoNode& neighbour, const InfoEdge&) {
+  graph.forEachInEdge(currentId, [&](auto neighbourId, InfoNode& neighbour, const auto&) {
     graph.dirty(neighbourId) = true;
     if (graph.moduleIndex(neighbourId) == oldModuleIndex) {
       nodeInOldModule = &neighbour;
@@ -256,11 +271,11 @@ template <typename Objective>
 template <typename Graph>
 void InfomapOptimizer<Objective>::markNodeNeighboursDirty(Graph& graph, typename Graph::ActiveNodeId nodeId)
 {
-  graph.forEachOutEdge(nodeId, [&](auto neighbourId, InfoNode&, const InfoEdge&) {
+  graph.forEachOutEdge(nodeId, [&](auto neighbourId, InfoNode&, const auto&) {
     graph.dirty(neighbourId) = true;
   });
 
-  graph.forEachInEdge(nodeId, [&](auto neighbourId, InfoNode&, const InfoEdge&) {
+  graph.forEachInEdge(nodeId, [&](auto neighbourId, InfoNode&, const auto&) {
     graph.dirty(neighbourId) = true;
   });
 }
@@ -291,6 +306,10 @@ void InfomapOptimizer<Objective>::initPartition()
 template <typename Objective>
 void InfomapOptimizer<Objective>::moveActiveNodesToPredefinedModules(std::vector<unsigned int>& modules)
 {
+  auto csrGraph = m_infomap->csrBackend();
+  if (csrGraph.available()) {
+    return moveActiveNodesToPredefinedModulesImpl(csrGraph, modules);
+  }
   auto graph = m_infomap->pointerBackend();
   moveActiveNodesToPredefinedModulesImpl(graph, modules);
 }
@@ -311,6 +330,10 @@ void InfomapOptimizer<Objective>::moveActiveNodesToPredefinedModulesImpl(Graph& 
 template <typename Objective>
 bool InfomapOptimizer<Objective>::moveNodeToPredefinedModule(InfoNode& current, unsigned int newModule)
 {
+  auto csrGraph = m_infomap->csrBackend();
+  if (csrGraph.available()) {
+    return moveNodeToPredefinedModuleImpl(csrGraph, csrGraph.idFor(current), newModule);
+  }
   auto graph = m_infomap->pointerBackend();
   return moveNodeToPredefinedModuleImpl(graph, graph.idFor(current), newModule);
 }
@@ -395,6 +418,10 @@ inline unsigned int InfomapOptimizer<Objective>::optimizeActiveNetwork()
 template <typename Objective>
 unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModule()
 {
+  auto csrGraph = m_infomap->csrBackend();
+  if (csrGraph.available()) {
+    return tryMoveEachNodeIntoBestModuleImpl(csrGraph);
+  }
   auto graph = m_infomap->pointerBackend();
   return tryMoveEachNodeIntoBestModuleImpl(graph);
 }

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -94,6 +94,7 @@ protected:
                            InfomapBase::CsrBackend::ActiveNodeId currentId,
                            unsigned int oldModuleIndex,
                            InfoNode*& nodeInOldModule,
+                           InfomapBase::CsrBackend::ActiveNodeId& nodeInOldModuleId,
                            unsigned int& numLinkedNodesInOldModule);
 
   template <typename Graph>
@@ -101,6 +102,7 @@ protected:
                            typename Graph::ActiveNodeId currentId,
                            unsigned int oldModuleIndex,
                            InfoNode*& nodeInOldModule,
+                           typename Graph::ActiveNodeId& nodeInOldModuleId,
                            unsigned int& numLinkedNodesInOldModule);
 
   void markNodeNeighboursDirty(InfomapBase::CsrBackend& graph, InfomapBase::CsrBackend::ActiveNodeId nodeId);
@@ -321,6 +323,7 @@ void InfomapOptimizer<Objective>::markNeighboursDirty(InfomapBase::CsrBackend& g
                                                       InfomapBase::CsrBackend::ActiveNodeId currentId,
                                                       unsigned int oldModuleIndex,
                                                       InfoNode*& nodeInOldModule,
+                                                      InfomapBase::CsrBackend::ActiveNodeId& nodeInOldModuleId,
                                                       unsigned int& numLinkedNodesInOldModule)
 {
   auto* dirtyFlags = graph.dirtyFlagsData();
@@ -332,6 +335,7 @@ void InfomapOptimizer<Objective>::markNeighboursDirty(InfomapBase::CsrBackend& g
     dirtyFlags[neighbourId] = 1u;
     if (moduleIndices[neighbourId] == oldModuleIndex) {
       nodeInOldModule = &graph.nodeFor(neighbourId);
+      nodeInOldModuleId = neighbourId;
       ++numLinkedNodesInOldModule;
     }
   }
@@ -342,6 +346,7 @@ void InfomapOptimizer<Objective>::markNeighboursDirty(InfomapBase::CsrBackend& g
     dirtyFlags[neighbourId] = 1u;
     if (moduleIndices[neighbourId] == oldModuleIndex) {
       nodeInOldModule = &graph.nodeFor(neighbourId);
+      nodeInOldModuleId = neighbourId;
       ++numLinkedNodesInOldModule;
     }
   }
@@ -353,12 +358,14 @@ void InfomapOptimizer<Objective>::markNeighboursDirty(Graph& graph,
                                                       typename Graph::ActiveNodeId currentId,
                                                       unsigned int oldModuleIndex,
                                                       InfoNode*& nodeInOldModule,
+                                                      typename Graph::ActiveNodeId& nodeInOldModuleId,
                                                       unsigned int& numLinkedNodesInOldModule)
 {
   graph.forEachOutEdge(currentId, [&](auto neighbourId, InfoNode& neighbour, const auto&) {
     graph.dirty(neighbourId) = true;
     if (graph.moduleIndex(neighbourId) == oldModuleIndex) {
       nodeInOldModule = &neighbour;
+      nodeInOldModuleId = neighbourId;
       ++numLinkedNodesInOldModule;
     }
   });
@@ -367,6 +374,7 @@ void InfomapOptimizer<Objective>::markNeighboursDirty(Graph& graph,
     graph.dirty(neighbourId) = true;
     if (graph.moduleIndex(neighbourId) == oldModuleIndex) {
       nodeInOldModule = &neighbour;
+      nodeInOldModuleId = neighbourId;
       ++numLinkedNodesInOldModule;
     }
   });
@@ -720,14 +728,15 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Info
       ++numMoved;
 
       InfoNode* nodeInOldModule = &current;
+      auto nodeInOldModuleId = currentId;
       unsigned int numLinkedNodesInOldModule = 0;
-      markNeighboursDirty(graph, currentId, oldModuleIndex, nodeInOldModule, numLinkedNodesInOldModule);
+      markNeighboursDirty(graph, currentId, oldModuleIndex, nodeInOldModule, nodeInOldModuleId, numLinkedNodesInOldModule);
 
       if (numLinkedNodesInOldModule == 1 && m_moduleMembers[oldModuleIndex] == 1) {
-        moveNodeToPredefinedModuleImpl(graph, graph.idFor(*nodeInOldModule), bestModuleIndex);
+        moveNodeToPredefinedModuleImpl(graph, nodeInOldModuleId, bestModuleIndex);
         ++numMoved;
         if (nodeInOldModule->degree() > 1) {
-          markNodeNeighboursDirty(graph, graph.idFor(*nodeInOldModule));
+          markNodeNeighboursDirty(graph, nodeInOldModuleId);
         }
       }
     } else {
@@ -869,18 +878,18 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Grap
       ++numMoved;
 
       InfoNode* nodeInOldModule = &current;
+      auto nodeInOldModuleId = currentId;
       unsigned int numLinkedNodesInOldModule = 0;
       // Mark neighbours as dirty
-      markNeighboursDirty(graph, currentId, oldModuleIndex, nodeInOldModule, numLinkedNodesInOldModule);
+      markNeighboursDirty(graph, currentId, oldModuleIndex, nodeInOldModule, nodeInOldModuleId, numLinkedNodesInOldModule);
 
       // Move single connected nodes to same module
       if (numLinkedNodesInOldModule == 1 && m_moduleMembers[oldModuleIndex] == 1) {
-        moveNodeToPredefinedModuleImpl(graph, graph.idFor(*nodeInOldModule), bestModuleIndex);
+        moveNodeToPredefinedModuleImpl(graph, nodeInOldModuleId, bestModuleIndex);
         ++numMoved;
         // Mark neighbours as dirty
         if (nodeInOldModule->degree() > 1) {
-          auto linkedNodeId = graph.idFor(*nodeInOldModule);
-          markNodeNeighboursDirty(graph, linkedNodeId);
+          markNodeNeighboursDirty(graph, nodeInOldModuleId);
         }
       }
     } else {

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -618,6 +618,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Info
   auto* dirtyFlags = graph.dirtyFlagsData();
 
   VectorMap<DeltaFlowDataType> deltaFlow(numNodes);
+  std::vector<unsigned int> moduleEnumeration;
 
   for (unsigned int i = 0; i < numNodes; ++i) {
     const auto currentId = nodeEnumeration[i];
@@ -665,7 +666,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Info
       }
     }
 
-    std::vector<unsigned int> moduleEnumeration(numModuleLinks);
+    moduleEnumeration.resize(numModuleLinks);
     m_infomap->m_rand.getRandomizedIndexVector(moduleEnumeration);
 
     DeltaFlowDataType bestDeltaModule(oldModuleDelta);
@@ -750,6 +751,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Grap
 
   // Create map with module links
   VectorMap<DeltaFlowDataType> deltaFlow(numNodes);
+  std::vector<unsigned int> moduleEnumeration;
 
   for (unsigned int i = 0; i < numNodes; ++i) {
     auto currentId = nodeEnumeration[i];
@@ -808,7 +810,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Grap
     }
 
     // Randomize link order for optimized search
-    std::vector<unsigned int> moduleEnumeration(numModuleLinks);
+    moduleEnumeration.resize(numModuleLinks);
     m_infomap->m_rand.getRandomizedIndexVector(moduleEnumeration);
 
     DeltaFlowDataType bestDeltaModule(oldModuleDelta);

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -70,8 +70,17 @@ public:
 protected:
   unsigned int numActiveModules() const override { return m_infomap->activeNetwork().size() - m_emptyModules.size(); }
 
+  void addNeighbourModuleLinks(InfomapBase::CsrBackend& graph, InfomapBase::CsrBackend::ActiveNodeId currentId, VectorMap<DeltaFlowDataType>& deltaFlow);
+
   template <typename Graph>
   void addNeighbourModuleLinks(Graph& graph, typename Graph::ActiveNodeId currentId, VectorMap<DeltaFlowDataType>& deltaFlow);
+
+  void accumulateMoveDelta(InfomapBase::CsrBackend& graph,
+                           InfomapBase::CsrBackend::ActiveNodeId currentId,
+                           unsigned int oldModule,
+                           unsigned int newModule,
+                           DeltaFlowDataType& oldModuleDelta,
+                           DeltaFlowDataType& newModuleDelta);
 
   template <typename Graph>
   void accumulateMoveDelta(Graph& graph,
@@ -81,6 +90,12 @@ protected:
                            DeltaFlowDataType& oldModuleDelta,
                            DeltaFlowDataType& newModuleDelta);
 
+  void markNeighboursDirty(InfomapBase::CsrBackend& graph,
+                           InfomapBase::CsrBackend::ActiveNodeId currentId,
+                           unsigned int oldModuleIndex,
+                           InfoNode*& nodeInOldModule,
+                           unsigned int& numLinkedNodesInOldModule);
+
   template <typename Graph>
   void markNeighboursDirty(Graph& graph,
                            typename Graph::ActiveNodeId currentId,
@@ -88,14 +103,22 @@ protected:
                            InfoNode*& nodeInOldModule,
                            unsigned int& numLinkedNodesInOldModule);
 
+  void markNodeNeighboursDirty(InfomapBase::CsrBackend& graph, InfomapBase::CsrBackend::ActiveNodeId nodeId);
+
   template <typename Graph>
   void markNodeNeighboursDirty(Graph& graph, typename Graph::ActiveNodeId nodeId);
 
   template <typename Graph>
   void moveActiveNodesToPredefinedModulesImpl(Graph& graph, std::vector<unsigned int>& modules);
 
+  bool moveNodeToPredefinedModuleImpl(InfomapBase::CsrBackend& graph,
+                                      InfomapBase::CsrBackend::ActiveNodeId currentId,
+                                      unsigned int newModule);
+
   template <typename Graph>
   bool moveNodeToPredefinedModuleImpl(Graph& graph, typename Graph::ActiveNodeId currentId, unsigned int newModule);
+
+  unsigned int tryMoveEachNodeIntoBestModuleImpl(InfomapBase::CsrBackend& graph);
 
   template <typename Graph>
   unsigned int tryMoveEachNodeIntoBestModuleImpl(Graph& graph);
@@ -200,6 +223,27 @@ inline void InfomapOptimizer<Objective>::initSuperNetwork()
 // ===================================================
 
 template <typename Objective>
+void InfomapOptimizer<Objective>::addNeighbourModuleLinks(InfomapBase::CsrBackend& graph,
+                                                          InfomapBase::CsrBackend::ActiveNodeId currentId,
+                                                          VectorMap<DeltaFlowDataType>& deltaFlow)
+{
+  const auto* moduleIndices = graph.moduleIndicesData();
+  const auto outEdges = graph.outEdges(currentId);
+  for (std::size_t i = 0; i < outEdges.size; ++i) {
+    const auto neighbourId = outEdges.targets[i];
+    const auto otherModule = moduleIndices[neighbourId];
+    deltaFlow.add(otherModule, DeltaFlowDataType(otherModule, outEdges.flows[i], 0.0));
+  }
+
+  const auto inEdges = graph.inEdges(currentId);
+  for (std::size_t i = 0; i < inEdges.size; ++i) {
+    const auto neighbourId = inEdges.targets[i];
+    const auto otherModule = moduleIndices[neighbourId];
+    deltaFlow.add(otherModule, DeltaFlowDataType(otherModule, 0.0, inEdges.flows[i]));
+  }
+}
+
+template <typename Objective>
 template <typename Graph>
 void InfomapOptimizer<Objective>::addNeighbourModuleLinks(Graph& graph, typename Graph::ActiveNodeId currentId, VectorMap<DeltaFlowDataType>& deltaFlow)
 {
@@ -212,6 +256,36 @@ void InfomapOptimizer<Objective>::addNeighbourModuleLinks(Graph& graph, typename
     auto otherModule = graph.moduleIndex(neighbourId);
     deltaFlow.add(otherModule, DeltaFlowDataType(otherModule, 0.0, detail::edgeFlow(edge)));
   });
+}
+
+template <typename Objective>
+void InfomapOptimizer<Objective>::accumulateMoveDelta(InfomapBase::CsrBackend& graph,
+                                                      InfomapBase::CsrBackend::ActiveNodeId currentId,
+                                                      unsigned int oldModule,
+                                                      unsigned int newModule,
+                                                      DeltaFlowDataType& oldModuleDelta,
+                                                      DeltaFlowDataType& newModuleDelta)
+{
+  const auto* moduleIndices = graph.moduleIndicesData();
+  const auto outEdges = graph.outEdges(currentId);
+  for (std::size_t i = 0; i < outEdges.size; ++i) {
+    const auto otherModule = moduleIndices[outEdges.targets[i]];
+    if (otherModule == oldModule) {
+      oldModuleDelta.deltaExit += outEdges.flows[i];
+    } else if (otherModule == newModule) {
+      newModuleDelta.deltaExit += outEdges.flows[i];
+    }
+  }
+
+  const auto inEdges = graph.inEdges(currentId);
+  for (std::size_t i = 0; i < inEdges.size; ++i) {
+    const auto otherModule = moduleIndices[inEdges.targets[i]];
+    if (otherModule == oldModule) {
+      oldModuleDelta.deltaEnter += inEdges.flows[i];
+    } else if (otherModule == newModule) {
+      newModuleDelta.deltaEnter += inEdges.flows[i];
+    }
+  }
 }
 
 template <typename Objective>
@@ -243,6 +317,37 @@ void InfomapOptimizer<Objective>::accumulateMoveDelta(Graph& graph,
 }
 
 template <typename Objective>
+void InfomapOptimizer<Objective>::markNeighboursDirty(InfomapBase::CsrBackend& graph,
+                                                      InfomapBase::CsrBackend::ActiveNodeId currentId,
+                                                      unsigned int oldModuleIndex,
+                                                      InfoNode*& nodeInOldModule,
+                                                      unsigned int& numLinkedNodesInOldModule)
+{
+  auto* dirtyFlags = graph.dirtyFlagsData();
+  const auto* moduleIndices = graph.moduleIndicesData();
+
+  const auto outEdges = graph.outEdges(currentId);
+  for (std::size_t i = 0; i < outEdges.size; ++i) {
+    const auto neighbourId = outEdges.targets[i];
+    dirtyFlags[neighbourId] = 1u;
+    if (moduleIndices[neighbourId] == oldModuleIndex) {
+      nodeInOldModule = &graph.nodeFor(neighbourId);
+      ++numLinkedNodesInOldModule;
+    }
+  }
+
+  const auto inEdges = graph.inEdges(currentId);
+  for (std::size_t i = 0; i < inEdges.size; ++i) {
+    const auto neighbourId = inEdges.targets[i];
+    dirtyFlags[neighbourId] = 1u;
+    if (moduleIndices[neighbourId] == oldModuleIndex) {
+      nodeInOldModule = &graph.nodeFor(neighbourId);
+      ++numLinkedNodesInOldModule;
+    }
+  }
+}
+
+template <typename Objective>
 template <typename Graph>
 void InfomapOptimizer<Objective>::markNeighboursDirty(Graph& graph,
                                                       typename Graph::ActiveNodeId currentId,
@@ -265,6 +370,22 @@ void InfomapOptimizer<Objective>::markNeighboursDirty(Graph& graph,
       ++numLinkedNodesInOldModule;
     }
   });
+}
+
+template <typename Objective>
+void InfomapOptimizer<Objective>::markNodeNeighboursDirty(InfomapBase::CsrBackend& graph, InfomapBase::CsrBackend::ActiveNodeId nodeId)
+{
+  auto* dirtyFlags = graph.dirtyFlagsData();
+
+  const auto outEdges = graph.outEdges(nodeId);
+  for (std::size_t i = 0; i < outEdges.size; ++i) {
+    dirtyFlags[outEdges.targets[i]] = 1u;
+  }
+
+  const auto inEdges = graph.inEdges(nodeId);
+  for (std::size_t i = 0; i < inEdges.size; ++i) {
+    dirtyFlags[inEdges.targets[i]] = 1u;
+  }
 }
 
 template <typename Objective>
@@ -345,6 +466,55 @@ bool InfomapOptimizer<Objective>::moveNodeToPredefinedModule(InfoNode& current, 
   }
   auto graph = m_infomap->pointerBackend();
   return moveNodeToPredefinedModuleImpl(graph, graph.idFor(current), newModule);
+}
+
+template <typename Objective>
+bool InfomapOptimizer<Objective>::moveNodeToPredefinedModuleImpl(InfomapBase::CsrBackend& graph,
+                                                                 InfomapBase::CsrBackend::ActiveNodeId currentId,
+                                                                 unsigned int newModule)
+{
+  InfoNode& current = graph.nodeFor(currentId);
+  auto* moduleIndices = graph.moduleIndicesData();
+  unsigned int oldM = moduleIndices[currentId];
+  unsigned int newM = newModule;
+
+  if (newM == oldM) {
+    return false;
+  }
+
+  DeltaFlowDataType oldModuleDelta(oldM, 0.0, 0.0);
+  DeltaFlowDataType newModuleDelta(newM, 0.0, 0.0);
+
+  accumulateMoveDelta(graph, currentId, oldM, newM, oldModuleDelta, newModuleDelta);
+
+  if (m_infomap->recordedTeleportation) {
+    auto& oldModuleFlowData = m_moduleFlowData[oldM];
+    double deltaEnterOld = (oldModuleFlowData.teleportFlow - current.data.teleportFlow) * current.data.teleportWeight;
+    double deltaExitOld = current.data.teleportFlow * (oldModuleFlowData.teleportWeight - current.data.teleportWeight);
+    oldModuleDelta.deltaEnter += deltaEnterOld;
+    oldModuleDelta.deltaExit += deltaExitOld;
+
+    auto& newModuleFlowData = m_moduleFlowData[newM];
+    double deltaEnterNew = current.data.teleportFlow * newModuleFlowData.teleportWeight;
+    double deltaExitNew = newModuleFlowData.teleportFlow * current.data.teleportWeight;
+    newModuleDelta.deltaEnter += deltaEnterNew;
+    newModuleDelta.deltaExit += deltaExitNew;
+  }
+
+  if (m_moduleMembers[newM] == 0) {
+    m_emptyModules.pop_back();
+  }
+  if (m_moduleMembers[oldM] == 1) {
+    m_emptyModules.push_back(oldM);
+  }
+
+  m_objective.updateCodelengthOnMovingNode(current, oldModuleDelta, newModuleDelta, m_moduleFlowData, m_moduleMembers);
+
+  m_moduleMembers[oldM] -= 1;
+  m_moduleMembers[newM] += 1;
+
+  moduleIndices[currentId] = newM;
+  return true;
 }
 
 template <typename Objective>
@@ -433,6 +603,138 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModule()
   }
   auto graph = m_infomap->pointerBackend();
   return tryMoveEachNodeIntoBestModuleImpl(graph);
+}
+
+template <typename Objective>
+unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(InfomapBase::CsrBackend& graph)
+{
+  std::vector<unsigned int> nodeEnumeration(graph.size());
+  m_infomap->m_rand.getRandomizedIndexVector(nodeEnumeration);
+
+  const auto numNodes = nodeEnumeration.size();
+  unsigned int numMoved = 0;
+
+  auto* moduleIndices = graph.moduleIndicesData();
+  auto* dirtyFlags = graph.dirtyFlagsData();
+
+  VectorMap<DeltaFlowDataType> deltaFlow(numNodes);
+
+  for (unsigned int i = 0; i < numNodes; ++i) {
+    const auto currentId = nodeEnumeration[i];
+    InfoNode& current = graph.nodeFor(currentId);
+    const unsigned int currentModuleIndex = moduleIndices[currentId];
+
+    if (dirtyFlags[currentId] == 0u)
+      continue;
+
+    if (m_moduleMembers[currentModuleIndex] > 1 && m_infomap->isFirstLoop() && m_infomap->tuneIterationLimit != 1)
+      continue;
+
+    deltaFlow.startRound();
+
+    addNeighbourModuleLinks(graph, currentId, deltaFlow);
+
+    deltaFlow.add(currentModuleIndex, DeltaFlowDataType(currentModuleIndex, 0.0, 0.0));
+    DeltaFlowDataType& oldModuleDelta = deltaFlow[currentModuleIndex];
+    oldModuleDelta.module = currentModuleIndex;
+
+    if (m_moduleMembers[currentModuleIndex] > 1 && !m_emptyModules.empty()) {
+      deltaFlow.add(m_emptyModules.back(), DeltaFlowDataType(m_emptyModules.back(), 0.0, 0.0));
+    }
+
+    m_objective.addMemoryContributions(current, oldModuleDelta, deltaFlow);
+
+    auto& moduleDeltaEnterExit = deltaFlow.values();
+    const unsigned int numModuleLinks = deltaFlow.size();
+
+    if (m_infomap->recordedTeleportation) {
+      for (unsigned int j = 0; j < numModuleLinks; ++j) {
+        auto& deltaEnterExit = moduleDeltaEnterExit[j];
+        const auto moduleIndex = deltaEnterExit.module;
+        if (moduleIndex == currentModuleIndex) {
+          auto& oldModuleFlowData = m_moduleFlowData[moduleIndex];
+          const double deltaEnterOld = (oldModuleFlowData.teleportFlow - current.data.teleportFlow) * current.data.teleportWeight;
+          const double deltaExitOld = current.data.teleportFlow * (oldModuleFlowData.teleportWeight - current.data.teleportWeight);
+          deltaFlow.add(moduleIndex, DeltaFlowDataType(moduleIndex, deltaExitOld, deltaEnterOld));
+        } else {
+          auto& newModuleFlowData = m_moduleFlowData[moduleIndex];
+          const double deltaEnterNew = newModuleFlowData.teleportFlow * current.data.teleportWeight;
+          const double deltaExitNew = current.data.teleportFlow * newModuleFlowData.teleportWeight;
+          deltaFlow.add(moduleIndex, DeltaFlowDataType(moduleIndex, deltaExitNew, deltaEnterNew));
+        }
+      }
+    }
+
+    std::vector<unsigned int> moduleEnumeration(numModuleLinks);
+    m_infomap->m_rand.getRandomizedIndexVector(moduleEnumeration);
+
+    DeltaFlowDataType bestDeltaModule(oldModuleDelta);
+    double bestDeltaCodelength = 0.0;
+    DeltaFlowDataType strongestConnectedModule(oldModuleDelta);
+    double deltaCodelengthOnStrongestConnectedModule = 0.0;
+
+    for (unsigned int k = 0; k < numModuleLinks; ++k) {
+      const auto j = moduleEnumeration[k];
+      const unsigned int otherModule = moduleDeltaEnterExit[j].module;
+      if (otherModule != currentModuleIndex) {
+        const double deltaCodelength = m_objective.getDeltaCodelengthOnMovingNode(current,
+                                                                                   oldModuleDelta,
+                                                                                   moduleDeltaEnterExit[j],
+                                                                                   m_moduleFlowData,
+                                                                                   m_moduleMembers);
+
+        if (deltaCodelength < bestDeltaCodelength - m_infomap->minimumSingleNodeCodelengthImprovement) {
+          bestDeltaModule = moduleDeltaEnterExit[j];
+          bestDeltaCodelength = deltaCodelength;
+        }
+
+        if (moduleDeltaEnterExit[j].deltaExit > strongestConnectedModule.deltaExit) {
+          strongestConnectedModule = moduleDeltaEnterExit[j];
+          deltaCodelengthOnStrongestConnectedModule = deltaCodelength;
+        }
+      }
+    }
+
+    if (strongestConnectedModule.module != bestDeltaModule.module && deltaCodelengthOnStrongestConnectedModule <= bestDeltaCodelength + m_infomap->minimumSingleNodeCodelengthImprovement) {
+      bestDeltaModule = strongestConnectedModule;
+    }
+
+    if (bestDeltaModule.module != currentModuleIndex) {
+      const unsigned int bestModuleIndex = bestDeltaModule.module;
+      if (m_moduleMembers[bestModuleIndex] == 0) {
+        m_emptyModules.pop_back();
+      }
+      if (m_moduleMembers[currentModuleIndex] == 1) {
+        m_emptyModules.push_back(currentModuleIndex);
+      }
+
+      m_objective.updateCodelengthOnMovingNode(current, oldModuleDelta, bestDeltaModule, m_moduleFlowData, m_moduleMembers);
+
+      m_moduleMembers[currentModuleIndex] -= 1;
+      m_moduleMembers[bestModuleIndex] += 1;
+
+      const unsigned int oldModuleIndex = currentModuleIndex;
+      moduleIndices[currentId] = bestModuleIndex;
+
+      ++numMoved;
+
+      InfoNode* nodeInOldModule = &current;
+      unsigned int numLinkedNodesInOldModule = 0;
+      markNeighboursDirty(graph, currentId, oldModuleIndex, nodeInOldModule, numLinkedNodesInOldModule);
+
+      if (numLinkedNodesInOldModule == 1 && m_moduleMembers[oldModuleIndex] == 1) {
+        moveNodeToPredefinedModuleImpl(graph, graph.idFor(*nodeInOldModule), bestModuleIndex);
+        ++numMoved;
+        if (nodeInOldModule->degree() > 1) {
+          markNodeNeighboursDirty(graph, graph.idFor(*nodeInOldModule));
+        }
+      }
+    } else {
+      dirtyFlags[currentId] = 0u;
+    }
+  }
+
+  return numMoved;
 }
 
 template <typename Objective>

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -967,7 +967,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleInParalle
       double deltaCodelengthOnStrongestConnectedModule = 0.0;
 
       // Find the move that minimizes the description length
-      for (unsigned int j = 0; j < deltaFlow.size(); ++j) {
+      for (unsigned int j = 0; j < numModuleLinks; ++j) {
         unsigned int otherModule = moduleDeltaEnterExit[j].module;
         if (otherModule != currentModuleIndex) {
           double deltaCodelength = m_objective.getDeltaCodelengthOnMovingNode(current,
@@ -998,61 +998,60 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleInParalle
       if (bestDeltaModule.module == currentModuleIndex) {
         graph.dirty(currentId) = false;
         continue;
-      } else {
+      }
 #pragma omp critical(moveUpdate)
-        {
-          unsigned int bestModuleIndex = bestDeltaModule.module;
-          unsigned int oldModuleIndex = graph.moduleIndex(currentId);
-          const bool targetsCurrentEmptyModule = !m_emptyModules.empty() && bestModuleIndex == m_emptyModules.back();
+      {
+        unsigned int bestModuleIndex = bestDeltaModule.module;
+        unsigned int oldModuleIndex = graph.moduleIndex(currentId);
+        const bool targetsCurrentEmptyModule = !m_emptyModules.empty() && bestModuleIndex == m_emptyModules.back();
 
-          bool validMove = targetsCurrentEmptyModule
-              // Check validity of move to empty target
-              ? m_moduleMembers[oldModuleIndex] > 1 && !m_emptyModules.empty()
-              // Not valid if the best module is empty now but not when decided
-              : m_moduleMembers[bestModuleIndex] > 0;
+        bool validMove = targetsCurrentEmptyModule
+            // Check validity of move to empty target
+            ? m_moduleMembers[oldModuleIndex] > 1 && !m_emptyModules.empty()
+            // Not valid if the best module is empty now but not when decided
+            : m_moduleMembers[bestModuleIndex] > 0;
 
-          if (validMove) {
-            // Recalculate delta codelength for proposed move to see if still an improvement
-            oldModuleDelta = DeltaFlowDataType(oldModuleIndex, 0.0, 0.0);
-            DeltaFlowDataType newModuleDelta(bestModuleIndex, 0.0, 0.0);
+        if (validMove) {
+          // Recalculate delta codelength for proposed move to see if still an improvement
+          oldModuleDelta = DeltaFlowDataType(oldModuleIndex, 0.0, 0.0);
+          DeltaFlowDataType newModuleDelta(bestModuleIndex, 0.0, 0.0);
 
-            accumulateMoveDelta(graph, currentId, oldModuleIndex, bestModuleIndex, oldModuleDelta, newModuleDelta);
+          accumulateMoveDelta(graph, currentId, oldModuleIndex, bestModuleIndex, oldModuleDelta, newModuleDelta);
 
-            // For memory networks
-            m_objective.addMemoryContributions(current, oldModuleDelta, deltaFlow);
+          // For memory networks
+          m_objective.addMemoryContributions(current, oldModuleDelta, deltaFlow);
 
-            double deltaCodelength = m_objective.getDeltaCodelengthOnMovingNode(current,
-                                                                                oldModuleDelta,
-                                                                                newModuleDelta,
-                                                                                m_moduleFlowData,
-                                                                                m_moduleMembers);
+          double deltaCodelength = m_objective.getDeltaCodelengthOnMovingNode(current,
+                                                                              oldModuleDelta,
+                                                                              newModuleDelta,
+                                                                              m_moduleFlowData,
+                                                                              m_moduleMembers);
 
-            if (deltaCodelength < 0.0 - m_infomap->minimumSingleNodeCodelengthImprovement) {
-              // Update empty module vector
-              if (m_moduleMembers[bestModuleIndex] == 0) {
-                m_emptyModules.pop_back();
-              }
-              if (m_moduleMembers[oldModuleIndex] == 1) {
-                m_emptyModules.push_back(oldModuleIndex);
-              }
-
-              m_objective.updateCodelengthOnMovingNode(current, oldModuleDelta, bestDeltaModule, m_moduleFlowData, m_moduleMembers);
-
-              m_moduleMembers[oldModuleIndex] -= 1;
-              m_moduleMembers[bestModuleIndex] += 1;
-
-              graph.moduleIndex(currentId) = bestModuleIndex;
-
-              ++numMoved;
-
-              // Mark neighbours as dirty
-              markNodeNeighboursDirty(graph, currentId);
-            } else {
-              ++numInvalidMoves;
+          if (deltaCodelength < 0.0 - m_infomap->minimumSingleNodeCodelengthImprovement) {
+            // Update empty module vector
+            if (m_moduleMembers[bestModuleIndex] == 0) {
+              m_emptyModules.pop_back();
             }
+            if (m_moduleMembers[oldModuleIndex] == 1) {
+              m_emptyModules.push_back(oldModuleIndex);
+            }
+
+            m_objective.updateCodelengthOnMovingNode(current, oldModuleDelta, bestDeltaModule, m_moduleFlowData, m_moduleMembers);
+
+            m_moduleMembers[oldModuleIndex] -= 1;
+            m_moduleMembers[bestModuleIndex] += 1;
+
+            graph.moduleIndex(currentId) = bestModuleIndex;
+
+            ++numMoved;
+
+            // Mark neighbours as dirty
+            markNodeNeighboursDirty(graph, currentId);
           } else {
             ++numInvalidMoves;
           }
+        } else {
+          ++numInvalidMoves;
         }
       }
     }

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -901,6 +901,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Grap
 template <typename Objective>
 unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleInParallel()
 {
+  auto graph = m_infomap->pointerBackend();
   // Get random enumeration of nodes
   auto& network = m_infomap->activeNetwork();
   std::vector<unsigned int> nodeEnumeration(network.size());
@@ -913,13 +914,15 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleInParalle
 #pragma omp parallel for schedule(dynamic) // Use dynamic scheduling as some threads could end early
   for (unsigned int i = 0; i < numNodes; ++i) {
     // Pick nodes in random order
-    InfoNode& current = *network[nodeEnumeration[i]];
+    const auto currentId = nodeEnumeration[i];
+    InfoNode& current = graph.nodeFor(currentId);
 
-    if (!current.dirty)
+    if (!graph.dirty(currentId))
       continue;
 
     // If other nodes have moved here, don't move away on first loop
-    if (m_moduleMembers[current.index] > 1 && m_infomap->isFirstLoop() && m_infomap->tuneIterationLimit != 1)
+    const auto currentModuleIndex = graph.moduleIndex(currentId);
+    if (m_moduleMembers[currentModuleIndex] > 1 && m_infomap->isFirstLoop() && m_infomap->tuneIterationLimit != 1)
       continue;
 
     // If no links connecting this node with other nodes, it won't move into others,
@@ -929,26 +932,15 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleInParalle
     // Create map with module links
     VectorMap<DeltaFlowDataType> deltaFlow(numNodes);
 
-    // For all outlinks
-    for (auto& e : current.outEdges()) {
-      auto& edge = *e;
-      InfoNode* neighbour = edge.target;
-      deltaFlow.add(neighbour->index, DeltaFlowDataType(neighbour->index, edge.data.flow, 0.0));
-    }
-    // For all inlinks
-    for (auto& e : current.inEdges()) {
-      auto& edge = *e;
-      InfoNode* neighbour = edge.source;
-      deltaFlow.add(neighbour->index, DeltaFlowDataType(neighbour->index, 0.0, edge.data.flow));
-    }
+    addNeighbourModuleLinks(graph, currentId, deltaFlow);
 
     // For not moving
-    deltaFlow.add(current.index, DeltaFlowDataType(current.index, 0.0, 0.0));
-    DeltaFlowDataType& oldModuleDelta = deltaFlow[current.index];
-    oldModuleDelta.module = current.index; // Make sure index is correct if created new
+    deltaFlow.add(currentModuleIndex, DeltaFlowDataType(currentModuleIndex, 0.0, 0.0));
+    DeltaFlowDataType& oldModuleDelta = deltaFlow[currentModuleIndex];
+    oldModuleDelta.module = currentModuleIndex; // Make sure index is correct if created new
 
     // Option to move to empty module (if node not already alone)
-    if (m_moduleMembers[current.index] > 1 && !m_emptyModules.empty()) {
+    if (m_moduleMembers[currentModuleIndex] > 1 && !m_emptyModules.empty()) {
       // deltaFlow[m_emptyModules.back()] += DeltaFlowDataType(m_emptyModules.back(), 0.0, 0.0);
       deltaFlow.add(m_emptyModules.back(), DeltaFlowDataType(m_emptyModules.back(), 0.0, 0.0));
     }
@@ -975,7 +967,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleInParalle
     // Find the move that minimizes the description length
     for (unsigned int j = 0; j < deltaFlow.size(); ++j) {
       unsigned int otherModule = moduleDeltaEnterExit[j].module;
-      if (otherModule != current.index) {
+      if (otherModule != currentModuleIndex) {
         double deltaCodelength = m_objective.getDeltaCodelengthOnMovingNode(current,
                                                                             oldModuleDelta,
                                                                             moduleDeltaEnterExit[j],
@@ -1001,14 +993,14 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleInParalle
     }
 
     // Make best possible move
-    if (bestDeltaModule.module == current.index) {
-      current.dirty = false;
+    if (bestDeltaModule.module == currentModuleIndex) {
+      graph.dirty(currentId) = false;
       continue;
     } else {
 #pragma omp critical(moveUpdate)
       {
         unsigned int bestModuleIndex = bestDeltaModule.module;
-        unsigned int oldModuleIndex = current.index;
+        unsigned int oldModuleIndex = graph.moduleIndex(currentId);
 
         bool validMove = bestModuleIndex == m_emptyModules.back()
             // Check validity of move to empty target
@@ -1021,24 +1013,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleInParalle
           oldModuleDelta = DeltaFlowDataType(oldModuleIndex, 0.0, 0.0);
           DeltaFlowDataType newModuleDelta(bestModuleIndex, 0.0, 0.0);
 
-          // For all outlinks
-          for (auto& e : current.outEdges()) {
-            auto& edge = *e;
-            unsigned int otherModule = edge.target->index;
-            if (otherModule == oldModuleIndex)
-              oldModuleDelta.deltaExit += edge.data.flow;
-            else if (otherModule == bestModuleIndex)
-              newModuleDelta.deltaExit += edge.data.flow;
-          }
-          // For all inlinks
-          for (auto& e : current.inEdges()) {
-            auto& edge = *e;
-            unsigned int otherModule = edge.source->index;
-            if (otherModule == oldModuleIndex)
-              oldModuleDelta.deltaEnter += edge.data.flow;
-            else if (otherModule == bestModuleIndex)
-              newModuleDelta.deltaEnter += edge.data.flow;
-          }
+          accumulateMoveDelta(graph, currentId, oldModuleIndex, bestModuleIndex, oldModuleDelta, newModuleDelta);
 
           // For memory networks
           m_objective.addMemoryContributions(current, oldModuleDelta, deltaFlow);
@@ -1063,15 +1038,12 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleInParalle
             m_moduleMembers[oldModuleIndex] -= 1;
             m_moduleMembers[bestModuleIndex] += 1;
 
-            current.index = bestModuleIndex;
+            graph.moduleIndex(currentId) = bestModuleIndex;
 
             ++numMoved;
 
             // Mark neighbours as dirty
-            for (auto& e : current.outEdges())
-              e->target->dirty = true;
-            for (auto& e : current.inEdges())
-              e->source->dirty = true;
+            markNodeNeighboursDirty(graph, currentId);
           } else {
             ++numInvalidMoves;
           }

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -268,7 +268,7 @@ void InfomapOptimizer<Objective>::markNodeNeighboursDirty(Graph& graph, typename
 template <typename Objective>
 void InfomapOptimizer<Objective>::initPartition()
 {
-  auto graph = m_infomap->pointerActiveGraph();
+  auto graph = m_infomap->pointerBackend();
   auto& network = m_infomap->activeNetwork();
   Log(4) << "InfomapOptimizer::initPartition() with " << graph.size() << " nodes...\n";
 
@@ -291,7 +291,7 @@ void InfomapOptimizer<Objective>::initPartition()
 template <typename Objective>
 void InfomapOptimizer<Objective>::moveActiveNodesToPredefinedModules(std::vector<unsigned int>& modules)
 {
-  auto graph = m_infomap->pointerActiveGraph();
+  auto graph = m_infomap->pointerBackend();
   moveActiveNodesToPredefinedModulesImpl(graph, modules);
 }
 
@@ -311,7 +311,7 @@ void InfomapOptimizer<Objective>::moveActiveNodesToPredefinedModulesImpl(Graph& 
 template <typename Objective>
 bool InfomapOptimizer<Objective>::moveNodeToPredefinedModule(InfoNode& current, unsigned int newModule)
 {
-  auto graph = m_infomap->pointerActiveGraph();
+  auto graph = m_infomap->pointerBackend();
   return moveNodeToPredefinedModuleImpl(graph, graph.idFor(current), newModule);
 }
 
@@ -395,7 +395,7 @@ inline unsigned int InfomapOptimizer<Objective>::optimizeActiveNetwork()
 template <typename Objective>
 unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModule()
 {
-  auto graph = m_infomap->pointerActiveGraph();
+  auto graph = m_infomap->pointerBackend();
   return tryMoveEachNodeIntoBestModuleImpl(graph);
 }
 
@@ -750,7 +750,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleInParalle
 template <typename Objective>
 inline void InfomapOptimizer<Objective>::consolidateModules(bool replaceExistingModules)
 {
-  auto graph = m_infomap->pointerActiveGraph();
+  auto graph = m_infomap->pointerBackend();
   auto numNodes = graph.size();
   std::vector<InfoNode*> modules(numNodes, nullptr);
 

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -622,6 +622,9 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Info
   const auto numNodes = nodeEnumeration.size();
   const bool lockFirstLoopMoves = m_infomap->isFirstLoop() && m_infomap->tuneIterationLimit != 1;
   const bool recordedTeleportation = m_infomap->recordedTeleportation;
+  const double minimumSingleNodeImprovement = m_infomap->minimumSingleNodeCodelengthImprovement;
+  auto& moduleFlowData = m_moduleFlowData;
+  auto& moduleMembers = m_moduleMembers;
   unsigned int numMoved = 0;
 
   auto* moduleIndices = graph.moduleIndicesData();
@@ -638,7 +641,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Info
     if (dirtyFlags[currentId] == 0u)
       continue;
 
-    if (m_moduleMembers[currentModuleIndex] > 1 && lockFirstLoopMoves)
+    if (moduleMembers[currentModuleIndex] > 1 && lockFirstLoopMoves)
       continue;
 
     deltaFlow.startRound();
@@ -649,7 +652,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Info
     DeltaFlowDataType& oldModuleDelta = deltaFlow[currentModuleIndex];
     oldModuleDelta.module = currentModuleIndex;
 
-    if (m_moduleMembers[currentModuleIndex] > 1 && !m_emptyModules.empty()) {
+    if (moduleMembers[currentModuleIndex] > 1 && !m_emptyModules.empty()) {
       deltaFlow.add(m_emptyModules.back(), DeltaFlowDataType(m_emptyModules.back(), 0.0, 0.0));
     }
 
@@ -663,12 +666,12 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Info
         auto& deltaEnterExit = moduleDeltaEnterExit[j];
         const auto moduleIndex = deltaEnterExit.module;
         if (moduleIndex == currentModuleIndex) {
-          auto& oldModuleFlowData = m_moduleFlowData[moduleIndex];
+          auto& oldModuleFlowData = moduleFlowData[moduleIndex];
           const double deltaEnterOld = (oldModuleFlowData.teleportFlow - current.data.teleportFlow) * current.data.teleportWeight;
           const double deltaExitOld = current.data.teleportFlow * (oldModuleFlowData.teleportWeight - current.data.teleportWeight);
           deltaFlow.add(moduleIndex, DeltaFlowDataType(moduleIndex, deltaExitOld, deltaEnterOld));
         } else {
-          auto& newModuleFlowData = m_moduleFlowData[moduleIndex];
+          auto& newModuleFlowData = moduleFlowData[moduleIndex];
           const double deltaEnterNew = newModuleFlowData.teleportFlow * current.data.teleportWeight;
           const double deltaExitNew = current.data.teleportFlow * newModuleFlowData.teleportWeight;
           deltaFlow.add(moduleIndex, DeltaFlowDataType(moduleIndex, deltaExitNew, deltaEnterNew));
@@ -691,10 +694,10 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Info
         const double deltaCodelength = m_objective.getDeltaCodelengthOnMovingNode(current,
                                                                                    oldModuleDelta,
                                                                                    moduleDeltaEnterExit[j],
-                                                                                   m_moduleFlowData,
-                                                                                   m_moduleMembers);
+                                                                                   moduleFlowData,
+                                                                                   moduleMembers);
 
-        if (deltaCodelength < bestDeltaCodelength - m_infomap->minimumSingleNodeCodelengthImprovement) {
+        if (deltaCodelength < bestDeltaCodelength - minimumSingleNodeImprovement) {
           bestDeltaModule = moduleDeltaEnterExit[j];
           bestDeltaCodelength = deltaCodelength;
         }
@@ -706,23 +709,23 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Info
       }
     }
 
-    if (strongestConnectedModule.module != bestDeltaModule.module && deltaCodelengthOnStrongestConnectedModule <= bestDeltaCodelength + m_infomap->minimumSingleNodeCodelengthImprovement) {
+    if (strongestConnectedModule.module != bestDeltaModule.module && deltaCodelengthOnStrongestConnectedModule <= bestDeltaCodelength + minimumSingleNodeImprovement) {
       bestDeltaModule = strongestConnectedModule;
     }
 
     if (bestDeltaModule.module != currentModuleIndex) {
       const unsigned int bestModuleIndex = bestDeltaModule.module;
-      if (m_moduleMembers[bestModuleIndex] == 0) {
+      if (moduleMembers[bestModuleIndex] == 0) {
         m_emptyModules.pop_back();
       }
-      if (m_moduleMembers[currentModuleIndex] == 1) {
+      if (moduleMembers[currentModuleIndex] == 1) {
         m_emptyModules.push_back(currentModuleIndex);
       }
 
-      m_objective.updateCodelengthOnMovingNode(current, oldModuleDelta, bestDeltaModule, m_moduleFlowData, m_moduleMembers);
+      m_objective.updateCodelengthOnMovingNode(current, oldModuleDelta, bestDeltaModule, moduleFlowData, moduleMembers);
 
-      m_moduleMembers[currentModuleIndex] -= 1;
-      m_moduleMembers[bestModuleIndex] += 1;
+      moduleMembers[currentModuleIndex] -= 1;
+      moduleMembers[bestModuleIndex] += 1;
 
       const unsigned int oldModuleIndex = currentModuleIndex;
       moduleIndices[currentId] = bestModuleIndex;
@@ -734,7 +737,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Info
       unsigned int numLinkedNodesInOldModule = 0;
       markNeighboursDirty(graph, currentId, oldModuleIndex, nodeInOldModule, nodeInOldModuleId, numLinkedNodesInOldModule);
 
-      if (numLinkedNodesInOldModule == 1 && m_moduleMembers[oldModuleIndex] == 1) {
+      if (numLinkedNodesInOldModule == 1 && moduleMembers[oldModuleIndex] == 1) {
         moveNodeToPredefinedModuleImpl(graph, nodeInOldModuleId, bestModuleIndex);
         ++numMoved;
         if (nodeInOldModule->degree() > 1) {
@@ -760,6 +763,9 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Grap
   auto numNodes = nodeEnumeration.size();
   const bool lockFirstLoopMoves = m_infomap->isFirstLoop() && m_infomap->tuneIterationLimit != 1;
   const bool recordedTeleportation = m_infomap->recordedTeleportation;
+  const double minimumSingleNodeImprovement = m_infomap->minimumSingleNodeCodelengthImprovement;
+  auto& moduleFlowData = m_moduleFlowData;
+  auto& moduleMembers = m_moduleMembers;
   unsigned int numMoved = 0;
 
   // Create map with module links
@@ -775,7 +781,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Grap
       continue;
 
     // If other nodes have moved here, don't move away on first loop
-    if (m_moduleMembers[currentModuleIndex] > 1 && lockFirstLoopMoves)
+    if (moduleMembers[currentModuleIndex] > 1 && lockFirstLoopMoves)
       continue;
 
     // If no links connecting this node with other nodes, it won't move into others,
@@ -793,7 +799,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Grap
     oldModuleDelta.module = currentModuleIndex; // Make sure index is correct if created new
 
     // Option to move to empty module (if node not already alone)
-    if (m_moduleMembers[currentModuleIndex] > 1 && !m_emptyModules.empty()) {
+    if (moduleMembers[currentModuleIndex] > 1 && !m_emptyModules.empty()) {
       deltaFlow.add(m_emptyModules.back(), DeltaFlowDataType(m_emptyModules.back(), 0.0, 0.0));
     }
 
@@ -809,12 +815,12 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Grap
         auto& deltaEnterExit = moduleDeltaEnterExit[j];
         auto moduleIndex = deltaEnterExit.module;
         if (moduleIndex == currentModuleIndex) {
-          auto& oldModuleFlowData = m_moduleFlowData[moduleIndex];
+          auto& oldModuleFlowData = moduleFlowData[moduleIndex];
           double deltaEnterOld = (oldModuleFlowData.teleportFlow - current.data.teleportFlow) * current.data.teleportWeight;
           double deltaExitOld = current.data.teleportFlow * (oldModuleFlowData.teleportWeight - current.data.teleportWeight);
           deltaFlow.add(moduleIndex, DeltaFlowDataType(moduleIndex, deltaExitOld, deltaEnterOld));
         } else {
-          auto& newModuleFlowData = m_moduleFlowData[moduleIndex];
+          auto& newModuleFlowData = moduleFlowData[moduleIndex];
           double deltaEnterNew = newModuleFlowData.teleportFlow * current.data.teleportWeight;
           double deltaExitNew = current.data.teleportFlow * newModuleFlowData.teleportWeight;
           deltaFlow.add(moduleIndex, DeltaFlowDataType(moduleIndex, deltaExitNew, deltaEnterNew));
@@ -839,10 +845,10 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Grap
         double deltaCodelength = m_objective.getDeltaCodelengthOnMovingNode(current,
                                                                             oldModuleDelta,
                                                                             moduleDeltaEnterExit[j],
-                                                                            m_moduleFlowData,
-                                                                            m_moduleMembers);
+                                                                            moduleFlowData,
+                                                                            moduleMembers);
 
-        if (deltaCodelength < bestDeltaCodelength - m_infomap->minimumSingleNodeCodelengthImprovement) {
+        if (deltaCodelength < bestDeltaCodelength - minimumSingleNodeImprovement) {
           bestDeltaModule = moduleDeltaEnterExit[j];
           bestDeltaCodelength = deltaCodelength;
         }
@@ -856,7 +862,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Grap
     }
 
     // Prefer strongest connected module if equal delta codelength
-    if (strongestConnectedModule.module != bestDeltaModule.module && deltaCodelengthOnStrongestConnectedModule <= bestDeltaCodelength + m_infomap->minimumSingleNodeCodelengthImprovement) {
+    if (strongestConnectedModule.module != bestDeltaModule.module && deltaCodelengthOnStrongestConnectedModule <= bestDeltaCodelength + minimumSingleNodeImprovement) {
       bestDeltaModule = strongestConnectedModule;
     }
 
@@ -864,17 +870,17 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Grap
     if (bestDeltaModule.module != currentModuleIndex) {
       unsigned int bestModuleIndex = bestDeltaModule.module;
       // Update empty module vector
-      if (m_moduleMembers[bestModuleIndex] == 0) {
+      if (moduleMembers[bestModuleIndex] == 0) {
         m_emptyModules.pop_back();
       }
-      if (m_moduleMembers[currentModuleIndex] == 1) {
+      if (moduleMembers[currentModuleIndex] == 1) {
         m_emptyModules.push_back(currentModuleIndex);
       }
 
-      m_objective.updateCodelengthOnMovingNode(current, oldModuleDelta, bestDeltaModule, m_moduleFlowData, m_moduleMembers);
+      m_objective.updateCodelengthOnMovingNode(current, oldModuleDelta, bestDeltaModule, moduleFlowData, moduleMembers);
 
-      m_moduleMembers[currentModuleIndex] -= 1;
-      m_moduleMembers[bestModuleIndex] += 1;
+      moduleMembers[currentModuleIndex] -= 1;
+      moduleMembers[bestModuleIndex] += 1;
 
       unsigned int oldModuleIndex = currentModuleIndex;
       graph.moduleIndex(currentId) = bestModuleIndex;
@@ -888,7 +894,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleImpl(Grap
       markNeighboursDirty(graph, currentId, oldModuleIndex, nodeInOldModule, nodeInOldModuleId, numLinkedNodesInOldModule);
 
       // Move single connected nodes to same module
-      if (numLinkedNodesInOldModule == 1 && m_moduleMembers[oldModuleIndex] == 1) {
+      if (numLinkedNodesInOldModule == 1 && moduleMembers[oldModuleIndex] == 1) {
         moveNodeToPredefinedModuleImpl(graph, nodeInOldModuleId, bestModuleIndex);
         ++numMoved;
         // Mark neighbours as dirty

--- a/test/bench/native_benchmark.cpp
+++ b/test/bench/native_benchmark.cpp
@@ -1,0 +1,166 @@
+#include "Infomap.h"
+#include "core/InfoEdge.h"
+#include "core/InfoNode.h"
+#include "utils/Stopwatch.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+#if defined(__unix__) || defined(__APPLE__)
+#include <sys/resource.h>
+#endif
+
+namespace {
+
+std::string jsonEscape(const std::string& value)
+{
+  std::ostringstream escaped;
+  for (char c : value) {
+    switch (c) {
+      case '\\': escaped << "\\\\"; break;
+      case '"': escaped << "\\\""; break;
+      case '\n': escaped << "\\n"; break;
+      case '\r': escaped << "\\r"; break;
+      case '\t': escaped << "\\t"; break;
+      default: escaped << c; break;
+    }
+  }
+  return escaped.str();
+}
+
+unsigned long long peakRssBytes()
+{
+#if defined(__unix__) || defined(__APPLE__)
+  struct rusage usage {};
+  if (getrusage(RUSAGE_SELF, &usage) != 0) {
+    return 0;
+  }
+#if defined(__APPLE__)
+  return static_cast<unsigned long long>(usage.ru_maxrss);
+#else
+  return static_cast<unsigned long long>(usage.ru_maxrss) * 1024ULL;
+#endif
+#else
+  return 0;
+#endif
+}
+
+void printUsage(const char* argv0)
+{
+  std::cerr << "Usage: " << argv0 << " --input <path> [--name <label>] [--flags <infomap flags>]\n";
+}
+
+} // namespace
+
+int main(int argc, char* argv[])
+{
+  std::string inputPath;
+  std::string caseName;
+  std::string flags = "--silent --no-file-output --num-trials 1 --seed 123";
+
+  for (int i = 1; i < argc; ++i) {
+    const std::string arg = argv[i];
+    if (arg == "--input" && i + 1 < argc) {
+      inputPath = argv[++i];
+    } else if (arg == "--name" && i + 1 < argc) {
+      caseName = argv[++i];
+    } else if (arg == "--flags" && i + 1 < argc) {
+      flags = argv[++i];
+    } else if (arg == "--help" || arg == "-h") {
+      printUsage(argv[0]);
+      return 0;
+    } else {
+      std::cerr << "Unknown or incomplete argument: " << arg << "\n";
+      printUsage(argv[0]);
+      return 2;
+    }
+  }
+
+  if (inputPath.empty()) {
+    printUsage(argv[0]);
+    return 2;
+  }
+  if (caseName.empty()) {
+    caseName = inputPath;
+  }
+
+  try {
+    infomap::InfomapWrapper im(flags);
+
+    infomap::Stopwatch readTimer(true);
+    im.readInputData(inputPath);
+    const double readInputSec = readTimer.getElapsedTimeInSec();
+
+    const auto inputNodeCount = im.network().numNodes();
+    const auto inputLinkCount = im.network().numLinks();
+    const auto higherOrderInput = im.network().haveMemoryInput();
+    const auto directedInput = im.network().haveDirectedInput();
+
+    infomap::Stopwatch runTimer(true);
+    im.run();
+    const double runSec = runTimer.getElapsedTimeInSec();
+
+    const auto& stats = im.benchmarkStats();
+    std::cout << "{";
+    std::cout << "\"name\":\"" << jsonEscape(caseName) << "\",";
+    std::cout << "\"path\":\"" << jsonEscape(inputPath) << "\",";
+    std::cout << "\"backend_mode\":\"pointer\",";
+    std::cout << "\"flags\":\"" << jsonEscape(flags) << "\",";
+    std::cout << "\"read_input_sec\":" << readInputSec << ",";
+    std::cout << "\"run_sec\":" << runSec << ",";
+    std::cout << "\"total_sec\":" << (readInputSec + runSec) << ",";
+    std::cout << "\"peak_rss_bytes\":" << peakRssBytes() << ",";
+    std::cout << "\"node_size_bytes\":" << sizeof(infomap::InfoNode) << ",";
+    std::cout << "\"edge_size_bytes\":" << sizeof(infomap::InfoEdge) << ",";
+    std::cout << "\"num_nodes\":" << inputNodeCount << ",";
+    std::cout << "\"num_links\":" << inputLinkCount << ",";
+    std::cout << "\"num_top_modules\":" << im.numTopModules() << ",";
+    std::cout << "\"num_levels\":" << im.numLevels() << ",";
+    std::cout << "\"codelength\":" << im.codelength() << ",";
+    std::cout << "\"higher_order_input\":" << (higherOrderInput ? "true" : "false") << ",";
+    std::cout << "\"directed_input\":" << (directedInput ? "true" : "false") << ",";
+    std::cout << "\"benchmark_stats\":{";
+    std::cout << "\"calculate_flow_sec\":" << stats.calculateFlowSec << ",";
+    std::cout << "\"init_network_sec\":" << stats.initNetworkSec << ",";
+    std::cout << "\"run_partition_sec\":" << stats.runPartitionSec << ",";
+    std::cout << "\"find_top_modules_sec\":" << stats.findTopModulesSec << ",";
+    std::cout << "\"fine_tune_sec\":" << stats.fineTuneSec << ",";
+    std::cout << "\"coarse_tune_sec\":" << stats.coarseTuneSec << ",";
+    std::cout << "\"recursive_partition_sec\":" << stats.recursivePartitionSec << ",";
+    std::cout << "\"super_modules_sec\":" << stats.superModulesSec << ",";
+    std::cout << "\"super_modules_fast_sec\":" << stats.superModulesFastSec << ",";
+    std::cout << "\"find_top_modules_calls\":" << stats.findTopModulesCalls << ",";
+    std::cout << "\"fine_tune_calls\":" << stats.fineTuneCalls << ",";
+    std::cout << "\"coarse_tune_calls\":" << stats.coarseTuneCalls << ",";
+    std::cout << "\"recursive_partition_calls\":" << stats.recursivePartitionCalls << ",";
+    std::cout << "\"super_modules_calls\":" << stats.superModulesCalls << ",";
+    std::cout << "\"super_modules_fast_calls\":" << stats.superModulesFastCalls << ",";
+    std::cout << "\"consolidation_count\":" << stats.consolidationCount << ",";
+    std::cout << "\"consolidations\":[";
+    for (std::size_t i = 0; i < stats.consolidations.size(); ++i) {
+      const auto& consolidation = stats.consolidations[i];
+      if (i > 0) {
+        std::cout << ",";
+      }
+      std::cout << "{";
+      std::cout << "\"level\":" << consolidation.level << ",";
+      std::cout << "\"active_node_count\":" << consolidation.activeNodeCount << ",";
+      std::cout << "\"module_node_count\":" << consolidation.moduleNodeCount << ",";
+      std::cout << "\"module_edge_count\":" << consolidation.moduleEdgeCount << ",";
+      std::cout << "\"replace_existing_modules\":" << (consolidation.replaceExistingModules ? "true" : "false");
+      std::cout << "}";
+    }
+    std::cout << "]";
+    std::cout << "}";
+    std::cout << "}\n";
+  } catch (const std::exception& error) {
+    std::cerr << "Error: " << error.what() << "\n";
+    return 1;
+  }
+
+  return 0;
+}

--- a/test/bench/native_benchmark.cpp
+++ b/test/bench/native_benchmark.cpp
@@ -128,7 +128,7 @@ int main(int argc, char* argv[])
     std::cout << "\"peak_rss_bytes\":" << peakRssBytes() << ",";
     std::cout << "\"node_size_bytes\":" << sizeof(infomap::InfoNode) << ",";
     std::cout << "\"edge_size_bytes\":" << sizeof(infomap::InfoEdge) << ",";
-    std::cout << "\"active_payload_nodes\":" << activeMaterialization.payloads.size() << ",";
+    std::cout << "\"active_payload_nodes\":0,";
     std::cout << "\"active_payload_bytes\":" << activeMaterialization.payloadBytes() << ",";
     std::cout << "\"num_nodes\":" << inputNodeCount << ",";
     std::cout << "\"num_links\":" << inputLinkCount << ",";

--- a/test/bench/native_benchmark.cpp
+++ b/test/bench/native_benchmark.cpp
@@ -51,7 +51,7 @@ unsigned long long peakRssBytes()
 
 void printUsage(const char* argv0)
 {
-  std::cerr << "Usage: " << argv0 << " --input <path> [--name <label>] [--flags <infomap flags>]\n";
+  std::cerr << "Usage: " << argv0 << " --input <path> [--name <label>] [--flags <infomap flags>] [--backend-mode auto|pointer]\n";
 }
 
 } // namespace
@@ -61,6 +61,7 @@ int main(int argc, char* argv[])
   std::string inputPath;
   std::string caseName;
   std::string flags = "--silent --no-file-output --num-trials 1 --seed 123";
+  std::string backendMode = "auto";
 
   for (int i = 1; i < argc; ++i) {
     const std::string arg = argv[i];
@@ -70,6 +71,8 @@ int main(int argc, char* argv[])
       caseName = argv[++i];
     } else if (arg == "--flags" && i + 1 < argc) {
       flags = argv[++i];
+    } else if (arg == "--backend-mode" && i + 1 < argc) {
+      backendMode = argv[++i];
     } else if (arg == "--help" || arg == "-h") {
       printUsage(argv[0]);
       return 0;
@@ -87,9 +90,17 @@ int main(int argc, char* argv[])
   if (caseName.empty()) {
     caseName = inputPath;
   }
+  if (backendMode != "auto" && backendMode != "pointer") {
+    std::cerr << "Unsupported backend mode: " << backendMode << "\n";
+    printUsage(argv[0]);
+    return 2;
+  }
 
   try {
     infomap::InfomapWrapper im(flags);
+    if (backendMode == "pointer") {
+      im.m_disableCsrMaterialization = true;
+    }
 
     infomap::Stopwatch readTimer(true);
     im.readInputData(inputPath);
@@ -109,7 +120,7 @@ int main(int argc, char* argv[])
     std::cout << "{";
     std::cout << "\"name\":\"" << jsonEscape(caseName) << "\",";
     std::cout << "\"path\":\"" << jsonEscape(inputPath) << "\",";
-    std::cout << "\"backend_mode\":\"pointer\",";
+    std::cout << "\"backend_mode\":\"" << jsonEscape(backendMode) << "\",";
     std::cout << "\"flags\":\"" << jsonEscape(flags) << "\",";
     std::cout << "\"read_input_sec\":" << readInputSec << ",";
     std::cout << "\"run_sec\":" << runSec << ",";

--- a/test/bench/native_benchmark.cpp
+++ b/test/bench/native_benchmark.cpp
@@ -67,7 +67,7 @@ void printStorageBreakdown(const infomap::InfomapBase::ActiveGraphStorageBreakdo
   std::cout << "\"csr_out_flow_bytes\":" << storage.csrOutFlowBytes << ",";
   std::cout << "\"csr_in_offset_bytes\":" << storage.csrInOffsetBytes << ",";
   std::cout << "\"csr_in_target_bytes\":" << storage.csrInTargetBytes << ",";
-  std::cout << "\"csr_in_flow_bytes\":" << storage.csrInFlowBytes << ",";
+  std::cout << "\"csr_in_flow_index_bytes\":" << storage.csrInFlowIndexBytes << ",";
   std::cout << "\"csr_module_index_bytes\":" << storage.csrModuleIndexBytes << ",";
   std::cout << "\"csr_dirty_flag_bytes\":" << storage.csrDirtyFlagBytes << ",";
   std::cout << "\"total_bytes\":" << storage.totalBytes() << ",";

--- a/test/bench/native_benchmark.cpp
+++ b/test/bench/native_benchmark.cpp
@@ -60,6 +60,8 @@ void printStorageBreakdown(const infomap::InfomapBase::ActiveGraphStorageBreakdo
   std::cout << "\"active_node_pointer_bytes\":" << storage.activeNodePointerBytes << ",";
   std::cout << "\"active_node_to_id_entry_bytes\":" << storage.activeNodeToIdEntryBytes << ",";
   std::cout << "\"active_node_to_id_bucket_bytes\":" << storage.activeNodeToIdBucketBytes << ",";
+  std::cout << "\"csr_state_id_entry_bytes\":" << storage.csrStateIdEntryBytes << ",";
+  std::cout << "\"csr_state_id_bucket_bytes\":" << storage.csrStateIdBucketBytes << ",";
   std::cout << "\"csr_out_offset_bytes\":" << storage.csrOutOffsetBytes << ",";
   std::cout << "\"csr_out_target_bytes\":" << storage.csrOutTargetBytes << ",";
   std::cout << "\"csr_out_flow_bytes\":" << storage.csrOutFlowBytes << ",";

--- a/test/bench/native_benchmark.cpp
+++ b/test/bench/native_benchmark.cpp
@@ -105,6 +105,7 @@ int main(int argc, char* argv[])
     const double runSec = runTimer.getElapsedTimeInSec();
 
     const auto& stats = im.benchmarkStats();
+    const auto& activeMaterialization = im.activeGraphMaterialization();
     std::cout << "{";
     std::cout << "\"name\":\"" << jsonEscape(caseName) << "\",";
     std::cout << "\"path\":\"" << jsonEscape(inputPath) << "\",";
@@ -116,6 +117,8 @@ int main(int argc, char* argv[])
     std::cout << "\"peak_rss_bytes\":" << peakRssBytes() << ",";
     std::cout << "\"node_size_bytes\":" << sizeof(infomap::InfoNode) << ",";
     std::cout << "\"edge_size_bytes\":" << sizeof(infomap::InfoEdge) << ",";
+    std::cout << "\"active_payload_nodes\":" << activeMaterialization.payloads.size() << ",";
+    std::cout << "\"active_payload_bytes\":" << activeMaterialization.payloadBytes() << ",";
     std::cout << "\"num_nodes\":" << inputNodeCount << ",";
     std::cout << "\"num_links\":" << inputLinkCount << ",";
     std::cout << "\"num_top_modules\":" << im.numTopModules() << ",";

--- a/test/bench/native_benchmark.cpp
+++ b/test/bench/native_benchmark.cpp
@@ -54,6 +54,25 @@ void printUsage(const char* argv0)
   std::cerr << "Usage: " << argv0 << " --input <path> [--name <label>] [--flags <infomap flags>] [--backend-mode auto|pointer]\n";
 }
 
+void printStorageBreakdown(const infomap::InfomapBase::ActiveGraphStorageBreakdown& storage)
+{
+  std::cout << "{";
+  std::cout << "\"active_node_pointer_bytes\":" << storage.activeNodePointerBytes << ",";
+  std::cout << "\"active_node_to_id_entry_bytes\":" << storage.activeNodeToIdEntryBytes << ",";
+  std::cout << "\"active_node_to_id_bucket_bytes\":" << storage.activeNodeToIdBucketBytes << ",";
+  std::cout << "\"csr_out_offset_bytes\":" << storage.csrOutOffsetBytes << ",";
+  std::cout << "\"csr_out_target_bytes\":" << storage.csrOutTargetBytes << ",";
+  std::cout << "\"csr_out_flow_bytes\":" << storage.csrOutFlowBytes << ",";
+  std::cout << "\"csr_in_offset_bytes\":" << storage.csrInOffsetBytes << ",";
+  std::cout << "\"csr_in_target_bytes\":" << storage.csrInTargetBytes << ",";
+  std::cout << "\"csr_in_flow_bytes\":" << storage.csrInFlowBytes << ",";
+  std::cout << "\"csr_module_index_bytes\":" << storage.csrModuleIndexBytes << ",";
+  std::cout << "\"csr_dirty_flag_bytes\":" << storage.csrDirtyFlagBytes << ",";
+  std::cout << "\"total_bytes\":" << storage.totalBytes() << ",";
+  std::cout << "\"csr_available\":" << (storage.csrAvailable ? "true" : "false");
+  std::cout << "}";
+}
+
 } // namespace
 
 int main(int argc, char* argv[])
@@ -117,6 +136,7 @@ int main(int argc, char* argv[])
 
     const auto& stats = im.benchmarkStats();
     const auto& activeMaterialization = im.activeGraphMaterialization();
+    const auto storage = im.activeGraphStorageBreakdown();
     std::cout << "{";
     std::cout << "\"name\":\"" << jsonEscape(caseName) << "\",";
     std::cout << "\"path\":\"" << jsonEscape(inputPath) << "\",";
@@ -130,6 +150,9 @@ int main(int argc, char* argv[])
     std::cout << "\"edge_size_bytes\":" << sizeof(infomap::InfoEdge) << ",";
     std::cout << "\"active_payload_nodes\":0,";
     std::cout << "\"active_payload_bytes\":" << activeMaterialization.payloadBytes() << ",";
+    std::cout << "\"active_graph_storage\":";
+    printStorageBreakdown(storage);
+    std::cout << ",";
     std::cout << "\"num_nodes\":" << inputNodeCount << ",";
     std::cout << "\"num_links\":" << inputLinkCount << ",";
     std::cout << "\"num_top_modules\":" << im.numTopModules() << ",";
@@ -154,6 +177,12 @@ int main(int argc, char* argv[])
     std::cout << "\"super_modules_calls\":" << stats.superModulesCalls << ",";
     std::cout << "\"super_modules_fast_calls\":" << stats.superModulesFastCalls << ",";
     std::cout << "\"consolidation_count\":" << stats.consolidationCount << ",";
+    std::cout << "\"last_active_graph_storage\":";
+    printStorageBreakdown(stats.lastActiveGraphStorage);
+    std::cout << ",";
+    std::cout << "\"max_active_graph_storage\":";
+    printStorageBreakdown(stats.maxActiveGraphStorage);
+    std::cout << ",";
     std::cout << "\"consolidations\":[";
     for (std::size_t i = 0; i < stats.consolidations.size(); ++i) {
       const auto& consolidation = stats.consolidations[i];

--- a/test/bench/native_benchmark.cpp
+++ b/test/bench/native_benchmark.cpp
@@ -165,6 +165,7 @@ int main(int argc, char* argv[])
     std::cout << "\"benchmark_stats\":{";
     std::cout << "\"calculate_flow_sec\":" << stats.calculateFlowSec << ",";
     std::cout << "\"init_network_sec\":" << stats.initNetworkSec << ",";
+    std::cout << "\"materialize_csr_sec\":" << stats.materializeCsrSec << ",";
     std::cout << "\"run_partition_sec\":" << stats.runPartitionSec << ",";
     std::cout << "\"find_top_modules_sec\":" << stats.findTopModulesSec << ",";
     std::cout << "\"fine_tune_sec\":" << stats.fineTuneSec << ",";

--- a/test/cpp/test_flow.cpp
+++ b/test/cpp/test_flow.cpp
@@ -63,6 +63,16 @@ TEST_CASE("Directed regularization remains numerically sane on the teleportation
   CHECK(result.codelength > result.indexCodelength);
 }
 
+TEST_CASE("Inner parallelization remains runnable and numerically sane on the directed fixture [fast][core][flow][openmp]")
+{
+  const auto result = runDirectedFixture("--inner-parallelization");
+
+  CHECK(result.numTopModules >= 1);
+  CHECK(result.numTopModules <= 6);
+  CHECK(result.partition.size() == result.numTopModules);
+  CHECK(result.codelength >= result.indexCodelength);
+}
+
 TEST_CASE("Precomputed flow rejects first-order input without vertex flows [fast][core][flow][parser]")
 {
   InfomapWrapper im(infomap::test::defaultFlags("--flow-model precomputed"));

--- a/test/cpp/test_flow.cpp
+++ b/test/cpp/test_flow.cpp
@@ -46,6 +46,34 @@ TEST_CASE("Recorded teleportation stays stable across trial counts for the direc
   CHECK(oneTrial.indexCodelength == doctest::Approx(twoTrials.indexCodelength));
 }
 
+TEST_CASE("Recorded teleportation serial leaf optimization matches pointer and CSR backends [fast][core][flow][lifecycle]")
+{
+  const auto flags = infomap::test::defaultFlags("--directed --recorded-teleportation");
+
+  InfomapWrapper pointerIm(flags);
+  infomap::test::readNetworkFixture(pointerIm, "teleport_directed.net");
+  pointerIm.initNetwork(pointerIm.network());
+  pointerIm.setActiveNetworkFromLeafs();
+  pointerIm.m_csrMaterialization.reset();
+  CHECK_FALSE(pointerIm.csrBackend().available());
+  pointerIm.initPartition();
+
+  InfomapWrapper csrIm(flags);
+  infomap::test::readNetworkFixture(csrIm, "teleport_directed.net");
+  csrIm.initNetwork(csrIm.network());
+  csrIm.setActiveNetworkFromLeafs();
+  REQUIRE(csrIm.csrBackend().available());
+  csrIm.initPartition();
+
+  const auto pointerLoops = pointerIm.optimizeActiveNetwork();
+  const auto csrLoops = csrIm.optimizeActiveNetwork();
+
+  CHECK(csrLoops == pointerLoops);
+  CHECK(infomap::test::canonicalPartition(csrIm.getModules()) == infomap::test::canonicalPartition(pointerIm.getModules()));
+  CHECK(csrIm.codelength() == doctest::Approx(pointerIm.codelength()));
+  CHECK(csrIm.getIndexCodelength() == doctest::Approx(pointerIm.getIndexCodelength()));
+}
+
 TEST_CASE("Directed to-nodes teleportation keeps the expected coarse partition [fast][core][flow]")
 {
   const auto result = runDirectedFixture("--to-nodes");

--- a/test/cpp/test_flow.cpp
+++ b/test/cpp/test_flow.cpp
@@ -101,6 +101,16 @@ TEST_CASE("Inner parallelization remains runnable and numerically sane on the di
   CHECK(result.codelength >= result.indexCodelength);
 }
 
+TEST_CASE("Inner parallelization keeps the active graph pointer-backed [fast][core][flow][openmp][lifecycle]")
+{
+  InfomapWrapper im(infomap::test::defaultFlags("--directed --inner-parallelization"));
+  infomap::test::readNetworkFixture(im, "teleport_directed.net");
+  im.initNetwork(im.network());
+  im.setActiveNetworkFromLeafs();
+
+  CHECK_FALSE(im.csrBackend().available());
+}
+
 TEST_CASE("Precomputed flow rejects first-order input without vertex flows [fast][core][flow][parser]")
 {
   InfomapWrapper im(infomap::test::defaultFlags("--flow-model precomputed"));

--- a/test/cpp/test_infomap_wrapper.cpp
+++ b/test/cpp/test_infomap_wrapper.cpp
@@ -148,6 +148,7 @@ TEST_CASE("Subnetwork generation preserves parent indices and clones internal ed
 
   REQUIRE(subInfomap.numLeafNodes() == module.childDegree());
   CHECK(subInfomap.root().owner == &module);
+  CHECK_FALSE(subInfomap.csrBackend().available());
   CHECK(internalEdgesForModule(subInfomap.root()) == originalEdges);
 
   childIndex = 0;

--- a/test/cpp/test_infomap_wrapper.cpp
+++ b/test/cpp/test_infomap_wrapper.cpp
@@ -4,11 +4,28 @@
 
 #include "TestUtils.h"
 
+#include <set>
+#include <tuple>
 #include <vector>
 
 namespace {
 
 using infomap::InfomapWrapper;
+
+using InternalEdge = std::tuple<unsigned int, unsigned int, double, double>;
+
+std::multiset<InternalEdge> internalEdgesForModule(infomap::InfoNode& module)
+{
+  std::multiset<InternalEdge> edges;
+  for (auto& node : module) {
+    for (auto* edge : node.outEdges()) {
+      if (edge->target->parent == &module) {
+        edges.emplace(edge->source->stateId, edge->target->stateId, edge->data.weight, edge->data.flow);
+      }
+    }
+  }
+  return edges;
+}
 
 TEST_CASE("Infomap partitions the unweighted two-triangle fixture into two modules [fast][core][lifecycle]")
 {
@@ -104,6 +121,40 @@ TEST_CASE("File-backed multilayer input clusters as a higher-order network [fast
   infomap::test::checkRunSanity(im);
   CHECK(im.network().haveMemoryInput());
   CHECK(im.getModules(1, true).size() == im.numLeafNodes());
+}
+
+TEST_CASE("Subnetwork generation preserves parent indices and clones internal edges [fast][core][lifecycle][subnetwork]")
+{
+  InfomapWrapper im(infomap::test::defaultFlags());
+  im.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+  im.run();
+
+  infomap::test::checkRunSanity(im);
+  REQUIRE(im.numTopModules() == 2);
+
+  auto& module = *im.root().firstChild;
+  REQUIRE(module.childDegree() == 3);
+
+  const auto originalEdges = internalEdgesForModule(module);
+  std::vector<unsigned int> sentinelIndices;
+  unsigned int childIndex = 0;
+  for (auto& node : module) {
+    node.index = 100 + childIndex;
+    sentinelIndices.push_back(node.index);
+    ++childIndex;
+  }
+
+  auto& subInfomap = im.getSubInfomap(module).initNetwork(module);
+
+  REQUIRE(subInfomap.numLeafNodes() == module.childDegree());
+  CHECK(subInfomap.root().owner == &module);
+  CHECK(internalEdgesForModule(subInfomap.root()) == originalEdges);
+
+  childIndex = 0;
+  for (auto& node : module) {
+    CHECK(node.index == sentinelIndices[childIndex]);
+    ++childIndex;
+  }
 }
 
 } // namespace

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -361,8 +361,8 @@ TEST_CASE("Active graph storage breakdown distinguishes pointer-only and CSR-bac
   CHECK(csrStorage.activeNodePointerBytes > 0);
   CHECK(csrStorage.activeNodeToIdEntryBytes == 0);
   CHECK(csrStorage.activeNodeToIdBucketBytes == 0);
-  CHECK(csrStorage.csrStateIdEntryBytes > 0);
-  CHECK(csrStorage.csrStateIdBucketBytes > 0);
+  CHECK(csrStorage.csrStateIdEntryBytes == 0);
+  CHECK(csrStorage.csrStateIdBucketBytes == 0);
   CHECK(csrStorage.csrOutOffsetBytes > 0);
   CHECK(csrStorage.csrInOffsetBytes > 0);
   CHECK(csrStorage.totalBytes() > pointerStorage.totalBytes());
@@ -385,7 +385,8 @@ TEST_CASE("Active graph reset releases stale reverse-lookup buckets [fast][core]
   csrIm.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
   csrIm.initNetwork(csrIm.network());
   csrIm.setActiveNetworkFromLeafs();
-  REQUIRE(csrIm.activeGraphStorageBreakdown().csrStateIdBucketBytes > 0);
+  CHECK(csrIm.activeGraphStorageBreakdown().csrStateIdEntryBytes == 0);
+  CHECK(csrIm.activeGraphStorageBreakdown().csrStateIdBucketBytes == 0);
   csrIm.setActiveNetworkFromChildrenOfRoot();
   CHECK(csrIm.activeGraphStorageBreakdown().csrStateIdEntryBytes == 0);
   CHECK(csrIm.activeGraphStorageBreakdown().csrStateIdBucketBytes == 0);

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -348,6 +348,8 @@ TEST_CASE("Active graph storage breakdown distinguishes pointer-only and CSR-bac
   CHECK(pointerStorage.csrStateIdEntryBytes == 0);
   CHECK(pointerStorage.csrOutOffsetBytes == 0);
   CHECK(pointerStorage.csrInOffsetBytes == 0);
+  CHECK(pointerIm.benchmarkStats().lastActiveGraphStorage.activeNodeToIdEntryBytes > 0);
+  CHECK(pointerIm.benchmarkStats().maxActiveGraphStorage.activeNodeToIdEntryBytes > 0);
 
   InfomapWrapper csrIm(infomap::test::defaultFlags());
   csrIm.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -270,7 +270,7 @@ TEST_CASE("Active graph wrappers sync payload back to hierarchy nodes [fast][cor
   CHECK(im.activeGraphMaterialization().payloads[0].data.flow == doctest::Approx(originalFlow + 0.25));
 }
 
-TEST_CASE("Pointer active graph view exposes payload, state, and adjacency by active node id [fast][core][partition][lifecycle]")
+TEST_CASE("Pointer backend exposes payload, state, and adjacency by active node id [fast][core][partition][lifecycle]")
 {
   InfomapWrapper im(infomap::test::defaultFlags());
   im.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
@@ -278,7 +278,7 @@ TEST_CASE("Pointer active graph view exposes payload, state, and adjacency by ac
   im.setActiveNetworkFromLeafs();
   im.initPartition();
 
-  auto view = im.pointerActiveGraph();
+  auto view = im.pointerBackend();
   REQUIRE(view.size() == im.numLeafNodes());
   REQUIRE_FALSE(view.empty());
 

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -419,7 +419,7 @@ TEST_CASE("CSR backend materializes leaf-level first-order adjacency [fast][core
     std::vector<CsrEdgeKey> csrIn;
     const auto inEdges = csr.inEdges(i);
     for (std::size_t j = 0; j < inEdges.size; ++j) {
-      csrIn.emplace_back(csr.nodeFor(inEdges.targets[j]).stateId, inEdges.flows[j]);
+      csrIn.emplace_back(csr.nodeFor(inEdges.targets[j]).stateId, inEdges.flowAt(j));
     }
     std::sort(csrIn.begin(), csrIn.end());
     CHECK(csrIn == pointerInEdgeTuples(node));

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -207,10 +207,13 @@ TEST_CASE("Active graph payload materialization mirrors the leaf-level active ne
   for (std::size_t i = 0; i < materialization.nodes.size(); ++i) {
     auto* node = im.activeNetwork()[i];
     CHECK(materialization.nodes[i] == node);
+    CHECK(materialization.idFor(*node) == i);
+    CHECK(&materialization.nodeFor(i) == node);
     CHECK(materialization.payloads[i].data.flow == doctest::Approx(node->data.flow));
     CHECK(materialization.payloads[i].stateId == node->stateId);
     CHECK(materialization.payloads[i].physicalId == node->physicalId);
     CHECK(materialization.payloads[i].layerId == node->layerId);
+    CHECK(materialization.payloadFor(i).stateId == node->stateId);
   }
 
   materialization.payloads[0].data.flow += 0.5;
@@ -236,6 +239,8 @@ TEST_CASE("Active graph payload materialization mirrors module-level active node
   for (std::size_t i = 0; i < materialization.nodes.size(); ++i) {
     auto* node = im.activeNetwork()[i];
     CHECK(materialization.nodes[i] == node);
+    CHECK(materialization.idFor(*node) == i);
+    CHECK(&materialization.nodeFor(i) == node);
     CHECK(materialization.payloads[i].data.flow == doctest::Approx(node->data.flow));
     CHECK(materialization.payloads[i].stateId == node->stateId);
   }

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -231,10 +231,6 @@ TEST_CASE("Active graph payload materialization mirrors the leaf-level active ne
     CHECK(materialization.idFor(*node) == i);
     CHECK(&materialization.nodeFor(i) == node);
     CHECK(materialization.payloads[i].data.flow == doctest::Approx(node->data.flow));
-    CHECK(materialization.payloads[i].stateId == node->stateId);
-    CHECK(materialization.payloads[i].physicalId == node->physicalId);
-    CHECK(materialization.payloads[i].layerId == node->layerId);
-    CHECK(materialization.payloadFor(i).stateId == node->stateId);
   }
 
   materialization.payloads[0].data.flow += 0.5;
@@ -263,7 +259,6 @@ TEST_CASE("Active graph payload materialization mirrors module-level active node
     CHECK(materialization.idFor(*node) == i);
     CHECK(&materialization.nodeFor(i) == node);
     CHECK(materialization.payloads[i].data.flow == doctest::Approx(node->data.flow));
-    CHECK(materialization.payloads[i].stateId == node->stateId);
   }
 }
 
@@ -306,7 +301,6 @@ TEST_CASE("Pointer backend exposes payload, state, and adjacency by active node 
   for (std::size_t i = 0; i < view.size(); ++i) {
     auto& node = view.nodeFor(static_cast<infomap::InfomapBase::ActiveGraphMaterialization::ActiveNodeId>(i));
     CHECK(view.idFor(node) == i);
-    CHECK(view.payloadFor(i).stateId == node.stateId);
     CHECK(view.payloadFor(i).data.flow == doctest::Approx(node.data.flow));
     CHECK(view.moduleIndex(i) == node.index);
     CHECK(view.dirty(i) == node.dirty);

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -213,7 +213,7 @@ TEST_CASE("InfoNode replace mutations preserve flattened tree structure [fast][c
   }
 }
 
-TEST_CASE("Active graph payload materialization mirrors the leaf-level active network [fast][core][partition][lifecycle]")
+TEST_CASE("Active graph materialization mirrors the leaf-level active network without duplicated payload storage [fast][core][partition][lifecycle]")
 {
   InfomapWrapper im(infomap::test::defaultFlags());
   im.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
@@ -222,24 +222,17 @@ TEST_CASE("Active graph payload materialization mirrors the leaf-level active ne
 
   auto& materialization = im.activeGraphMaterialization();
   REQUIRE(materialization.nodes.size() == im.activeNetwork().size());
-  REQUIRE(materialization.payloads.size() == im.activeNetwork().size());
-  CHECK(materialization.payloadBytes() == materialization.payloads.size() * sizeof(infomap::InfomapBase::ActiveNodePayload));
+  CHECK(materialization.payloadBytes() == 0);
 
   for (std::size_t i = 0; i < materialization.nodes.size(); ++i) {
     auto* node = im.activeNetwork()[i];
     CHECK(materialization.nodes[i] == node);
     CHECK(materialization.idFor(*node) == i);
     CHECK(&materialization.nodeFor(i) == node);
-    CHECK(materialization.payloads[i].data.flow == doctest::Approx(node->data.flow));
   }
-
-  materialization.payloads[0].data.flow += 0.5;
-  im.syncActiveGraphPayloadToHierarchy();
-
-  CHECK(im.activeNetwork()[0]->data.flow == doctest::Approx(materialization.payloads[0].data.flow));
 }
 
-TEST_CASE("Active graph payload materialization mirrors module-level active nodes [fast][core][partition][lifecycle]")
+TEST_CASE("Active graph materialization mirrors module-level active nodes without duplicated payload storage [fast][core][partition][lifecycle]")
 {
   InfomapWrapper im(infomap::test::defaultFlags());
   im.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
@@ -258,11 +251,10 @@ TEST_CASE("Active graph payload materialization mirrors module-level active node
     CHECK(materialization.nodes[i] == node);
     CHECK(materialization.idFor(*node) == i);
     CHECK(&materialization.nodeFor(i) == node);
-    CHECK(materialization.payloads[i].data.flow == doctest::Approx(node->data.flow));
   }
 }
 
-TEST_CASE("Active graph wrappers sync payload back to hierarchy nodes [fast][core][partition][lifecycle]")
+TEST_CASE("Active graph wrappers preserve hierarchy payload without duplicated payload storage [fast][core][partition][lifecycle]")
 {
   InfomapWrapper im(infomap::test::defaultFlags());
   im.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
@@ -271,10 +263,9 @@ TEST_CASE("Active graph wrappers sync payload back to hierarchy nodes [fast][cor
   im.initPartition();
 
   auto& materialization = im.activeGraphMaterialization();
-  REQUIRE_FALSE(materialization.payloads.empty());
+  CHECK(materialization.payloadBytes() == 0);
 
   const auto originalFlow = im.activeNetwork()[0]->data.flow;
-  materialization.payloads[0].data.flow = originalFlow + 0.25;
 
   std::vector<unsigned int> modules(im.numLeafNodes());
   for (unsigned int i = 0; i < im.numLeafNodes(); ++i) {
@@ -282,11 +273,11 @@ TEST_CASE("Active graph wrappers sync payload back to hierarchy nodes [fast][cor
   }
   im.moveActiveNodesToPredefinedModules(modules);
 
-  CHECK(im.activeNetwork()[0]->data.flow == doctest::Approx(originalFlow + 0.25));
-  CHECK(im.activeGraphMaterialization().payloads[0].data.flow == doctest::Approx(originalFlow + 0.25));
+  CHECK(im.activeNetwork()[0]->data.flow == doctest::Approx(originalFlow));
+  CHECK(im.activeGraphMaterialization().payloadBytes() == 0);
 }
 
-TEST_CASE("Pointer backend exposes payload, state, and adjacency by active node id [fast][core][partition][lifecycle]")
+TEST_CASE("Pointer backend exposes state and adjacency by active node id [fast][core][partition][lifecycle]")
 {
   InfomapWrapper im(infomap::test::defaultFlags());
   im.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
@@ -301,7 +292,6 @@ TEST_CASE("Pointer backend exposes payload, state, and adjacency by active node 
   for (std::size_t i = 0; i < view.size(); ++i) {
     auto& node = view.nodeFor(static_cast<infomap::InfomapBase::ActiveGraphMaterialization::ActiveNodeId>(i));
     CHECK(view.idFor(node) == i);
-    CHECK(view.payloadFor(i).data.flow == doctest::Approx(node.data.flow));
     CHECK(view.moduleIndex(i) == node.index);
     CHECK(view.dirty(i) == node.dirty);
 

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -462,6 +462,42 @@ TEST_CASE("CSR backend matches pointer backend for one serial move pass on leaf-
   CHECK(csrIm.getIndexCodelength() == doctest::Approx(pointerIm.getIndexCodelength()));
 }
 
+TEST_CASE("CSR backend matches pointer backend for biased first-order serial move passes [fast][core][partition][lifecycle]")
+{
+  const std::vector<std::string> biasedFlagSets{
+      "--preferred-number-of-modules 1",
+      "--entropy-corrected",
+  };
+
+  for (const auto& extraFlags : biasedFlagSets) {
+    INFO(extraFlags);
+    const auto flags = infomap::test::defaultFlags(extraFlags);
+
+    InfomapWrapper pointerIm(flags);
+    pointerIm.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+    pointerIm.initNetwork(pointerIm.network());
+    pointerIm.setActiveNetworkFromLeafs();
+    pointerIm.initPartition();
+    pointerIm.m_csrMaterialization.reset();
+    CHECK_FALSE(pointerIm.csrBackend().available());
+
+    InfomapWrapper csrIm(flags);
+    csrIm.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+    csrIm.initNetwork(csrIm.network());
+    csrIm.setActiveNetworkFromLeafs();
+    csrIm.initPartition();
+    REQUIRE(csrIm.csrBackend().available());
+
+    const auto pointerMoved = pointerIm.optimizeActiveNetwork();
+    const auto csrMoved = csrIm.optimizeActiveNetwork();
+
+    CHECK(csrMoved == pointerMoved);
+    CHECK(csrIm.getModules() == pointerIm.getModules());
+    CHECK(csrIm.getCodelength() == doctest::Approx(pointerIm.getCodelength()));
+    CHECK(csrIm.getIndexCodelength() == doctest::Approx(pointerIm.getIndexCodelength()));
+  }
+}
+
 TEST_CASE("Soft cluster-data can be optimized away when it is suboptimal [fast][core][partition]")
 {
   InfomapWrapper im(infomap::test::defaultFlags());

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -498,6 +498,34 @@ TEST_CASE("CSR backend matches pointer backend for biased first-order serial mov
   }
 }
 
+TEST_CASE("End-to-end first-order runs match with CSR materialization enabled or disabled [fast][core][partition][lifecycle]")
+{
+  const std::vector<std::string> flagSets{
+      "",
+      "--preferred-number-of-modules 1",
+  };
+
+  for (const auto& extraFlags : flagSets) {
+    INFO(extraFlags);
+
+    InfomapWrapper pointerIm(infomap::test::defaultFlags(extraFlags));
+    pointerIm.m_disableCsrMaterialization = true;
+    pointerIm.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+    pointerIm.run();
+
+    InfomapWrapper csrIm(infomap::test::defaultFlags(extraFlags));
+    csrIm.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+    csrIm.run();
+
+    infomap::test::checkRunSanity(pointerIm);
+    infomap::test::checkRunSanity(csrIm);
+    CHECK(csrIm.numTopModules() == pointerIm.numTopModules());
+    CHECK(infomap::test::canonicalPartition(csrIm.getModules()) == infomap::test::canonicalPartition(pointerIm.getModules()));
+    CHECK(csrIm.codelength() == doctest::Approx(pointerIm.codelength()));
+    CHECK(csrIm.getIndexCodelength() == doctest::Approx(pointerIm.getIndexCodelength()));
+  }
+}
+
 TEST_CASE("Soft cluster-data can be optimized away when it is suboptimal [fast][core][partition]")
 {
   InfomapWrapper im(infomap::test::defaultFlags());

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -15,7 +15,7 @@ using infomap::InfomapWrapper;
 using infomap::InfoNode;
 
 using EdgeKey = std::pair<unsigned int, unsigned int>;
-using CsrEdgeKey = std::tuple<unsigned int, double, double>;
+using CsrEdgeKey = std::pair<unsigned int, double>;
 
 std::vector<unsigned int> childStateIds(const InfoNode& node)
 {
@@ -68,7 +68,7 @@ std::vector<CsrEdgeKey> pointerOutEdgeTuples(InfoNode& node)
 {
   std::vector<CsrEdgeKey> edges;
   for (auto* edge : node.outEdges()) {
-    edges.emplace_back(edge->target->stateId, edge->data.weight, edge->data.flow);
+    edges.emplace_back(edge->target->stateId, edge->data.flow);
   }
   std::sort(edges.begin(), edges.end());
   return edges;
@@ -78,7 +78,7 @@ std::vector<CsrEdgeKey> pointerInEdgeTuples(InfoNode& node)
 {
   std::vector<CsrEdgeKey> edges;
   for (auto* edge : node.inEdges()) {
-    edges.emplace_back(edge->source->stateId, edge->data.weight, edge->data.flow);
+    edges.emplace_back(edge->source->stateId, edge->data.flow);
   }
   std::sort(edges.begin(), edges.end());
   return edges;
@@ -368,7 +368,7 @@ TEST_CASE("CSR backend materializes leaf-level first-order adjacency [fast][core
     std::vector<CsrEdgeKey> csrOut;
     const auto outEdges = csr.outEdges(i);
     for (std::size_t j = 0; j < outEdges.size; ++j) {
-      csrOut.emplace_back(csr.nodeFor(outEdges.targets[j]).stateId, outEdges.weights[j], outEdges.flows[j]);
+      csrOut.emplace_back(csr.nodeFor(outEdges.targets[j]).stateId, outEdges.flows[j]);
     }
     std::sort(csrOut.begin(), csrOut.end());
     CHECK(csrOut == pointerOutEdgeTuples(node));
@@ -376,7 +376,7 @@ TEST_CASE("CSR backend materializes leaf-level first-order adjacency [fast][core
     std::vector<CsrEdgeKey> csrIn;
     const auto inEdges = csr.inEdges(i);
     for (std::size_t j = 0; j < inEdges.size; ++j) {
-      csrIn.emplace_back(csr.nodeFor(inEdges.targets[j]).stateId, inEdges.weights[j], inEdges.flows[j]);
+      csrIn.emplace_back(csr.nodeFor(inEdges.targets[j]).stateId, inEdges.flows[j]);
     }
     std::sort(csrIn.begin(), csrIn.end());
     CHECK(csrIn == pointerInEdgeTuples(node));

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -241,6 +241,30 @@ TEST_CASE("Active graph payload materialization mirrors module-level active node
   }
 }
 
+TEST_CASE("Active graph wrappers sync payload back to hierarchy nodes [fast][core][partition][lifecycle]")
+{
+  InfomapWrapper im(infomap::test::defaultFlags());
+  im.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+  im.initNetwork(im.network());
+  im.setActiveNetworkFromLeafs();
+  im.initPartition();
+
+  auto& materialization = im.activeGraphMaterialization();
+  REQUIRE_FALSE(materialization.payloads.empty());
+
+  const auto originalFlow = im.activeNetwork()[0]->data.flow;
+  materialization.payloads[0].data.flow = originalFlow + 0.25;
+
+  std::vector<unsigned int> modules(im.numLeafNodes());
+  for (unsigned int i = 0; i < im.numLeafNodes(); ++i) {
+    modules[i] = i;
+  }
+  im.moveActiveNodesToPredefinedModules(modules);
+
+  CHECK(im.activeNetwork()[0]->data.flow == doctest::Approx(originalFlow + 0.25));
+  CHECK(im.activeGraphMaterialization().payloads[0].data.flow == doctest::Approx(originalFlow + 0.25));
+}
+
 TEST_CASE("Soft cluster-data can be optimized away when it is suboptimal [fast][core][partition]")
 {
   InfomapWrapper im(infomap::test::defaultFlags());

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -15,6 +15,7 @@ using infomap::InfomapWrapper;
 using infomap::InfoNode;
 
 using EdgeKey = std::pair<unsigned int, unsigned int>;
+using CsrEdgeKey = std::tuple<unsigned int, double, double>;
 
 std::vector<unsigned int> childStateIds(const InfoNode& node)
 {
@@ -61,6 +62,26 @@ std::map<EdgeKey, double> aggregatedModuleFlow(InfoNode& root, bool undirected)
     }
   }
   return flows;
+}
+
+std::vector<CsrEdgeKey> pointerOutEdgeTuples(InfoNode& node)
+{
+  std::vector<CsrEdgeKey> edges;
+  for (auto* edge : node.outEdges()) {
+    edges.emplace_back(edge->target->stateId, edge->data.weight, edge->data.flow);
+  }
+  std::sort(edges.begin(), edges.end());
+  return edges;
+}
+
+std::vector<CsrEdgeKey> pointerInEdgeTuples(InfoNode& node)
+{
+  std::vector<CsrEdgeKey> edges;
+  for (auto* edge : node.inEdges()) {
+    edges.emplace_back(edge->source->stateId, edge->data.weight, edge->data.flow);
+  }
+  std::sort(edges.begin(), edges.end());
+  return edges;
 }
 
 TEST_CASE("Cluster-data clu fixture initializes a two-level partition [fast][core][partition]")
@@ -325,6 +346,64 @@ TEST_CASE("Pointer backend exposes payload, state, and adjacency by active node 
   CHECK(im.activeNetwork()[0]->dirty == !originalDirty);
   view.moduleIndex(0) = originalModule;
   view.dirty(0) = originalDirty;
+}
+
+TEST_CASE("CSR backend materializes leaf-level first-order adjacency [fast][core][partition][lifecycle]")
+{
+  InfomapWrapper im(infomap::test::defaultFlags());
+  im.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+  im.initNetwork(im.network());
+  im.setActiveNetworkFromLeafs();
+
+  auto csr = im.csrBackend();
+  REQUIRE(csr.available());
+  REQUIRE(csr.size() == im.numLeafNodes());
+  CHECK(im.csrMaterialization().outOffsets.size() == im.numLeafNodes() + 1);
+  CHECK(im.csrMaterialization().inOffsets.size() == im.numLeafNodes() + 1);
+  CHECK(im.csrMaterialization().adjacencyBytes() > 0);
+
+  for (std::size_t i = 0; i < csr.size(); ++i) {
+    auto& node = csr.nodeFor(static_cast<infomap::InfomapBase::ActiveGraphMaterialization::ActiveNodeId>(i));
+
+    std::vector<CsrEdgeKey> csrOut;
+    const auto outEdges = csr.outEdges(i);
+    for (std::size_t j = 0; j < outEdges.size; ++j) {
+      csrOut.emplace_back(csr.nodeFor(outEdges.targets[j]).stateId, outEdges.weights[j], outEdges.flows[j]);
+    }
+    std::sort(csrOut.begin(), csrOut.end());
+    CHECK(csrOut == pointerOutEdgeTuples(node));
+
+    std::vector<CsrEdgeKey> csrIn;
+    const auto inEdges = csr.inEdges(i);
+    for (std::size_t j = 0; j < inEdges.size; ++j) {
+      csrIn.emplace_back(csr.nodeFor(inEdges.targets[j]).stateId, inEdges.weights[j], inEdges.flows[j]);
+    }
+    std::sort(csrIn.begin(), csrIn.end());
+    CHECK(csrIn == pointerInEdgeTuples(node));
+  }
+}
+
+TEST_CASE("CSR backend stays disabled for module-level and higher-order active graphs [fast][core][partition][lifecycle]")
+{
+  {
+    InfomapWrapper im(infomap::test::defaultFlags());
+    im.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+    im.run();
+
+    infomap::test::checkRunSanity(im);
+    im.setActiveNetworkFromChildrenOfRoot();
+    CHECK_FALSE(im.csrBackend().available());
+  }
+
+  {
+    InfomapWrapper im(infomap::test::defaultFlags());
+    im.readInputData(infomap::test::repoPath("examples/networks/states.net"));
+    im.run();
+
+    infomap::test::checkRunSanity(im);
+    im.setActiveNetworkFromLeafs();
+    CHECK_FALSE(im.csrBackend().available());
+  }
 }
 
 TEST_CASE("Soft cluster-data can be optimized away when it is suboptimal [fast][core][partition]")

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -368,6 +368,29 @@ TEST_CASE("Active graph storage breakdown distinguishes pointer-only and CSR-bac
   CHECK(csrStorage.totalBytes() > pointerStorage.totalBytes());
 }
 
+TEST_CASE("Active graph reset releases stale reverse-lookup buckets [fast][core][partition][lifecycle]")
+{
+  InfomapWrapper pointerIm(infomap::test::defaultFlags());
+  pointerIm.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+  pointerIm.initNetwork(pointerIm.network());
+  pointerIm.m_disableCsrMaterialization = true;
+  pointerIm.setActiveNetworkFromLeafs();
+  pointerIm.pointerBackend().ensureReverseLookup();
+  REQUIRE(pointerIm.activeGraphStorageBreakdown().activeNodeToIdBucketBytes > 0);
+  pointerIm.setActiveNetworkFromLeafs();
+  CHECK(pointerIm.activeGraphStorageBreakdown().activeNodeToIdEntryBytes == 0);
+  CHECK(pointerIm.activeGraphStorageBreakdown().activeNodeToIdBucketBytes == 0);
+
+  InfomapWrapper csrIm(infomap::test::defaultFlags());
+  csrIm.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+  csrIm.initNetwork(csrIm.network());
+  csrIm.setActiveNetworkFromLeafs();
+  REQUIRE(csrIm.activeGraphStorageBreakdown().csrStateIdBucketBytes > 0);
+  csrIm.setActiveNetworkFromChildrenOfRoot();
+  CHECK(csrIm.activeGraphStorageBreakdown().csrStateIdEntryBytes == 0);
+  CHECK(csrIm.activeGraphStorageBreakdown().csrStateIdBucketBytes == 0);
+}
+
 TEST_CASE("CSR backend materializes leaf-level first-order adjacency [fast][core][partition][lifecycle]")
 {
   InfomapWrapper im(infomap::test::defaultFlags());

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -5,11 +5,63 @@
 #include "TestUtils.h"
 
 #include <map>
+#include <set>
+#include <tuple>
 #include <vector>
 
 namespace {
 
 using infomap::InfomapWrapper;
+using infomap::InfoNode;
+
+using EdgeKey = std::pair<unsigned int, unsigned int>;
+
+std::vector<unsigned int> childStateIds(const InfoNode& node)
+{
+  std::vector<unsigned int> ids;
+  for (const auto& child : node.children()) {
+    ids.push_back(child.stateId);
+  }
+  return ids;
+}
+
+std::map<EdgeKey, double> aggregatedInterModuleFlow(std::vector<InfoNode*>& nodes, bool undirected)
+{
+  std::map<EdgeKey, double> flows;
+  for (auto* node : nodes) {
+    for (auto* edge : node->outEdges()) {
+      auto module1 = node->index;
+      auto module2 = edge->target->index;
+      if (module1 == module2) {
+        continue;
+      }
+      if (undirected && module1 > module2) {
+        std::swap(module1, module2);
+      }
+      flows[{module1, module2}] += edge->data.flow;
+    }
+  }
+  return flows;
+}
+
+std::map<EdgeKey, double> aggregatedModuleFlow(InfoNode& root, bool undirected)
+{
+  std::map<EdgeKey, double> flows;
+  for (auto& module : root.children()) {
+    for (auto* edge : module.outEdges()) {
+      auto module1 = module.index;
+      auto module2 = edge->target->index;
+      if (module1 == module2) {
+        continue;
+      }
+      if (undirected && module1 > module2) {
+        std::swap(module1, module2);
+      }
+      flows[{module1, module2}] += edge->data.flow;
+    }
+  }
+  return flows;
+}
 
 TEST_CASE("Cluster-data clu fixture initializes a two-level partition [fast][core][partition]")
 {
@@ -64,6 +116,82 @@ TEST_CASE("Tree cluster-data fixture initializes a multi-level tree [fast][core]
   infomap::test::checkRunSanity(im);
 }
 
+TEST_CASE("InfoNode hierarchy mutations preserve parentage and child order [fast][core][partition][tree]")
+{
+  InfoNode root;
+
+  auto* childA = new InfoNode({}, 10);
+  auto* childB = new InfoNode({}, 20);
+  auto* childC = new InfoNode({}, 30);
+  root.addChild(childA);
+  root.addChild(childB);
+  root.addChild(childC);
+
+  CHECK(root.childDegree() == 3);
+  CHECK(childStateIds(root) == std::vector<unsigned int>{10, 20, 30});
+
+  CHECK(root.collapseChildren() == 3);
+  CHECK(root.childDegree() == 0);
+  CHECK(root.firstChild == nullptr);
+  CHECK(root.lastChild == nullptr);
+
+  CHECK(root.expandChildren() == 3);
+  CHECK(root.childDegree() == 3);
+  CHECK(childStateIds(root) == std::vector<unsigned int>{10, 20, 30});
+  CHECK(childA->parent == &root);
+  CHECK(childB->parent == &root);
+  CHECK(childC->parent == &root);
+
+  root.releaseChildren();
+  CHECK(root.childDegree() == 0);
+  CHECK(root.firstChild == nullptr);
+  CHECK(root.lastChild == nullptr);
+
+  delete childA;
+  delete childB;
+  delete childC;
+
+  auto* rebuiltA = new InfoNode({}, 40);
+  auto* rebuiltB = new InfoNode({}, 50);
+  root.addChild(rebuiltA);
+  root.addChild(rebuiltB);
+
+  CHECK(root.childDegree() == 2);
+  CHECK(childStateIds(root) == std::vector<unsigned int>{40, 50});
+}
+
+TEST_CASE("InfoNode replace mutations preserve flattened tree structure [fast][core][partition][tree]")
+{
+  InfoNode root;
+  auto* moduleA = new InfoNode({}, 100);
+  auto* moduleB = new InfoNode({}, 200);
+  root.addChild(moduleA);
+  root.addChild(moduleB);
+  moduleA->addChild(new InfoNode({}, 1));
+  moduleA->addChild(new InfoNode({}, 2));
+  moduleB->addChild(new InfoNode({}, 3));
+  moduleB->addChild(new InfoNode({}, 4));
+
+  CHECK(root.childDegree() == 2);
+  CHECK(moduleA->childDegree() == 2);
+  CHECK(moduleB->childDegree() == 2);
+
+  CHECK(moduleA->replaceWithChildren() == 1);
+  CHECK(root.childDegree() == 3);
+  CHECK(childStateIds(root) == std::vector<unsigned int>{1, 2, 200});
+  CHECK(root.firstChild->parent == &root);
+  CHECK(root.firstChild->next->parent == &root);
+  CHECK(root.lastChild == moduleB);
+
+  CHECK(root.replaceChildrenWithGrandChildren() == 1);
+  CHECK(root.childDegree() == 4);
+  CHECK(childStateIds(root) == std::vector<unsigned int>{1, 2, 3, 4});
+  for (const auto& child : root.children()) {
+    CHECK(child.parent == &root);
+    CHECK(child.isLeaf());
+  }
+}
+
 TEST_CASE("Soft cluster-data can be optimized away when it is suboptimal [fast][core][partition]")
 {
   InfomapWrapper im(infomap::test::defaultFlags());
@@ -100,6 +228,27 @@ TEST_CASE("Hard cluster-data preserves the imposed coarse partition [fast][core]
   CHECK(im.numLeafNodes() == 6);
   CHECK(im.numTopModules() == 2);
   infomap::test::checkCanonicalPartition(im, {{1, 2, 3}, {4, 5, 6}});
+}
+
+TEST_CASE("Consolidate modules preserves aggregated inter-module flow [fast][core][partition][tree]")
+{
+  InfomapWrapper im(infomap::test::defaultFlags());
+  im.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+  im.initNetwork(im.network());
+  im.setActiveNetworkFromLeafs();
+  im.initPartition();
+
+  std::vector<unsigned int> modules{0, 0, 0, 1, 1, 1};
+  im.moveActiveNodesToPredefinedModules(modules);
+
+  const auto expectedFlows = aggregatedInterModuleFlow(im.activeNetwork(), im.isUndirectedClustering());
+  REQUIRE(expectedFlows.size() == 1);
+
+  im.consolidateModules(false);
+
+  CHECK(im.numTopModules() == 2);
+  CHECK(im.root().childDegree() == 2);
+  CHECK(aggregatedModuleFlow(im.root(), im.isUndirectedClustering()) == expectedFlows);
 }
 
 TEST_CASE("Invalid cluster-data fixtures fail deterministically [fast][core][partition][parser]")

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -406,6 +406,62 @@ TEST_CASE("CSR backend stays disabled for module-level and higher-order active g
   }
 }
 
+TEST_CASE("CSR backend matches pointer backend for predefined moves on leaf-level first-order graphs [fast][core][partition][lifecycle]")
+{
+  const auto flags = infomap::test::defaultFlags();
+  std::vector<unsigned int> modules{0, 0, 0, 1, 1, 1};
+
+  InfomapWrapper pointerIm(flags);
+  pointerIm.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+  pointerIm.initNetwork(pointerIm.network());
+  pointerIm.setActiveNetworkFromLeafs();
+  pointerIm.initPartition();
+  pointerIm.m_csrMaterialization.reset();
+  CHECK_FALSE(pointerIm.csrBackend().available());
+
+  InfomapWrapper csrIm(flags);
+  csrIm.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+  csrIm.initNetwork(csrIm.network());
+  csrIm.setActiveNetworkFromLeafs();
+  csrIm.initPartition();
+  REQUIRE(csrIm.csrBackend().available());
+
+  pointerIm.moveActiveNodesToPredefinedModules(modules);
+  csrIm.moveActiveNodesToPredefinedModules(modules);
+
+  CHECK(csrIm.getModules() == pointerIm.getModules());
+  CHECK(csrIm.getCodelength() == doctest::Approx(pointerIm.getCodelength()));
+  CHECK(csrIm.getIndexCodelength() == doctest::Approx(pointerIm.getIndexCodelength()));
+}
+
+TEST_CASE("CSR backend matches pointer backend for one serial move pass on leaf-level first-order graphs [fast][core][partition][lifecycle]")
+{
+  const auto flags = infomap::test::defaultFlags();
+
+  InfomapWrapper pointerIm(flags);
+  pointerIm.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+  pointerIm.initNetwork(pointerIm.network());
+  pointerIm.setActiveNetworkFromLeafs();
+  pointerIm.initPartition();
+  pointerIm.m_csrMaterialization.reset();
+  CHECK_FALSE(pointerIm.csrBackend().available());
+
+  InfomapWrapper csrIm(flags);
+  csrIm.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+  csrIm.initNetwork(csrIm.network());
+  csrIm.setActiveNetworkFromLeafs();
+  csrIm.initPartition();
+  REQUIRE(csrIm.csrBackend().available());
+
+  const auto pointerMoved = pointerIm.optimizeActiveNetwork();
+  const auto csrMoved = csrIm.optimizeActiveNetwork();
+
+  CHECK(csrMoved == pointerMoved);
+  CHECK(csrIm.getModules() == pointerIm.getModules());
+  CHECK(csrIm.getCodelength() == doctest::Approx(pointerIm.getCodelength()));
+  CHECK(csrIm.getIndexCodelength() == doctest::Approx(pointerIm.getIndexCodelength()));
+}
+
 TEST_CASE("Soft cluster-data can be optimized away when it is suboptimal [fast][core][partition]")
 {
   InfomapWrapper im(infomap::test::defaultFlags());

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -415,9 +415,9 @@ TEST_CASE("CSR backend matches pointer backend for predefined moves on leaf-leve
   pointerIm.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
   pointerIm.initNetwork(pointerIm.network());
   pointerIm.setActiveNetworkFromLeafs();
-  pointerIm.initPartition();
   pointerIm.m_csrMaterialization.reset();
   CHECK_FALSE(pointerIm.csrBackend().available());
+  pointerIm.initPartition();
 
   InfomapWrapper csrIm(flags);
   csrIm.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
@@ -442,9 +442,9 @@ TEST_CASE("CSR backend matches pointer backend for one serial move pass on leaf-
   pointerIm.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
   pointerIm.initNetwork(pointerIm.network());
   pointerIm.setActiveNetworkFromLeafs();
-  pointerIm.initPartition();
   pointerIm.m_csrMaterialization.reset();
   CHECK_FALSE(pointerIm.csrBackend().available());
+  pointerIm.initPartition();
 
   InfomapWrapper csrIm(flags);
   csrIm.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
@@ -477,9 +477,9 @@ TEST_CASE("CSR backend matches pointer backend for biased first-order serial mov
     pointerIm.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
     pointerIm.initNetwork(pointerIm.network());
     pointerIm.setActiveNetworkFromLeafs();
-    pointerIm.initPartition();
     pointerIm.m_csrMaterialization.reset();
     CHECK_FALSE(pointerIm.csrBackend().available());
+    pointerIm.initPartition();
 
     InfomapWrapper csrIm(flags);
     csrIm.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
@@ -524,6 +524,38 @@ TEST_CASE("End-to-end first-order runs match with CSR materialization enabled or
     CHECK(csrIm.codelength() == doctest::Approx(pointerIm.codelength()));
     CHECK(csrIm.getIndexCodelength() == doctest::Approx(pointerIm.getIndexCodelength()));
   }
+}
+
+TEST_CASE("CSR active state syncs back module assignment and dirty flags to hierarchy nodes [fast][core][partition][lifecycle]")
+{
+  InfomapWrapper im(infomap::test::defaultFlags());
+  im.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+  im.initNetwork(im.network());
+  im.setActiveNetworkFromLeafs();
+  REQUIRE(im.csrBackend().available());
+
+  auto csr = im.csrBackend();
+  im.initPartition();
+
+  const auto firstId = csr.idFor(*im.activeNetwork().front());
+  const auto secondId = csr.idFor(*im.activeNetwork()[1]);
+
+  im.activeNetwork().front()->index = 99;
+  im.activeNetwork().front()->dirty = false;
+  im.activeNetwork()[1]->index = 77;
+  im.activeNetwork()[1]->dirty = false;
+
+  csr.moduleIndex(firstId) = 5;
+  csr.dirty(firstId) = true;
+  csr.moduleIndex(secondId) = 4;
+  csr.dirty(secondId) = true;
+
+  im.syncActiveGraphStateToHierarchy();
+
+  CHECK(im.activeNetwork().front()->index == 5);
+  CHECK(im.activeNetwork().front()->dirty);
+  CHECK(im.activeNetwork()[1]->index == 4);
+  CHECK(im.activeNetwork()[1]->dirty);
 }
 
 TEST_CASE("Soft cluster-data can be optimized away when it is suboptimal [fast][core][partition]")

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -270,6 +270,63 @@ TEST_CASE("Active graph wrappers sync payload back to hierarchy nodes [fast][cor
   CHECK(im.activeGraphMaterialization().payloads[0].data.flow == doctest::Approx(originalFlow + 0.25));
 }
 
+TEST_CASE("Pointer active graph view exposes payload, state, and adjacency by active node id [fast][core][partition][lifecycle]")
+{
+  InfomapWrapper im(infomap::test::defaultFlags());
+  im.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+  im.initNetwork(im.network());
+  im.setActiveNetworkFromLeafs();
+  im.initPartition();
+
+  auto view = im.pointerActiveGraph();
+  REQUIRE(view.size() == im.numLeafNodes());
+  REQUIRE_FALSE(view.empty());
+
+  for (std::size_t i = 0; i < view.size(); ++i) {
+    auto& node = view.nodeFor(static_cast<infomap::InfomapBase::ActiveGraphMaterialization::ActiveNodeId>(i));
+    CHECK(view.idFor(node) == i);
+    CHECK(view.payloadFor(i).stateId == node.stateId);
+    CHECK(view.payloadFor(i).data.flow == doctest::Approx(node.data.flow));
+    CHECK(view.moduleIndex(i) == node.index);
+    CHECK(view.dirty(i) == node.dirty);
+
+    std::vector<unsigned int> expectedOutTargets;
+    for (auto* edge : node.outEdges()) {
+      expectedOutTargets.push_back(edge->target->stateId);
+    }
+    std::sort(expectedOutTargets.begin(), expectedOutTargets.end());
+
+    std::vector<unsigned int> actualOutTargets;
+    for (const auto& edge : view.outEdges(i)) {
+      actualOutTargets.push_back(view.nodeFor(edge.neighbourId).stateId);
+    }
+    std::sort(actualOutTargets.begin(), actualOutTargets.end());
+    CHECK(actualOutTargets == expectedOutTargets);
+
+    std::vector<unsigned int> expectedInSources;
+    for (auto* edge : node.inEdges()) {
+      expectedInSources.push_back(edge->source->stateId);
+    }
+    std::sort(expectedInSources.begin(), expectedInSources.end());
+
+    std::vector<unsigned int> actualInSources;
+    for (const auto& edge : view.inEdges(i)) {
+      actualInSources.push_back(view.nodeFor(edge.neighbourId).stateId);
+    }
+    std::sort(actualInSources.begin(), actualInSources.end());
+    CHECK(actualInSources == expectedInSources);
+  }
+
+  const auto originalModule = view.moduleIndex(0);
+  const auto originalDirty = view.dirty(0);
+  view.moduleIndex(0) = originalModule + 7;
+  view.dirty(0) = !originalDirty;
+  CHECK(im.activeNetwork()[0]->index == originalModule + 7);
+  CHECK(im.activeNetwork()[0]->dirty == !originalDirty);
+  view.moduleIndex(0) = originalModule;
+  view.dirty(0) = originalDirty;
+}
+
 TEST_CASE("Soft cluster-data can be optimized away when it is suboptimal [fast][core][partition]")
 {
   InfomapWrapper im(infomap::test::defaultFlags());

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -339,11 +339,13 @@ TEST_CASE("Active graph storage breakdown distinguishes pointer-only and CSR-bac
   pointerIm.initNetwork(pointerIm.network());
   pointerIm.m_disableCsrMaterialization = true;
   pointerIm.setActiveNetworkFromLeafs();
+  pointerIm.pointerBackend().ensureReverseLookup();
 
   const auto pointerStorage = pointerIm.activeGraphStorageBreakdown();
   CHECK_FALSE(pointerStorage.csrAvailable);
   CHECK(pointerStorage.activeNodePointerBytes > 0);
   CHECK(pointerStorage.activeNodeToIdEntryBytes > 0);
+  CHECK(pointerStorage.csrStateIdEntryBytes == 0);
   CHECK(pointerStorage.csrOutOffsetBytes == 0);
   CHECK(pointerStorage.csrInOffsetBytes == 0);
 
@@ -355,7 +357,10 @@ TEST_CASE("Active graph storage breakdown distinguishes pointer-only and CSR-bac
   const auto csrStorage = csrIm.activeGraphStorageBreakdown();
   REQUIRE(csrStorage.csrAvailable);
   CHECK(csrStorage.activeNodePointerBytes > 0);
-  CHECK(csrStorage.activeNodeToIdEntryBytes > 0);
+  CHECK(csrStorage.activeNodeToIdEntryBytes == 0);
+  CHECK(csrStorage.activeNodeToIdBucketBytes == 0);
+  CHECK(csrStorage.csrStateIdEntryBytes > 0);
+  CHECK(csrStorage.csrStateIdBucketBytes > 0);
   CHECK(csrStorage.csrOutOffsetBytes > 0);
   CHECK(csrStorage.csrInOffsetBytes > 0);
   CHECK(csrStorage.totalBytes() > pointerStorage.totalBytes());

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -192,6 +192,55 @@ TEST_CASE("InfoNode replace mutations preserve flattened tree structure [fast][c
   }
 }
 
+TEST_CASE("Active graph payload materialization mirrors the leaf-level active network [fast][core][partition][lifecycle]")
+{
+  InfomapWrapper im(infomap::test::defaultFlags());
+  im.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+  im.initNetwork(im.network());
+  im.setActiveNetworkFromLeafs();
+
+  auto& materialization = im.activeGraphMaterialization();
+  REQUIRE(materialization.nodes.size() == im.activeNetwork().size());
+  REQUIRE(materialization.payloads.size() == im.activeNetwork().size());
+  CHECK(materialization.payloadBytes() == materialization.payloads.size() * sizeof(infomap::InfomapBase::ActiveNodePayload));
+
+  for (std::size_t i = 0; i < materialization.nodes.size(); ++i) {
+    auto* node = im.activeNetwork()[i];
+    CHECK(materialization.nodes[i] == node);
+    CHECK(materialization.payloads[i].data.flow == doctest::Approx(node->data.flow));
+    CHECK(materialization.payloads[i].stateId == node->stateId);
+    CHECK(materialization.payloads[i].physicalId == node->physicalId);
+    CHECK(materialization.payloads[i].layerId == node->layerId);
+  }
+
+  materialization.payloads[0].data.flow += 0.5;
+  im.syncActiveGraphPayloadToHierarchy();
+
+  CHECK(im.activeNetwork()[0]->data.flow == doctest::Approx(materialization.payloads[0].data.flow));
+}
+
+TEST_CASE("Active graph payload materialization mirrors module-level active nodes [fast][core][partition][lifecycle]")
+{
+  InfomapWrapper im(infomap::test::defaultFlags());
+  im.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+  im.run();
+
+  infomap::test::checkRunSanity(im);
+  REQUIRE(im.numTopModules() == 2);
+
+  im.setActiveNetworkFromChildrenOfRoot();
+  const auto& materialization = im.activeGraphMaterialization();
+
+  REQUIRE(materialization.nodes.size() == im.activeNetwork().size());
+  REQUIRE(materialization.nodes.size() == im.numTopModules());
+  for (std::size_t i = 0; i < materialization.nodes.size(); ++i) {
+    auto* node = im.activeNetwork()[i];
+    CHECK(materialization.nodes[i] == node);
+    CHECK(materialization.payloads[i].data.flow == doctest::Approx(node->data.flow));
+    CHECK(materialization.payloads[i].stateId == node->stateId);
+  }
+}
+
 TEST_CASE("Soft cluster-data can be optimized away when it is suboptimal [fast][core][partition]")
 {
   InfomapWrapper im(infomap::test::defaultFlags());

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -332,6 +332,35 @@ TEST_CASE("Pointer backend exposes state and adjacency by active node id [fast][
   view.dirty(0) = originalDirty;
 }
 
+TEST_CASE("Active graph storage breakdown distinguishes pointer-only and CSR-backed leaf materialization [fast][core][partition][lifecycle]")
+{
+  InfomapWrapper pointerIm(infomap::test::defaultFlags());
+  pointerIm.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+  pointerIm.initNetwork(pointerIm.network());
+  pointerIm.m_disableCsrMaterialization = true;
+  pointerIm.setActiveNetworkFromLeafs();
+
+  const auto pointerStorage = pointerIm.activeGraphStorageBreakdown();
+  CHECK_FALSE(pointerStorage.csrAvailable);
+  CHECK(pointerStorage.activeNodePointerBytes > 0);
+  CHECK(pointerStorage.activeNodeToIdEntryBytes > 0);
+  CHECK(pointerStorage.csrOutOffsetBytes == 0);
+  CHECK(pointerStorage.csrInOffsetBytes == 0);
+
+  InfomapWrapper csrIm(infomap::test::defaultFlags());
+  csrIm.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+  csrIm.initNetwork(csrIm.network());
+  csrIm.setActiveNetworkFromLeafs();
+
+  const auto csrStorage = csrIm.activeGraphStorageBreakdown();
+  REQUIRE(csrStorage.csrAvailable);
+  CHECK(csrStorage.activeNodePointerBytes > 0);
+  CHECK(csrStorage.activeNodeToIdEntryBytes > 0);
+  CHECK(csrStorage.csrOutOffsetBytes > 0);
+  CHECK(csrStorage.csrInOffsetBytes > 0);
+  CHECK(csrStorage.totalBytes() > pointerStorage.totalBytes());
+}
+
 TEST_CASE("CSR backend materializes leaf-level first-order adjacency [fast][core][partition][lifecycle]")
 {
   InfomapWrapper im(infomap::test::defaultFlags());


### PR DESCRIPTION
## Summary

This branch executed the planned InfoNode active-graph -> CSR refactor far enough to validate the architecture and the narrow first-order runtime hypothesis.

What it now proves:
- the active-graph lifecycle seam exists in production code: `materialize -> optimize -> sync-back`
- pointer and CSR backends can coexist behind that seam
- serial leaf-level first-order optimization can use CSR correctly
- the branch has strong benchmark/test infrastructure for backend A/B comparison
- the prerequisite `generateSubNetwork(...)` coupling to `InfoNode.index` has been removed

What it does **not** prove:
- meaningful peak-RSS reduction from this CSR design
- that CSR should be broadened to module-level, higher-order, or OpenMP paths
- that the current plan should continue toward “CSR everywhere”

This PR will be closed rather than merged as-is. The benchmark harness, conformance work, and other reusable scaffolding will be moved into a follow-up PR with a tighter scope.

## What Landed On This Branch

Implemented here:
- Phase 0 prerequisite cleanup
  - `generateSubNetwork(...)` no longer clobbers `InfoNode.index`
- benchmark harness work
  - `backend_mode=auto|pointer`
  - per-phase timing
  - active-graph storage breakdown
  - `sizeof(InfoNode)` / `sizeof(InfoEdge)` reporting
  - `materialize_csr_sec`
- Tier 1 conformance additions
  - hierarchy mutation invariants
  - consolidation bridge correctness
  - clarified OpenMP contract: runnable + numerically sane, not exact parity
- active-graph lifecycle seam
  - explicit materialization and sync-back
  - active-node id mapping
  - pointer backend compatibility layer
- CSR implementation work
  - serial leaf-level first-order CSR backend
  - compressed inbound flow storage via indices into `outFlows`
  - scatter-based inbound CSR build from outbound arrays

## Main Findings

### 1. The architecture work was valuable

This branch produced a real backend seam and a benchmark/test surface that made the subsequent decisions much more evidence-based.

### 2. CSR gives a real runtime win on the narrow path it targets

On the current branch state, the 100k-node first-order benchmarks show runtime wins for `auto` vs `pointer`:
- `sparse_100k`: about `-5.9%` runtime
- `ring_of_cliques_100k`: about `-3.9%` runtime

This became true only after materialization cost was reduced significantly, especially by replacing hash-map-heavy inbound construction with scatter from outbound CSR arrays.

### 3. Materialization cost was the key bottleneck during Checkpoint D

Adding `materialize_csr_sec` exposed that CSR materialization was initially a large fraction of partition time at 100k scale. The largest wins in this phase came from reducing that cost, not from micro-optimizing the move loop further.

### 4. The memory goal in the original plan is not realistic for this design

The current CSR approach is additive:
- the `InfoNode` / `InfoEdge` tree remains fully alive
- CSR adjacency/state is materialized on top

That means this branch can achieve a narrow runtime improvement, but it is not a plausible path to strong peak-RSS reduction without a much broader redesign. In practice, CSR remained slightly above pointer-only in RSS on the large first-order cases.

### 5. Broadening CSR further is not justified by the evidence gathered here

This branch does **not** support moving next into:
- module-level CSR
- higher-order CSR
- OpenMP CSR
- “CSR for everything”

The evidence instead suggests that:
- this architecture is worth keeping for benchmarking / seam validation / narrow first-order acceleration
- true memory reduction would need a different project, likely centered on slimming `InfoNode` rather than continuing additive CSR materialization

## Why This PR Is Being Closed

This branch has become a research/prototyping thread that answered the core question for Checkpoint D:
- the seam works
- the first-order serial CSR path can be correct and faster
- the additive CSR design does not deliver the intended memory story

That makes this branch useful as a source of extracted, lower-scope follow-up changes, but not as a merge target in its current form.

## Planned Follow-Up

The next PR will extract the reusable, lower-risk pieces from this work, starting with benchmark/test/scaffolding surfaces such as:
- benchmark harness improvements
- conformance tests
- prerequisite cleanup (`generateSubNetwork(...)`)
- possibly other backend-seam pieces that are independently defensible

The goal of the split is to preserve the useful infrastructure and findings without merging the full experimental CSR branch.

## Reference

Checkpoint document:
- `docs/plans/2026-04-03-infonode-csr-refactor-plan.md`

Local `.codex-bin/` is not included.
