### PR TITLE
refactor: own sub infomap with unique_ptr

### DIFF
--- a/interfaces/python/generated/infomap_wrap.cpp
+++ b/interfaces/python/generated/infomap_wrap.cpp
@@ -3492,74 +3492,75 @@ SWIG_Python_NonDynamicSetAttr(PyObject *obj, PyObject *name, PyObject *value) {
 #define SWIGTYPE_p_infomap__InfoEdge swig_types[46]
 #define SWIGTYPE_p_infomap__InfoNode swig_types[47]
 #define SWIGTYPE_p_infomap__InfomapBase swig_types[48]
-#define SWIGTYPE_p_infomap__InfomapConfigT_infomap__InfomapBase_t swig_types[49]
-#define SWIGTYPE_p_infomap__InfomapIterator swig_types[50]
-#define SWIGTYPE_p_infomap__InfomapIteratorPhysical swig_types[51]
-#define SWIGTYPE_p_infomap__InfomapLeafIterator swig_types[52]
-#define SWIGTYPE_p_infomap__InfomapLeafIteratorPhysical swig_types[53]
-#define SWIGTYPE_p_infomap__InfomapLeafModuleIterator swig_types[54]
-#define SWIGTYPE_p_infomap__InfomapModuleIterator swig_types[55]
-#define SWIGTYPE_p_infomap__InfomapParentIterator swig_types[56]
-#define SWIGTYPE_p_infomap__InfomapWrapper swig_types[57]
-#define SWIGTYPE_p_infomap__LayerNode swig_types[58]
-#define SWIGTYPE_p_infomap__MemDeltaFlow swig_types[59]
-#define SWIGTYPE_p_infomap__Network swig_types[60]
-#define SWIGTYPE_p_infomap__PhysData swig_types[61]
-#define SWIGTYPE_p_infomap__StateNetwork swig_types[62]
-#define SWIGTYPE_p_infomap__StateNetwork__PhysNode swig_types[63]
-#define SWIGTYPE_p_infomap__StateNetwork__StateNode swig_types[64]
-#define SWIGTYPE_p_infomap__detail__PartitionQueue swig_types[65]
-#define SWIGTYPE_p_infomap__detail__PerLevelStat swig_types[66]
-#define SWIGTYPE_p_infomap_child_iterator swig_types[67]
-#define SWIGTYPE_p_infomap_child_iterator_wrapper swig_types[68]
-#define SWIGTYPE_p_infomap_iterator_wrapper swig_types[69]
-#define SWIGTYPE_p_key_type swig_types[70]
-#define SWIGTYPE_p_leaf_module_iterator swig_types[71]
-#define SWIGTYPE_p_leaf_node_iterator swig_types[72]
-#define SWIGTYPE_p_mapped_type swig_types[73]
-#define SWIGTYPE_p_p_PyObject swig_types[74]
-#define SWIGTYPE_p_post_depth_first_iterator swig_types[75]
-#define SWIGTYPE_p_second_type swig_types[76]
-#define SWIGTYPE_p_size_t swig_types[77]
-#define SWIGTYPE_p_size_type swig_types[78]
-#define SWIGTYPE_p_std__allocatorT_double_t swig_types[79]
-#define SWIGTYPE_p_std__allocatorT_std__pairT_std__pairT_unsigned_int_unsigned_int_t_const_double_t_t swig_types[80]
-#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_std__string_t_t swig_types[81]
-#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_std__vectorT_unsigned_int_t_t_t swig_types[82]
-#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t swig_types[83]
-#define SWIGTYPE_p_std__allocatorT_unsigned_int_t swig_types[84]
-#define SWIGTYPE_p_std__dequeT_infomap__InfoNode_p_std__allocatorT_infomap__InfoNode_p_t_t__size_type swig_types[85]
-#define SWIGTYPE_p_std__dequeT_unsigned_int_t swig_types[86]
-#define SWIGTYPE_p_std__invalid_argument swig_types[87]
-#define SWIGTYPE_p_std__lessT_std__pairT_unsigned_int_unsigned_int_t_t swig_types[88]
-#define SWIGTYPE_p_std__lessT_unsigned_int_t swig_types[89]
-#define SWIGTYPE_p_std__mapT_infomap__StateNetwork__StateNode_std__mapT_infomap__StateNetwork__StateNode_infomap__StateNetwork__LinkData_std__lessT_infomap__StateNetwork__StateNode_t_std__allocatorT_std__pairT_infomap__StateNetwork__StateNode_const_infomap__StateNetwork__LinkData_t_t_t_std__lessT_infomap__StateNetwork__StateNode_t_std__allocatorT_std__pairT_infomap__StateNetwork__StateNode_const_std__mapT_infomap__StateNetwork__StateNode_infomap__StateNetwork__LinkData_std__lessT_infomap__StateNetwork__StateNode_t_std__allocatorT_std__pairT_infomap__StateNetwork__StateNode_const_infomap__StateNetwork__LinkData_t_t_t_t_t_t swig_types[90]
-#define SWIGTYPE_p_std__mapT_std__pairT_unsigned_int_unsigned_int_t_double_t swig_types[91]
-#define SWIGTYPE_p_std__mapT_unsigned_int_double_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_double_t_t_t swig_types[92]
-#define SWIGTYPE_p_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t swig_types[93]
-#define SWIGTYPE_p_std__mapT_unsigned_int_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t_t_t_t swig_types[94]
-#define SWIGTYPE_p_std__mapT_unsigned_int_std__string_t swig_types[95]
-#define SWIGTYPE_p_std__mapT_unsigned_int_std__vectorT_int_std__allocatorT_int_t_t_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_std__vectorT_int_std__allocatorT_int_t_t_t_t_t swig_types[96]
-#define SWIGTYPE_p_std__mapT_unsigned_int_std__vectorT_unsigned_int_t_t swig_types[97]
-#define SWIGTYPE_p_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t swig_types[98]
-#define SWIGTYPE_p_std__ostream swig_types[99]
-#define SWIGTYPE_p_std__pairT_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t__iterator_bool_t swig_types[100]
-#define SWIGTYPE_p_std__pairT_std__mapT_unsigned_int_std__string_t__iterator_bool_t swig_types[101]
-#define SWIGTYPE_p_std__pairT_unsigned_int_unsigned_int_t swig_types[102]
-#define SWIGTYPE_p_std__vectorT_ParsedOption_std__allocatorT_ParsedOption_t_t swig_types[103]
-#define SWIGTYPE_p_std__vectorT_double_t swig_types[104]
-#define SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator swig_types[105]
-#define SWIGTYPE_p_std__vectorT_infomap__InfoNode_p_std__allocatorT_infomap__InfoNode_p_t_t swig_types[106]
-#define SWIGTYPE_p_std__vectorT_infomap__PhysData_std__allocatorT_infomap__PhysData_t_t swig_types[107]
-#define SWIGTYPE_p_std__vectorT_infomap__detail__PerLevelStat_std__allocatorT_infomap__detail__PerLevelStat_t_t swig_types[108]
-#define SWIGTYPE_p_std__vectorT_int_std__allocatorT_int_t_t swig_types[109]
-#define SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t swig_types[110]
-#define SWIGTYPE_p_std__vectorT_unsigned_int_t swig_types[111]
-#define SWIGTYPE_p_swig__SwigPyIterator swig_types[112]
-#define SWIGTYPE_p_tree_iterator swig_types[113]
-#define SWIGTYPE_p_value_type swig_types[114]
-static swig_type_info *swig_types[116];
-static swig_module_info swig_module = {swig_types, 115, 0, 0, 0, 0};
+#define SWIGTYPE_p_infomap__InfomapBaseDeleter swig_types[49]
+#define SWIGTYPE_p_infomap__InfomapConfigT_infomap__InfomapBase_t swig_types[50]
+#define SWIGTYPE_p_infomap__InfomapIterator swig_types[51]
+#define SWIGTYPE_p_infomap__InfomapIteratorPhysical swig_types[52]
+#define SWIGTYPE_p_infomap__InfomapLeafIterator swig_types[53]
+#define SWIGTYPE_p_infomap__InfomapLeafIteratorPhysical swig_types[54]
+#define SWIGTYPE_p_infomap__InfomapLeafModuleIterator swig_types[55]
+#define SWIGTYPE_p_infomap__InfomapModuleIterator swig_types[56]
+#define SWIGTYPE_p_infomap__InfomapParentIterator swig_types[57]
+#define SWIGTYPE_p_infomap__InfomapWrapper swig_types[58]
+#define SWIGTYPE_p_infomap__LayerNode swig_types[59]
+#define SWIGTYPE_p_infomap__MemDeltaFlow swig_types[60]
+#define SWIGTYPE_p_infomap__Network swig_types[61]
+#define SWIGTYPE_p_infomap__PhysData swig_types[62]
+#define SWIGTYPE_p_infomap__StateNetwork swig_types[63]
+#define SWIGTYPE_p_infomap__StateNetwork__PhysNode swig_types[64]
+#define SWIGTYPE_p_infomap__StateNetwork__StateNode swig_types[65]
+#define SWIGTYPE_p_infomap__detail__PartitionQueue swig_types[66]
+#define SWIGTYPE_p_infomap__detail__PerLevelStat swig_types[67]
+#define SWIGTYPE_p_infomap_child_iterator swig_types[68]
+#define SWIGTYPE_p_infomap_child_iterator_wrapper swig_types[69]
+#define SWIGTYPE_p_infomap_iterator_wrapper swig_types[70]
+#define SWIGTYPE_p_key_type swig_types[71]
+#define SWIGTYPE_p_leaf_module_iterator swig_types[72]
+#define SWIGTYPE_p_leaf_node_iterator swig_types[73]
+#define SWIGTYPE_p_mapped_type swig_types[74]
+#define SWIGTYPE_p_p_PyObject swig_types[75]
+#define SWIGTYPE_p_post_depth_first_iterator swig_types[76]
+#define SWIGTYPE_p_second_type swig_types[77]
+#define SWIGTYPE_p_size_t swig_types[78]
+#define SWIGTYPE_p_size_type swig_types[79]
+#define SWIGTYPE_p_std__allocatorT_double_t swig_types[80]
+#define SWIGTYPE_p_std__allocatorT_std__pairT_std__pairT_unsigned_int_unsigned_int_t_const_double_t_t swig_types[81]
+#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_std__string_t_t swig_types[82]
+#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_std__vectorT_unsigned_int_t_t_t swig_types[83]
+#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t swig_types[84]
+#define SWIGTYPE_p_std__allocatorT_unsigned_int_t swig_types[85]
+#define SWIGTYPE_p_std__dequeT_infomap__InfoNode_p_std__allocatorT_infomap__InfoNode_p_t_t__size_type swig_types[86]
+#define SWIGTYPE_p_std__dequeT_unsigned_int_t swig_types[87]
+#define SWIGTYPE_p_std__invalid_argument swig_types[88]
+#define SWIGTYPE_p_std__lessT_std__pairT_unsigned_int_unsigned_int_t_t swig_types[89]
+#define SWIGTYPE_p_std__lessT_unsigned_int_t swig_types[90]
+#define SWIGTYPE_p_std__mapT_infomap__StateNetwork__StateNode_std__mapT_infomap__StateNetwork__StateNode_infomap__StateNetwork__LinkData_std__lessT_infomap__StateNetwork__StateNode_t_std__allocatorT_std__pairT_infomap__StateNetwork__StateNode_const_infomap__StateNetwork__LinkData_t_t_t_std__lessT_infomap__StateNetwork__StateNode_t_std__allocatorT_std__pairT_infomap__StateNetwork__StateNode_const_std__mapT_infomap__StateNetwork__StateNode_infomap__StateNetwork__LinkData_std__lessT_infomap__StateNetwork__StateNode_t_std__allocatorT_std__pairT_infomap__StateNetwork__StateNode_const_infomap__StateNetwork__LinkData_t_t_t_t_t_t swig_types[91]
+#define SWIGTYPE_p_std__mapT_std__pairT_unsigned_int_unsigned_int_t_double_t swig_types[92]
+#define SWIGTYPE_p_std__mapT_unsigned_int_double_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_double_t_t_t swig_types[93]
+#define SWIGTYPE_p_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t swig_types[94]
+#define SWIGTYPE_p_std__mapT_unsigned_int_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t_t_t_t swig_types[95]
+#define SWIGTYPE_p_std__mapT_unsigned_int_std__string_t swig_types[96]
+#define SWIGTYPE_p_std__mapT_unsigned_int_std__vectorT_int_std__allocatorT_int_t_t_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_std__vectorT_int_std__allocatorT_int_t_t_t_t_t swig_types[97]
+#define SWIGTYPE_p_std__mapT_unsigned_int_std__vectorT_unsigned_int_t_t swig_types[98]
+#define SWIGTYPE_p_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t swig_types[99]
+#define SWIGTYPE_p_std__ostream swig_types[100]
+#define SWIGTYPE_p_std__pairT_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t__iterator_bool_t swig_types[101]
+#define SWIGTYPE_p_std__pairT_std__mapT_unsigned_int_std__string_t__iterator_bool_t swig_types[102]
+#define SWIGTYPE_p_std__pairT_unsigned_int_unsigned_int_t swig_types[103]
+#define SWIGTYPE_p_std__vectorT_ParsedOption_std__allocatorT_ParsedOption_t_t swig_types[104]
+#define SWIGTYPE_p_std__vectorT_double_t swig_types[105]
+#define SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator swig_types[106]
+#define SWIGTYPE_p_std__vectorT_infomap__InfoNode_p_std__allocatorT_infomap__InfoNode_p_t_t swig_types[107]
+#define SWIGTYPE_p_std__vectorT_infomap__PhysData_std__allocatorT_infomap__PhysData_t_t swig_types[108]
+#define SWIGTYPE_p_std__vectorT_infomap__detail__PerLevelStat_std__allocatorT_infomap__detail__PerLevelStat_t_t swig_types[109]
+#define SWIGTYPE_p_std__vectorT_int_std__allocatorT_int_t_t swig_types[110]
+#define SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t swig_types[111]
+#define SWIGTYPE_p_std__vectorT_unsigned_int_t swig_types[112]
+#define SWIGTYPE_p_swig__SwigPyIterator swig_types[113]
+#define SWIGTYPE_p_tree_iterator swig_types[114]
+#define SWIGTYPE_p_value_type swig_types[115]
+static swig_type_info *swig_types[117];
+static swig_module_info swig_module = {swig_types, 116, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -18024,6 +18025,102 @@ SWIGINTERN PyObject *vector_uint_swigregister(PyObject *SWIGUNUSEDPARM(self), Py
 }
 
 SWIGINTERN PyObject *vector_uint_swiginit(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  return SWIG_Python_InitShadowInstance(args);
+}
+
+SWIGINTERN PyObject *_wrap_InfomapBaseDeleter___call__(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  infomap::InfomapBaseDeleter *arg1 = 0 ;
+  infomap::InfomapBase *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject *swig_obj[2] ;
+  
+  (void)self;
+  if (!SWIG_Python_UnpackTuple(args, "InfomapBaseDeleter___call__", 2, 2, swig_obj)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__InfomapBaseDeleter, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapBaseDeleter___call__" "', argument " "1"" of type '" "infomap::InfomapBaseDeleter const *""'"); 
+  }
+  arg1 = reinterpret_cast< infomap::InfomapBaseDeleter * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2,SWIGTYPE_p_infomap__InfomapBase, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "InfomapBaseDeleter___call__" "', argument " "2"" of type '" "infomap::InfomapBase *""'"); 
+  }
+  arg2 = reinterpret_cast< infomap::InfomapBase * >(argp2);
+  {
+    try {
+      ((infomap::InfomapBaseDeleter const *)arg1)->operator ()(arg2);
+    } catch (const std::exception& e) {
+      SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_InfomapBaseDeleter(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  infomap::InfomapBaseDeleter *result = 0 ;
+  
+  (void)self;
+  if (!SWIG_Python_UnpackTuple(args, "new_InfomapBaseDeleter", 0, 0, 0)) SWIG_fail;
+  {
+    try {
+      result = (infomap::InfomapBaseDeleter *)new infomap::InfomapBaseDeleter();
+    } catch (const std::exception& e) {
+      SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_infomap__InfomapBaseDeleter, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_InfomapBaseDeleter(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  infomap::InfomapBaseDeleter *arg1 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  
+  (void)self;
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__InfomapBaseDeleter, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_InfomapBaseDeleter" "', argument " "1"" of type '" "infomap::InfomapBaseDeleter *""'"); 
+  }
+  arg1 = reinterpret_cast< infomap::InfomapBaseDeleter * >(argp1);
+  {
+    try {
+      delete arg1;
+    } catch (const std::exception& e) {
+      SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *InfomapBaseDeleter_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj = NULL;
+  if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_infomap__InfomapBaseDeleter, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *InfomapBaseDeleter_swiginit(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   return SWIG_Python_InitShadowInstance(args);
 }
 
@@ -57142,6 +57239,11 @@ static PyMethodDef SwigMethods[] = {
 	 { "delete_vector_uint", _wrap_delete_vector_uint, METH_O, NULL},
 	 { "vector_uint_swigregister", vector_uint_swigregister, METH_O, NULL},
 	 { "vector_uint_swiginit", vector_uint_swiginit, METH_VARARGS, NULL},
+	 { "InfomapBaseDeleter___call__", _wrap_InfomapBaseDeleter___call__, METH_VARARGS, NULL},
+	 { "new_InfomapBaseDeleter", _wrap_new_InfomapBaseDeleter, METH_NOARGS, NULL},
+	 { "delete_InfomapBaseDeleter", _wrap_delete_InfomapBaseDeleter, METH_O, NULL},
+	 { "InfomapBaseDeleter_swigregister", InfomapBaseDeleter_swigregister, METH_O, NULL},
+	 { "InfomapBaseDeleter_swiginit", InfomapBaseDeleter_swiginit, METH_VARARGS, NULL},
 	 { "InfoNode_data_set", _wrap_InfoNode_data_set, METH_VARARGS, NULL},
 	 { "InfoNode_data_get", _wrap_InfoNode_data_get, METH_O, NULL},
 	 { "InfoNode_index_set", _wrap_InfoNode_index_set, METH_VARARGS, NULL},
@@ -58018,6 +58120,7 @@ static swig_type_info _swigt__p_infomap__FlowModel = {"_p_infomap__FlowModel", "
 static swig_type_info _swigt__p_infomap__InfoEdge = {"_p_infomap__InfoEdge", "infomap::InfoEdge *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_infomap__InfoNode = {"_p_infomap__InfoNode", "infomap::InfoNode *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_infomap__InfomapBase = {"_p_infomap__InfomapBase", "infomap::InfomapBase *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_infomap__InfomapBaseDeleter = {"_p_infomap__InfomapBaseDeleter", "infomap::InfomapBaseDeleter *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_infomap__InfomapConfigT_infomap__InfomapBase_t = {"_p_infomap__InfomapConfigT_infomap__InfomapBase_t", "infomap::InfomapConfig< infomap::InfomapBase > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_infomap__InfomapIterator = {"_p_infomap__InfomapIterator", "infomap::InfomapIterator *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_infomap__InfomapIteratorPhysical = {"_p_infomap__InfomapIteratorPhysical", "infomap::InfomapIteratorPhysical *", 0, 0, (void*)0, 0};
@@ -58135,6 +58238,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_infomap__InfoEdge,
   &_swigt__p_infomap__InfoNode,
   &_swigt__p_infomap__InfomapBase,
+  &_swigt__p_infomap__InfomapBaseDeleter,
   &_swigt__p_infomap__InfomapConfigT_infomap__InfomapBase_t,
   &_swigt__p_infomap__InfomapIterator,
   &_swigt__p_infomap__InfomapIteratorPhysical,
@@ -58252,6 +58356,7 @@ static swig_cast_info _swigc__p_infomap__FlowModel[] = {  {&_swigt__p_infomap__F
 static swig_cast_info _swigc__p_infomap__InfoEdge[] = {  {&_swigt__p_infomap__InfoEdge, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_infomap__InfoNode[] = {  {&_swigt__p_infomap__InfoNode, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_infomap__InfomapBase[] = {  {&_swigt__p_infomap__InfomapBase, 0, 0, 0},  {&_swigt__p_infomap__InfomapWrapper, _p_infomap__InfomapWrapperTo_p_infomap__InfomapBase, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_infomap__InfomapBaseDeleter[] = {  {&_swigt__p_infomap__InfomapBaseDeleter, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_infomap__InfomapConfigT_infomap__InfomapBase_t[] = {  {&_swigt__p_infomap__InfomapConfigT_infomap__InfomapBase_t, 0, 0, 0},  {&_swigt__p_infomap__InfomapBase, _p_infomap__InfomapBaseTo_p_infomap__InfomapConfigT_infomap__InfomapBase_t, 0, 0},  {&_swigt__p_infomap__InfomapWrapper, _p_infomap__InfomapWrapperTo_p_infomap__InfomapConfigT_infomap__InfomapBase_t, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_infomap__InfomapIterator[] = {  {&_swigt__p_infomap__InfomapIterator, 0, 0, 0},  {&_swigt__p_infomap__InfomapIteratorPhysical, _p_infomap__InfomapIteratorPhysicalTo_p_infomap__InfomapIterator, 0, 0},  {&_swigt__p_infomap__InfomapLeafIterator, _p_infomap__InfomapLeafIteratorTo_p_infomap__InfomapIterator, 0, 0},  {&_swigt__p_infomap__InfomapLeafIteratorPhysical, _p_infomap__InfomapLeafIteratorPhysicalTo_p_infomap__InfomapIterator, 0, 0},  {&_swigt__p_infomap__InfomapLeafModuleIterator, _p_infomap__InfomapLeafModuleIteratorTo_p_infomap__InfomapIterator, 0, 0},  {&_swigt__p_infomap__InfomapModuleIterator, _p_infomap__InfomapModuleIteratorTo_p_infomap__InfomapIterator, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_infomap__InfomapIteratorPhysical[] = {  {&_swigt__p_infomap__InfomapIteratorPhysical, 0, 0, 0},  {&_swigt__p_infomap__InfomapLeafIteratorPhysical, _p_infomap__InfomapLeafIteratorPhysicalTo_p_infomap__InfomapIteratorPhysical, 0, 0},{0, 0, 0, 0}};
@@ -58369,6 +58474,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_infomap__InfoEdge,
   _swigc__p_infomap__InfoNode,
   _swigc__p_infomap__InfomapBase,
+  _swigc__p_infomap__InfomapBaseDeleter,
   _swigc__p_infomap__InfomapConfigT_infomap__InfomapBase_t,
   _swigc__p_infomap__InfomapIterator,
   _swigc__p_infomap__InfomapIteratorPhysical,

--- a/interfaces/python/src/infomap/_swig.py
+++ b/interfaces/python/src/infomap/_swig.py
@@ -503,6 +503,19 @@ class vector_uint(object):
 
 # Register vector_uint in _infomap:
 _infomap.vector_uint_swigregister(vector_uint)
+class InfomapBaseDeleter(object):
+    thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
+    __repr__ = _swig_repr
+
+    def __call__(self, infomap):
+        return _infomap.InfomapBaseDeleter___call__(self, infomap)
+
+    def __init__(self):
+        _infomap.InfomapBaseDeleter_swiginit(self, _infomap.new_InfomapBaseDeleter())
+    __swig_destroy__ = _infomap.delete_InfomapBaseDeleter
+
+# Register InfomapBaseDeleter in _infomap:
+_infomap.InfomapBaseDeleter_swigregister(InfomapBaseDeleter)
 class InfoNode(object):
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
     __repr__ = _swig_repr

--- a/src/core/InfoNode.cpp
+++ b/src/core/InfoNode.cpp
@@ -13,12 +13,13 @@
 
 namespace infomap {
 
+void InfomapBaseDeleter::operator()(InfomapBase* infomap) const noexcept
+{
+  delete infomap;
+}
+
 InfoNode::~InfoNode() noexcept
 {
-  if (m_infomap != nullptr) {
-    delete m_infomap;
-  }
-
   deleteChildren();
 
   if (next != nullptr)
@@ -43,8 +44,7 @@ InfoNode::~InfoNode() noexcept
 
 InfomapBase& InfoNode::setInfomap(InfomapBase* infomap)
 {
-  disposeInfomap();
-  m_infomap = infomap;
+  m_infomap.reset(infomap);
   if (infomap == nullptr)
     throw std::logic_error("InfoNode::setInfomap(...) called with null infomap");
   return *m_infomap;
@@ -77,8 +77,7 @@ InfoNode const* InfoNode::getInfomapRoot() const noexcept
 bool InfoNode::disposeInfomap() noexcept
 {
   if (m_infomap != nullptr) {
-    delete m_infomap;
-    m_infomap = nullptr;
+    m_infomap.reset();
     return true;
   }
   return false;

--- a/src/core/InfoNode.h
+++ b/src/core/InfoNode.h
@@ -26,6 +26,10 @@ namespace infomap {
 
 class InfomapBase;
 
+struct InfomapBaseDeleter {
+  void operator()(InfomapBase* infomap) const noexcept;
+};
+
 /**
  * Tree node with raw-pointer ownership.
  *
@@ -34,8 +38,9 @@ class InfomapBase;
  * collapsedLastChild. Destruction deletes both chains. releaseChildren() only
  * detaches the active chain from this parent; the caller must reattach or delete
  * those nodes. Reparenting helpers detach children before deleting the removed
- * intermediate node. An InfoNode also owns its sub-Infomap pointer and outgoing
- * InfoEdge objects; incoming edge pointers are non-owning back-references.
+ * intermediate node. An InfoNode also owns its sub-Infomap through a unique_ptr
+ * and owns outgoing InfoEdge objects; incoming edge pointers are non-owning
+ * back-references.
  */
 class InfoNode {
 public:
@@ -101,7 +106,7 @@ private:
   std::vector<InfoEdge*> m_outEdges;
   std::vector<InfoEdge*> m_inEdges;
 
-  InfomapBase* m_infomap = nullptr;
+  std::unique_ptr<InfomapBase, InfomapBaseDeleter> m_infomap;
 
 public:
   InfoNode(const FlowData& flowData)

--- a/test/cpp/test_infomap_wrapper.cpp
+++ b/test/cpp/test_infomap_wrapper.cpp
@@ -336,6 +336,31 @@ TEST_CASE("Subnetwork reuse and dispose stay stable on the same parent module [f
   CHECK(module.getInfomapRoot() == nullptr);
 }
 
+TEST_CASE("Subnetwork ownership replaces and disposes the module Infomap instance [fast][core][lifecycle][subnetwork]")
+{
+  InfomapWrapper im(infomap::test::defaultFlags());
+  im.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+  im.run();
+
+  infomap::test::checkRunSanity(im);
+  REQUIRE(im.numTopModules() == 2);
+
+  auto& module = *im.root().firstChild;
+
+  auto& firstSubInfomap = im.getSubInfomap(module).initNetwork(module);
+  REQUIRE(module.getInfomapRoot() == &firstSubInfomap.root());
+  REQUIRE(firstSubInfomap.root().owner == &module);
+
+  auto& replacementSubInfomap = im.getSubInfomap(module).initNetwork(module);
+  CHECK(module.getInfomapRoot() == &replacementSubInfomap.root());
+  CHECK(replacementSubInfomap.root().owner == &module);
+  CHECK(replacementSubInfomap.numLeafNodes() == module.childDegree());
+
+  CHECK(module.disposeInfomap());
+  CHECK(module.getInfomapRoot() == nullptr);
+  CHECK_FALSE(module.disposeInfomap());
+}
+
 TEST_CASE("Higher-order subnetwork rebuild preserves state identities and internal edges [fast][core][lifecycle][subnetwork]")
 {
   InfomapWrapper im(infomap::test::defaultFlags());


### PR DESCRIPTION
## Summary

- Stack this PR on #440 (`fix/cpp17-baseline`).
- Move `InfoNode` sub-Infomap ownership from a private raw pointer to `std::unique_ptr` with an out-of-line deleter.
- Preserve the existing public methods and raw-pointer call sites while keeping child-chain and edge ownership unchanged.

## Verification

- `make test-native CTEST_ARGS='-R infomap_cpp_lifecycle_tests --output-on-failure'`
- `make test-native`
- `make test-sanitizers`

## Notes

- #440 was rebased on latest `master` and force-pushed with lease before creating this stack branch.
- The custom deleter keeps `InfomapBase` forward-declared in `InfoNode.h` while allowing `unique_ptr` cleanup in `InfoNode.cpp`, where `InfomapBase` is complete.
