### PR TITLE
test: document and test InfoNode ownership contract

### DIFF
--- a/src/core/InfoNode.h
+++ b/src/core/InfoNode.h
@@ -26,6 +26,17 @@ namespace infomap {
 
 class InfomapBase;
 
+/**
+ * Tree node with raw-pointer ownership.
+ *
+ * An InfoNode owns the active child chain reachable through firstChild/lastChild
+ * and the collapsed child chain reachable through collapsedFirstChild/
+ * collapsedLastChild. Destruction deletes both chains. releaseChildren() only
+ * detaches the active chain from this parent; the caller must reattach or delete
+ * those nodes. Reparenting helpers detach children before deleting the removed
+ * intermediate node. An InfoNode also owns its sub-Infomap pointer and outgoing
+ * InfoEdge objects; incoming edge pointers are non-owning back-references.
+ */
 class InfoNode {
 public:
   using child_iterator = ChildIterator<InfoNode*>;
@@ -311,13 +322,15 @@ public:
   void sortChildrenOnFlow(bool recurse = true) noexcept;
 
   /**
-   * Release the children and store the child pointers for later expansion
+   * Move the active child chain to the collapsed child chain without deleting
+   * it. The node owns the collapsed chain until expandChildren() restores it or
+   * deleteChildren()/destruction deletes it.
    * @return the number of children collapsed
    */
   unsigned int collapseChildren() noexcept;
 
   /**
-   * Expand collapsed children
+   * Move the collapsed child chain back to the active child chain.
    * @return the number of collapsed children expanded
    */
   unsigned int expandChildren();
@@ -329,8 +342,17 @@ public:
 
   void setNumLeafNodes(unsigned int value) noexcept { m_numLeafMembers = value; }
 
+  /**
+   * Append child to this node's active child chain and transfer tree ownership
+   * to this parent. The child must not still be owned by another active chain.
+   */
   void addChild(InfoNode* child) noexcept;
 
+  /**
+   * Detach this node from its active child chain without deleting any child.
+   * Child parent/sibling links are not rewritten; callers must reattach or
+   * delete the detached chain before those stale links can be observed.
+   */
   void releaseChildren() noexcept;
 
   /**
@@ -354,8 +376,18 @@ public:
 
   void replaceChildrenWithGrandChildrenDebug() noexcept;
 
+  /**
+   * Delete this node.
+   *
+   * removeChildren=false leaves firstChild intact, so the destructor deletes the
+   * active child chain. removeChildren=true clears firstChild before deletion,
+   * leaving the previous child chain for the caller to reattach or delete.
+   */
   void remove(bool removeChildren) noexcept;
 
+  /**
+   * Delete active and collapsed child chains owned by this node.
+   */
   void deleteChildren() noexcept;
 
   void addOutEdge(InfoNode& target, double weight, double flow = 0.0) noexcept

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -200,6 +200,30 @@ TEST_CASE("InfoNode hierarchy mutations preserve parentage and child order [fast
   CHECK(childStateIds(root) == std::vector<unsigned int> { 40, 50 });
 }
 
+TEST_CASE("InfoNode releaseChildren detaches active children without deleting them [fast][core][partition][tree][ownership]")
+{
+  InfoNode root;
+  auto* childA = new InfoNode({}, 10);
+  auto* childB = new InfoNode({}, 20);
+  root.addChild(childA);
+  root.addChild(childB);
+
+  root.releaseChildren();
+
+  CHECK(root.childDegree() == 0);
+  CHECK(root.firstChild == nullptr);
+  CHECK(root.lastChild == nullptr);
+  CHECK(childA->stateId == 10);
+  CHECK(childB->stateId == 20);
+  CHECK(childA->parent == &root);
+  CHECK(childB->parent == &root);
+  CHECK(childA->next == childB);
+  CHECK(childB->previous == childA);
+
+  delete childA;
+  delete childB;
+}
+
 TEST_CASE("Reinitializing a network clears collapsed root children [fast][core][partition][tree]")
 {
   InfomapWrapper im(infomap::test::defaultFlags());
@@ -227,6 +251,24 @@ TEST_CASE("InfoNode deleteChildren also clears collapsed children [fast][core][p
   CHECK(root.childDegree() == 0);
   CHECK(root.firstChild == nullptr);
   CHECK(root.collapsedFirstChild != nullptr);
+
+  root.deleteChildren();
+
+  CHECK(root.childDegree() == 0);
+  CHECK(root.firstChild == nullptr);
+  CHECK(root.lastChild == nullptr);
+  CHECK(root.collapsedFirstChild == nullptr);
+  CHECK(root.collapsedLastChild == nullptr);
+}
+
+TEST_CASE("InfoNode deleteChildren clears both active and collapsed child chains [fast][core][partition][tree][ownership]")
+{
+  InfoNode root;
+  root.addChild(new InfoNode({}, 10));
+  root.addChild(new InfoNode({}, 20));
+
+  CHECK(root.collapseChildren() == 2);
+  root.addChild(new InfoNode({}, 30));
 
   root.deleteChildren();
 
@@ -290,6 +332,75 @@ TEST_CASE("InfoNode replace mutations preserve flattened tree structure [fast][c
     CHECK(child.parent == &root);
     CHECK(child.isLeaf());
   }
+}
+
+TEST_CASE("InfoNode replaceWithChildren reparents a middle child chain before deleting the module [fast][core][partition][tree][ownership]")
+{
+  InfoNode root;
+  auto* before = new InfoNode({}, 10);
+  auto* module = new InfoNode({}, 20);
+  auto* after = new InfoNode({}, 30);
+  root.addChild(before);
+  root.addChild(module);
+  root.addChild(after);
+  module->addChild(new InfoNode({}, 1));
+  module->addChild(new InfoNode({}, 2));
+
+  CHECK(module->replaceWithChildren() == 1);
+
+  CHECK(childStateIds(root) == std::vector<unsigned int> { 10, 1, 2, 30 });
+  CHECK(root.firstChild == before);
+  CHECK(root.lastChild == after);
+  CHECK(before->next->stateId == 1);
+  CHECK(before->next->parent == &root);
+  CHECK(before->next->next->stateId == 2);
+  CHECK(before->next->next->parent == &root);
+  CHECK(before->next->next->next == after);
+  CHECK(after->previous->stateId == 2);
+}
+
+TEST_CASE("InfoNode remove documents current child-chain ownership semantics [fast][core][partition][tree][ownership]")
+{
+  InfoNode deleteRoot;
+  auto* deletingParent = new InfoNode({}, 10);
+  deletingParent->addChild(new InfoNode({}, 11));
+  deleteRoot.addChild(deletingParent);
+
+  deletingParent->remove(false);
+
+  CHECK(deleteRoot.firstChild == nullptr);
+  CHECK(deleteRoot.lastChild == nullptr);
+
+  InfoNode detachRoot;
+  auto* detachingParent = new InfoNode({}, 20);
+  auto* detachedChild = new InfoNode({}, 21);
+  detachingParent->addChild(detachedChild);
+  detachRoot.addChild(detachingParent);
+
+  detachingParent->remove(true);
+
+  CHECK(detachRoot.firstChild == nullptr);
+  CHECK(detachRoot.lastChild == nullptr);
+  CHECK(detachedChild->stateId == 21);
+
+  detachedChild->parent = nullptr;
+  detachedChild->previous = nullptr;
+  detachedChild->next = nullptr;
+  delete detachedChild;
+}
+
+TEST_CASE("InfoNode owns outgoing edges while incoming edges are non-owning references [fast][core][partition][tree][ownership]")
+{
+  auto* source = new InfoNode({}, 10);
+  InfoNode target({}, 20);
+  source->addOutEdge(target, 1.0, 0.5);
+
+  CHECK(source->outDegree() == 1);
+  CHECK(target.inDegree() == 1);
+
+  delete source;
+
+  CHECK(target.inDegree() == 1);
 }
 
 TEST_CASE("Soft cluster-data can be optimized away when it is suboptimal [fast][core][partition]")


### PR DESCRIPTION
## Summary

- Document the current raw-pointer ownership contract for `InfoNode` near the type definition.
- Add focused C++ tests for active/collapsed child chains, detach/delete semantics, reparenting, and outgoing edge ownership.
- Preserve existing runtime behavior; no ownership refactor or public API change.

## Verification

- `make test-native CTEST_ARGS='-R infomap_cpp_partition_tests --output-on-failure'`
- `make test-native`
- `make test-sanitizers`

## Notes

- The tests document the current `remove(bool)` behavior: `remove(false)` deletes the child chain through the destructor, while `remove(true)` detaches the child chain before deleting the node.
