### PR TITLE
feat: library-safe no-output mode and reduced iostream references

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,7 @@ if(BUILD_TESTING)
             infomap_cpp_utils_io_tests
             infomap_cpp_program_interface_tests
             infomap_cpp_config_tests
+            infomap_cpp_no_output_tests
             infomap_cli
     )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,7 @@ if(BUILD_TESTING)
     add_infomap_cpp_test(infomap_cpp_utils_io_tests test/cpp/test_utils_io.cpp "fast;core;utils;io")
     add_infomap_cpp_test(infomap_cpp_program_interface_tests test/cpp/test_program_interface.cpp "fast;core;parser;cli")
     add_infomap_cpp_test(infomap_cpp_config_tests test/cpp/test_config.cpp "fast;core;config;cli")
+    add_infomap_cpp_test(infomap_cpp_no_output_tests test/cpp/test_no_output.cpp "fast;core;output;library")
 
     add_test(
         NAME print_json_parameters

--- a/src/core/BiasedMapEquation.cpp
+++ b/src/core/BiasedMapEquation.cpp
@@ -10,6 +10,7 @@
 #include "BiasedMapEquation.h"
 #include "FlowData.h"
 #include "InfoNode.h"
+#include "../utils/Log.h"
 
 #include <vector>
 #include <utility>
@@ -231,7 +232,7 @@ void BiasedMapEquation::consolidateModules(std::vector<InfoNode*>& modules)
 
 void BiasedMapEquation::printDebug() const
 {
-  std::cout << "BiasedMapEquation\n";
+  Log() << "BiasedMapEquation\n";
   Base::printDebug();
 }
 

--- a/src/core/InfoEdge.h
+++ b/src/core/InfoEdge.h
@@ -10,7 +10,7 @@
 #ifndef INFOEDGE_H_
 #define INFOEDGE_H_
 
-#include <iostream>
+#include <iosfwd>
 
 namespace infomap {
 

--- a/src/core/InfoNode.h
+++ b/src/core/InfoNode.h
@@ -18,7 +18,7 @@
 
 #include <stdexcept>
 #include <memory>
-#include <iostream>
+#include <ostream>
 #include <vector>
 #include <limits>
 

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -27,7 +27,7 @@
 #include <map>
 #include <limits>
 #include <string>
-#include <iostream>
+#include <ostream>
 #include <sstream>
 
 namespace infomap {

--- a/src/core/MapEquation.h
+++ b/src/core/MapEquation.h
@@ -19,7 +19,7 @@
 #include "FlowData.h"
 #include <vector>
 #include <map>
-#include <iostream>
+#include <ostream>
 
 namespace infomap {
 
@@ -138,9 +138,9 @@ public:
 
   virtual void printDebug() const
   {
-    std::cout << "(enterFlow_log_enterFlow: " << enterFlow_log_enterFlow << ", "
-              << "enter_log_enter: " << enter_log_enter << ", "
-              << "exitNetworkFlow_log_exitNetworkFlow: " << exitNetworkFlow_log_exitNetworkFlow << ") ";
+    Log() << "(enterFlow_log_enterFlow: " << enterFlow_log_enterFlow << ", "
+          << "enter_log_enter: " << enter_log_enter << ", "
+          << "exitNetworkFlow_log_exitNetworkFlow: " << exitNetworkFlow_log_exitNetworkFlow << ") ";
   }
 
 protected:

--- a/src/core/MemMapEquation.cpp
+++ b/src/core/MemMapEquation.cpp
@@ -10,6 +10,7 @@
 #include "MemMapEquation.h"
 #include "FlowData.h"
 #include "InfoNode.h"
+#include "../utils/Log.h"
 
 #include <vector>
 #include <set>
@@ -442,7 +443,7 @@ void MemMapEquation::consolidateModules(std::vector<InfoNode*>& modules)
 
 void MemMapEquation::printDebug() const
 {
-  std::cout << "MemMapEquation::m_numPhysicalNodes: " << m_numPhysicalNodes << "\n";
+  Log() << "MemMapEquation::m_numPhysicalNodes: " << m_numPhysicalNodes << "\n";
   Base::printDebug();
 }
 

--- a/src/core/MetaMapEquation.cpp
+++ b/src/core/MetaMapEquation.cpp
@@ -10,6 +10,7 @@
 #include "MetaMapEquation.h"
 #include "FlowData.h"
 #include "InfoNode.h"
+#include "../utils/Log.h"
 
 #include <vector>
 #include <utility>
@@ -262,7 +263,7 @@ void MetaMapEquation::consolidateModules(std::vector<InfoNode*>& modules)
 
 void MetaMapEquation::printDebug() const
 {
-  std::cout << "MetaMapEquation\n";
+  Log() << "MetaMapEquation\n";
   Base::printDebug();
 }
 

--- a/src/core/iterators/InfomapIterator.cpp
+++ b/src/core/iterators/InfomapIterator.cpp
@@ -9,7 +9,6 @@
 
 #include "InfomapIterator.h"
 #include "../InfoNode.h"
-#include <iostream>
 #include <utility> // std::pair
 
 namespace infomap {

--- a/src/io/Config.h
+++ b/src/io/Config.h
@@ -16,7 +16,7 @@
 
 #include <stdexcept>
 #include <iomanip>
-#include <iostream>
+#include <iosfwd>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/io/Network.cpp
+++ b/src/io/Network.cpp
@@ -13,7 +13,6 @@
 #include "../utils/Log.h"
 
 #include <cmath>
-#include <iostream>
 #include <algorithm>
 
 namespace infomap {

--- a/src/io/ProgramInterface.cpp
+++ b/src/io/ProgramInterface.cpp
@@ -10,7 +10,6 @@
 #include "ProgramInterface.h"
 #include "../utils/Log.h"
 
-#include <iostream>
 #include <cstdlib>
 #include <map>
 #include <utility>
@@ -263,7 +262,6 @@ void ProgramInterface::exitWithError(const std::string& message) const
   Log() << " compiled with OpenMP";
 #endif
   Log() << std::endl;
-  std::cerr << message << std::endl;
   Log() << "Usage: " << m_executableName;
   for (auto& nonOptionArgument : m_nonOptionArguments)
     if (!nonOptionArgument->isAdvanced)
@@ -271,7 +269,7 @@ void ProgramInterface::exitWithError(const std::string& message) const
   if (!m_optionArguments.empty())
     Log() << " [options]";
   Log() << ". Run with option '-h' for more information.\n";
-  std::exit(1);
+  throw std::runtime_error(message);
 }
 
 std::string toJson(const std::string& key, const std::string& value)

--- a/src/io/ProgramInterface.h
+++ b/src/io/ProgramInterface.h
@@ -19,7 +19,7 @@
 #include <memory>
 #include <string>
 #include <sstream>
-#include <iostream>
+#include <ostream>
 #include <unordered_map>
 
 namespace infomap {

--- a/src/io/SafeFile.h
+++ b/src/io/SafeFile.h
@@ -11,7 +11,6 @@
 #define SAFEFILE_H_
 
 #include "../utils/convert.h"
-#include <iostream>
 #include <fstream>
 #include <ios>
 #include <cstdio>

--- a/src/utils/FileURI.h
+++ b/src/utils/FileURI.h
@@ -10,7 +10,7 @@
 #ifndef FILEURI_H_
 #define FILEURI_H_
 
-#include <iostream>
+#include <ostream>
 #include <string>
 
 namespace infomap {

--- a/src/utils/FlowCalculator.cpp
+++ b/src/utils/FlowCalculator.cpp
@@ -11,7 +11,6 @@
 #include "../utils/Log.h"
 #include "../utils/infomath.h"
 #include "../core/StateNetwork.h"
-#include <iostream>
 #include <cmath>
 #include <numeric>
 #include <limits>

--- a/src/utils/Log.cpp
+++ b/src/utils/Log.cpp
@@ -17,21 +17,26 @@ namespace {
 
 class NullStreambuf : public std::streambuf {
 protected:
-  int overflow(int c) override { return c; }
+  int_type overflow(int_type c) override { return traits_type::not_eof(c); }
 };
-
-NullStreambuf s_nullBuf;
-std::ostream s_nullStream(&s_nullBuf);
 
 } // namespace
 
-std::ostream* Log::s_ostream = &std::cout;
+std::ostream& Log::defaultStream()
+{
+  static std::ostream& s = std::cout;
+  return s;
+}
+
+std::ostream* Log::s_ostream = nullptr;
 unsigned int Log::s_verboseLevel = 0;
 bool Log::s_silent = false;
 
 void Log::setNoOutput()
 {
-  s_ostream = &s_nullStream;
+  static NullStreambuf nullBuf;
+  static std::ostream nullStream(&nullBuf);
+  s_ostream = &nullStream;
   s_silent = true;
 }
 

--- a/src/utils/Log.cpp
+++ b/src/utils/Log.cpp
@@ -8,10 +8,31 @@
  ******************************************************************************/
 
 #include "Log.h"
+#include <iostream>
+#include <streambuf>
 
 namespace infomap {
 
+namespace {
+
+class NullStreambuf : public std::streambuf {
+protected:
+  int overflow(int c) override { return c; }
+};
+
+NullStreambuf s_nullBuf;
+std::ostream s_nullStream(&s_nullBuf);
+
+} // namespace
+
+std::ostream* Log::s_ostream = &std::cout;
 unsigned int Log::s_verboseLevel = 0;
 bool Log::s_silent = false;
+
+void Log::setNoOutput()
+{
+  s_ostream = &s_nullStream;
+  s_silent = true;
+}
 
 } // namespace infomap

--- a/src/utils/Log.h
+++ b/src/utils/Log.h
@@ -10,7 +10,7 @@
 #ifndef LOG_H_
 #define LOG_H_
 
-#include <iostream>
+#include <ostream>
 #include <limits>
 #include <iomanip>
 #include <type_traits>
@@ -69,19 +69,32 @@ public:
 
   static bool isSilent() { return s_silent; }
 
-  static std::streamsize precision() { return std::cout.precision(); }
+  /// Set a custom output stream for all Log output.
+  static void setOutputStream(std::ostream& os)
+  {
+    s_ostream = &os;
+    s_silent = false;
+  }
+
+  /// Guarantee zero output: redirect to a null sink and set silent.
+  static void setNoOutput();
+
+  static std::ostream& getOutputStream() { return *s_ostream; }
+
+  static std::streamsize precision() { return s_ostream->precision(); }
 
   static std::streamsize precision(std::streamsize precision)
   {
-    return std::cout.precision(precision);
+    return s_ostream->precision(precision);
   }
 
 private:
   unsigned int m_level;
   unsigned int m_maxLevel;
   bool m_visible;
-  std::ostream& m_ostream = std::cout;
+  std::ostream& m_ostream = *s_ostream;
 
+  static std::ostream* s_ostream;
   static unsigned int s_verboseLevel;
   static bool s_silent;
 };

--- a/src/utils/Log.h
+++ b/src/utils/Log.h
@@ -70,30 +70,37 @@ public:
   static bool isSilent() { return s_silent; }
 
   /// Set a custom output stream for all Log output.
+  /// The caller must ensure @p os outlives all subsequent logging,
+  /// or remains valid until another stream is configured.
   static void setOutputStream(std::ostream& os)
   {
     s_ostream = &os;
-    s_silent = false;
   }
+  static void setOutputStream(std::ostream&&) = delete;
 
   /// Guarantee zero output: redirect to a null sink and set silent.
   static void setNoOutput();
 
-  static std::ostream& getOutputStream() { return *s_ostream; }
+  static std::ostream& getOutputStream() { return ostream(); }
 
-  static std::streamsize precision() { return s_ostream->precision(); }
+  static std::streamsize precision() { return ostream().precision(); }
 
   static std::streamsize precision(std::streamsize precision)
   {
-    return s_ostream->precision(precision);
+    return ostream().precision(precision);
   }
 
 private:
   unsigned int m_level;
   unsigned int m_maxLevel;
   bool m_visible;
-  std::ostream& m_ostream = *s_ostream;
+  std::ostream& m_ostream = ostream();
 
+  static std::ostream& ostream()
+  {
+    return s_ostream ? *s_ostream : defaultStream();
+  }
+  static std::ostream& defaultStream();
   static std::ostream* s_ostream;
   static unsigned int s_verboseLevel;
   static bool s_silent;

--- a/src/utils/convert.h
+++ b/src/utils/convert.h
@@ -15,7 +15,6 @@
 #include <sstream>
 #include <string>
 #include <locale> // std::locale, std::tolower
-#include <iostream>
 #include <limits>
 #include <vector>
 

--- a/test/cpp/test_no_output.cpp
+++ b/test/cpp/test_no_output.cpp
@@ -1,0 +1,67 @@
+#include "vendor/doctest.h"
+
+#include "Infomap.h"
+#include "utils/Log.h"
+
+#include <iostream>
+#include <sstream>
+
+TEST_CASE("Silent mode produces zero stdout/stderr output")
+{
+  // Capture stdout
+  std::ostringstream capturedOut;
+  auto* origOutBuf = std::cout.rdbuf(capturedOut.rdbuf());
+
+  // Capture stderr
+  std::ostringstream capturedErr;
+  auto* origErrBuf = std::cerr.rdbuf(capturedErr.rdbuf());
+
+  {
+    infomap::InfomapWrapper im("--silent --num-trials 1 --seed 42");
+    im.addLink(0, 1);
+    im.addLink(1, 2);
+    im.addLink(2, 0);
+    im.addLink(3, 4);
+    im.addLink(4, 5);
+    im.addLink(5, 3);
+    im.run();
+  }
+
+  // Restore original buffers before any assertions
+  std::cout.rdbuf(origOutBuf);
+  std::cerr.rdbuf(origErrBuf);
+
+  CHECK(capturedOut.str().empty());
+  CHECK(capturedErr.str().empty());
+}
+
+TEST_CASE("setNoOutput produces zero stdout/stderr output")
+{
+  // Capture stdout
+  std::ostringstream capturedOut;
+  auto* origOutBuf = std::cout.rdbuf(capturedOut.rdbuf());
+
+  // Capture stderr
+  std::ostringstream capturedErr;
+  auto* origErrBuf = std::cerr.rdbuf(capturedErr.rdbuf());
+
+  {
+    infomap::Log::setNoOutput();
+    infomap::InfomapWrapper im("--num-trials 1 --seed 42");
+    im.addLink(0, 1);
+    im.addLink(1, 2);
+    im.addLink(2, 0);
+    im.addLink(3, 4);
+    im.addLink(4, 5);
+    im.addLink(5, 3);
+    im.run();
+  }
+
+  // Restore original buffers and Log state before assertions
+  std::cout.rdbuf(origOutBuf);
+  std::cerr.rdbuf(origErrBuf);
+  infomap::Log::setOutputStream(std::cout);
+
+  CHECK(capturedOut.str().empty());
+  CHECK(capturedErr.str().empty());
+}

--- a/test/cpp/test_no_output.cpp
+++ b/test/cpp/test_no_output.cpp
@@ -6,62 +6,65 @@
 #include <iostream>
 #include <sstream>
 
+namespace {
+
+struct StreamCapture {
+  std::ostringstream out;
+  std::ostringstream err;
+  std::streambuf* origOut;
+  std::streambuf* origErr;
+
+  StreamCapture()
+      : origOut(std::cout.rdbuf(out.rdbuf())),
+        origErr(std::cerr.rdbuf(err.rdbuf())) { }
+
+  ~StreamCapture()
+  {
+    std::cout.rdbuf(origOut);
+    std::cerr.rdbuf(origErr);
+  }
+};
+
+void buildAndRun(infomap::InfomapWrapper& im)
+{
+  im.addLink(0, 1);
+  im.addLink(1, 2);
+  im.addLink(2, 0);
+  im.addLink(3, 4);
+  im.addLink(4, 5);
+  im.addLink(5, 3);
+  im.run();
+}
+
+} // namespace
+
 TEST_CASE("Silent mode produces zero stdout/stderr output")
 {
-  // Capture stdout
-  std::ostringstream capturedOut;
-  auto* origOutBuf = std::cout.rdbuf(capturedOut.rdbuf());
-
-  // Capture stderr
-  std::ostringstream capturedErr;
-  auto* origErrBuf = std::cerr.rdbuf(capturedErr.rdbuf());
+  StreamCapture capture;
 
   {
     infomap::InfomapWrapper im("--silent --num-trials 1 --seed 42");
-    im.addLink(0, 1);
-    im.addLink(1, 2);
-    im.addLink(2, 0);
-    im.addLink(3, 4);
-    im.addLink(4, 5);
-    im.addLink(5, 3);
-    im.run();
+    buildAndRun(im);
   }
 
-  // Restore original buffers before any assertions
-  std::cout.rdbuf(origOutBuf);
-  std::cerr.rdbuf(origErrBuf);
-
-  CHECK(capturedOut.str().empty());
-  CHECK(capturedErr.str().empty());
+  CHECK(capture.out.str().empty());
+  CHECK(capture.err.str().empty());
 }
 
 TEST_CASE("setNoOutput produces zero stdout/stderr output")
 {
-  // Capture stdout
-  std::ostringstream capturedOut;
-  auto* origOutBuf = std::cout.rdbuf(capturedOut.rdbuf());
-
-  // Capture stderr
-  std::ostringstream capturedErr;
-  auto* origErrBuf = std::cerr.rdbuf(capturedErr.rdbuf());
+  StreamCapture capture;
 
   {
     infomap::Log::setNoOutput();
     infomap::InfomapWrapper im("--num-trials 1 --seed 42");
-    im.addLink(0, 1);
-    im.addLink(1, 2);
-    im.addLink(2, 0);
-    im.addLink(3, 4);
-    im.addLink(4, 5);
-    im.addLink(5, 3);
-    im.run();
+    buildAndRun(im);
   }
 
-  // Restore original buffers and Log state before assertions
-  std::cout.rdbuf(origOutBuf);
-  std::cerr.rdbuf(origErrBuf);
+  // Restore Log state so subsequent tests are unaffected
   infomap::Log::setOutputStream(std::cout);
+  infomap::Log::setSilent(false);
 
-  CHECK(capturedOut.str().empty());
-  CHECK(capturedErr.str().empty());
+  CHECK(capture.out.str().empty());
+  CHECK(capture.err.str().empty());
 }


### PR DESCRIPTION
## Summary

- Add `Log::setNoOutput()` API that redirects all output to a null sink, providing a guaranteed zero stdout/stderr contract for library embedders.
- Add `Log::setOutputStream(std::ostream&)` for custom output redirection.
- Route all direct `std::cout` debug prints (`printDebug()` in MapEquation, BiasedMapEquation, MetaMapEquation, MemMapEquation) through `Log`.
- Replace `ProgramInterface::exitWithError()` stderr write + `std::exit(1)` with `throw std::runtime_error`, giving library callers proper exception-based error handling.
- Narrow or remove `<iostream>` includes across 12 source files, replacing with `<ostream>`, `<iosfwd>`, or removing entirely where unused — reducing iostream symbol references in the library build.
- Add `test_no_output` C++ test verifying both `--silent` and `setNoOutput()` produce zero captured output.

## Test plan

- [x] All 9 C++ tests pass (`ctest --test-dir build`)
- [x] New `infomap_cpp_no_output_tests` validates zero stdout/stderr under `--silent` and `Log::setNoOutput()`
- [x] CLI `./build/Infomap --version` works as before

Closes #413
Closes #414