### PR TITLE
feat: add structured run events for JS integrations

### DIFF
--- a/interfaces/js/README.md
+++ b/interfaces/js/README.md
@@ -50,6 +50,45 @@ infomap.run({
 });
 ```
 
+## Structured run events
+
+The package can emit structured run events in addition to the default text
+output. Set `logFormat` to `jsonl` or `both` to enable it.
+
+```js
+import Infomap from "@mapequation/infomap";
+
+const infomap = new Infomap()
+  .on("event", (event) => {
+    if (event.type === "summary") {
+      console.log("codelength", event.codelength);
+    }
+  })
+  .on("jsonl", (line) => console.log(line))
+  .on("finished", (result) => console.log(result));
+
+infomap.run({
+  network: "#source target\n1 2\n2 1\n",
+  args: "--tree --clu --silent",
+  logFormat: "both",
+});
+```
+
+Supported structured event types:
+
+- `run_started`
+- `log_line`
+- `trial_started`
+- `trial_finished`
+- `summary`
+- `partition_result`
+- `warning`
+- `run_failed`
+- `run_finished`
+
+`logFormat: "text"` remains the default and preserves the existing `data`
+callback behavior.
+
 React users can import the hook entrypoint directly from the main package:
 
 ```js

--- a/interfaces/js/pre-worker-module.js
+++ b/interfaces/js/pre-worker-module.js
@@ -7,6 +7,53 @@ function readFile(filename) {
 }
 
 let outName = "Untitled";
