### PR TITLE
build: refresh Python SWIG outputs

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -80,6 +80,11 @@ make dev-python-install
 make test-python
 ```
 
+Run `make dev-python-install` again after changing C++ extension sources,
+SWIG interfaces, or tracked SWIG outputs. Local tests import the installed
+editable package; without reinstalling, they can load an older `_infomap`
+extension that does not match the current Python wrapper.
+
 More targeted checks are available when you only need one slice:
 
 - `make test-python-unit`

--- a/interfaces/python/generated/infomap_wrap.cpp
+++ b/interfaces/python/generated/infomap_wrap.cpp
@@ -9049,6 +9049,60 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_Config_maxFlowIterations_set(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  infomap::Config *arg1 = 0 ;
+  unsigned int arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned int val2 ;
+  int ecode2 = 0 ;
+  PyObject *swig_obj[2] ;
+  
+  (void)self;
+  if (!SWIG_Python_UnpackTuple(args, "Config_maxFlowIterations_set", 2, 2, swig_obj)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__Config, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Config_maxFlowIterations_set" "', argument " "1"" of type '" "infomap::Config *""'"); 
+  }
+  arg1 = reinterpret_cast< infomap::Config * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_int(swig_obj[1], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "Config_maxFlowIterations_set" "', argument " "2"" of type '" "unsigned int""'");
+  } 
+  arg2 = static_cast< unsigned int >(val2);
+  if (arg1) (arg1)->maxFlowIterations = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_Config_maxFlowIterations_get(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  infomap::Config *arg1 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  unsigned int result;
+  
+  (void)self;
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__Config, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Config_maxFlowIterations_get" "', argument " "1"" of type '" "infomap::Config *""'"); 
+  }
+  arg1 = reinterpret_cast< infomap::Config * >(argp1);
+  result = (unsigned int) ((arg1)->maxFlowIterations);
+  resultobj = SWIG_From_unsigned_SS_int(static_cast< unsigned int >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_Config_twoLevel_set(PyObject *self, PyObject *args) {
   PyObject *resultobj = 0;
   infomap::Config *arg1 = 0 ;
@@ -56851,6 +56905,8 @@ static PyMethodDef SwigMethods[] = {
 	 { "Config_multilayerRelaxByJensenShannonDivergence_get", _wrap_Config_multilayerRelaxByJensenShannonDivergence_get, METH_O, NULL},
 	 { "Config_multilayerJSRelaxLimit_set", _wrap_Config_multilayerJSRelaxLimit_set, METH_VARARGS, NULL},
 	 { "Config_multilayerJSRelaxLimit_get", _wrap_Config_multilayerJSRelaxLimit_get, METH_O, NULL},
+	 { "Config_maxFlowIterations_set", _wrap_Config_maxFlowIterations_set, METH_VARARGS, NULL},
+	 { "Config_maxFlowIterations_get", _wrap_Config_maxFlowIterations_get, METH_O, NULL},
 	 { "Config_twoLevel_set", _wrap_Config_twoLevel_set, METH_VARARGS, NULL},
 	 { "Config_twoLevel_get", _wrap_Config_twoLevel_get, METH_O, NULL},
 	 { "Config_noCoarseTune_set", _wrap_Config_noCoarseTune_set, METH_VARARGS, NULL},

--- a/interfaces/python/src/infomap/_swig.py
+++ b/interfaces/python/src/infomap/_swig.py
@@ -119,6 +119,7 @@ class Config(object):
     multilayerJSRelaxRate = property(_infomap.Config_multilayerJSRelaxRate_get, _infomap.Config_multilayerJSRelaxRate_set)
     multilayerRelaxByJensenShannonDivergence = property(_infomap.Config_multilayerRelaxByJensenShannonDivergence_get, _infomap.Config_multilayerRelaxByJensenShannonDivergence_set)
     multilayerJSRelaxLimit = property(_infomap.Config_multilayerJSRelaxLimit_get, _infomap.Config_multilayerJSRelaxLimit_set)
+    maxFlowIterations = property(_infomap.Config_maxFlowIterations_get, _infomap.Config_maxFlowIterations_set)
     twoLevel = property(_infomap.Config_twoLevel_get, _infomap.Config_twoLevel_set)
     noCoarseTune = property(_infomap.Config_noCoarseTune_get, _infomap.Config_noCoarseTune_set)
     recordedTeleportation = property(_infomap.Config_recordedTeleportation_get, _infomap.Config_recordedTeleportation_set)

--- a/scripts/generate_python_swig.py
+++ b/scripts/generate_python_swig.py
@@ -5,7 +5,6 @@ import os
 import re
 import shutil
 import subprocess
-import sys
 import tempfile
 from pathlib import Path
 
@@ -13,6 +12,18 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 INTERFACE_FILE = REPO_ROOT / "interfaces" / "swig" / "Infomap.i"
 REQUIRED_SWIG_VERSION = "4.4.1"
+
+
+def github_actions_escape(value: str) -> str:
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A").replace(":", "%3A")
+
+
+def print_github_actions_error(message: str) -> None:
+    if os.environ.get("GITHUB_ACTIONS") != "true":
+        return
+    title = github_actions_escape("Tracked Python SWIG outputs are stale")
+    body = github_actions_escape(message)
+    print(f"::error title={title}::{body}")
 
 
 def get_swig_command() -> str:
@@ -93,10 +104,20 @@ def main() -> int:
             if not files_match(cpp_out, generated_cpp):
                 failures.append(str(cpp_out))
             if failures:
+                print_github_actions_error(
+                    "Regenerate the Python SWIG wrapper outputs with `make build-python-swig` "
+                    "and commit the updated generated files."
+                )
                 print("Tracked SWIG outputs are stale:")
                 for path in failures:
                     print(f"  {path}")
+                print()
+                print(
+                    "This usually means a C++ header or SWIG interface changed, "
+                    "but the generated Python wrapper files were not regenerated."
+                )
                 print("Run: make build-python-swig")
+                print("Then commit the updated files listed above.")
                 return 1
             print("Tracked SWIG outputs are fresh.")
             return 0


### PR DESCRIPTION
## Summary

Refresh the tracked Python SWIG wrapper outputs after the new `Config::maxFlowIterations` field changed the C++ interface.

This also makes the SWIG freshness failure more self-explanatory in CI by adding a GitHub Actions error annotation and clearer remediation text, and documents the local `dev-python-install` step needed after C++ extension or wrapper changes.