### PR TITLE
build: notify infomap-online after npm releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,7 +168,7 @@ jobs:
           version="${RELEASE_TAG#v}"
           gh api repos/mapequation/infomap-online/dispatches \
             -f event_type=infomap_release_published \
-            -F client_payload[package]=@mapequation/infomap \
+            -f client_payload[package]=@mapequation/infomap \
             -F client_payload[version]="$version" \
             -F client_payload[release_tag]="$RELEASE_TAG" \
             -F client_payload[release_url]="https://github.com/${{ github.repository }}/releases/tag/$RELEASE_TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,3 +149,26 @@ jobs:
 
       - name: Publish npm package
         run: npm publish --provenance --access public dist/npm/*.tgz
+
+  notify-infomap-online:
+    name: Notify infomap-online
+    if: github.event_name == 'push'
+    needs: [publish-npm]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Dispatch infomap-online update workflow
+        env:
+          GH_TOKEN: ${{ secrets.INFOMAP_ONLINE_REPO_DISPATCH_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          version="${RELEASE_TAG#v}"
+          gh api repos/mapequation/infomap-online/dispatches \
+            -f event_type=infomap_release_published \
+            -F client_payload[package]=@mapequation/infomap \
+            -F client_payload[version]="$version" \
+            -F client_payload[release_tag]="$RELEASE_TAG" \
+            -F client_payload[release_url]="https://github.com/${{ github.repository }}/releases/tag/$RELEASE_TAG"


### PR DESCRIPTION
## Summary
- notify `infomap-online` after successful npm publishes from the tagged release workflow
- dispatch the published package version, tag, and release URL so the site repo can open an automated bump PR

## Testing
- workflow YAML validated locally