+let logFormat = "text";
+
+function shouldEmitText() {
+  return logFormat === "text" || logFormat === "both";
+}
+
+function shouldEmitStructured() {
+  return logFormat === "jsonl" || logFormat === "both";
+}
+
+function shouldEmitJsonl() {
+  return logFormat === "jsonl" || logFormat === "both";
+}
+
+function emitStructured(event) {
+  if (!shouldEmitStructured()) {
+    return;
+  }
+
+  postMessage({ type: "event", content: event });
+
+  if (shouldEmitJsonl()) {
+    postMessage({ type: "jsonl", content: JSON.stringify(event) });
+  }
+}
+
+globalThis.__infomapEmitStructuredEvent = function (type, payloadJson) {
+  if (!shouldEmitStructured()) {
+    return;
+  }
+
+  let payload = {};
+
+  if (payloadJson && payloadJson !== "{}") {
+    try {
+      payload = JSON.parse(payloadJson);
+    } catch (error) {
+      postMessage({
+        type: "error",
+        content: `Failed to parse structured Infomap event payload: ${error.message}`,
+      });
+      return;
+    }
+  }
+
+  emitStructured({ type, ...payload });
+};
 
 var Module = {
   arguments: [],
@@ -14,7 +61,10 @@ var Module = {
     addRunDependency("filesReady");
   },
   print: function (content) {
-    postMessage({ type: "data", content });
+    if (shouldEmitText()) {
+      postMessage({ type: "data", content });
+    }
+    emitStructured({ type: "log_line", message: content });
   },
   printErr: function (content) {
     postMessage({ type: "error", content });
@@ -67,6 +117,7 @@ var Module = {
 onmessage = function onmessage(message) {
   const data = message.data;
   outName = data.outName;
+  logFormat = data.logFormat || "text";
   Module.arguments.push(...[data.filename, ".", ...data.arguments]);
   FS.writeFile(data.filename, data.network);
   for (let filename of Object.keys(data.files)) {

--- a/interfaces/js/src/index.ts
+++ b/interfaces/js/src/index.ts
@@ -4,7 +4,7 @@ import fileToString, {
   type TreeStateNode as StateNode
 } from "./filetypes";
 import networkToString from "./network";
-import type { RunOptions } from "./run-options";
+import type { LogFormat, RunOptions } from "./run-options";
 import { createInfomapWorker } from "./worker";
 import changelog from "../generated/changelog.json";
 import parameters from "../generated/parameters.json";
@@ -99,8 +99,97 @@ export interface Result {
   flow_as_physical?: string;
 }
 
+export interface RunStartedEvent {
+  type: "run_started";
+  version: string;
+  startedAt: string;
+  inputNetwork: string;
+  outputPath: string;
+  arguments: string;
+  numTrials: number;
+  noFileOutput: boolean;
+  initialPartitionCount: number;
+}
+
+export interface LogLineEvent {
+  type: "log_line";
+  message: string;
+}
+
+export interface TrialStartedEvent {
+  type: "trial_started";
+  trial: number;
+  numTrials: number;
+  startedAt: string;
+}
+
+export interface TrialFinishedEvent {
+  type: "trial_finished";
+  trial: number;
+  numTrials: number;
+  elapsedSeconds: number;
+  codelength: number;
+  numTopModules: number;
+}
+
+export interface SummaryEvent {
+  type: "summary";
+  numTrials: number;
+  bestTrial: number;
+  numNodes: number;
+  numLinks: number;
+  averageDegree: number;
+  numTopModules: number;
+  numLevels: number;
+  oneLevelCodelength: number;
+  codelength: number;
+  relativeCodelengthSavings: number;
+  minCodelength?: number;
+  averageCodelength?: number;
+  maxCodelength?: number;
+  minNumTopModules?: number;
+  averageNumTopModules?: number;
+  maxNumTopModules?: number;
+}
+
+export interface PartitionResultEvent {
+  type: "partition_result";
+  codelength: number;
+  numTopModules: number;
+  numNonTrivialTopModules: number;
+}
+
+export interface WarningEvent {
+  type: "warning";
+  message: string;
+}
+
+export interface RunFailedEvent {
+  type: "run_failed";
+  message: string;
+}
+
+export interface RunFinishedEvent {
+  type: "run_finished";
+  endedAt: string;
+  elapsedSeconds: number;
+}
+
+export type InfomapRunEvent =
+  | RunStartedEvent
+  | LogLineEvent
+  | TrialStartedEvent
+  | TrialFinishedEvent
+  | SummaryEvent
+  | PartitionResultEvent
+  | WarningEvent
+  | RunFailedEvent
+  | RunFinishedEvent;
+
 export interface EventCallbacks {
   data?: (output: string, id: number) => void;
+  event?: (event: InfomapRunEvent, id: number) => void;
+  jsonl?: (line: string, id: number) => void;
   progress?: (progress: number, id: number) => void;
   error?: (message: string, id: number) => void;
   finished?: (result: Result, id: number) => void;
@@ -113,9 +202,42 @@ interface Event<Type extends keyof EventCallbacks> {
 
 type EventData =
   | Event<"data">
+  | Event<"event">
+  | Event<"jsonl">
   | Event<"progress">
   | Event<"error">
   | Event<"finished">;
+
+function getLegacyProgress(output: string) {
+  const match = output.match(/^Trial (\d+)\/(\d+)/);
+  if (match) {
+    const trial = Number(match[1]);
+    const totalTrials = Number(match[2]);
+    return (100 * trial) / (totalTrials + 1);
+  }
+
+  if (output.match(/^Summary after/)) {
+    return 100;
+  }
+
+  return undefined;
+}
+
+function getStructuredProgress(event: InfomapRunEvent) {
+  switch (event.type) {
+    case "run_started":
+      return 0;
+    case "trial_started":
+      return (100 * (event.trial - 1)) / (event.numTrials + 1);
+    case "trial_finished":
+      return (100 * event.trial) / (event.numTrials + 1);
+    case "summary":
+    case "run_finished":
+      return 100;
+    default:
+      return undefined;
+  }
+}
 
 class Infomap {
   static __version__: string = packageJson.version;
@@ -123,6 +245,7 @@ class Infomap {
   protected events: EventCallbacks = {};
   protected workerId = 0;
   protected workers: { [id: number]: Worker } = {};
+  protected workerFormats: { [id: number]: LogFormat } = {};
 
   run(...args: Parameters<Infomap["createWorker"]>) {
     const id = this.createWorker(...args);
@@ -147,11 +270,13 @@ class Infomap {
     filename,
     args,
     files,
+    logFormat,
   }: RunOptions) {
     network = network ?? "";
     filename = filename ?? "network.net";
     args = args ?? "";
     files = files ?? {};
+    logFormat = logFormat ?? "text";
 
     if (typeof network !== "string") {
       network = networkToString(network);
@@ -177,6 +302,7 @@ class Infomap {
     const worker = createInfomapWorker();
     const id = this.workerId++;
     this.workers[id] = worker;
+    this.workerFormats[id] = logFormat;
 
     worker.postMessage({
       arguments: args.split(" "),
@@ -184,6 +310,7 @@ class Infomap {
       network,
       outName,
       files,
+      logFormat,
     });
 
     return id;
@@ -191,26 +318,36 @@ class Infomap {
 
   protected setHandlers(id: number, events = this.events) {
     const worker = this.workers[id];
-    const { data, progress, error, finished } = { ...this.events, ...events };
+    const format = this.workerFormats[id] ?? "text";
+    const { data, event: onEvent, jsonl, progress, error, finished } = {
+      ...this.events,
+      ...events,
+    };
 
     worker.onmessage = (event: MessageEvent<EventData>) => {
       if (event.data.type === "data") {
         if (data) {
           data(event.data.content, id);
         }
-        if (progress) {
-          const match = event.data.content.match(/^Trial (\d+)\/(\d+)/);
-          if (match) {
-            const trial = Number(match[1]);
-            const totTrials = Number(match[2]);
-            const currentProgress = (100 * trial) / (totTrials + 1);
+        if (progress && format === "text") {
+          const currentProgress = getLegacyProgress(event.data.content);
+          if (currentProgress != null) {
             progress(currentProgress, id);
-          } else {
-            const summary = event.data.content.match(/^Summary after/);
-            if (summary) {
-              progress(100, id);
-            }
           }
+        }
+      } else if (event.data.type === "event") {
+        if (onEvent) {
+          onEvent(event.data.content, id);
+        }
+        if (progress && format !== "text") {
+          const currentProgress = getStructuredProgress(event.data.content);
+          if (currentProgress != null) {
+            progress(currentProgress, id);
+          }
+        }
+      } else if (event.data.type === "jsonl") {
+        if (jsonl) {
+          jsonl(event.data.content, id);
         }
       } else if (error && event.data.type === "error") {
         void this._terminate(id);
@@ -245,6 +382,7 @@ class Infomap {
       }
 
       delete this.workers[id];
+      delete this.workerFormats[id];
     });
   }
 

--- a/interfaces/js/src/run-options.ts
+++ b/interfaces/js/src/run-options.ts
@@ -2,9 +2,12 @@ import type { Arguments } from "./arguments";
 import type { FileTypes } from "./filetypes";
 import type { NetworkTypes } from "./network";
 
+export type LogFormat = "text" | "jsonl" | "both";
+
 export interface RunOptions {
   network?: string | NetworkTypes;
   filename?: string;
   args?: string | Arguments;
   files?: { [filename: string]: string | FileTypes };
+  logFormat?: LogFormat;
 }

--- a/interfaces/js/test/browser/fixtures/worker.html
+++ b/interfaces/js/test/browser/fixtures/worker.html
@@ -16,17 +16,21 @@
       async function run() {
         try {
           status.textContent = Infomap.__version__;
-          const infomap = new Infomap();
+          const eventTypes = [];
+          const infomap = new Infomap().on("event", (event) => {
+            eventTypes.push(event.type);
+          });
           const output = await infomap.runAsync({
             network: "#source target\n1 2\n2 1\n2 3\n3 2\n",
-            args: "--tree --clu --silent"
+            args: "--tree --clu --silent",
+            logFormat: "jsonl"
           });
 
-          if (!output.tree || !output.clu) {
+          if (!output.tree || !output.clu || !eventTypes.includes("summary")) {
             throw new Error("Missing expected output");
           }
 
-          result.textContent = `${output.tree}\n${output.clu}`;
+          result.textContent = `${eventTypes.join(",")}\n${output.tree}\n${output.clu}`;
           status.textContent = "ok";
         } catch (error) {
           status.textContent = String(error);

--- a/interfaces/js/test/browser/smoke.spec.ts
+++ b/interfaces/js/test/browser/smoke.spec.ts
@@ -3,5 +3,6 @@ import { expect, test } from "@playwright/test";
 test("UMD bundle runs a worker job in the browser", async ({ page }) => {
   await page.goto("/interfaces/js/test/browser/fixtures/worker.html");
   await expect(page.locator("#status")).toHaveText("ok");
+  await expect(page.locator("#result")).toContainText("summary");
   await expect(page.locator("#result")).toContainText("1");
 });

--- a/interfaces/js/test/unit/worker-events.test.ts
+++ b/interfaces/js/test/unit/worker-events.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const postMessage = vi.fn();
 const terminate = vi.fn();
@@ -17,6 +17,11 @@ vi.mock("../../src/worker", () => ({
 const { default: Infomap } = await import("../../src/index");
 
 describe("Infomap", () => {
+  beforeEach(() => {
+    postMessage.mockClear();
+    terminate.mockClear();
+  });
+
   test("converts progress events from worker data output", () => {
     const progress = vi.fn();
     const infomap = new Infomap().on("progress", progress);
@@ -34,5 +39,75 @@ describe("Infomap", () => {
 
     expect(postMessage).toHaveBeenCalled();
     expect(progress).toHaveBeenCalledWith(40, id);
+  });
+
+  test("dispatches structured events and jsonl output", () => {
+    const onEvent = vi.fn();
+    const onJsonl = vi.fn();
+    const progress = vi.fn();
+    const infomap = new Infomap()
+      .on("event", onEvent)
+      .on("jsonl", onJsonl)
+      .on("progress", progress);
+    const id = infomap.run({
+      network: "#source target\n1 2\n",
+      logFormat: "jsonl",
+    });
+    const worker = (
+      infomap as unknown as { workers: Record<number, WorkerMock> }
+    ).workers[id];
+
+    worker.onmessage?.({
+      data: {
+        type: "event",
+        content: {
+          type: "trial_started",
+          trial: 2,
+          numTrials: 4,
+          startedAt: "2026-04-13 10:00:00",
+        },
+      },
+    } as MessageEvent);
+    worker.onmessage?.({
+      data: {
+        type: "jsonl",
+        content:
+          '{"type":"trial_started","trial":2,"numTrials":4,"startedAt":"2026-04-13 10:00:00"}',
+      },
+    } as MessageEvent);
+    worker.onmessage?.({
+      data: {
+        type: "event",
+        content: {
+          type: "summary",
+          numTrials: 4,
+          bestTrial: 2,
+          numNodes: 3,
+          numLinks: 2,
+          averageDegree: 1.3,
+          numTopModules: 2,
+          numLevels: 2,
+          oneLevelCodelength: 1.9,
+          codelength: 1.5,
+          relativeCodelengthSavings: 0.2,
+        },
+      },
+    } as MessageEvent);
+
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ logFormat: "jsonl" })
+    );
+    expect(onEvent).toHaveBeenCalledTimes(2);
+    expect(onEvent).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ type: "trial_started", trial: 2 }),
+      id
+    );
+    expect(onJsonl).toHaveBeenCalledWith(
+      '{"type":"trial_started","trial":2,"numTrials":4,"startedAt":"2026-04-13 10:00:00"}',
+      id
+    );
+    expect(progress).toHaveBeenNthCalledWith(1, 20, id);
+    expect(progress).toHaveBeenNthCalledWith(2, 100, id);
   });
 });

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1213,14 +1213,6 @@ void InfomapBase::partition()
   if (m_numNonTrivialTopModules != numTopModules())
     Log() << " (" << m_numNonTrivialTopModules << " non-trivial)";
   Log() << " modules.\n";
-  if (isMainInfomap()) {
-    Log::emitStructuredEvent("partition_result",
-                             jsonObject({
-                                 jsonField("codelength", jsonNumber(m_hierarchicalCodelength)),
-                                 jsonField("numTopModules", jsonNumber(numTopModules())),
-                                 jsonField("numNonTrivialTopModules", jsonNumber(m_numNonTrivialTopModules)),
-                             }));
-  }
 
   const bool regularizedPriorOnly = regularized && network().numLinks() == 0;
   if (!preferModularSolution && preferredNumberOfModules == 0 && (haveNonTrivialModules() || regularizedPriorOnly) && getCodelength() > getOneLevelCodelength()) {
@@ -1250,6 +1242,15 @@ void InfomapBase::partition()
     calcCodelengthOnTree(root(), false);
     m_root.codelength = getIndexCodelength();
     m_hierarchicalCodelength = getCodelength();
+  }
+
+  if (isMainInfomap()) {
+    Log::emitStructuredEvent("partition_result",
+                             jsonObject({
+                                 jsonField("codelength", jsonNumber(m_hierarchicalCodelength)),
+                                 jsonField("numTopModules", jsonNumber(numTopModules())),
+                                 jsonField("numNonTrivialTopModules", jsonNumber(m_numNonTrivialTopModules)),
+                             }));
   }
 }
 

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -30,12 +30,64 @@
 #include <cstdlib>
 #include <algorithm>
 #include <cmath>
+#include <numeric>
 
 #ifdef _OPENMP
 #include <omp.h>
 #endif
 
 namespace infomap {
+
+namespace {
+
+std::string jsonString(const std::string& value)
+{
+  return "\"" + Log::escapeJsonString(value) + "\"";
+}
+
+std::string jsonBool(bool value)
+{
+  return value ? "true" : "false";
+}
+
+template <typename T>
+std::string jsonNumber(T value)
+{
+  std::ostringstream out;
+  out << std::setprecision(std::numeric_limits<double>::digits10 + 1) << value;
+  return out.str();
+}
+
+std::string jsonField(const std::string& key, const std::string& value)
+{
+  return "\"" + key + "\":" + value;
+}
+
+std::string jsonObject(std::initializer_list<std::string> fields)
+{
+  std::ostringstream out;
+  out << "{";
+  bool first = true;
+  for (const auto& field : fields) {
+    if (field.empty()) {
+      continue;
+    }
+    if (!first) {
+      out << ",";
+    }
+    out << field;
+    first = false;
+  }
+  out << "}";
+  return out.str();
+}
+
+std::string dateToString(const Date& date)
+{
+  return io::Str() << date;
+}
+
+} // namespace
 
 std::map<unsigned int, std::vector<unsigned int>> InfomapBase::getMultilevelModules(bool states)
 {
@@ -117,6 +169,17 @@ void InfomapBase::run(const std::string& parameters)
   }
 
   Log::init(verbosity, silent, verboseNumberPrecision);
+  Log::emitStructuredEvent("run_started",
+                           jsonObject({
+                               jsonField("version", jsonString(INFOMAP_VERSION)),
+                               jsonField("startedAt", jsonString(dateToString(m_startDate))),
+                               jsonField("inputNetwork", jsonString(networkFile)),
+                               jsonField("outputPath", jsonString(outDirectory)),
+                               jsonField("arguments", jsonString(parsedString)),
+                               jsonField("numTrials", jsonNumber(numTrials)),
+                               jsonField("noFileOutput", jsonBool(noFileOutput)),
+                               jsonField("initialPartitionCount", jsonNumber(m_initialPartition.size())),
+                           }));
 
   Log() << "=======================================================\n";
   Log() << "  Infomap v" << INFOMAP_VERSION << " starts at " << m_startDate << "\n";
@@ -156,6 +219,11 @@ void InfomapBase::run(const std::string& parameters)
   Log() << "  Infomap ends at " << m_endDate << "\n";
   Log() << "  (Elapsed time: " << m_elapsedTime << ")\n";
   Log() << "===================================================\n";
+  Log::emitStructuredEvent("run_finished",
+                           jsonObject({
+                               jsonField("endedAt", jsonString(dateToString(m_endDate))),
+                               jsonField("elapsedSeconds", jsonNumber(m_elapsedTime.getElapsedTimeInSec())),
+                           }));
 }
 
 void InfomapBase::run(Network& network)
@@ -202,6 +270,10 @@ void InfomapBase::run(Network& network)
   } else {
     if (haveMemory() || network.higherOrderInputMethodCalled()) {
       Log() << "  -> Warning: Higher order network specified but no higher order input found.\n";
+      Log::emitStructuredEvent("warning",
+                               jsonObject({
+                                   jsonField("message", jsonString("Higher order network specified but no higher order input found.")),
+                               }));
       // Use state output anyway for consistency even in the special case when input is first order
       setStateOutput();
     }
@@ -266,6 +338,12 @@ void InfomapBase::run(Network& network)
     Stopwatch timer(true);
 
     if (isMainInfomap()) {
+      Log::emitStructuredEvent("trial_started",
+                               jsonObject({
+                                   jsonField("trial", jsonNumber(i + 1)),
+                                   jsonField("numTrials", jsonNumber(numTrials)),
+                                   jsonField("startedAt", jsonString(dateToString(startDate))),
+                               }));
       Log() << "\n";
       Log() << "================================================\n";
       Log() << "Trial " << (i + 1) << "/" << numTrials << " starting at " << startDate << "\n";
@@ -287,6 +365,14 @@ void InfomapBase::run(Network& network)
 
     if (isMainInfomap()) {
       Log() << "\n=> Trial " << (i + 1) << "/" << numTrials << " finished in " << timer.getElapsedTimeInSec() << "s with codelength " << m_hierarchicalCodelength << "\n";
+      Log::emitStructuredEvent("trial_finished",
+                               jsonObject({
+                                   jsonField("trial", jsonNumber(i + 1)),
+                                   jsonField("numTrials", jsonNumber(numTrials)),
+                                   jsonField("elapsedSeconds", jsonNumber(timer.getElapsedTimeInSec())),
+                                   jsonField("codelength", jsonNumber(m_hierarchicalCodelength)),
+                                   jsonField("numTopModules", jsonNumber(numTopModules())),
+                               }));
       m_codelengths.push_back(m_hierarchicalCodelength);
       m_numTopModules.push_back(numTopModules());
 
@@ -366,6 +452,25 @@ void InfomapBase::run(Network& network)
     Log() << "Relative codelength savings: " << io::toPrecision(getRelativeCodelengthSavings() * 100, 2, true) << "%\n";
     Log() << "\n";
     Log() << bestSolutionStatistics.str() << '\n';
+    Log::emitStructuredEvent("summary",
+                             jsonObject({
+                                 jsonField("numTrials", jsonNumber(numTrials)),
+                                 jsonField("bestTrial", jsonNumber(bestTrialIndex + 1)),
+                                 jsonField("numNodes", jsonNumber(numLeafNodes())),
+                                 jsonField("numLinks", jsonNumber(network.numLinks())),
+                                 jsonField("averageDegree", jsonNumber(network.numLinks() * 2.0 / numLeafNodes())),
+                                 jsonField("numTopModules", jsonNumber(numTopModules())),
+                                 jsonField("numLevels", jsonNumber(bestNumLevels)),
+                                 jsonField("oneLevelCodelength", jsonNumber(getOneLevelCodelength())),
+                                 jsonField("codelength", jsonNumber(bestHierarchicalCodelength)),
+                                 jsonField("relativeCodelengthSavings", jsonNumber(getRelativeCodelengthSavings())),
+                                 numTrials > 1 ? jsonField("minCodelength", jsonNumber(*std::min_element(m_codelengths.begin(), m_codelengths.end()))) : "",
+                                 numTrials > 1 ? jsonField("averageCodelength", jsonNumber(std::accumulate(m_codelengths.begin(), m_codelengths.end(), 0.0) / numTrials)) : "",
+                                 numTrials > 1 ? jsonField("maxCodelength", jsonNumber(*std::max_element(m_codelengths.begin(), m_codelengths.end()))) : "",
+                                 numTrials > 1 ? jsonField("minNumTopModules", jsonNumber(*std::min_element(m_numTopModules.begin(), m_numTopModules.end()))) : "",
+                                 numTrials > 1 ? jsonField("averageNumTopModules", jsonNumber(std::accumulate(m_numTopModules.begin(), m_numTopModules.end(), 0.0) / numTrials)) : "",
+                                 numTrials > 1 ? jsonField("maxNumTopModules", jsonNumber(*std::max_element(m_numTopModules.begin(), m_numTopModules.end()))) : "",
+                             }));
   }
 }
 
@@ -1108,6 +1213,14 @@ void InfomapBase::partition()
   if (m_numNonTrivialTopModules != numTopModules())
     Log() << " (" << m_numNonTrivialTopModules << " non-trivial)";
   Log() << " modules.\n";
+  if (isMainInfomap()) {
+    Log::emitStructuredEvent("partition_result",
+                             jsonObject({
+                                 jsonField("codelength", jsonNumber(m_hierarchicalCodelength)),
+                                 jsonField("numTopModules", jsonNumber(numTopModules())),
+                                 jsonField("numNonTrivialTopModules", jsonNumber(m_numNonTrivialTopModules)),
+                             }));
+  }
 
   const bool regularizedPriorOnly = regularized && network().numLinks() == 0;
   if (!preferModularSolution && preferredNumberOfModules == 0 && (haveNonTrivialModules() || regularizedPriorOnly) && getCodelength() > getOneLevelCodelength()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
  ******************************************************************************/
 
 #include "Infomap.h"
+#include "utils/Log.h"
 #include <iostream>
 #include <stdexcept>
 
@@ -17,14 +18,25 @@
 
 namespace infomap {
 
+namespace {
+
+std::string jsonString(const std::string& value)
+{
+  return "\"" + Log::escapeJsonString(value) + "\"";
+}
+
+} // namespace
+
 int run(const std::string& flags)
 {
   try {
     InfomapWrapper(Config(flags, true)).run();
   } catch (std::exception& e) {
+    Log::emitStructuredEvent("run_failed", "{\"message\":" + jsonString(e.what()) + "}");
     std::cerr << "Error: " << e.what() << '\n';
     return 1;
   } catch (char const* e) {
+    Log::emitStructuredEvent("run_failed", "{\"message\":" + jsonString(e) + "}");
     std::cerr << "Str error: " << e << '\n';
     return 1;
   }

--- a/src/utils/Log.cpp
+++ b/src/utils/Log.cpp
@@ -9,9 +9,70 @@
 
 #include "Log.h"
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
+#include <sstream>
+
 namespace infomap {
 
 unsigned int Log::s_verboseLevel = 0;
 bool Log::s_silent = false;
+
+std::string Log::escapeJsonString(const std::string& value)
+{
+  std::ostringstream out;
+  for (unsigned char c : value) {
+    switch (c) {
+    case '"':
+      out << "\\\"";
+      break;
+    case '\\':
+      out << "\\\\";
+      break;
+    case '\b':
+      out << "\\b";
+      break;
+    case '\f':
+      out << "\\f";
+      break;
+    case '\n':
+      out << "\\n";
+      break;
+    case '\r':
+      out << "\\r";
+      break;
+    case '\t':
+      out << "\\t";
+      break;
+    default:
+      if (c < 0x20) {
+        out << "\\u" << std::hex << std::setw(4) << std::setfill('0') << static_cast<int>(c) << std::dec << std::setfill(' ');
+      } else {
+        out << static_cast<char>(c);
+      }
+      break;
+    }
+  }
+  return out.str();
+}
+
+void Log::emitStructuredEvent(const std::string& type, const std::string& payload)
+{
+#ifdef __EMSCRIPTEN__
+  EM_ASM(
+      {
+        if (typeof globalThis.__infomapEmitStructuredEvent === "function") {
+          globalThis.__infomapEmitStructuredEvent(UTF8ToString($0), UTF8ToString($1));
+        }
+      },
+      type.c_str(),
+      payload.c_str());
+#else
+  (void)type;
+  (void)payload;
+#endif
+}
 
 } // namespace infomap

--- a/src/utils/Log.h
+++ b/src/utils/Log.h
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <limits>
 #include <iomanip>
+#include <string>
 #include <type_traits>
 
 namespace infomap {
@@ -68,6 +69,10 @@ public:
   static void setSilent(bool silent) { s_silent = silent; }
 
   static bool isSilent() { return s_silent; }
+
+  static std::string escapeJsonString(const std::string& value);
+
+  static void emitStructuredEvent(const std::string& type, const std::string& payload = "{}");
 
   static std::streamsize precision() { return std::cout.precision(); }
 


### PR DESCRIPTION
## Summary

This PR adds an additive structured run stream to `@mapequation/infomap` for browser and worker integrations.

It introduces:
- a new `logFormat` run option with `text`, `jsonl`, and `both`
- typed `event` callbacks and `jsonl` line callbacks in the JS API
- structured native run events for lifecycle, trials, partition summaries, warnings, and failures
- worker support for routing structured events without changing the default text mode
- README and browser/unit test coverage for the new contract

## Why

Downstream integrations need a stable machine-readable stream instead of parsing human-oriented console output.

This keeps the current default behavior intact while making it possible for clients to consume richer progress and summary information through a documented public API.

## Impact

- Existing consumers keep working with the default `logFormat: "text"` behavior.
- New consumers can opt into structured events or JSONL without changing result-file handling.
- Progress can now be derived from semantic events in structured mode instead of regex matching text output.

## Validation

Passed:
- `PATH="/opt/homebrew/bin:$PATH" npm ci`
- `PATH="/opt/homebrew/bin:$PATH" make test-js`
- `PATH="/opt/homebrew/bin:$PATH" npm run typecheck`

Not fully verified in this environment:
- `make build-native` currently fails locally because the OpenMP header `omp.h` is not available in this setup.
