### PR TITLE
fix: delete collapsed children when resetting InfoNode trees

### DIFF
--- a/src/core/InfoNode.cpp
+++ b/src/core/InfoNode.cpp
@@ -300,18 +300,23 @@ void InfoNode::remove(bool removeChildren) noexcept
 
 void InfoNode::deleteChildren() noexcept
 {
-  if (firstChild == nullptr)
-    return;
+  auto delete_child_chain = [](InfoNode*& first, InfoNode*& last) {
+    if (first == nullptr)
+      return;
 
-  child_iterator nodeIt = begin_child();
-  do {
-    InfoNode* n = nodeIt.current();
-    ++nodeIt;
-    delete n;
-  } while (nodeIt.current() != nullptr);
+    InfoNode* node = first;
+    while (node != nullptr) {
+      InfoNode* next_node = node->next;
+      delete node;
+      node = next_node;
+    }
 
-  firstChild = nullptr;
-  lastChild = nullptr;
+    first = nullptr;
+    last = nullptr;
+  };
+
+  delete_child_chain(firstChild, lastChild);
+  delete_child_chain(collapsedFirstChild, collapsedLastChild);
   m_childDegree = 0;
 }
 

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -383,7 +383,7 @@ InfomapBase& InfomapBase::initNetwork(Network& network)
 {
   if (network.numNodes() == 0)
     throw std::domain_error("No nodes in network");
-  if (m_root.childDegree() > 0) {
+  if (m_root.firstChild != nullptr || m_root.collapsedFirstChild != nullptr) {
     m_root.deleteChildren();
     m_leafNodes.clear();
   }

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -160,6 +160,26 @@ TEST_CASE("InfoNode hierarchy mutations preserve parentage and child order [fast
   CHECK(childStateIds(root) == std::vector<unsigned int>{40, 50});
 }
 
+TEST_CASE("InfoNode deleteChildren also clears collapsed children [fast][core][partition][tree]")
+{
+  InfoNode root;
+  root.addChild(new InfoNode({}, 10));
+  root.addChild(new InfoNode({}, 20));
+
+  CHECK(root.collapseChildren() == 2);
+  CHECK(root.childDegree() == 0);
+  CHECK(root.firstChild == nullptr);
+  CHECK(root.collapsedFirstChild != nullptr);
+
+  root.deleteChildren();
+
+  CHECK(root.childDegree() == 0);
+  CHECK(root.firstChild == nullptr);
+  CHECK(root.lastChild == nullptr);
+  CHECK(root.collapsedFirstChild == nullptr);
+  CHECK(root.collapsedLastChild == nullptr);
+}
+
 TEST_CASE("InfoNode replace mutations preserve flattened tree structure [fast][core][partition][tree]")
 {
   InfoNode root;


### PR DESCRIPTION
## Summary
This PR replaces the tree cleanup portion of #400 with a narrower `src/core` fix.

It fixes cleanup of collapsed child chains in `InfoNode` trees and makes `initNetwork()` treat collapsed root children as existing state that must be cleared before reinitialization.

## Changes
- make `InfoNode::deleteChildren()` delete both active and collapsed child chains
- treat `collapsedFirstChild` on the root as existing state in `InfomapBase::initNetwork()`
- add a regression test that proves collapsed children are cleared too

## Verification
- `PATH="/opt/homebrew/bin:$PATH" make build-native`
- `PATH="/opt/homebrew/bin:$PATH" make test-native JOBS=1 CTEST_ARGS='-R infomap_cpp_partition_tests'`

## Relationship to #400
This PR replaces the collapsed-children cleanup portion of #400.
