### PR TITLE
refactor: harden io/config parsing and add output regressions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,18 @@ if(BUILD_TESTING)
     add_infomap_cpp_test(infomap_cpp_lifecycle_tests test/cpp/test_infomap_wrapper.cpp "fast;core;lifecycle;crash")
     add_infomap_cpp_test(infomap_cpp_partition_tests test/cpp/test_partition.cpp "fast;core;partition;parser")
     add_infomap_cpp_test(infomap_cpp_flow_tests test/cpp/test_flow.cpp "fast;core;flow")
+    add_infomap_cpp_test(infomap_cpp_utils_io_tests test/cpp/test_utils_io.cpp "fast;core;utils;io")
+    add_infomap_cpp_test(infomap_cpp_program_interface_tests test/cpp/test_program_interface.cpp "fast;core;parser;cli")
+    add_infomap_cpp_test(infomap_cpp_config_tests test/cpp/test_config.cpp "fast;core;config;cli")
+
+    add_test(
+        NAME print_json_parameters
+        COMMAND
+            "${Python3_EXECUTABLE}"
+            "${CMAKE_CURRENT_SOURCE_DIR}/test/scripts/check_print_json_parameters.py"
+            "$<TARGET_FILE:infomap_cli>"
+    )
+    set_tests_properties(print_json_parameters PROPERTIES LABELS "fast;core;parser;cli")
 
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
         target_compile_options(infomap_cpp_lifecycle_tests PRIVATE -fno-access-control)
@@ -151,5 +163,9 @@ if(BUILD_TESTING)
             infomap_cpp_lifecycle_tests
             infomap_cpp_partition_tests
             infomap_cpp_flow_tests
+            infomap_cpp_utils_io_tests
+            infomap_cpp_program_interface_tests
+            infomap_cpp_config_tests
+            infomap_cli
     )
 endif()

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,11 @@ import importlib.util
 from pathlib import Path
 
 from setuptools import Extension, setup
+from setuptools.command.build_ext import build_ext
 
 
 REPO_ROOT = Path(__file__).resolve().parent
+SWIG_CPP_SOURCE = REPO_ROOT / "interfaces" / "python" / "generated" / "infomap_wrap.cpp"
 
 
 def repo_rel(path: Path) -> str:
@@ -22,11 +24,38 @@ def load_build_config():
 
 
 def collect_cpp_sources():
-    generated = REPO_ROOT / "interfaces" / "python" / "generated" / "infomap_wrap.cpp"
-    sources = [repo_rel(generated)]
+    sources = [repo_rel(SWIG_CPP_SOURCE)]
     for path in sorted((REPO_ROOT / "src").rglob("*.cpp")):
         sources.append(repo_rel(path))
     return sources
+
+
+def swig_warning_suppression(compiler_family):
+    if compiler_family == "msvc":
+        return ["/w"]
+    if compiler_family in {"clang", "gnu", "unknown"}:
+        return ["-w"]
+    return []
+
+
+class BuildExt(build_ext):
+    def build_extensions(self):
+        original_compile = self.compiler._compile
+        quiet_swig_flags = swig_warning_suppression(shared_build["compiler_family"])
+        swig_source = str(SWIG_CPP_SOURCE)
+
+        def compile_with_source_overrides(obj, src, ext, cc_args, extra_postargs, pp_opts):
+            source = os.path.abspath(src)
+            compile_args = list(extra_postargs or [])
+            if source == swig_source and quiet_swig_flags:
+                compile_args.extend(quiet_swig_flags)
+            return original_compile(obj, src, ext, cc_args, compile_args, pp_opts)
+
+        self.compiler._compile = compile_with_source_overrides
+        try:
+            super().build_extensions()
+        finally:
+            self.compiler._compile = original_compile
 
 
 build_config = load_build_config()
