### PR TITLE
perf(ci): add PR perf regression benchmark check

### DIFF
--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -33,6 +33,8 @@ jobs:
       - name: Checkout PR head
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
           path: head
 
       - name: Checkout PR base

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -1,0 +1,106 @@
+name: PR Performance
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - ".github/workflows/perf-pr.yml"
+      - ".github/workflows/ci.yml"
+      - ".github/workflows/_native-build.yml"
+      - "CMakeLists.txt"
+      - "examples/networks/**"
+      - "mk/**"
+      - "scripts/benchmarks/**"
+      - "src/**"
+      - "test/bench/**"
+      - "test/fixtures/meta/**"
+      - "test/python/test_native_benchmark_script.py"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: perf-pr-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  native-regression-check:
+    name: Native perf regression check
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: head
+
+      - name: Checkout PR base
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.14"
+
+      - name: Build base and head benchmark binaries
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          build_native_benchmark() {
+            local tree="$1"
+            cmake -S "$tree" -B "$tree/build/cmake" \
+              -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+              -DINFOMAP_MODE=release \
+              -DINFOMAP_USE_OPENMP=ON
+            cmake --build "$tree/build/cmake" --target infomap_native_benchmark --parallel 1
+          }
+
+          build_native_benchmark "$GITHUB_WORKSPACE/base"
+          build_native_benchmark "$GITHUB_WORKSPACE/head"
+
+      - name: Run base and head PR benchmarks
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$GITHUB_WORKSPACE/artifacts"
+
+          python "$GITHUB_WORKSPACE/head/scripts/benchmarks/run_native_benchmarks.py" \
+            --binary "$GITHUB_WORKSPACE/base/build/cmake/infomap_native_benchmark" \
+            --profile pr \
+            --repeats 3 \
+            --iterations 1 \
+            --output "$GITHUB_WORKSPACE/artifacts/base-native-benchmarks.json"
+
+          python "$GITHUB_WORKSPACE/head/scripts/benchmarks/run_native_benchmarks.py" \
+            --binary "$GITHUB_WORKSPACE/head/build/cmake/infomap_native_benchmark" \
+            --profile pr \
+            --repeats 3 \
+            --iterations 1 \
+            --output "$GITHUB_WORKSPACE/artifacts/head-native-benchmarks.json"
+
+      - name: Compare base and head benchmark reports
+        shell: bash
+        run: |
+          set -euo pipefail
+          python "$GITHUB_WORKSPACE/head/scripts/benchmarks/compare_native_benchmarks.py" \
+            --base "$GITHUB_WORKSPACE/artifacts/base-native-benchmarks.json" \
+            --head "$GITHUB_WORKSPACE/artifacts/head-native-benchmarks.json" \
+            --markdown-out "$GITHUB_WORKSPACE/artifacts/perf-summary.md" \
+            --json-out "$GITHUB_WORKSPACE/artifacts/perf-comparison.json"
+          cat "$GITHUB_WORKSPACE/artifacts/perf-summary.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload comparison artifacts
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: pr-native-perf
+          path: |
+            artifacts/base-native-benchmarks.json
+            artifacts/head-native-benchmarks.json
+            artifacts/perf-comparison.json
+            artifacts/perf-summary.md
+          retention-days: 14

