### PR TITLE
fix: stop using InfoNode.index as subnetwork scratch state

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ if(BUILD_TESTING)
     add_infomap_cpp_test(infomap_cpp_flow_tests test/cpp/test_flow.cpp "fast;core;flow")
 
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+        target_compile_options(infomap_cpp_lifecycle_tests PRIVATE -fno-access-control)
         target_compile_options(infomap_cpp_partition_tests PRIVATE -fno-access-control)
     endif()
 

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -27,6 +27,7 @@
 #include <limits>
 #include <map>
 #include <set>
+#include <unordered_map>
 #include <cstdlib>
 #include <algorithm>
 #include <cmath>
@@ -883,11 +884,13 @@ void InfomapBase::generateSubNetwork(InfoNode& parent)
   Log(1) << "Generate sub network with " << numNodes << " nodes...\n";
 
   unsigned int childIndex = 0;
+  std::unordered_map<InfoNode*, unsigned int> nodeIndexMap;
+  nodeIndexMap.reserve(numNodes);
   for (InfoNode& node : parent) {
     auto* clonedNode = new InfoNode(node);
     clonedNode->initClean();
     m_root.addChild(clonedNode);
-    node.index = childIndex; // Set index to its place in this subnetwork to be able to find edge target below
+    nodeIndexMap[&node] = childIndex;
     m_leafNodes[childIndex] = clonedNode;
     ++childIndex;
   }
@@ -899,7 +902,7 @@ void InfomapBase::generateSubNetwork(InfoNode& parent)
       InfoEdge& edge = *e;
       // If neighbour node is within the same module, add the link to this subnetwork.
       if (edge.target->parent == parentPtr) {
-        m_leafNodes[edge.source->index]->addOutEdge(*m_leafNodes[edge.target->index], edge.data.weight, edge.data.flow);
+        m_leafNodes[nodeIndexMap.at(edge.source)]->addOutEdge(*m_leafNodes[nodeIndexMap.at(edge.target)], edge.data.weight, edge.data.flow);
       }
     }
   }

--- a/test/cpp/test_infomap_wrapper.cpp
+++ b/test/cpp/test_infomap_wrapper.cpp
@@ -4,11 +4,28 @@
 
 #include "TestUtils.h"
 
+#include <set>
+#include <tuple>
 #include <vector>
 
 namespace {
 
 using infomap::InfomapWrapper;
+
+using InternalEdge = std::tuple<unsigned int, unsigned int, double, double>;
+
+std::multiset<InternalEdge> internalEdgesForModule(infomap::InfoNode& module)
+{
+  std::multiset<InternalEdge> edges;
+  for (auto& node : module) {
+    for (auto* edge : node.outEdges()) {
+      if (edge->target->parent == &module) {
+        edges.emplace(edge->source->stateId, edge->target->stateId, edge->data.weight, edge->data.flow);
+      }
+    }
+  }
+  return edges;
+}
 
 TEST_CASE("Infomap partitions the unweighted two-triangle fixture into two modules [fast][core][lifecycle]")
 {
@@ -104,6 +121,40 @@ TEST_CASE("File-backed multilayer input clusters as a higher-order network [fast
   infomap::test::checkRunSanity(im);
   CHECK(im.network().haveMemoryInput());
   CHECK(im.getModules(1, true).size() == im.numLeafNodes());
+}
+
+TEST_CASE("Subnetwork generation preserves parent indices and clones internal edges [fast][core][lifecycle][subnetwork]")
+{
+  InfomapWrapper im(infomap::test::defaultFlags());
+  im.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+  im.run();
+
+  infomap::test::checkRunSanity(im);
+  REQUIRE(im.numTopModules() == 2);
+
+  auto& module = *im.root().firstChild;
+  REQUIRE(module.childDegree() == 3);
+
+  const auto originalEdges = internalEdgesForModule(module);
+  std::vector<unsigned int> sentinelIndices;
+  unsigned int childIndex = 0;
+  for (auto& node : module) {
+    node.index = 100 + childIndex;
+    sentinelIndices.push_back(node.index);
+    ++childIndex;
+  }
+
+  auto& subInfomap = im.getSubInfomap(module).initNetwork(module);
+
+  REQUIRE(subInfomap.numLeafNodes() == module.childDegree());
+  CHECK(subInfomap.root().owner == &module);
+  CHECK(internalEdgesForModule(subInfomap.root()) == originalEdges);
+
+  childIndex = 0;
+  for (auto& node : module) {
+    CHECK(node.index == sentinelIndices[childIndex]);
+    ++childIndex;
+  }
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

Stop using `InfoNode.index` as scratch storage while generating sub-Infomap networks.

`InfomapBase::generateSubNetwork(InfoNode&)` previously overwrote each child node's `index` with its temporary position in the new subnetwork, then reused that mutated state to clone internal edges. That worked as a local shortcut, but it also leaked a write to a field that carries real optimizer and tree state elsewhere in the codebase.

This change replaces that side-channel with a local `InfoNode* -> position` map and adds a regression test that proves subnetwork generation no longer clobbers parent node indices.

## Problem

The old implementation did this during subnetwork construction:
- clone each child node
- write `node.index = childIndex`
- later use `edge.source->index` / `edge.target->index` to find the cloned endpoints

That meant `generateSubNetwork(...)` mutated caller-visible `InfoNode.index` state as an implementation detail and never restored it.

Why that is a bug:
- `InfoNode.index` is not scratch-only state
- it is used elsewhere for optimizer module assignment, consolidation, and other tree/partition bookkeeping
- a helper that silently rewrites it creates hidden coupling and makes the surrounding code harder to reason about

Even when the mutation does not immediately surface as a user-visible partition bug, it is still state corruption at the function boundary.

## Fix

In [src/core/InfomapBase.cpp](/Users/anton/kod/infomap/src/core/InfomapBase.cpp), replace the temporary `node.index` write with a local `std::unordered_map<InfoNode*, unsigned int>`:
- map original child node pointer -> cloned subnetwork position
- use that map when cloning internal edges
- leave the original nodes' `index` values untouched

## Tests

Add a regression in [test/cpp/test_infomap_wrapper.cpp](/Users/anton/kod/infomap/test/cpp/test_infomap_wrapper.cpp) that:
- builds a small partitioned fixture
- records sentinel `index` values on the parent module's children
- generates the subnetwork
- verifies those sentinel indices are preserved
- verifies the generated subnetwork clones the module's internal edge set exactly

Also add the required `-fno-access-control` compile option for the lifecycle test target in [CMakeLists.txt](/Users/anton/kod/infomap/CMakeLists.txt) so the regression can exercise the internal path directly.

## Risk

Medium.

This changes C++ core logic, but the surface is tightly bounded:
- one helper function
- no public API changes
- behavior is preserved except for removing the leaked side effect on `InfoNode.index`

The new mapping is local to subnetwork generation and does not change the cloned graph semantics.

## Verification

Ran:
- `PATH="/opt/homebrew/bin:$PATH" make test-native JOBS=1`

## Why This Should Merge Independently

This fix stands on its own.

It is not inherently tied to the larger CSR experimentation branch; that work only made the hidden coupling around `InfoNode.index` more obvious. Removing the side-channel is independently valuable because it:
- makes `generateSubNetwork(...)` respect its caller's state
- removes a hidden dependency on a semantically overloaded field
- adds a focused regression for a fragile internal path