@@ -57,6 +86,7 @@ if sys.platform == "win32":
 
 
 setup(
+    cmdclass={"build_ext": BuildExt},
     ext_modules=[
         Extension(
             "infomap._infomap",

--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -24,6 +24,44 @@ constexpr int FlowModel::outdirdir;
 constexpr int FlowModel::rawdir;
 constexpr int FlowModel::precomputed;
 
+namespace {
+
+void applyFlowModelSelection(Config& config, const std::string& flowModelArg)
+{
+  if (flowModelArg == "directed" || config.directed) {
+    config.setFlowModel(FlowModel::directed);
+  } else if (flowModelArg == "undirected") {
+    config.setFlowModel(FlowModel::undirected);
+  } else if (flowModelArg == "undirdir") {
+    config.setFlowModel(FlowModel::undirdir);
+  } else if (flowModelArg == "outdirdir") {
+    config.setFlowModel(FlowModel::outdirdir);
+  } else if (flowModelArg == "rawdir") {
+    config.setFlowModel(FlowModel::rawdir);
+  } else if (flowModelArg == "precomputed") {
+    config.setFlowModel(FlowModel::precomputed);
+  } else if (!flowModelArg.empty()) {
+    throw std::runtime_error(io::Str() << "Unrecognized flow model: '" << flowModelArg << "'");
+  }
+}
+
+void normalizeOutputDirectory(Config& config)
+{
+  if (!config.haveOutput() || config.outDirectory.empty())
+    return;
+
+  if (config.outDirectory.back() != '/')
+    config.outDirectory.push_back('/');
+}
+
+void validateOutputDirectory(const Config& config)
+{
+  if (config.haveOutput() && !isDirectoryWritable(config.outDirectory))
+    throw std::runtime_error(io::Str() << "Can't write to directory '" << config.outDirectory << "'. Check that the directory exists and that you have write permissions.");
+}
+
+} // namespace
+
 Config::Config(const std::string& flags, bool isCLI) : isCLI(isCLI)
 {
   ProgramInterface api("Infomap",
@@ -177,31 +215,14 @@ Config::Config(const std::string& flags, bool isCLI) : isCLI(isCLI)
     throw std::runtime_error("Missing out_directory");
   }
 
-  if (flowModelArg == "directed" || directed) {
-    setFlowModel(FlowModel::directed);
-  } else if (flowModelArg == "undirected") {
-    setFlowModel(FlowModel::undirected);
-  } else if (flowModelArg == "undirdir") {
-    setFlowModel(FlowModel::undirdir);
-  } else if (flowModelArg == "outdirdir") {
-    setFlowModel(FlowModel::outdirdir);
-  } else if (flowModelArg == "rawdir") {
-    setFlowModel(FlowModel::rawdir);
-  } else if (flowModelArg == "precomputed") {
-    setFlowModel(FlowModel::precomputed);
-  } else if (!flowModelArg.empty()) {
-    throw std::runtime_error(io::Str() << "Unrecognized flow model: '" << flowModelArg << "'");
-  }
+  applyFlowModelSelection(*this, flowModelArg);
 
   if (regularized) {
     recordedTeleportation = true;
   }
 
-  if (*--outDirectory.end() != '/')
-    outDirectory.append("/");
-
-  if (haveOutput() && !isDirectoryWritable(outDirectory))
-    throw std::runtime_error(io::Str() << "Can't write to directory '" << outDirectory << "'. Check that the directory exists and that you have write permissions.");
+  normalizeOutputDirectory(*this);
+  validateOutputDirectory(*this);
 
   if (outName.empty()) {
     outName = !networkFile.empty() ? FileURI(networkFile).getName() : "no-name";

--- a/src/io/Output.cpp
+++ b/src/io/Output.cpp
@@ -190,10 +190,6 @@ std::map<std::string, LinkMap> aggregateModuleLinks(InfomapBase& im, bool states
           stateIdToParent[stateId] = it->parent;
           stateIdToChildIndex[stateId] = it.childIndex();
         }
-      } else {
-        // Use stateId to store depth on modules to simplify link aggregation
-        it->stateId = it.depth();
-        it->index = it.childIndex();
       }
     }
   } else {
@@ -201,10 +197,6 @@ std::map<std::string, LinkMap> aggregateModuleLinks(InfomapBase& im, bool states
       if (it->isLeaf()) {
         stateIdToParent[it->stateId] = it->parent;
         stateIdToChildIndex[it->stateId] = it.childIndex();
-      } else {
-        // Use stateId to store depth on modules to simplify link aggregation
-        it->stateId = it.depth();
-        it->index = it.childIndex();
       }
     }
   }
@@ -252,8 +244,8 @@ std::map<std::string, LinkMap> aggregateModuleLinks(InfomapBase& im, bool states
           }
         }
 
-        sourceChildIndex = sourceParentIt->index;
-        targetChildIndex = targetParentIt->index;
+        sourceChildIndex = sourceParentIt->childIndex();
+        targetChildIndex = targetParentIt->childIndex();
 
         ++sourceParentIt;
         ++targetParentIt;
@@ -276,7 +268,6 @@ void writeTreeLinks(InfomapBase& im, std::ostream& outStream, bool states)
   outStream << "*Links " << (im.isUndirectedFlow() ? "undirected" : "directed") << "\n";
   outStream << "#*Links path enterFlow exitFlow numEdges numChildren\n";
 
-  // Use stateId to store depth on modules to optimize link aggregation
   for (auto it(im.iterModules()); !it.isEnd(); ++it) {
     auto parentId = io::stringify(it.path(), ":");
     auto& module = *it;

--- a/src/io/ProgramInterface.cpp
+++ b/src/io/ProgramInterface.cpp
@@ -35,6 +35,136 @@ const std::unordered_map<std::string, char> ArgType::toShort = {
   { "list", 'l' },
 };
 
+namespace {
+
+using ShortOptionMap = std::map<char, Option*>;
+using LongOptionMap = std::map<std::string, Option*>;
+using NonOptionArguments = std::deque<std::unique_ptr<TargetBase>>;
+
+struct OptionLookup {
+  ShortOptionMap shortOptions;
+  LongOptionMap longOptions;
+};
+
+OptionLookup buildOptionLookup(std::deque<std::unique_ptr<Option>>& options)
+{
+  OptionLookup lookup;
+  for (auto& optionArgument : options) {
+    auto& opt = *optionArgument;
+    if (opt.shortName != '\0') {
+      auto inserted = lookup.shortOptions.insert(std::make_pair(opt.shortName, &opt));
+      if (!inserted.second)
+        throw std::runtime_error(io::Str() << "Duplication of option '" << opt.shortName << "'");
+    }
+
+    auto inserted = lookup.longOptions.insert(std::make_pair(opt.longName, &opt));
+    if (!inserted.second)
+      throw std::runtime_error(io::Str() << "Duplication of option \"" << opt.longName << "\"");
+  }
+  return lookup;
+}
+
+std::vector<std::string> tokenizeArgs(const std::string& args)
+{
+  std::vector<std::string> flags;
+  std::istringstream argStream(args);
+  std::string arg;
+  while (!(argStream >> arg).fail())
+    flags.push_back(arg);
+  return flags;
+}
+
+void parseOptionValue(Option& opt, const std::string& value)
+{
+  if (!opt.parse(value))
+    throw std::runtime_error(io::Str() << "Cannot parse '" << value << "' as argument to option '" << opt.longName << "'. ");
+}
+
+void parseLongOption(const std::string& arg, const LongOptionMap& longOptions, const std::vector<std::string>& flags, unsigned int& i)
+{
+  if (arg.length() < 3)
+    throw std::runtime_error("Illegal argument '--'");
+
+  std::string longOpt = arg.substr(2);
+  bool flagValue = true;
+  auto it = longOptions.find(longOpt);
+  if (it == longOptions.end()) {
+    // Unrecognized option, check if it negates a recognised option with the '--no-' prefix
+    if (longOpt.compare(0, 3, "no-") == 0 && longOptions.find(std::string(longOpt, 3)) != longOptions.end()) {
+      longOpt = std::string(longOpt, 3);
+      it = longOptions.find(longOpt);
+      flagValue = false;
+    } else {
+      throw std::runtime_error(io::Str() << "Unrecognized option: '--" << longOpt << "'");
+    }
+  }
+
+  auto& opt = *it->second;
+  if (!opt.requireArgument || opt.incrementalArgument) {
+    opt.set(flagValue);
+    return;
+  }
+
+  const auto numArgsLeft = flags.size() - i - 1;
+  if (numArgsLeft == 0)
+    throw std::runtime_error(io::Str() << "Option '" << opt.longName << "' requires argument");
+
+  ++i;
+  parseOptionValue(opt, flags[i]);
+}
+
+void parseShortOptions(const std::string& arg, const ShortOptionMap& shortOptions, const std::vector<std::string>& flags, unsigned int& i)
+{
+  for (unsigned int j = 1; j < arg.length(); ++j) {
+    const auto optionName = arg[j];
+    const auto numCharsLeft = arg.length() - j - 1;
+    auto it = shortOptions.find(optionName);
+    if (it == shortOptions.end())
+      throw std::runtime_error(io::Str() << "Unrecognized option: '-" << optionName << "'");
+
+    auto& opt = *it->second;
+    if (!opt.requireArgument || opt.incrementalArgument) {
+      opt.set(true);
+      continue;
+    }
+
+    std::string optArg;
+    const auto numArgsLeft = flags.size() - i - 1;
+    if (numCharsLeft > 0) {
+      optArg = arg.substr(j + 1);
+      j = arg.length() - 1;
+    } else if (numArgsLeft > 0) {
+      ++i;
+      optArg = flags[i];
+    } else {
+      throw std::runtime_error(io::Str() << "Option '" << opt.longName << "' requires argument");
+    }
+
+    parseOptionValue(opt, optArg);
+  }
+}
+
+void parseNonOptionArguments(std::deque<std::string>& nonOpts, NonOptionArguments& nonOptionArguments, unsigned int numRequiredArguments)
+{
+  if (nonOpts.size() < numRequiredArguments)
+    throw std::runtime_error("Missing required arguments.");
+
+  unsigned int i = 0;
+  unsigned int numVectorArguments = nonOpts.size() - (nonOptionArguments.size() - 1);
+  while (!nonOpts.empty()) {
+    std::string arg = nonOpts.front();
+    nonOpts.pop_front();
+    if (nonOptionArguments[i]->isOptionalVector && numVectorArguments == 0)
+      ++i;
+    if (!nonOptionArguments[i]->parse(arg))
+      throw std::runtime_error("Argument error.");
+    if (!nonOptionArguments[i]->isOptionalVector || --numVectorArguments == 0)
+      ++i;
+  }
+}
+
+} // namespace
+
 ProgramInterface::ProgramInterface(std::string name, std::string shortDescription, std::string version)
     : m_programName(std::move(name)),
       m_shortProgramDescription(std::move(shortDescription)),
@@ -200,40 +330,12 @@ void ProgramInterface::exitWithJsonParameters() const
 
 void ProgramInterface::parseArgs(const std::string& args)
 {
-  // Map the options on short and long name, and check for duplication
-  std::map<char, Option*> shortOptionMap;
-  std::map<std::string, Option*> longOptionMap;
-  for (auto& optionArgument : m_optionArguments) {
-    auto& opt = *optionArgument;
-    if (opt.shortName != '\0') {
-      auto it = shortOptionMap.find(opt.shortName);
-      if (it != shortOptionMap.end())
-        throw std::runtime_error(io::Str() << "Duplication of option '" << opt.shortName << "'");
-      shortOptionMap.insert(std::make_pair(opt.shortName, &opt));
-    }
-
-    auto it = longOptionMap.find(opt.longName);
-    if (it != longOptionMap.end())
-      throw std::runtime_error(io::Str() << "Duplication of option \"" << opt.longName << "\"");
-    longOptionMap.insert(std::make_pair(opt.longName, &opt));
-  }
-
-  // Split the flags on whitespace
-  std::vector<std::string> flags;
-  std::istringstream argStream(args);
-
-  {
-    std::string arg;
-    while (!(argStream >> arg).fail())
-      flags.push_back(arg);
-  }
+  const auto optionLookup = buildOptionLookup(m_optionArguments);
+  const auto flags = tokenizeArgs(args);
 
   std::deque<std::string> nonOpts;
   try {
     for (unsigned int i = 0; i < flags.size(); ++i) {
-      bool flagValue = true;
-      unsigned int numArgsLeft = flags.size() - i - 1;
-
       const std::string& arg = flags[i];
       if (arg.length() == 0)
         throw std::runtime_error("Illegal argument ''");
@@ -245,57 +347,9 @@ void ProgramInterface::parseArgs(const std::string& args)
           throw std::runtime_error("Illegal argument '-'");
 
         if (arg[1] == '-') {
-          // Long option
-          if (arg.length() < 3)
-            throw std::runtime_error("Illegal argument '--'");
-          std::string longOpt = arg.substr(2);
-          auto it = longOptionMap.find(longOpt);
-          if (it == longOptionMap.end()) {
-            // Unrecognized option, check if it negates a recognised option with the '--no-' prefix
-            if (longOpt.compare(0, 3, "no-") == 0 && longOptionMap.find(std::string(longOpt, 3)) != longOptionMap.end()) {
-              longOpt = std::string(longOpt, 3);
-              it = longOptionMap.find(longOpt);
-              flagValue = false;
-            } else {
-              throw std::runtime_error(io::Str() << "Unrecognized option: '--" << longOpt << "'");
-            }
-          }
-          auto& opt = *it->second;
-          if (!opt.requireArgument || opt.incrementalArgument)
-            opt.set(flagValue);
-          else {
-            if (numArgsLeft == 0)
-              throw std::runtime_error(io::Str() << "Option '" << opt.longName << "' requires argument");
-            ++i;
-            if (!opt.parse(flags[i]))
-              throw std::runtime_error(io::Str() << "Cannot parse '" << flags[i] << "' as argument to option '" << opt.longName << "'. ");
-          }
+          parseLongOption(arg, optionLookup.longOptions, flags, i);
         } else {
-          // Short option(s)
-          for (unsigned int j = 1; j < arg.length(); ++j) {
-            char o = arg[j];
-            unsigned int numCharsLeft = arg.length() - j - 1;
-            auto it = shortOptionMap.find(o);
-            if (it == shortOptionMap.end())
-              throw std::runtime_error(io::Str() << "Unrecognized option: '-" << o << "'");
-            auto& opt = *it->second;
-            if (!opt.requireArgument || opt.incrementalArgument)
-              opt.set(flagValue);
-            else {
-              std::string optArg;
-              if (numCharsLeft > 0) {
-                optArg = arg.substr(j + 1);
-                j = arg.length() - 1;
-              } else if (numArgsLeft) {
-                ++i;
-                optArg = flags[i];
-              } else
-                throw std::runtime_error(io::Str() << "Option '" << opt.longName << "' requires argument");
-
-              if (!opt.parse(optArg))
-                throw std::runtime_error(io::Str() << "Cannot parse '" << optArg << "' as argument to option '" << opt.longName << "'. ");
-            }
-          }
+          parseShortOptions(arg, optionLookup.shortOptions, flags, i);
         }
       }
       if (m_displayHelp > 0)
@@ -309,20 +363,10 @@ void ProgramInterface::parseArgs(const std::string& args)
     exitWithError(e.what());
   }
 
-  if (nonOpts.size() < numRequiredArguments())
-    exitWithError("Missing required arguments.");
-
-  unsigned int i = 0;
-  unsigned int numVectorArguments = nonOpts.size() - (m_nonOptionArguments.size() - 1);
-  while (!nonOpts.empty()) {
-    std::string arg = nonOpts.front();
-    nonOpts.pop_front();
-    if (m_nonOptionArguments[i]->isOptionalVector && numVectorArguments == 0)
-      ++i;
-    if (!m_nonOptionArguments[i]->parse(arg))
-      exitWithError("Argument error.");
-    if (!m_nonOptionArguments[i]->isOptionalVector || --numVectorArguments == 0)
-      ++i;
+  try {
+    parseNonOptionArguments(nonOpts, m_nonOptionArguments, numRequiredArguments());
+  } catch (std::exception& e) {
+    exitWithError(e.what());
   }
 }
 

--- a/src/utils/FileURI.cpp
+++ b/src/utils/FileURI.cpp
@@ -24,10 +24,13 @@ FileURI::FileURI(string filename, bool requireExtension)
     return s;
   };
 
+  if (m_filename.empty())
+    throw std::invalid_argument(getErrorMessage(m_filename, m_requireExtension));
+
   auto name = m_filename;
   auto pos = m_filename.find_last_of('/');
   if (pos != string::npos) {
-    if (pos == m_filename.length()) // File could not end with slash
+    if (pos == m_filename.length() - 1) // File could not end with slash
       throw std::invalid_argument(getErrorMessage(m_filename, m_requireExtension));
     m_directory = m_filename.substr(0, pos + 1); // Include the last slash in the directory
     name = m_filename.substr(pos + 1); // No slash in the name

--- a/src/utils/convert.h
+++ b/src/utils/convert.h
@@ -16,6 +16,7 @@
 #include <string>
 #include <locale> // std::locale, std::tolower
 #include <iostream>
+#include <limits>
 #include <vector>
 
 namespace infomap {
@@ -52,7 +53,7 @@ namespace io {
   }
 
   template <typename T>
-  inline std::string stringify(T& x)
+  inline std::string stringify(const T& x)
   {
     std::ostringstream o;
     if (!(o << x))
@@ -61,7 +62,7 @@ namespace io {
   }
 
   template <>
-  inline std::string stringify(bool& x)
+  inline std::string stringify(const bool& x)
   {
     return x ? "true" : "false";
   }
@@ -151,26 +152,36 @@ namespace io {
     return !!(istream >> value);
   }
 
+  template <typename T>
+  inline bool stringToUnsignedValue(std::string const& str, T& value)
+  {
+    std::istringstream istream(str);
+    istream >> std::ws;
+    if (!istream.good() || istream.peek() == '-' || istream.peek() == std::char_traits<char>::eof())
+      return false;
+
+    unsigned long long target = 0;
+    if (!(istream >> target))
+      return false;
+
+    istream >> std::ws;
+    if (!istream.eof() || target > std::numeric_limits<T>::max())
+      return false;
+
+    value = static_cast<T>(target);
+    return true;
+  }
+
   template <>
   inline bool stringToValue(std::string const& str, unsigned int& value)
   {
-    std::istringstream istream(str);
-    int target = 0;
-    istream >> target;
-    if (target < 0) return false;
-    value = target;
-    return true;
+    return stringToUnsignedValue(str, value);
   }
 
   template <>
   inline bool stringToValue(std::string const& str, unsigned long& value)
   {
-    std::istringstream istream(str);
-    int target = 0;
-    istream >> target;
-    if (target < 0) return false;
-    value = target;
-    return true;
+    return stringToUnsignedValue(str, value);
   }
 
   inline std::string firstWord(const std::string& line)

--- a/test/cpp/TestUtils.h
+++ b/test/cpp/TestUtils.h
@@ -5,9 +5,11 @@
 #include "Infomap.h"
 
 #include <algorithm>
+#include <cstdio>
 #include <cmath>
 #include <fstream>
 #include <map>
+#include <memory>
 #include <sstream>
 #include <set>
 #include <stdexcept>
@@ -104,6 +106,27 @@ inline void addEdgeFixtureLinks(InfomapWrapper& im, const std::string& relativeP
   for (const auto& link : readEdgeFixture(relativePath)) {
     im.addLink(link.sourceId, link.targetId, link.weight);
   }
+}
+
+template <typename SetupFn>
+inline std::unique_ptr<InfomapWrapper> makeRunningInfomap(SetupFn&& setup, const std::string& extraFlags = "")
+{
+  std::unique_ptr<InfomapWrapper> im(new InfomapWrapper(defaultFlags(extraFlags)));
+  setup(*im);
+  im->run();
+  return im;
+}
+
+inline std::string readTextFile(const std::string& path)
+{
+  std::ifstream input(path.c_str());
+  if (!input) {
+    throw std::runtime_error("Could not open text file: " + path);
+  }
+
+  std::ostringstream output;
+  output << input.rdbuf();
+  return output.str();
 }
 
 inline void readNetworkFixture(InfomapWrapper& im, const std::string& filename, bool accumulate = true)

--- a/test/cpp/test_config.cpp
+++ b/test/cpp/test_config.cpp
@@ -1,0 +1,40 @@
+#include "vendor/doctest.h"
+
+#include "io/Config.h"
+
+namespace {
+
+using infomap::Config;
+using infomap::FlowModel;
+
+TEST_CASE("Config accepts no-file-output without an output directory [fast][core][config][cli]")
+{
+  CHECK_NOTHROW(Config("input.net --silent --no-file-output", true));
+
+  const Config config("input.net --silent --no-file-output", true);
+  CHECK(config.noFileOutput);
+  CHECK(config.outDirectory.empty());
+  CHECK(config.networkFile == "input.net");
+}
+
+TEST_CASE("Config parses flow model selection and output formats [fast][core][config][cli]")
+{
+  const Config config("input.net --silent --no-file-output --flow-model precomputed --output json,tree", true);
+  CHECK(config.flowModel == FlowModel::precomputed);
+  CHECK(config.printJson);
+  CHECK(config.printTree);
+}
+
+TEST_CASE("Config treats directed shorthand as directed flow model [fast][core][config][cli]")
+{
+  const Config config("input.net --silent --no-file-output --directed", true);
+  CHECK(config.flowModel == FlowModel::directed);
+}
+
+TEST_CASE("Config rejects unknown flow models and output formats [fast][core][config][cli]")
+{
+  CHECK_THROWS_AS(Config("input.net --silent --no-file-output --flow-model unknown", true), std::runtime_error);
+  CHECK_THROWS_AS(Config("input.net --silent --no-file-output --output tree,unknown", true), std::runtime_error);
+}
+
+} // namespace

--- a/test/cpp/test_config.cpp
+++ b/test/cpp/test_config.cpp
@@ -5,8 +5,6 @@
 namespace {
 
 using infomap::Config;
-using infomap::FlowModel;
-
 TEST_CASE("Config accepts no-file-output without an output directory [fast][core][config][cli]")
 {
   CHECK_NOTHROW(Config("input.net --silent --no-file-output", true));
@@ -20,7 +18,7 @@ TEST_CASE("Config accepts no-file-output without an output directory [fast][core
 TEST_CASE("Config parses flow model selection and output formats [fast][core][config][cli]")
 {
   const Config config("input.net --silent --no-file-output --flow-model precomputed --output json,tree", true);
-  CHECK(config.flowModel == FlowModel::precomputed);
+  CHECK(infomap::flowModelToString(config.flowModel) == std::string("precomputed"));
   CHECK(config.printJson);
   CHECK(config.printTree);
 }
@@ -28,7 +26,7 @@ TEST_CASE("Config parses flow model selection and output formats [fast][core][co
 TEST_CASE("Config treats directed shorthand as directed flow model [fast][core][config][cli]")
 {
   const Config config("input.net --silent --no-file-output --directed", true);
-  CHECK(config.flowModel == FlowModel::directed);
+  CHECK(infomap::flowModelToString(config.flowModel) == std::string("directed"));
 }
 
 TEST_CASE("Config rejects unknown flow models and output formats [fast][core][config][cli]")

--- a/test/cpp/test_infomap_wrapper.cpp
+++ b/test/cpp/test_infomap_wrapper.cpp
@@ -4,6 +4,8 @@
 
 #include "TestUtils.h"
 
+#include <cstdio>
+#include <unistd.h>
 #include <set>
 #include <tuple>
 #include <vector>
@@ -53,6 +55,19 @@ std::vector<std::vector<unsigned int>> canonicalSubInfomapPartition(infomap::Inf
     ++moduleIndex;
   }
   return infomap::test::canonicalPartition(modules);
+}
+
+std::string temporaryOutputPath(const std::string& prefix, const std::string& suffix)
+{
+  char buffer[] = "/tmp/infomap-output-XXXXXX";
+  const int fd = ::mkstemp(buffer);
+  if (fd == -1) {
+    throw std::runtime_error("Could not generate a temporary output path");
+  }
+
+  ::close(fd);
+  std::remove(buffer);
+  return std::string(buffer) + "_" + prefix + suffix;
 }
 
 TEST_CASE("Infomap partitions the unweighted two-triangle fixture into two modules [fast][core][lifecycle]")
@@ -442,6 +457,49 @@ TEST_CASE("Higher-order metadata-bearing subnetwork rebuild stays stable [fast][
   CHECK(std::get<0>(secondRun) == std::get<0>(firstRun));
   CHECK(std::get<1>(secondRun) == doctest::Approx(std::get<1>(firstRun)));
   CHECK(std::get<2>(secondRun) == doctest::Approx(std::get<2>(firstRun)));
+}
+
+TEST_CASE("writeTree and writeClu render higher-order state output [fast][core][output]")
+{
+  auto im = infomap::test::makeRunningInfomap(
+      [&](InfomapWrapper& infomap) { infomap::test::readNetworkFixture(infomap, "states.net"); });
+
+  const auto treePath = temporaryOutputPath("states_tree", ".tree");
+  const auto cluPath = temporaryOutputPath("states_clu", ".clu");
+
+  im->writeTree(treePath, true);
+  im->writeClu(cluPath, true, 1);
+
+  const auto treeText = infomap::test::readTextFile(treePath);
+  const auto cluText = infomap::test::readTextFile(cluPath);
+
+  CHECK(treeText.find("# path flow name state_id node_id") != std::string::npos);
+  CHECK(treeText.find("state_id") != std::string::npos);
+  CHECK(cluText.find("# state_id module flow node_id") != std::string::npos);
+  CHECK(cluText.find("# module level 1") != std::string::npos);
+
+  std::remove(treePath.c_str());
+  std::remove(cluPath.c_str());
+}
+
+TEST_CASE("writeFlowTree is stable across repeated calls on the same instance [fast][core][output][regression]")
+{
+  auto im = infomap::test::makeRunningInfomap(
+      [&](InfomapWrapper& infomap) { infomap::test::addEdgeFixtureLinks(infomap, "graphs/twotriangles_unweighted.edges"); });
+
+  const auto firstPath = temporaryOutputPath("first_flow_tree", ".ftree");
+  const auto secondPath = temporaryOutputPath("second_flow_tree", ".ftree");
+
+  im->writeFlowTree(firstPath);
+  im->writeFlowTree(secondPath);
+
+  const auto firstText = infomap::test::readTextFile(firstPath);
+  const auto secondText = infomap::test::readTextFile(secondPath);
+  CHECK(firstText == secondText);
+  CHECK(firstText.find("#*Links path enterFlow exitFlow numEdges numChildren") != std::string::npos);
+
+  std::remove(firstPath.c_str());
+  std::remove(secondPath.c_str());
 }
 
 } // namespace

--- a/test/cpp/test_program_interface.cpp
+++ b/test/cpp/test_program_interface.cpp
@@ -1,0 +1,60 @@
+#include "vendor/doctest.h"
+
+#include "io/ProgramInterface.h"
+
+#include <string>
+#include <vector>
+
+namespace {
+
+TEST_CASE("ProgramInterface parses bool, incremental and positional arguments [fast][core][parser][cli]")
+{
+  bool toggle = false;
+  bool feature = true;
+  unsigned int verbosity = 0;
+  unsigned int count = 0;
+  std::string input;
+  std::vector<std::string> extras;
+
+  infomap::ProgramInterface api("Test", "Test parser", "1.0");
+  api.addOptionArgument(toggle, 't', "toggle", "Toggle on", "Core");
+  api.addOptionArgument(feature, "feature", "Feature flag", "Core");
+  api.addIncrementalOptionArgument(verbosity, 'v', "verbose", "Verbose", "Core");
+  api.addOptionArgument(count, 'c', "count", "Count", infomap::ArgType::integer, "Core");
+  api.addNonOptionArgument(input, "input", "Input file", "Core");
+  api.addOptionalNonOptionArguments(extras, "extras", "Extra files", "Core");
+
+  api.parseArgs("-tvv -c7 --no-feature primary.net extra-a extra-b");
+
+  CHECK(toggle);
+  CHECK_FALSE(feature);
+  CHECK(verbosity == 2u);
+  CHECK(count == 7u);
+  CHECK(input == "primary.net");
+  CHECK(extras == std::vector<std::string> { "extra-a", "extra-b" });
+
+  const auto used = api.getUsedOptionArguments();
+  REQUIRE(used.size() == 4);
+  CHECK(used[0].longName == "toggle");
+  CHECK(used[1].longName == "feature");
+  CHECK(used[1].negated);
+  CHECK(used[2].longName == "verbose");
+  CHECK(used[3].longName == "count");
+}
+
+TEST_CASE("ProgramInterface parses long options with separate values [fast][core][parser][cli]")
+{
+  unsigned long seed = 0;
+  double rate = 0.0;
+
+  infomap::ProgramInterface api("Test", "Test parser", "1.0");
+  api.addOptionArgument(seed, 's', "seed", "Seed", infomap::ArgType::integer, "Core");
+  api.addOptionArgument(rate, '\0', "rate", "Rate", infomap::ArgType::number, "Core");
+
+  api.parseArgs("--seed 123 --rate 0.25");
+
+  CHECK(seed == 123ul);
+  CHECK(rate == doctest::Approx(0.25));
+}
+
+} // namespace

--- a/test/cpp/test_utils_io.cpp
+++ b/test/cpp/test_utils_io.cpp
@@ -1,0 +1,102 @@
+#include "vendor/doctest.h"
+
+#include "io/SafeFile.h"
+#include "utils/FileURI.h"
+#include "utils/convert.h"
+
+#include <array>
+#include <cerrno>
+#include <cstring>
+#include <limits>
+#include <string>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <vector>
+
+namespace {
+
+using infomap::FileURI;
+
+class TempDir {
+public:
+  TempDir()
+  {
+    std::array<char, 64> pathTemplate {};
+    const auto prefix = std::string("/tmp/infomap-tests-XXXXXX");
+    std::copy(prefix.begin(), prefix.end(), pathTemplate.begin());
+    pathTemplate[prefix.size()] = '\0';
+    auto* dir = mkdtemp(pathTemplate.data());
+    REQUIRE_MESSAGE(dir != nullptr, std::strerror(errno));
+    m_path = dir;
+  }
+
+  ~TempDir()
+  {
+    rmdir(m_path.c_str());
+  }
+
+  const std::string& path() const { return m_path; }
+
+private:
+  std::string m_path;
+};
+
+TEST_CASE("convert parses unsigned integer values strictly [fast][core][utils][io]")
+{
+  unsigned int value = 0;
+  CHECK(infomap::io::stringToValue("42", value));
+  CHECK(value == 42u);
+
+  CHECK_FALSE(infomap::io::stringToValue("", value));
+  CHECK_FALSE(infomap::io::stringToValue("-1", value));
+  CHECK_FALSE(infomap::io::stringToValue("12abc", value));
+  CHECK_FALSE(infomap::io::stringToValue("4294967296", value));
+}
+
+TEST_CASE("convert parses unsigned long values strictly [fast][core][utils][io]")
+{
+  unsigned long value = 0;
+  CHECK(infomap::io::stringToValue("42", value));
+  CHECK(value == 42ul);
+
+  CHECK_FALSE(infomap::io::stringToValue("", value));
+  CHECK_FALSE(infomap::io::stringToValue("-1", value));
+  CHECK_FALSE(infomap::io::stringToValue("12abc", value));
+
+  const auto overflow = infomap::io::stringify(std::numeric_limits<unsigned long long>::max()) + "0";
+  CHECK_FALSE(infomap::io::stringToValue(overflow, value));
+}
+
+TEST_CASE("convert helpers preserve current tokenization behavior [fast][core][utils][io]")
+{
+  const auto parts = infomap::io::split("alpha,,beta,gamma", ',');
+  CHECK(parts == std::vector<std::string> { "alpha", "beta", "gamma" });
+  CHECK(infomap::io::firstWord("  one two three") == "one");
+  CHECK(infomap::io::stringify(parts, "|") == "alpha|beta|gamma");
+  CHECK(infomap::io::tolower("MiXeD") == "mixed");
+  CHECK(infomap::io::InsensitiveCompare {}("abc", "ABD"));
+}
+
+TEST_CASE("FileURI splits valid paths and rejects invalid ones [fast][core][utils][io]")
+{
+  const FileURI nested("dir/subdir/file.net");
+  CHECK(nested.getFilename() == "dir/subdir/file.net");
+  CHECK(nested.getName() == "file");
+  CHECK(nested.getExtension() == "net");
+
+  const FileURI noExt("plain-file");
+  CHECK(noExt.getName() == "plain-file");
+  CHECK(noExt.getExtension().empty());
+
+  CHECK_THROWS_AS(FileURI("dir/"), std::invalid_argument);
+  CHECK_THROWS_AS(FileURI("file.", true), std::invalid_argument);
+}
+
+TEST_CASE("SafeFile detects writable and missing directories [fast][core][utils][io]")
+{
+  const TempDir tempDir;
+  CHECK(infomap::isDirectoryWritable(tempDir.path() + "/"));
+  CHECK_FALSE(infomap::isDirectoryWritable(tempDir.path() + "/missing/"));
+}
+
+} // namespace

--- a/test/python/test_output.py
+++ b/test/python/test_output.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+pytestmark = pytest.mark.fast
+
+
+def _run_small_network(make_infomap, load_graph_fixture):
+    im = make_infomap()
+    load_graph_fixture(im, "twotriangles_unweighted.edges", method="add_link")
+    im.run()
+    return im
+
+
+def test_output_writers_are_stable_across_repeat_calls(make_infomap, load_graph_fixture, output_dir):
+    im = _run_small_network(make_infomap, load_graph_fixture)
+
+    tree_a = output_dir / "first.tree"
+    tree_b = output_dir / "second.tree"
+    json_a = output_dir / "first.json"
+    json_b = output_dir / "second.json"
+    clu_a = output_dir / "first.clu"
+    clu_b = output_dir / "second.clu"
+
+    im.write_tree(str(tree_a))
+    im.write_tree(str(tree_b))
+    im.write_json(str(json_a))
+    im.write_json(str(json_b))
+    im.write_clu(str(clu_a))
+    im.write_clu(str(clu_b))
+
+    assert tree_a.read_text() == tree_b.read_text()
+    assert json_a.read_text() == json_b.read_text()
+    assert clu_a.read_text() == clu_b.read_text()
+
+    parsed = json.loads(json_a.read_text())
+    assert parsed["version"].startswith("v")
+    assert "nodes" in parsed
+    assert "modules" in parsed
+    assert "# path flow name node_id" in tree_a.read_text()
+    assert "# module level 1" in clu_a.read_text()
+
+
+def test_state_output_writers_include_state_columns(make_infomap, network_fixture_path, output_dir):
+    im = make_infomap()
+    im.read_file(str(network_fixture_path("states.net")))
+    im.run()
+
+    tree_path = output_dir / "states.tree"
+    json_path = output_dir / "states.json"
+    clu_path = output_dir / "states.clu"
+
+    im.write_tree(str(tree_path), states=True)
+    im.write_json(str(json_path), states=True)
+    im.write_clu(str(clu_path), states=True)
+
+    tree_text = tree_path.read_text()
+    json_text = json_path.read_text()
+    clu_text = clu_path.read_text()
+
+    assert "# path flow name state_id node_id" in tree_text
+    assert "# state_id module flow node_id" in clu_text
+
+    parsed = json.loads(json_text)
+    assert parsed["stateLevel"] is True
+    assert parsed["higherOrder"] is True

--- a/test/python/test_wrapper_args.py
+++ b/test/python/test_wrapper_args.py
@@ -69,3 +69,12 @@ def test_run_forwards_variable_markov_options(monkeypatch):
     assert captured["rendered_args"] == "--synthetic"
     assert captured["kwargs"]["variable_markov_time"] is True
     assert captured["kwargs"]["variable_markov_damping"] == 0.25
+
+
+def test_no_file_output_runs_without_output_directory(make_infomap, load_graph_fixture):
+    im = make_infomap(no_file_output=True)
+    load_graph_fixture(im, "twotriangles_unweighted.edges")
+
+    im.run()
+
+    assert im.num_top_modules == 2

--- a/test/scripts/check_print_json_parameters.py
+++ b/test/scripts/check_print_json_parameters.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import json
+import subprocess
+import sys
+
+
+def main() -> int:
+    cli = sys.argv[1]
+    result = subprocess.run(
+        [cli, "--print-json-parameters"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+    parameters = payload["parameters"]
+    assert parameters[0]["long"] == "--help"
+    assert parameters[1]["long"] == "--version"
+    assert any(param["long"] == "--flow-model" for param in parameters)
+    assert any(param["long"] == "--output" for param in parameters)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- harden convert, FileURI, ProgramInterface and Config parsing without changing SWIG-sensitive public types
- remove permanent node mutation from output link aggregation and add repeat-call output regressions
- add focused C++ and Python tests for parser/config/output behavior plus a CLI JSON-parameters regression

## Verification
- PATH="/opt/homebrew/bin:$PATH" cmake --build build/cmake-noccache --target infomap_cpp_tests --parallel
- PATH="/opt/homebrew/bin:$PATH" ctest --test-dir build/cmake-noccache --output-on-failure -R 'infomap_cpp_(utils_io|program_interface|config|lifecycle)_tests|print_json_parameters'\n- make test-python-swig-freshness\n- PATH="/opt/homebrew/bin:/Users/anton/Library/Python/3.14/bin:$PATH" /opt/homebrew/Frameworks/Python.framework/Versions/3.14/bin/python3.14 -m pytest test/python/test_wrapper_args.py test/python/test_output.py -q\n\n## Notes\n- `make build-python` is still blocked in this environment because `python -m build` is unavailable (`No module named build.__main__`).