--- a/scripts/benchmarks/compare_native_benchmarks.py
+++ b/scripts/benchmarks/compare_native_benchmarks.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+RELATIVE_REGRESSION_THRESHOLD = 0.15
+ABSOLUTE_REGRESSION_THRESHOLD_SEC = 0.05
+SEVERE_RELATIVE_REGRESSION_THRESHOLD = 0.25
+SEVERE_ABSOLUTE_REGRESSION_THRESHOLD_SEC = 0.10
+CV_INCONCLUSIVE_THRESHOLD = 0.10
+MIN_BASELINE_RUNTIME_SEC = 0.20
+CODELENGTH_REL_TOL = 1e-9
+CODELENGTH_ABS_TOL = 1e-9
+
+
+def load_report(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def index_benchmarks(report: dict[str, object]) -> dict[str, dict[str, object]]:
+    return {str(benchmark["name"]): benchmark for benchmark in report.get("benchmarks", [])}
+
+
+def outputs_match(base_case: dict[str, object], head_case: dict[str, object]) -> bool:
+    if int(base_case["num_top_modules"]) != int(head_case["num_top_modules"]):
+        return False
+    if int(base_case["num_levels"]) != int(head_case["num_levels"]):
+        return False
+    return math.isclose(
+        float(base_case["codelength"]),
+        float(head_case["codelength"]),
+        rel_tol=CODELENGTH_REL_TOL,
+        abs_tol=CODELENGTH_ABS_TOL,
+    )
+
+
+def classify_case(name: str, base_case: dict[str, object], head_case: dict[str, object]) -> dict[str, object]:
+    base_runtime = float(base_case["median_run_sec"])
+    head_runtime = float(head_case["median_run_sec"])
+    delta_sec = head_runtime - base_runtime
+    delta_pct = (delta_sec / base_runtime) if base_runtime else 0.0
+    base_cv = float(base_case.get("cv_run_sec", 0.0))
+    head_cv = float(head_case.get("cv_run_sec", 0.0))
+    status = "ok"
+    reason = "within_threshold"
+    severe = False
+
+    if not outputs_match(base_case, head_case):
+        status = "manual_review"
+        reason = "output_changed"
+    elif base_runtime < MIN_BASELINE_RUNTIME_SEC:
+        status = "inconclusive"
+        reason = "baseline_too_small"
+    elif max(base_cv, head_cv) > CV_INCONCLUSIVE_THRESHOLD:
+        status = "inconclusive"
+        reason = "high_variance"
+    elif delta_sec >= SEVERE_ABSOLUTE_REGRESSION_THRESHOLD_SEC and delta_pct >= SEVERE_RELATIVE_REGRESSION_THRESHOLD:
+        status = "regression"
+        reason = "severe_regression"
+        severe = True
+    elif delta_sec >= ABSOLUTE_REGRESSION_THRESHOLD_SEC and delta_pct >= RELATIVE_REGRESSION_THRESHOLD:
+        status = "regression"
+        reason = "regression"
+    elif delta_sec <= -ABSOLUTE_REGRESSION_THRESHOLD_SEC and delta_pct <= -RELATIVE_REGRESSION_THRESHOLD:
+        status = "improvement"
+        reason = "improvement"
+
+    return {
+        "name": name,
+        "status": status,
+        "reason": reason,
+        "severe": severe,
+        "base_median_run_sec": base_runtime,
+        "head_median_run_sec": head_runtime,
+        "delta_sec": delta_sec,
+        "delta_pct": delta_pct,
+        "base_cv_run_sec": base_cv,
+        "head_cv_run_sec": head_cv,
+        "base_num_top_modules": int(base_case["num_top_modules"]),
+        "head_num_top_modules": int(head_case["num_top_modules"]),
+        "base_num_levels": int(base_case["num_levels"]),
+        "head_num_levels": int(head_case["num_levels"]),
+        "base_codelength": float(base_case["codelength"]),
+        "head_codelength": float(head_case["codelength"]),
+    }
+
+
+def compare_reports(base_report: dict[str, object], head_report: dict[str, object]) -> dict[str, object]:
+    base_benchmarks = index_benchmarks(base_report)
+    head_benchmarks = index_benchmarks(head_report)
+    all_names = sorted(set(base_benchmarks) | set(head_benchmarks))
+
+    cases: list[dict[str, object]] = []
+    for name in all_names:
+        if name not in base_benchmarks or name not in head_benchmarks:
+            cases.append(
+                {
+                    "name": name,
+                    "status": "manual_review",
+                    "reason": "case_missing",
+                    "severe": False,
+                }
+            )
+            continue
+        cases.append(classify_case(name, base_benchmarks[name], head_benchmarks[name]))
+
+    manual_review = [case for case in cases if case["status"] == "manual_review"]
+    regressions = [case for case in cases if case["status"] == "regression"]
+    severe_regressions = [case for case in regressions if case["severe"]]
+    inconclusive = [case for case in cases if case["status"] == "inconclusive"]
+    improvements = [case for case in cases if case["status"] == "improvement"]
+
+    if manual_review:
+        overall_status = "manual_review"
+        summary = "manual review needed"
+    elif len(regressions) >= 2 or severe_regressions:
+        overall_status = "possible_regression"
+        summary = "possible regression"
+    else:
+        overall_status = "no_regression"
+        summary = "no regression"
+
+    return {
+        "overall_status": overall_status,
+        "summary": summary,
+        "thresholds": {
+            "relative_regression_threshold": RELATIVE_REGRESSION_THRESHOLD,
+            "absolute_regression_threshold_sec": ABSOLUTE_REGRESSION_THRESHOLD_SEC,
+            "severe_relative_regression_threshold": SEVERE_RELATIVE_REGRESSION_THRESHOLD,
+            "severe_absolute_regression_threshold_sec": SEVERE_ABSOLUTE_REGRESSION_THRESHOLD_SEC,
+            "cv_inconclusive_threshold": CV_INCONCLUSIVE_THRESHOLD,
+            "min_baseline_runtime_sec": MIN_BASELINE_RUNTIME_SEC,
+        },
+        "counts": {
+            "regression": len(regressions),
+            "inconclusive": len(inconclusive),
+            "improvement": len(improvements),
+            "manual_review": len(manual_review),
+        },
+        "cases": cases,
+    }
+
+
+def render_markdown(result: dict[str, object]) -> str:
+    lines = [
+        "## PR Native Benchmark Comparison",
+        "",
+        f"Overall result: **{result['summary']}**",
+        "",
+        "| Case | Status | Base median run (s) | Head median run (s) | Delta (s) | Delta (%) | Reason |",
+        "| --- | --- | ---: | ---: | ---: | ---: | --- |",
+    ]
+
+    for case in result["cases"]:
+        base_runtime = float(case.get("base_median_run_sec", 0.0))
+        head_runtime = float(case.get("head_median_run_sec", 0.0))
+        delta_sec = float(case.get("delta_sec", 0.0))
+        delta_pct = float(case.get("delta_pct", 0.0)) * 100.0
+        lines.append(
+            "| {name} | {status} | {base_runtime:.6f} | {head_runtime:.6f} | {delta_sec:.6f} | {delta_pct:.1f} | {reason} |".format(
+                name=case["name"],
+                status=case["status"],
+                base_runtime=base_runtime,
+                head_runtime=head_runtime,
+                delta_sec=delta_sec,
+                delta_pct=delta_pct,
+                reason=case["reason"],
+            )
+        )
+
+    counts = result["counts"]
+    lines.extend(
+        [
+            "",
+            "Thresholds: "
+            f"regression >= {RELATIVE_REGRESSION_THRESHOLD:.0%} and >= {ABSOLUTE_REGRESSION_THRESHOLD_SEC:.2f}s, "
+            f"severe >= {SEVERE_RELATIVE_REGRESSION_THRESHOLD:.0%} and >= {SEVERE_ABSOLUTE_REGRESSION_THRESHOLD_SEC:.2f}s, "
+            f"inconclusive when baseline < {MIN_BASELINE_RUNTIME_SEC:.2f}s or CV > {CV_INCONCLUSIVE_THRESHOLD:.2f}.",
+            "",
+            f"Counts: {counts['regression']} regression, {counts['manual_review']} manual review, {counts['inconclusive']} inconclusive, {counts['improvement']} improvement.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compare native benchmark reports for PR perf regression detection.")
+    parser.add_argument("--base", type=Path, required=True, help="Path to the base benchmark JSON report.")
+    parser.add_argument("--head", type=Path, required=True, help="Path to the head benchmark JSON report.")
+    parser.add_argument("--markdown-out", type=Path, default=None, help="Optional Markdown summary output path.")
+    parser.add_argument("--json-out", type=Path, default=None, help="Optional JSON comparison output path.")
+    args = parser.parse_args()
+
+    result = compare_reports(load_report(args.base), load_report(args.head))
+    markdown = render_markdown(result)
+
+    if args.markdown_out is not None:
+        args.markdown_out.parent.mkdir(parents=True, exist_ok=True)
+        args.markdown_out.write_text(markdown, encoding="utf-8")
+
+    if args.json_out is not None:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+
+    print(markdown)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmarks/compare_native_benchmarks.py
+++ b/scripts/benchmarks/compare_native_benchmarks.py
@@ -154,18 +154,30 @@ def render_markdown(result: dict[str, object]) -> str:
     ]
 
     for case in result["cases"]:
-        base_runtime = float(case.get("base_median_run_sec", 0.0))
-        head_runtime = float(case.get("head_median_run_sec", 0.0))
-        delta_sec = float(case.get("delta_sec", 0.0))
-        delta_pct = float(case.get("delta_pct", 0.0)) * 100.0
+        base_runtime = case.get("base_median_run_sec")
+        head_runtime = case.get("head_median_run_sec")
+        delta_sec = case.get("delta_sec")
+        delta_pct = case.get("delta_pct")
+
+        if base_runtime is None or head_runtime is None or delta_sec is None or delta_pct is None:
+            base_runtime_text = "n/a"
+            head_runtime_text = "n/a"
+            delta_sec_text = "n/a"
+            delta_pct_text = "n/a"
+        else:
+            base_runtime_text = f"{float(base_runtime):.6f}"
+            head_runtime_text = f"{float(head_runtime):.6f}"
+            delta_sec_text = f"{float(delta_sec):.6f}"
+            delta_pct_text = f"{float(delta_pct) * 100.0:.1f}"
+
         lines.append(
-            "| {name} | {status} | {base_runtime:.6f} | {head_runtime:.6f} | {delta_sec:.6f} | {delta_pct:.1f} | {reason} |".format(
+            "| {name} | {status} | {base_runtime} | {head_runtime} | {delta_sec} | {delta_pct} | {reason} |".format(
                 name=case["name"],
                 status=case["status"],
-                base_runtime=base_runtime,
-                head_runtime=head_runtime,
-                delta_sec=delta_sec,
-                delta_pct=delta_pct,
+                base_runtime=base_runtime_text,
+                head_runtime=head_runtime_text,
+                delta_sec=delta_sec_text,
+                delta_pct=delta_pct_text,
                 reason=case["reason"],
             )
         )

--- a/scripts/benchmarks/run_native_benchmarks.py
+++ b/scripts/benchmarks/run_native_benchmarks.py
@@ -94,6 +94,69 @@ def collect_module_size_bucket_labels(run_samples: list[dict[str, object]]) -> l
     return sorted(labels)
 
 
+def build_benchmark_cases(profile: str, repo_root: Path, generated_dir: Path) -> list[dict[str, str | Path]]:
+    cases: list[dict[str, str | Path]] = [
+        {"name": "twotriangles", "path": repo_root / "examples" / "networks" / "twotriangles.net", "flags": ""},
+        {"name": "ninetriangles", "path": repo_root / "examples" / "networks" / "ninetriangles.net", "flags": ""},
+        {"name": "modular_w", "path": repo_root / "examples" / "networks" / "modular_w.net", "flags": ""},
+        {"name": "modular_wd", "path": repo_root / "examples" / "networks" / "modular_wd.net", "flags": ""},
+        {"name": "states", "path": repo_root / "examples" / "networks" / "states.net", "flags": ""},
+        {
+            "name": "states_meta",
+            "path": repo_root / "examples" / "networks" / "states.net",
+            "flags": f"--meta-data {repo_root / 'test' / 'fixtures' / 'meta' / 'states.meta'} --meta-data-rate 2",
+        },
+        {"name": "multilayer", "path": repo_root / "examples" / "networks" / "multilayer.net", "flags": ""},
+        {"name": "bipartite", "path": repo_root / "examples" / "networks" / "bipartite.net", "flags": ""},
+        {
+            "name": "twotriangles_meta",
+            "path": repo_root / "examples" / "networks" / "twotriangles.net",
+            "flags": f"--meta-data {repo_root / 'test' / 'fixtures' / 'meta' / 'twotriangles.meta'} --meta-data-rate 2",
+        },
+    ]
+
+    sparse_10k = generated_dir / "sparse_10k.net"
+    ring_10k = generated_dir / "ring_of_cliques_10k.net"
+    state_5k = generated_dir / "state_ring_5k.net"
+    generate_sparse_graph(sparse_10k, num_nodes=10_000, avg_degree=10, seed=123)
+    generate_ring_of_cliques(ring_10k, clique_count=1_000, clique_size=10)
+    generate_state_ring(state_5k, physical_nodes=5_000)
+    smoke_cases = [
+        {"name": "sparse_10k", "path": sparse_10k, "flags": ""},
+        {"name": "ring_of_cliques_10k", "path": ring_10k, "flags": ""},
+        {"name": "state_ring_5k", "path": state_5k, "flags": ""},
+    ]
+
+    sparse_100k = generated_dir / "sparse_100k.net"
+    ring_100k = generated_dir / "ring_of_cliques_100k.net"
+    generate_sparse_graph(sparse_100k, num_nodes=100_000, avg_degree=10, seed=456)
+    generate_ring_of_cliques(ring_100k, clique_count=10_000, clique_size=10)
+    baseline_only_cases = [
+        {"name": "sparse_100k", "path": sparse_100k, "flags": ""},
+        {"name": "ring_of_cliques_100k", "path": ring_100k, "flags": ""},
+    ]
+
+    if profile == "pr":
+        return [
+            {"name": "states_meta", "path": repo_root / "examples" / "networks" / "states.net", "flags": f"--meta-data {repo_root / 'test' / 'fixtures' / 'meta' / 'states.meta'} --meta-data-rate 2"},
+            {"name": "state_ring_5k", "path": state_5k, "flags": ""},
+            {"name": "sparse_100k", "path": sparse_100k, "flags": ""},
+            {"name": "ring_of_cliques_100k", "path": ring_100k, "flags": ""},
+        ]
+
+    cases.extend(smoke_cases)
+
+    if profile in {"baseline", "full"}:
+        cases.extend(baseline_only_cases)
+
+    if profile == "full":
+        sparse_1m = generated_dir / "sparse_1m.net"
+        generate_sparse_graph(sparse_1m, num_nodes=1_000_000, avg_degree=10, seed=789)
+        cases.append({"name": "sparse_1m", "path": sparse_1m, "flags": ""})
+
+    return cases
+
+
 def benchmark_case(
     binary: Path,
     name: str,
@@ -279,7 +342,7 @@ def main() -> None:
     parser.add_argument("--iterations", type=int, default=1, help="Number of in-process iterations per benchmark run.")
     parser.add_argument(
         "--profile",
-        choices=("smoke", "baseline", "full"),
+        choices=("smoke", "baseline", "full", "pr"),
         default="baseline",
         help="Benchmark corpus size.",
     )
@@ -297,59 +360,9 @@ def main() -> None:
     if not args.binary.is_file():
         raise FileNotFoundError(f"Benchmark binary not found: {args.binary}")
 
-    cases: list[dict[str, str | Path]] = [
-        {"name": "twotriangles", "path": repo_root / "examples" / "networks" / "twotriangles.net", "flags": ""},
-        {"name": "ninetriangles", "path": repo_root / "examples" / "networks" / "ninetriangles.net", "flags": ""},
-        {"name": "modular_w", "path": repo_root / "examples" / "networks" / "modular_w.net", "flags": ""},
-        {"name": "modular_wd", "path": repo_root / "examples" / "networks" / "modular_wd.net", "flags": ""},
-        {"name": "states", "path": repo_root / "examples" / "networks" / "states.net", "flags": ""},
-        {
-            "name": "states_meta",
-            "path": repo_root / "examples" / "networks" / "states.net",
-            "flags": f"--meta-data {repo_root / 'test' / 'fixtures' / 'meta' / 'states.meta'} --meta-data-rate 2",
-        },
-        {"name": "multilayer", "path": repo_root / "examples" / "networks" / "multilayer.net", "flags": ""},
-        {"name": "bipartite", "path": repo_root / "examples" / "networks" / "bipartite.net", "flags": ""},
-        {
-            "name": "twotriangles_meta",
-            "path": repo_root / "examples" / "networks" / "twotriangles.net",
-            "flags": f"--meta-data {repo_root / 'test' / 'fixtures' / 'meta' / 'twotriangles.meta'} --meta-data-rate 2",
-        },
-    ]
-
     with tempfile.TemporaryDirectory() as temp_dir:
         generated_dir = Path(temp_dir)
-        sparse_10k = generated_dir / "sparse_10k.net"
-        ring_10k = generated_dir / "ring_of_cliques_10k.net"
-        state_5k = generated_dir / "state_ring_5k.net"
-        generate_sparse_graph(sparse_10k, num_nodes=10_000, avg_degree=10, seed=123)
-        generate_ring_of_cliques(ring_10k, clique_count=1_000, clique_size=10)
-        generate_state_ring(state_5k, physical_nodes=5_000)
-        cases.extend(
-            [
-                {"name": "sparse_10k", "path": sparse_10k, "flags": ""},
-                {"name": "ring_of_cliques_10k", "path": ring_10k, "flags": ""},
-                {"name": "state_ring_5k", "path": state_5k, "flags": ""},
-            ]
-        )
-
-        if args.profile in {"baseline", "full"}:
-            sparse_100k = generated_dir / "sparse_100k.net"
-            ring_100k = generated_dir / "ring_of_cliques_100k.net"
-            generate_sparse_graph(sparse_100k, num_nodes=100_000, avg_degree=10, seed=456)
-            generate_ring_of_cliques(ring_100k, clique_count=10_000, clique_size=10)
-            cases.extend(
-                [
-                    {"name": "sparse_100k", "path": sparse_100k, "flags": ""},
-                    {"name": "ring_of_cliques_100k", "path": ring_100k, "flags": ""},
-                ]
-            )
-
-        if args.profile == "full":
-            sparse_1m = generated_dir / "sparse_1m.net"
-            generate_sparse_graph(sparse_1m, num_nodes=1_000_000, avg_degree=10, seed=789)
-            cases.append({"name": "sparse_1m", "path": sparse_1m, "flags": ""})
-
+        cases = build_benchmark_cases(args.profile, repo_root, generated_dir)
         results = [
             benchmark_case(
                 args.binary,

--- a/scripts/benchmarks/run_native_benchmarks.py
+++ b/scripts/benchmarks/run_native_benchmarks.py
@@ -114,6 +114,7 @@ def build_benchmark_cases(profile: str, repo_root: Path, generated_dir: Path) ->
             "flags": f"--meta-data {repo_root / 'test' / 'fixtures' / 'meta' / 'twotriangles.meta'} --meta-data-rate 2",
         },
     ]
+    case_index = {str(case["name"]): case for case in cases}
 
     state_5k = generated_dir / "state_ring_5k.net"
     generate_state_ring(state_5k, physical_nodes=5_000)
@@ -131,7 +132,7 @@ def build_benchmark_cases(profile: str, repo_root: Path, generated_dir: Path) ->
 
     if profile == "pr":
         return [
-            {"name": "states_meta", "path": repo_root / "examples" / "networks" / "states.net", "flags": f"--meta-data {repo_root / 'test' / 'fixtures' / 'meta' / 'states.meta'} --meta-data-rate 2"},
+            case_index["states_meta"],
             {"name": "state_ring_5k", "path": state_5k, "flags": ""},
             *baseline_only_cases,
         ]

--- a/scripts/benchmarks/run_native_benchmarks.py
+++ b/scripts/benchmarks/run_native_benchmarks.py
@@ -115,34 +115,36 @@ def build_benchmark_cases(profile: str, repo_root: Path, generated_dir: Path) ->
         },
     ]
 
-    sparse_10k = generated_dir / "sparse_10k.net"
-    ring_10k = generated_dir / "ring_of_cliques_10k.net"
     state_5k = generated_dir / "state_ring_5k.net"
-    generate_sparse_graph(sparse_10k, num_nodes=10_000, avg_degree=10, seed=123)
-    generate_ring_of_cliques(ring_10k, clique_count=1_000, clique_size=10)
     generate_state_ring(state_5k, physical_nodes=5_000)
-    smoke_cases = [
-        {"name": "sparse_10k", "path": sparse_10k, "flags": ""},
-        {"name": "ring_of_cliques_10k", "path": ring_10k, "flags": ""},
-        {"name": "state_ring_5k", "path": state_5k, "flags": ""},
-    ]
 
-    sparse_100k = generated_dir / "sparse_100k.net"
-    ring_100k = generated_dir / "ring_of_cliques_100k.net"
-    generate_sparse_graph(sparse_100k, num_nodes=100_000, avg_degree=10, seed=456)
-    generate_ring_of_cliques(ring_100k, clique_count=10_000, clique_size=10)
-    baseline_only_cases = [
-        {"name": "sparse_100k", "path": sparse_100k, "flags": ""},
-        {"name": "ring_of_cliques_100k", "path": ring_100k, "flags": ""},
-    ]
+    baseline_only_cases: list[dict[str, str | Path]] = []
+    if profile in {"baseline", "full", "pr"}:
+        sparse_100k = generated_dir / "sparse_100k.net"
+        ring_100k = generated_dir / "ring_of_cliques_100k.net"
+        generate_sparse_graph(sparse_100k, num_nodes=100_000, avg_degree=10, seed=456)
+        generate_ring_of_cliques(ring_100k, clique_count=10_000, clique_size=10)
+        baseline_only_cases = [
+            {"name": "sparse_100k", "path": sparse_100k, "flags": ""},
+            {"name": "ring_of_cliques_100k", "path": ring_100k, "flags": ""},
+        ]
 
     if profile == "pr":
         return [
             {"name": "states_meta", "path": repo_root / "examples" / "networks" / "states.net", "flags": f"--meta-data {repo_root / 'test' / 'fixtures' / 'meta' / 'states.meta'} --meta-data-rate 2"},
             {"name": "state_ring_5k", "path": state_5k, "flags": ""},
-            {"name": "sparse_100k", "path": sparse_100k, "flags": ""},
-            {"name": "ring_of_cliques_100k", "path": ring_100k, "flags": ""},
+            *baseline_only_cases,
         ]
+
+    sparse_10k = generated_dir / "sparse_10k.net"
+    ring_10k = generated_dir / "ring_of_cliques_10k.net"
+    generate_sparse_graph(sparse_10k, num_nodes=10_000, avg_degree=10, seed=123)
+    generate_ring_of_cliques(ring_10k, clique_count=1_000, clique_size=10)
+    smoke_cases = [
+        {"name": "sparse_10k", "path": sparse_10k, "flags": ""},
+        {"name": "ring_of_cliques_10k", "path": ring_10k, "flags": ""},
+        {"name": "state_ring_5k", "path": state_5k, "flags": ""},
+    ]
 
     cases.extend(smoke_cases)
 

--- a/test/python/test_compare_native_benchmarks.py
+++ b/test/python/test_compare_native_benchmarks.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.fast
+
+
+def _load_compare_module():
+    module_path = Path(__file__).resolve().parents[2] / "scripts" / "benchmarks" / "compare_native_benchmarks.py"
+    spec = importlib.util.spec_from_file_location("compare_native_benchmarks", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _case(
+    name: str,
+    *,
+    median_run_sec: float,
+    cv_run_sec: float = 0.02,
+    num_top_modules: int = 3,
+    num_levels: int = 2,
+    codelength: float = 1.234,
+) -> dict[str, object]:
+    return {
+        "name": name,
+        "median_run_sec": median_run_sec,
+        "cv_run_sec": cv_run_sec,
+        "num_top_modules": num_top_modules,
+        "num_levels": num_levels,
+        "codelength": codelength,
+    }
+
+
+def test_compare_reports_marks_stable_regression():
+    compare_module = _load_compare_module()
+    result = compare_module.compare_reports(
+        {"benchmarks": [_case("ring", median_run_sec=0.50)]},
+        {"benchmarks": [_case("ring", median_run_sec=0.60)]},
+    )
+
+    assert result["cases"][0]["status"] == "regression"
+    assert result["cases"][0]["reason"] == "regression"
+    assert result["overall_status"] == "no_regression"
+
+
+def test_compare_reports_ignores_small_delta():
+    compare_module = _load_compare_module()
+    result = compare_module.compare_reports(
+        {"benchmarks": [_case("ring", median_run_sec=1.00)]},
+        {"benchmarks": [_case("ring", median_run_sec=1.10)]},
+    )
+
+    assert result["cases"][0]["status"] == "ok"
+    assert result["overall_status"] == "no_regression"
+
+
+def test_compare_reports_marks_high_variance_inconclusive():
+    compare_module = _load_compare_module()
+    result = compare_module.compare_reports(
+        {"benchmarks": [_case("ring", median_run_sec=1.00, cv_run_sec=0.11)]},
+        {"benchmarks": [_case("ring", median_run_sec=1.30, cv_run_sec=0.04)]},
+    )
+
+    assert result["cases"][0]["status"] == "inconclusive"
+    assert result["cases"][0]["reason"] == "high_variance"
+
+
+def test_compare_reports_promotes_single_severe_regression():
+    compare_module = _load_compare_module()
+    result = compare_module.compare_reports(
+        {"benchmarks": [_case("ring", median_run_sec=0.50)]},
+        {"benchmarks": [_case("ring", median_run_sec=0.70)]},
+    )
+
+    assert result["cases"][0]["status"] == "regression"
+    assert result["cases"][0]["severe"] is True
+    assert result["overall_status"] == "possible_regression"
+
+
+def test_compare_reports_requires_manual_review_when_outputs_change():
+    compare_module = _load_compare_module()
+    result = compare_module.compare_reports(
+        {"benchmarks": [_case("ring", median_run_sec=1.00, num_top_modules=3)]},
+        {"benchmarks": [_case("ring", median_run_sec=1.20, num_top_modules=4)]},
+    )
+
+    assert result["cases"][0]["status"] == "manual_review"
+    assert result["overall_status"] == "manual_review"
+
+
+def test_main_writes_markdown_and_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    compare_module = _load_compare_module()
+    base_path = tmp_path / "base.json"
+    head_path = tmp_path / "head.json"
+    markdown_path = tmp_path / "summary.md"
+    json_path = tmp_path / "comparison.json"
+    base_path.write_text(json.dumps({"benchmarks": [_case("ring", median_run_sec=1.00)]}) + "\n", encoding="utf-8")
+    head_path.write_text(json.dumps({"benchmarks": [_case("ring", median_run_sec=1.30)]}) + "\n", encoding="utf-8")
+
+    import sys
+
+    old_argv = sys.argv
+    sys.argv = [
+        "compare_native_benchmarks.py",
+        "--base",
+        str(base_path),
+        "--head",
+        str(head_path),
+        "--markdown-out",
+        str(markdown_path),
+        "--json-out",
+        str(json_path),
+    ]
+    try:
+        compare_module.main()
+    finally:
+        sys.argv = old_argv
+
+    captured = capsys.readouterr()
+    assert "PR Native Benchmark Comparison" in captured.out
+    assert "possible regression" in markdown_path.read_text(encoding="utf-8")
+    assert json.loads(json_path.read_text(encoding="utf-8"))["overall_status"] == "possible_regression"

--- a/test/python/test_compare_native_benchmarks.py
+++ b/test/python/test_compare_native_benchmarks.py
@@ -96,6 +96,18 @@ def test_compare_reports_requires_manual_review_when_outputs_change():
     assert result["overall_status"] == "manual_review"
 
 
+def test_render_markdown_uses_na_for_missing_case_metrics():
+    compare_module = _load_compare_module()
+    result = compare_module.compare_reports(
+        {"benchmarks": [_case("ring", median_run_sec=1.00)]},
+        {"benchmarks": []},
+    )
+
+    markdown = compare_module.render_markdown(result)
+
+    assert "| ring | manual_review | n/a | n/a | n/a | n/a | case_missing |" in markdown
+
+
 def test_main_writes_markdown_and_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
     compare_module = _load_compare_module()
     base_path = tmp_path / "base.json"

--- a/test/python/test_native_benchmark_script.py
+++ b/test/python/test_native_benchmark_script.py
@@ -146,3 +146,21 @@ def test_build_benchmark_cases_pr_profile_focuses_on_stable_cases(tmp_path: Path
     names = [case["name"] for case in cases]
 
     assert names == ["states_meta", "state_ring_5k", "sparse_100k", "ring_of_cliques_100k"]
+
+
+def test_build_benchmark_cases_smoke_skips_100k_generation(monkeypatch, tmp_path: Path):
+    benchmark_module = _load_benchmark_module()
+    repo_root = Path(__file__).resolve().parents[2]
+    calls: list[int] = []
+
+    original_generate_sparse_graph = benchmark_module.generate_sparse_graph
+
+    def recording_generate_sparse_graph(path: Path, num_nodes: int, avg_degree: int, seed: int) -> None:
+        calls.append(num_nodes)
+        original_generate_sparse_graph(path, num_nodes, avg_degree, seed)
+
+    monkeypatch.setattr(benchmark_module, "generate_sparse_graph", recording_generate_sparse_graph)
+
+    benchmark_module.build_benchmark_cases("smoke", repo_root, tmp_path)
+
+    assert calls == [10_000]

--- a/test/python/test_native_benchmark_script.py
+++ b/test/python/test_native_benchmark_script.py
@@ -138,14 +138,32 @@ def test_benchmark_case_collects_dynamic_rebuild_bucket_labels(monkeypatch, tmp_
     assert result["rebuild"]["module_size_buckets"]["33-64"]["mean_sec"] == pytest.approx(0.03)
 
 
-def test_build_benchmark_cases_pr_profile_focuses_on_stable_cases(tmp_path: Path):
+def test_build_benchmark_cases_pr_profile_focuses_on_stable_cases(monkeypatch, tmp_path: Path):
     benchmark_module = _load_benchmark_module()
     repo_root = Path(__file__).resolve().parents[2]
+    generated_paths: list[Path] = []
+
+    def stub_generate_state_ring(path: Path, physical_nodes: int) -> None:
+        generated_paths.append(path)
+
+    def stub_generate_sparse_graph(path: Path, num_nodes: int, avg_degree: int, seed: int) -> None:
+        generated_paths.append(path)
+
+    def stub_generate_ring_of_cliques(path: Path, clique_count: int, clique_size: int) -> None:
+        generated_paths.append(path)
+
+    monkeypatch.setattr(benchmark_module, "generate_state_ring", stub_generate_state_ring)
+    monkeypatch.setattr(benchmark_module, "generate_sparse_graph", stub_generate_sparse_graph)
+    monkeypatch.setattr(benchmark_module, "generate_ring_of_cliques", stub_generate_ring_of_cliques)
 
     cases = benchmark_module.build_benchmark_cases("pr", repo_root, tmp_path)
     names = [case["name"] for case in cases]
+    paths = [Path(case["path"]) for case in cases]
 
     assert names == ["states_meta", "state_ring_5k", "sparse_100k", "ring_of_cliques_100k"]
+    assert paths[0] == repo_root / "examples" / "networks" / "states.net"
+    assert paths[1:] == generated_paths
+    assert [path.name for path in generated_paths] == ["state_ring_5k.net", "sparse_100k.net", "ring_of_cliques_100k.net"]
 
 
 def test_build_benchmark_cases_smoke_skips_100k_generation(monkeypatch, tmp_path: Path):

--- a/test/python/test_native_benchmark_script.py
+++ b/test/python/test_native_benchmark_script.py
@@ -136,3 +136,13 @@ def test_benchmark_case_collects_dynamic_rebuild_bucket_labels(monkeypatch, tmp_
 
     assert result["rebuild"]["mean_total_sec"] == pytest.approx(0.05)
     assert result["rebuild"]["module_size_buckets"]["33-64"]["mean_sec"] == pytest.approx(0.03)
+
+
+def test_build_benchmark_cases_pr_profile_focuses_on_stable_cases(tmp_path: Path):
+    benchmark_module = _load_benchmark_module()
+    repo_root = Path(__file__).resolve().parents[2]
+
+    cases = benchmark_module.build_benchmark_cases("pr", repo_root, tmp_path)
+    names = [case["name"] for case in cases]
+
+    assert names == ["states_meta", "state_ring_5k", "sparse_100k", "ring_of_cliques_100k"]


### PR DESCRIPTION
## Summary
Add an advisory pull request benchmark workflow that compares native benchmark results for the PR head against the PR base SHA in the same GitHub Actions job.

## What Changed
- added a new `PR Performance` workflow that runs on perf-relevant pull requests
- added a dedicated native benchmark `pr` profile with a smaller, more stable benchmark corpus
- added a native benchmark comparison script that classifies regressions, improvements, inconclusive cases, and output-shape changes
- added focused tests for the new benchmark profile and comparison logic

## Why
Nightly benchmarks are useful for broad trend monitoring, but they do not give fast feedback on whether a pull request is likely introducing a runtime regression. This change adds a low-noise PR signal by building and benchmarking the base and head revisions in the same runner environment and by using conservative thresholds before surfacing a possible regression.

## Developer Impact
The new workflow is advisory-only in this first version. It publishes a job summary and benchmark artifacts without blocking merges on the comparison result, while still allowing real workflow failures such as build errors or script failures to surface normally.

## Validation
- `python3 -m pytest test/python/test_native_benchmark_script.py test/python/test_compare_native_benchmarks.py`
- YAML parse smoke check for `.github/workflows/perf-pr.yml`
