### PR TITLE
build: raise C++ baseline to C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ list(REMOVE_ITEM infomap_sources "${infomap_main_source}")
 
 add_library(infomap_core ${infomap_headers} ${infomap_sources})
 target_include_directories(infomap_core PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/src")
-target_compile_features(infomap_core PUBLIC cxx_std_14)
+target_compile_features(infomap_core PUBLIC cxx_std_17)
 set_target_properties(infomap_core PROPERTIES CXX_EXTENSIONS OFF)
 target_compile_options(infomap_core PRIVATE ${INFOMAP_COMPILE_FLAGS})
 target_link_options(infomap_core PUBLIC ${INFOMAP_LINK_FLAGS})

--- a/examples/cpp/Infomap-igraph-interface-library/Makefile
+++ b/examples/cpp/Infomap-igraph-interface-library/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS = -Wall -O3 -std=c++14
+CXXFLAGS = -Wall -O3 -std=c++17
 
 # Set INFOMAP_DIR to your Infomap directory
 INFOMAP_DIR = ../../..

--- a/examples/cpp/minimal/Makefile
+++ b/examples/cpp/minimal/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS += -Wall -O3 -std=c++14
+CXXFLAGS += -Wall -O3 -std=c++17
 LDFLAGS += 
 
 # Set INFOMAP_DIR to your Infomap directory

--- a/mk/js.mk
+++ b/mk/js.mk
@@ -32,7 +32,7 @@ test-js-metadata: build-native
 $(JS_WORKER_TARGET): $(SOURCES) $(HEADERS) $(PRE_WORKER_MODULE) $(MK_FILES) Makefile
 	@echo "Compiling Infomap to run in a worker in the browser..."
 	@mkdir -p $(dir $@)
-	$(EMXX) -std=c++14 -O3 -s WASM=0 -s ALLOW_MEMORY_GROWTH=1 -s DISABLE_EXCEPTION_CATCHING=0 -s ENVIRONMENT=worker --pre-js $(PRE_WORKER_MODULE) -o $@ $(SOURCES)
+	$(EMXX) -std=c++17 -O3 -s WASM=0 -s ALLOW_MEMORY_GROWTH=1 -s DISABLE_EXCEPTION_CATCHING=0 -s ENVIRONMENT=worker --pre-js $(PRE_WORKER_MODULE) -o $@ $(SOURCES)
 
 test-js: build-js
 	$(RM) -r $(NPM_UNPACK_DIR) $(NPM_STAGE_DIR)/*.tgz $(NPM_PACK_JSON)

--- a/scripts/build_config.py
+++ b/scripts/build_config.py
@@ -113,9 +113,9 @@ def shutil_which(name):
 
 def _base_compile_flags(compiler_family):
     if compiler_family == "msvc":
-        return ["/std:c++14"]
+        return ["/std:c++17"]
 
-    flags = ["-Wall", "-Wextra", "-pedantic", "-Wnon-virtual-dtor", "-std=c++14"]
+    flags = ["-Wall", "-Wextra", "-pedantic", "-Wnon-virtual-dtor", "-std=c++17"]
     if compiler_family in {"clang", "gnu"}:
         flags.append("-Wshadow")
     return flags

--- a/test/python/test_build_config.py
+++ b/test/python/test_build_config.py
@@ -21,7 +21,7 @@ def test_windows_cl_exe_uses_msvc_flags():
     config = resolve_build_config(platform_name="win32", compiler="cl.exe", openmp=True)
 
     assert config["compiler_family"] == "msvc"
-    assert "/std:c++14" in config["compile_flags"]
+    assert "/std:c++17" in config["compile_flags"]
     assert "-Wextra" not in config["compile_flags"]
     assert "-fopenmp" not in config["compile_flags"]
 
@@ -34,7 +34,7 @@ def test_windows_quoted_cl_path_uses_msvc_flags():
     config = resolve_build_config(platform_name="win32", compiler=compiler, openmp=True)
 
     assert config["compiler_family"] == "msvc"
-    assert "/std:c++14" in config["compile_flags"]
+    assert "/std:c++17" in config["compile_flags"]
     assert "-Wextra" not in config["compile_flags"]
     assert "-fopenmp" not in config["compile_flags"]
 
@@ -43,7 +43,7 @@ def test_windows_unknown_compiler_defaults_to_msvc_flags():
     config = resolve_build_config(platform_name="win32", compiler="c++", openmp=True)
 
     assert config["compiler_family"] == "msvc"
-    assert "/std:c++14" in config["compile_flags"]
+    assert "/std:c++17" in config["compile_flags"]
     assert "-Wextra" not in config["compile_flags"]
     assert "-fopenmp" not in config["compile_flags"]
 
@@ -62,7 +62,7 @@ def test_clang_debug_and_release_share_warning_policy():
         openmp=False,
     )
 
-    for flag in ["-Wall", "-Wextra", "-Wshadow", "-pedantic", "-Wnon-virtual-dtor", "-std=c++14"]:
+    for flag in ["-Wall", "-Wextra", "-Wshadow", "-pedantic", "-Wnon-virtual-dtor", "-std=c++17"]:
         assert flag in debug_config["compile_flags"]
         assert flag in release_config["compile_flags"]
 


### PR DESCRIPTION
## Summary

- Raise the C++ build baseline from C++14 to C++17 across native, Python extension, JS worker, and C++ examples.
- Keep the change mechanical: no runtime, API, or algorithm behavior changes.
- Update build policy tests to expect C++17 flags.

## Verification

- `python3 -m pytest test/python/test_build_config.py`
- `make build-native`
- `make test-native`
- `make build-python PYTHON=.venv/bin/python`
- `make dev-python-install PYTHON=.venv/bin/python`
- `make test-python PYTHON=/Users/anton/kod/infomap/.venv/bin/python`
- `make build-js`
- `make test-js`
- `rg "c\\+\\+14|cxx_std_14|std=c\\+\\+14|/std:c\\+\\+14|C\\+\\+14" . -g '!node_modules' -g '!docs' -g '!interfaces/python/generated/infomap_wrap.cpp'`

## Notes

- Local Python verification used the existing `.venv` because system `python3` did not have executable `python -m build` support in this checkout.
- Local JS verification used `em++ 5.0.4-git` and Node `25.9.0`; CI remains the source of truth for the documented Emscripten/Node versions.
