### PR TITLE
fix: guard empty-module access in parallel move path

### DIFF
--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -582,9 +582,10 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleInParalle
         unsigned int bestModuleIndex = bestDeltaModule.module;
         unsigned int oldModuleIndex = current.index;
 
-        bool validMove = bestModuleIndex == m_emptyModules.back()
+        bool movingToEmptyModule = !m_emptyModules.empty() && bestModuleIndex == m_emptyModules.back();
+        bool validMove = movingToEmptyModule
             // Check validity of move to empty target
-            ? m_moduleMembers[oldModuleIndex] > 1 && !m_emptyModules.empty()
+            ? m_moduleMembers[oldModuleIndex] > 1
             // Not valid if the best module is empty now but not when decided
             : m_moduleMembers[bestModuleIndex] > 0;
 


### PR DESCRIPTION
## Summary
This PR replaces the OpenMP/runtime safety portion of #400 with a single-file core fix.

It guards access to `m_emptyModules.back()` in the parallel move path so the optimizer no longer reads from an empty vector before checking whether an empty module exists.

## Changes
- introduce a guarded `movingToEmptyModule` check before consulting `m_emptyModules.back()`
- keep the move-validity logic otherwise unchanged

## Verification
- `PATH="/opt/homebrew/bin:$PATH" make build-native`
- `PATH="/opt/homebrew/bin:$PATH" make test-sanitizers JOBS=1 CTEST_ARGS='-R infomap_cpp_flow_tests'`

## Risk
This touches the OpenMP move path in `src/core`, so it stays isolated and draft for review.

## Relationship to #400
This PR replaces the OpenMP guard portion of #400.
