### PR TITLE
refactor: own outgoing edges with unique_ptr

### DIFF
--- a/interfaces/python/generated/infomap_wrap.cpp
+++ b/interfaces/python/generated/infomap_wrap.cpp
@@ -3454,113 +3454,119 @@ SWIG_Python_NonDynamicSetAttr(PyObject *obj, PyObject *name, PyObject *value) {
 #define SWIGTYPE_p_IterWrapperT_InfomapChildIteratorT_infomap__InfoNode_p_t_t swig_types[8]
 #define SWIGTYPE_p_IterWrapperT_TreeIteratorT_infomap__InfoNode_const_p_t_t swig_types[9]
 #define SWIGTYPE_p_IterWrapperT_TreeIteratorT_infomap__InfoNode_p_t_t swig_types[10]
-#define SWIGTYPE_p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t swig_types[11]
-#define SWIGTYPE_p_LeafModuleIteratorT_infomap__InfoNode_p_t swig_types[12]
-#define SWIGTYPE_p_LeafNodeIteratorT_infomap__InfoNode_p_t swig_types[13]
-#define SWIGTYPE_p_MetaCollection swig_types[14]
-#define SWIGTYPE_p_NodeLinkMap swig_types[15]
-#define SWIGTYPE_p_NodeMap swig_types[16]
-#define SWIGTYPE_p_OutLinkMap swig_types[17]
-#define SWIGTYPE_p_PartitionQueue swig_types[18]
-#define SWIGTYPE_p_Stopwatch swig_types[19]
-#define SWIGTYPE_p_TreeIteratorT_infomap__InfoNode_const_p_t swig_types[20]
-#define SWIGTYPE_p_TreeIteratorT_infomap__InfoNode_p_t swig_types[21]
-#define SWIGTYPE_p_allocator_type swig_types[22]
-#define SWIGTYPE_p_char swig_types[23]
-#define SWIGTYPE_p_child_iterator swig_types[24]
-#define SWIGTYPE_p_child_iterator_wrapper swig_types[25]
-#define SWIGTYPE_p_const_child_iterator swig_types[26]
-#define SWIGTYPE_p_const_child_iterator_wrapper swig_types[27]
-#define SWIGTYPE_p_const_edge_iterator swig_types[28]
-#define SWIGTYPE_p_const_edge_iterator_wrapper swig_types[29]
-#define SWIGTYPE_p_const_infomap_child_iterator swig_types[30]
-#define SWIGTYPE_p_const_infomap_child_iterator_wrapper swig_types[31]
-#define SWIGTYPE_p_const_infomap_iterator_wrapper swig_types[32]
-#define SWIGTYPE_p_const_leaf_module_iterator swig_types[33]
-#define SWIGTYPE_p_const_leaf_node_iterator swig_types[34]
-#define SWIGTYPE_p_const_post_depth_first_iterator swig_types[35]
-#define SWIGTYPE_p_const_tree_iterator swig_types[36]
-#define SWIGTYPE_p_difference_type swig_types[37]
-#define SWIGTYPE_p_edge_iterator swig_types[38]
-#define SWIGTYPE_p_edge_iterator_wrapper swig_types[39]
-#define SWIGTYPE_p_first_type swig_types[40]
-#define SWIGTYPE_p_infomap__Config swig_types[41]
-#define SWIGTYPE_p_infomap__DeltaFlow swig_types[42]
-#define SWIGTYPE_p_infomap__EdgeData swig_types[43]
-#define SWIGTYPE_p_infomap__FlowData swig_types[44]
-#define SWIGTYPE_p_infomap__FlowModel swig_types[45]
-#define SWIGTYPE_p_infomap__InfoEdge swig_types[46]
-#define SWIGTYPE_p_infomap__InfoNode swig_types[47]
-#define SWIGTYPE_p_infomap__InfomapBase swig_types[48]
-#define SWIGTYPE_p_infomap__InfomapBaseDeleter swig_types[49]
-#define SWIGTYPE_p_infomap__InfomapConfigT_infomap__InfomapBase_t swig_types[50]
-#define SWIGTYPE_p_infomap__InfomapIterator swig_types[51]
-#define SWIGTYPE_p_infomap__InfomapIteratorPhysical swig_types[52]
-#define SWIGTYPE_p_infomap__InfomapLeafIterator swig_types[53]
-#define SWIGTYPE_p_infomap__InfomapLeafIteratorPhysical swig_types[54]
-#define SWIGTYPE_p_infomap__InfomapLeafModuleIterator swig_types[55]
-#define SWIGTYPE_p_infomap__InfomapModuleIterator swig_types[56]
-#define SWIGTYPE_p_infomap__InfomapParentIterator swig_types[57]
-#define SWIGTYPE_p_infomap__InfomapWrapper swig_types[58]
-#define SWIGTYPE_p_infomap__LayerNode swig_types[59]
-#define SWIGTYPE_p_infomap__MemDeltaFlow swig_types[60]
-#define SWIGTYPE_p_infomap__Network swig_types[61]
-#define SWIGTYPE_p_infomap__PhysData swig_types[62]
-#define SWIGTYPE_p_infomap__StateNetwork swig_types[63]
-#define SWIGTYPE_p_infomap__StateNetwork__PhysNode swig_types[64]
-#define SWIGTYPE_p_infomap__StateNetwork__StateNode swig_types[65]
-#define SWIGTYPE_p_infomap__detail__PartitionQueue swig_types[66]
-#define SWIGTYPE_p_infomap__detail__PerLevelStat swig_types[67]
-#define SWIGTYPE_p_infomap_child_iterator swig_types[68]
-#define SWIGTYPE_p_infomap_child_iterator_wrapper swig_types[69]
-#define SWIGTYPE_p_infomap_iterator_wrapper swig_types[70]
-#define SWIGTYPE_p_key_type swig_types[71]
-#define SWIGTYPE_p_leaf_module_iterator swig_types[72]
-#define SWIGTYPE_p_leaf_node_iterator swig_types[73]
-#define SWIGTYPE_p_mapped_type swig_types[74]
-#define SWIGTYPE_p_p_PyObject swig_types[75]
-#define SWIGTYPE_p_post_depth_first_iterator swig_types[76]
-#define SWIGTYPE_p_second_type swig_types[77]
-#define SWIGTYPE_p_size_t swig_types[78]
-#define SWIGTYPE_p_size_type swig_types[79]
-#define SWIGTYPE_p_std__allocatorT_double_t swig_types[80]
-#define SWIGTYPE_p_std__allocatorT_std__pairT_std__pairT_unsigned_int_unsigned_int_t_const_double_t_t swig_types[81]
-#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_std__string_t_t swig_types[82]
-#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_std__vectorT_unsigned_int_t_t_t swig_types[83]
-#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t swig_types[84]
-#define SWIGTYPE_p_std__allocatorT_unsigned_int_t swig_types[85]
-#define SWIGTYPE_p_std__dequeT_infomap__InfoNode_p_std__allocatorT_infomap__InfoNode_p_t_t__size_type swig_types[86]
-#define SWIGTYPE_p_std__dequeT_unsigned_int_t swig_types[87]
-#define SWIGTYPE_p_std__invalid_argument swig_types[88]
-#define SWIGTYPE_p_std__lessT_std__pairT_unsigned_int_unsigned_int_t_t swig_types[89]
-#define SWIGTYPE_p_std__lessT_unsigned_int_t swig_types[90]
-#define SWIGTYPE_p_std__mapT_infomap__StateNetwork__StateNode_std__mapT_infomap__StateNetwork__StateNode_infomap__StateNetwork__LinkData_std__lessT_infomap__StateNetwork__StateNode_t_std__allocatorT_std__pairT_infomap__StateNetwork__StateNode_const_infomap__StateNetwork__LinkData_t_t_t_std__lessT_infomap__StateNetwork__StateNode_t_std__allocatorT_std__pairT_infomap__StateNetwork__StateNode_const_std__mapT_infomap__StateNetwork__StateNode_infomap__StateNetwork__LinkData_std__lessT_infomap__StateNetwork__StateNode_t_std__allocatorT_std__pairT_infomap__StateNetwork__StateNode_const_infomap__StateNetwork__LinkData_t_t_t_t_t_t swig_types[91]
-#define SWIGTYPE_p_std__mapT_std__pairT_unsigned_int_unsigned_int_t_double_t swig_types[92]
-#define SWIGTYPE_p_std__mapT_unsigned_int_double_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_double_t_t_t swig_types[93]
-#define SWIGTYPE_p_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t swig_types[94]
-#define SWIGTYPE_p_std__mapT_unsigned_int_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t_t_t_t swig_types[95]
-#define SWIGTYPE_p_std__mapT_unsigned_int_std__string_t swig_types[96]
-#define SWIGTYPE_p_std__mapT_unsigned_int_std__vectorT_int_std__allocatorT_int_t_t_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_std__vectorT_int_std__allocatorT_int_t_t_t_t_t swig_types[97]
-#define SWIGTYPE_p_std__mapT_unsigned_int_std__vectorT_unsigned_int_t_t swig_types[98]
-#define SWIGTYPE_p_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t swig_types[99]
-#define SWIGTYPE_p_std__ostream swig_types[100]
-#define SWIGTYPE_p_std__pairT_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t__iterator_bool_t swig_types[101]
-#define SWIGTYPE_p_std__pairT_std__mapT_unsigned_int_std__string_t__iterator_bool_t swig_types[102]
-#define SWIGTYPE_p_std__pairT_unsigned_int_unsigned_int_t swig_types[103]
-#define SWIGTYPE_p_std__vectorT_ParsedOption_std__allocatorT_ParsedOption_t_t swig_types[104]
-#define SWIGTYPE_p_std__vectorT_double_t swig_types[105]
-#define SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator swig_types[106]
-#define SWIGTYPE_p_std__vectorT_infomap__InfoNode_p_std__allocatorT_infomap__InfoNode_p_t_t swig_types[107]
-#define SWIGTYPE_p_std__vectorT_infomap__PhysData_std__allocatorT_infomap__PhysData_t_t swig_types[108]
-#define SWIGTYPE_p_std__vectorT_infomap__detail__PerLevelStat_std__allocatorT_infomap__detail__PerLevelStat_t_t swig_types[109]
-#define SWIGTYPE_p_std__vectorT_int_std__allocatorT_int_t_t swig_types[110]
-#define SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t swig_types[111]
-#define SWIGTYPE_p_std__vectorT_unsigned_int_t swig_types[112]
-#define SWIGTYPE_p_swig__SwigPyIterator swig_types[113]
-#define SWIGTYPE_p_tree_iterator swig_types[114]
-#define SWIGTYPE_p_value_type swig_types[115]
-static swig_type_info *swig_types[117];
-static swig_module_info swig_module = {swig_types, 116, 0, 0, 0, 0};
+#define SWIGTYPE_p_IterWrapperT_infomap__OwnedEdgePtrIteratorT_std__vectorT_std__unique_ptrT_infomap__InfoEdge_t_std__allocatorT_std__unique_ptrT_infomap__InfoEdge_t_t_t__iterator_t_t swig_types[11]
+#define SWIGTYPE_p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t swig_types[12]
+#define SWIGTYPE_p_LeafModuleIteratorT_infomap__InfoNode_p_t swig_types[13]
+#define SWIGTYPE_p_LeafNodeIteratorT_infomap__InfoNode_p_t swig_types[14]
+#define SWIGTYPE_p_MetaCollection swig_types[15]
+#define SWIGTYPE_p_NodeLinkMap swig_types[16]
+#define SWIGTYPE_p_NodeMap swig_types[17]
+#define SWIGTYPE_p_OutLinkMap swig_types[18]
+#define SWIGTYPE_p_PartitionQueue swig_types[19]
+#define SWIGTYPE_p_Stopwatch swig_types[20]
+#define SWIGTYPE_p_TreeIteratorT_infomap__InfoNode_const_p_t swig_types[21]
+#define SWIGTYPE_p_TreeIteratorT_infomap__InfoNode_p_t swig_types[22]
+#define SWIGTYPE_p_allocator_type swig_types[23]
+#define SWIGTYPE_p_char swig_types[24]
+#define SWIGTYPE_p_child_iterator swig_types[25]
+#define SWIGTYPE_p_child_iterator_wrapper swig_types[26]
+#define SWIGTYPE_p_const_child_iterator swig_types[27]
+#define SWIGTYPE_p_const_child_iterator_wrapper swig_types[28]
+#define SWIGTYPE_p_const_edge_iterator swig_types[29]
+#define SWIGTYPE_p_const_edge_iterator_wrapper swig_types[30]
+#define SWIGTYPE_p_const_in_edge_iterator swig_types[31]
+#define SWIGTYPE_p_const_in_edge_iterator_wrapper swig_types[32]
+#define SWIGTYPE_p_const_infomap_child_iterator swig_types[33]
+#define SWIGTYPE_p_const_infomap_child_iterator_wrapper swig_types[34]
+#define SWIGTYPE_p_const_infomap_iterator_wrapper swig_types[35]
+#define SWIGTYPE_p_const_leaf_module_iterator swig_types[36]
+#define SWIGTYPE_p_const_leaf_node_iterator swig_types[37]
+#define SWIGTYPE_p_const_post_depth_first_iterator swig_types[38]
+#define SWIGTYPE_p_const_tree_iterator swig_types[39]
+#define SWIGTYPE_p_difference_type swig_types[40]
+#define SWIGTYPE_p_edge_iterator swig_types[41]
+#define SWIGTYPE_p_edge_iterator_wrapper swig_types[42]
+#define SWIGTYPE_p_first_type swig_types[43]
+#define SWIGTYPE_p_in_edge_iterator swig_types[44]
+#define SWIGTYPE_p_in_edge_iterator_wrapper swig_types[45]
+#define SWIGTYPE_p_infomap__Config swig_types[46]
+#define SWIGTYPE_p_infomap__DeltaFlow swig_types[47]
+#define SWIGTYPE_p_infomap__EdgeData swig_types[48]
+#define SWIGTYPE_p_infomap__FlowData swig_types[49]
+#define SWIGTYPE_p_infomap__FlowModel swig_types[50]
+#define SWIGTYPE_p_infomap__InfoEdge swig_types[51]
+#define SWIGTYPE_p_infomap__InfoNode swig_types[52]
+#define SWIGTYPE_p_infomap__InfomapBase swig_types[53]
+#define SWIGTYPE_p_infomap__InfomapBaseDeleter swig_types[54]
+#define SWIGTYPE_p_infomap__InfomapConfigT_infomap__InfomapBase_t swig_types[55]
+#define SWIGTYPE_p_infomap__InfomapIterator swig_types[56]
+#define SWIGTYPE_p_infomap__InfomapIteratorPhysical swig_types[57]
+#define SWIGTYPE_p_infomap__InfomapLeafIterator swig_types[58]
+#define SWIGTYPE_p_infomap__InfomapLeafIteratorPhysical swig_types[59]
+#define SWIGTYPE_p_infomap__InfomapLeafModuleIterator swig_types[60]
+#define SWIGTYPE_p_infomap__InfomapModuleIterator swig_types[61]
+#define SWIGTYPE_p_infomap__InfomapParentIterator swig_types[62]
+#define SWIGTYPE_p_infomap__InfomapWrapper swig_types[63]
+#define SWIGTYPE_p_infomap__LayerNode swig_types[64]
+#define SWIGTYPE_p_infomap__MemDeltaFlow swig_types[65]
+#define SWIGTYPE_p_infomap__Network swig_types[66]
+#define SWIGTYPE_p_infomap__OwnedEdgePtrIteratorT_std__vectorT_std__unique_ptrT_infomap__InfoEdge_t_std__allocatorT_std__unique_ptrT_infomap__InfoEdge_t_t_t__iterator_t swig_types[67]
+#define SWIGTYPE_p_infomap__PhysData swig_types[68]
+#define SWIGTYPE_p_infomap__StateNetwork swig_types[69]
+#define SWIGTYPE_p_infomap__StateNetwork__PhysNode swig_types[70]
+#define SWIGTYPE_p_infomap__StateNetwork__StateNode swig_types[71]
+#define SWIGTYPE_p_infomap__detail__PartitionQueue swig_types[72]
+#define SWIGTYPE_p_infomap__detail__PerLevelStat swig_types[73]
+#define SWIGTYPE_p_infomap_child_iterator swig_types[74]
+#define SWIGTYPE_p_infomap_child_iterator_wrapper swig_types[75]
+#define SWIGTYPE_p_infomap_iterator_wrapper swig_types[76]
+#define SWIGTYPE_p_key_type swig_types[77]
+#define SWIGTYPE_p_leaf_module_iterator swig_types[78]
+#define SWIGTYPE_p_leaf_node_iterator swig_types[79]
+#define SWIGTYPE_p_mapped_type swig_types[80]
+#define SWIGTYPE_p_p_PyObject swig_types[81]
+#define SWIGTYPE_p_post_depth_first_iterator swig_types[82]
+#define SWIGTYPE_p_second_type swig_types[83]
+#define SWIGTYPE_p_size_t swig_types[84]
+#define SWIGTYPE_p_size_type swig_types[85]
+#define SWIGTYPE_p_std__allocatorT_double_t swig_types[86]
+#define SWIGTYPE_p_std__allocatorT_std__pairT_std__pairT_unsigned_int_unsigned_int_t_const_double_t_t swig_types[87]
+#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_std__string_t_t swig_types[88]
+#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_std__vectorT_unsigned_int_t_t_t swig_types[89]
+#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t swig_types[90]
+#define SWIGTYPE_p_std__allocatorT_unsigned_int_t swig_types[91]
+#define SWIGTYPE_p_std__dequeT_infomap__InfoNode_p_std__allocatorT_infomap__InfoNode_p_t_t__size_type swig_types[92]
+#define SWIGTYPE_p_std__dequeT_unsigned_int_t swig_types[93]
+#define SWIGTYPE_p_std__invalid_argument swig_types[94]
+#define SWIGTYPE_p_std__lessT_std__pairT_unsigned_int_unsigned_int_t_t swig_types[95]
+#define SWIGTYPE_p_std__lessT_unsigned_int_t swig_types[96]
+#define SWIGTYPE_p_std__mapT_infomap__StateNetwork__StateNode_std__mapT_infomap__StateNetwork__StateNode_infomap__StateNetwork__LinkData_std__lessT_infomap__StateNetwork__StateNode_t_std__allocatorT_std__pairT_infomap__StateNetwork__StateNode_const_infomap__StateNetwork__LinkData_t_t_t_std__lessT_infomap__StateNetwork__StateNode_t_std__allocatorT_std__pairT_infomap__StateNetwork__StateNode_const_std__mapT_infomap__StateNetwork__StateNode_infomap__StateNetwork__LinkData_std__lessT_infomap__StateNetwork__StateNode_t_std__allocatorT_std__pairT_infomap__StateNetwork__StateNode_const_infomap__StateNetwork__LinkData_t_t_t_t_t_t swig_types[97]
+#define SWIGTYPE_p_std__mapT_std__pairT_unsigned_int_unsigned_int_t_double_t swig_types[98]
+#define SWIGTYPE_p_std__mapT_unsigned_int_double_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_double_t_t_t swig_types[99]
+#define SWIGTYPE_p_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t swig_types[100]
+#define SWIGTYPE_p_std__mapT_unsigned_int_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t_t_t_t swig_types[101]
+#define SWIGTYPE_p_std__mapT_unsigned_int_std__string_t swig_types[102]
+#define SWIGTYPE_p_std__mapT_unsigned_int_std__vectorT_int_std__allocatorT_int_t_t_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_std__vectorT_int_std__allocatorT_int_t_t_t_t_t swig_types[103]
+#define SWIGTYPE_p_std__mapT_unsigned_int_std__vectorT_unsigned_int_t_t swig_types[104]
+#define SWIGTYPE_p_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t swig_types[105]
+#define SWIGTYPE_p_std__ostream swig_types[106]
+#define SWIGTYPE_p_std__pairT_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t__iterator_bool_t swig_types[107]
+#define SWIGTYPE_p_std__pairT_std__mapT_unsigned_int_std__string_t__iterator_bool_t swig_types[108]
+#define SWIGTYPE_p_std__pairT_unsigned_int_unsigned_int_t swig_types[109]
+#define SWIGTYPE_p_std__vectorT_ParsedOption_std__allocatorT_ParsedOption_t_t swig_types[110]
+#define SWIGTYPE_p_std__vectorT_double_t swig_types[111]
+#define SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator swig_types[112]
+#define SWIGTYPE_p_std__vectorT_infomap__InfoNode_p_std__allocatorT_infomap__InfoNode_p_t_t swig_types[113]
+#define SWIGTYPE_p_std__vectorT_infomap__PhysData_std__allocatorT_infomap__PhysData_t_t swig_types[114]
+#define SWIGTYPE_p_std__vectorT_infomap__detail__PerLevelStat_std__allocatorT_infomap__detail__PerLevelStat_t_t swig_types[115]
+#define SWIGTYPE_p_std__vectorT_int_std__allocatorT_int_t_t swig_types[116]
+#define SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t swig_types[117]
+#define SWIGTYPE_p_std__vectorT_unsigned_int_t swig_types[118]
+#define SWIGTYPE_p_swig__SwigPyIterator swig_types[119]
+#define SWIGTYPE_p_tree_iterator swig_types[120]
+#define SWIGTYPE_p_value_type swig_types[121]
+static swig_type_info *swig_types[123];
+static swig_module_info swig_module = {swig_types, 122, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -21030,7 +21036,7 @@ SWIGINTERN PyObject *_wrap_InfoNode_begin_outEdge(PyObject *self, PyObject *args
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject *swig_obj[1] ;
-  SwigValueWrapper< std::vector< infomap::InfoEdge *,std::allocator< infomap::InfoEdge * > >::iterator > result;
+  SwigValueWrapper< infomap::OwnedEdgePtrIterator< std::vector< std::unique_ptr< infomap::InfoEdge >,std::allocator< std::unique_ptr< infomap::InfoEdge > > >::iterator > > result;
   
   (void)self;
   if (!args) SWIG_fail;
@@ -21047,7 +21053,7 @@ SWIGINTERN PyObject *_wrap_InfoNode_begin_outEdge(PyObject *self, PyObject *args
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator(result)), SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator(result)), SWIGTYPE_p_infomap__OwnedEdgePtrIteratorT_std__vectorT_std__unique_ptrT_infomap__InfoEdge_t_std__allocatorT_std__unique_ptrT_infomap__InfoEdge_t_t_t__iterator_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -21060,7 +21066,7 @@ SWIGINTERN PyObject *_wrap_InfoNode_end_outEdge(PyObject *self, PyObject *args) 
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject *swig_obj[1] ;
-  SwigValueWrapper< std::vector< infomap::InfoEdge *,std::allocator< infomap::InfoEdge * > >::iterator > result;
+  SwigValueWrapper< infomap::OwnedEdgePtrIterator< std::vector< std::unique_ptr< infomap::InfoEdge >,std::allocator< std::unique_ptr< infomap::InfoEdge > > >::iterator > > result;
   
   (void)self;
   if (!args) SWIG_fail;
@@ -21077,7 +21083,7 @@ SWIGINTERN PyObject *_wrap_InfoNode_end_outEdge(PyObject *self, PyObject *args) 
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator(result)), SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator(result)), SWIGTYPE_p_infomap__OwnedEdgePtrIteratorT_std__vectorT_std__unique_ptrT_infomap__InfoEdge_t_std__allocatorT_std__unique_ptrT_infomap__InfoEdge_t_t_t__iterator_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -21107,7 +21113,7 @@ SWIGINTERN PyObject *_wrap_InfoNode_begin_inEdge(PyObject *self, PyObject *args)
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator(result)), SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::in_edge_iterator(result)), SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -21137,7 +21143,7 @@ SWIGINTERN PyObject *_wrap_InfoNode_end_inEdge(PyObject *self, PyObject *args) {
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator(result)), SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::in_edge_iterator(result)), SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -21150,7 +21156,7 @@ SWIGINTERN PyObject *_wrap_InfoNode_outEdges(PyObject *self, PyObject *args) {
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject *swig_obj[1] ;
-  SwigValueWrapper< IterWrapper< std::vector< infomap::InfoEdge *,std::allocator< infomap::InfoEdge * > >::iterator > > result;
+  SwigValueWrapper< IterWrapper< infomap::OwnedEdgePtrIterator< std::vector< std::unique_ptr< infomap::InfoEdge >,std::allocator< std::unique_ptr< infomap::InfoEdge > > >::iterator > > > result;
   
   (void)self;
   if (!args) SWIG_fail;
@@ -21167,7 +21173,7 @@ SWIGINTERN PyObject *_wrap_InfoNode_outEdges(PyObject *self, PyObject *args) {
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator_wrapper(result)), SWIGTYPE_p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator_wrapper(result)), SWIGTYPE_p_IterWrapperT_infomap__OwnedEdgePtrIteratorT_std__vectorT_std__unique_ptrT_infomap__InfoEdge_t_std__allocatorT_std__unique_ptrT_infomap__InfoEdge_t_t_t__iterator_t_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -21197,7 +21203,7 @@ SWIGINTERN PyObject *_wrap_InfoNode_inEdges(PyObject *self, PyObject *args) {
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator_wrapper(result)), SWIGTYPE_p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::in_edge_iterator_wrapper(result)), SWIGTYPE_p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -28257,7 +28263,7 @@ SWIGINTERN PyObject *_wrap_InfomapIterator_begin_outEdge(PyObject *self, PyObjec
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject *swig_obj[1] ;
-  SwigValueWrapper< std::vector< infomap::InfoEdge *,std::allocator< infomap::InfoEdge * > >::iterator > result;
+  SwigValueWrapper< infomap::OwnedEdgePtrIterator< std::vector< std::unique_ptr< infomap::InfoEdge >,std::allocator< std::unique_ptr< infomap::InfoEdge > > >::iterator > > result;
   
   (void)self;
   if (!args) SWIG_fail;
@@ -28274,7 +28280,7 @@ SWIGINTERN PyObject *_wrap_InfomapIterator_begin_outEdge(PyObject *self, PyObjec
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator(result)), SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator(result)), SWIGTYPE_p_infomap__OwnedEdgePtrIteratorT_std__vectorT_std__unique_ptrT_infomap__InfoEdge_t_std__allocatorT_std__unique_ptrT_infomap__InfoEdge_t_t_t__iterator_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -28287,7 +28293,7 @@ SWIGINTERN PyObject *_wrap_InfomapIterator_end_outEdge(PyObject *self, PyObject 
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject *swig_obj[1] ;
-  SwigValueWrapper< std::vector< infomap::InfoEdge *,std::allocator< infomap::InfoEdge * > >::iterator > result;
+  SwigValueWrapper< infomap::OwnedEdgePtrIterator< std::vector< std::unique_ptr< infomap::InfoEdge >,std::allocator< std::unique_ptr< infomap::InfoEdge > > >::iterator > > result;
   
   (void)self;
   if (!args) SWIG_fail;
@@ -28304,7 +28310,7 @@ SWIGINTERN PyObject *_wrap_InfomapIterator_end_outEdge(PyObject *self, PyObject 
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator(result)), SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator(result)), SWIGTYPE_p_infomap__OwnedEdgePtrIteratorT_std__vectorT_std__unique_ptrT_infomap__InfoEdge_t_std__allocatorT_std__unique_ptrT_infomap__InfoEdge_t_t_t__iterator_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -28334,7 +28340,7 @@ SWIGINTERN PyObject *_wrap_InfomapIterator_begin_inEdge(PyObject *self, PyObject
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator(result)), SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::in_edge_iterator(result)), SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -28364,7 +28370,7 @@ SWIGINTERN PyObject *_wrap_InfomapIterator_end_inEdge(PyObject *self, PyObject *
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator(result)), SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::in_edge_iterator(result)), SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -28377,7 +28383,7 @@ SWIGINTERN PyObject *_wrap_InfomapIterator_outEdges(PyObject *self, PyObject *ar
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject *swig_obj[1] ;
-  SwigValueWrapper< IterWrapper< std::vector< infomap::InfoEdge *,std::allocator< infomap::InfoEdge * > >::iterator > > result;
+  SwigValueWrapper< IterWrapper< infomap::OwnedEdgePtrIterator< std::vector< std::unique_ptr< infomap::InfoEdge >,std::allocator< std::unique_ptr< infomap::InfoEdge > > >::iterator > > > result;
   
   (void)self;
   if (!args) SWIG_fail;
@@ -28394,7 +28400,7 @@ SWIGINTERN PyObject *_wrap_InfomapIterator_outEdges(PyObject *self, PyObject *ar
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator_wrapper(result)), SWIGTYPE_p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator_wrapper(result)), SWIGTYPE_p_IterWrapperT_infomap__OwnedEdgePtrIteratorT_std__vectorT_std__unique_ptrT_infomap__InfoEdge_t_std__allocatorT_std__unique_ptrT_infomap__InfoEdge_t_t_t__iterator_t_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -28424,7 +28430,7 @@ SWIGINTERN PyObject *_wrap_InfomapIterator_inEdges(PyObject *self, PyObject *arg
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator_wrapper(result)), SWIGTYPE_p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::in_edge_iterator_wrapper(result)), SWIGTYPE_p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -35401,7 +35407,7 @@ SWIGINTERN PyObject *_wrap_InfomapParentIterator_begin_outEdge(PyObject *self, P
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject *swig_obj[1] ;
-  SwigValueWrapper< std::vector< infomap::InfoEdge *,std::allocator< infomap::InfoEdge * > >::iterator > result;
+  SwigValueWrapper< infomap::OwnedEdgePtrIterator< std::vector< std::unique_ptr< infomap::InfoEdge >,std::allocator< std::unique_ptr< infomap::InfoEdge > > >::iterator > > result;
   
   (void)self;
   if (!args) SWIG_fail;
@@ -35418,7 +35424,7 @@ SWIGINTERN PyObject *_wrap_InfomapParentIterator_begin_outEdge(PyObject *self, P
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator(result)), SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator(result)), SWIGTYPE_p_infomap__OwnedEdgePtrIteratorT_std__vectorT_std__unique_ptrT_infomap__InfoEdge_t_std__allocatorT_std__unique_ptrT_infomap__InfoEdge_t_t_t__iterator_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -35431,7 +35437,7 @@ SWIGINTERN PyObject *_wrap_InfomapParentIterator_end_outEdge(PyObject *self, PyO
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject *swig_obj[1] ;
-  SwigValueWrapper< std::vector< infomap::InfoEdge *,std::allocator< infomap::InfoEdge * > >::iterator > result;
+  SwigValueWrapper< infomap::OwnedEdgePtrIterator< std::vector< std::unique_ptr< infomap::InfoEdge >,std::allocator< std::unique_ptr< infomap::InfoEdge > > >::iterator > > result;
   
   (void)self;
   if (!args) SWIG_fail;
@@ -35448,7 +35454,7 @@ SWIGINTERN PyObject *_wrap_InfomapParentIterator_end_outEdge(PyObject *self, PyO
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator(result)), SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator(result)), SWIGTYPE_p_infomap__OwnedEdgePtrIteratorT_std__vectorT_std__unique_ptrT_infomap__InfoEdge_t_std__allocatorT_std__unique_ptrT_infomap__InfoEdge_t_t_t__iterator_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -35478,7 +35484,7 @@ SWIGINTERN PyObject *_wrap_InfomapParentIterator_begin_inEdge(PyObject *self, Py
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator(result)), SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::in_edge_iterator(result)), SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -35508,7 +35514,7 @@ SWIGINTERN PyObject *_wrap_InfomapParentIterator_end_inEdge(PyObject *self, PyOb
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator(result)), SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::in_edge_iterator(result)), SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -35521,7 +35527,7 @@ SWIGINTERN PyObject *_wrap_InfomapParentIterator_outEdges(PyObject *self, PyObje
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject *swig_obj[1] ;
-  SwigValueWrapper< IterWrapper< std::vector< infomap::InfoEdge *,std::allocator< infomap::InfoEdge * > >::iterator > > result;
+  SwigValueWrapper< IterWrapper< infomap::OwnedEdgePtrIterator< std::vector< std::unique_ptr< infomap::InfoEdge >,std::allocator< std::unique_ptr< infomap::InfoEdge > > >::iterator > > > result;
   
   (void)self;
   if (!args) SWIG_fail;
@@ -35538,7 +35544,7 @@ SWIGINTERN PyObject *_wrap_InfomapParentIterator_outEdges(PyObject *self, PyObje
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator_wrapper(result)), SWIGTYPE_p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator_wrapper(result)), SWIGTYPE_p_IterWrapperT_infomap__OwnedEdgePtrIteratorT_std__vectorT_std__unique_ptrT_infomap__InfoEdge_t_std__allocatorT_std__unique_ptrT_infomap__InfoEdge_t_t_t__iterator_t_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -35568,7 +35574,7 @@ SWIGINTERN PyObject *_wrap_InfomapParentIterator_inEdges(PyObject *self, PyObjec
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::edge_iterator_wrapper(result)), SWIGTYPE_p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new infomap::InfoNode::in_edge_iterator_wrapper(result)), SWIGTYPE_p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -58082,7 +58088,8 @@ static swig_type_info _swigt__p_IterWrapperT_InfomapChildIteratorT_infomap__Info
 static swig_type_info _swigt__p_IterWrapperT_InfomapChildIteratorT_infomap__InfoNode_p_t_t = {"_p_IterWrapperT_InfomapChildIteratorT_infomap__InfoNode_p_t_t", "infomap::InfoNode::infomap_child_iterator_wrapper *|IterWrapper< InfomapChildIterator< infomap::InfoNode * > > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_IterWrapperT_TreeIteratorT_infomap__InfoNode_const_p_t_t = {"_p_IterWrapperT_TreeIteratorT_infomap__InfoNode_const_p_t_t", "infomap::InfoNode::const_infomap_iterator_wrapper *|IterWrapper< TreeIterator< infomap::InfoNode const * > > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_IterWrapperT_TreeIteratorT_infomap__InfoNode_p_t_t = {"_p_IterWrapperT_TreeIteratorT_infomap__InfoNode_p_t_t", "infomap::InfoNode::infomap_iterator_wrapper *|IterWrapper< TreeIterator< infomap::InfoNode * > > *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t = {"_p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t", "infomap::InfoNode::edge_iterator_wrapper *|IterWrapper< std::vector< infomap::InfoEdge *,std::allocator< infomap::InfoEdge * > >::iterator > *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_IterWrapperT_infomap__OwnedEdgePtrIteratorT_std__vectorT_std__unique_ptrT_infomap__InfoEdge_t_std__allocatorT_std__unique_ptrT_infomap__InfoEdge_t_t_t__iterator_t_t = {"_p_IterWrapperT_infomap__OwnedEdgePtrIteratorT_std__vectorT_std__unique_ptrT_infomap__InfoEdge_t_std__allocatorT_std__unique_ptrT_infomap__InfoEdge_t_t_t__iterator_t_t", "infomap::InfoNode::edge_iterator_wrapper *|IterWrapper< infomap::OwnedEdgePtrIterator< std::vector< std::unique_ptr< infomap::InfoEdge >,std::allocator< std::unique_ptr< infomap::InfoEdge > > >::iterator > > *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t = {"_p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t", "infomap::InfoNode::in_edge_iterator_wrapper *|IterWrapper< std::vector< infomap::InfoEdge *,std::allocator< infomap::InfoEdge * > >::iterator > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_LeafModuleIteratorT_infomap__InfoNode_p_t = {"_p_LeafModuleIteratorT_infomap__InfoNode_p_t", "infomap::InfoNode::leaf_module_iterator *|LeafModuleIterator< infomap::InfoNode * > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_LeafNodeIteratorT_infomap__InfoNode_p_t = {"_p_LeafNodeIteratorT_infomap__InfoNode_p_t", "infomap::InfoNode::leaf_node_iterator *|LeafNodeIterator< infomap::InfoNode * > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_MetaCollection = {"_p_MetaCollection", "MetaCollection *", 0, 0, (void*)0, 0};
@@ -58101,6 +58108,8 @@ static swig_type_info _swigt__p_const_child_iterator = {"_p_const_child_iterator
 static swig_type_info _swigt__p_const_child_iterator_wrapper = {"_p_const_child_iterator_wrapper", "const_child_iterator_wrapper *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_const_edge_iterator = {"_p_const_edge_iterator", "const_edge_iterator *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_const_edge_iterator_wrapper = {"_p_const_edge_iterator_wrapper", "const_edge_iterator_wrapper *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_const_in_edge_iterator = {"_p_const_in_edge_iterator", "const_in_edge_iterator *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_const_in_edge_iterator_wrapper = {"_p_const_in_edge_iterator_wrapper", "const_in_edge_iterator_wrapper *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_const_infomap_child_iterator = {"_p_const_infomap_child_iterator", "const_infomap_child_iterator *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_const_infomap_child_iterator_wrapper = {"_p_const_infomap_child_iterator_wrapper", "const_infomap_child_iterator_wrapper *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_const_infomap_iterator_wrapper = {"_p_const_infomap_iterator_wrapper", "const_infomap_iterator_wrapper *", 0, 0, (void*)0, 0};
@@ -58112,6 +58121,8 @@ static swig_type_info _swigt__p_difference_type = {"_p_difference_type", "differ
 static swig_type_info _swigt__p_edge_iterator = {"_p_edge_iterator", "edge_iterator *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_edge_iterator_wrapper = {"_p_edge_iterator_wrapper", "edge_iterator_wrapper *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_first_type = {"_p_first_type", "first_type *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_in_edge_iterator = {"_p_in_edge_iterator", "in_edge_iterator *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_in_edge_iterator_wrapper = {"_p_in_edge_iterator_wrapper", "in_edge_iterator_wrapper *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_infomap__Config = {"_p_infomap__Config", "infomap::Config *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_infomap__DeltaFlow = {"_p_infomap__DeltaFlow", "infomap::DeltaFlow *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_infomap__EdgeData = {"_p_infomap__EdgeData", "infomap::EdgeData *", 0, 0, (void*)0, 0};
@@ -58133,6 +58144,7 @@ static swig_type_info _swigt__p_infomap__InfomapWrapper = {"_p_infomap__InfomapW
 static swig_type_info _swigt__p_infomap__LayerNode = {"_p_infomap__LayerNode", "infomap::LayerNode *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_infomap__MemDeltaFlow = {"_p_infomap__MemDeltaFlow", "infomap::MemDeltaFlow *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_infomap__Network = {"_p_infomap__Network", "infomap::Network *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_infomap__OwnedEdgePtrIteratorT_std__vectorT_std__unique_ptrT_infomap__InfoEdge_t_std__allocatorT_std__unique_ptrT_infomap__InfoEdge_t_t_t__iterator_t = {"_p_infomap__OwnedEdgePtrIteratorT_std__vectorT_std__unique_ptrT_infomap__InfoEdge_t_std__allocatorT_std__unique_ptrT_infomap__InfoEdge_t_t_t__iterator_t", "infomap::InfoNode::edge_iterator *|infomap::OwnedEdgePtrIterator< std::vector< std::unique_ptr< infomap::InfoEdge >,std::allocator< std::unique_ptr< infomap::InfoEdge > > >::iterator > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_infomap__PhysData = {"_p_infomap__PhysData", "infomap::PhysData *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_infomap__StateNetwork = {"_p_infomap__StateNetwork", "infomap::StateNetwork *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_infomap__StateNetwork__PhysNode = {"_p_infomap__StateNetwork__PhysNode", "infomap::StateNetwork::PhysNode *", 0, 0, (void*)0, 0};
@@ -58177,7 +58189,7 @@ static swig_type_info _swigt__p_std__pairT_std__mapT_unsigned_int_std__string_t_
 static swig_type_info _swigt__p_std__pairT_unsigned_int_unsigned_int_t = {"_p_std__pairT_unsigned_int_unsigned_int_t", "std::pair< unsigned int,unsigned int > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__vectorT_ParsedOption_std__allocatorT_ParsedOption_t_t = {"_p_std__vectorT_ParsedOption_std__allocatorT_ParsedOption_t_t", "std::vector< ParsedOption,std::allocator< ParsedOption > > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__vectorT_double_t = {"_p_std__vectorT_double_t", "std::vector< double,std::allocator< double > > *|std::vector< double > *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator = {"_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator", "infomap::InfoNode::edge_iterator *|std::vector< infomap::InfoEdge *,std::allocator< infomap::InfoEdge * > >::iterator *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator = {"_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator", "infomap::InfoNode::in_edge_iterator *|std::vector< infomap::InfoEdge *,std::allocator< infomap::InfoEdge * > >::iterator *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__vectorT_infomap__InfoNode_p_std__allocatorT_infomap__InfoNode_p_t_t = {"_p_std__vectorT_infomap__InfoNode_p_std__allocatorT_infomap__InfoNode_p_t_t", "std::vector< infomap::InfoNode *,std::allocator< infomap::InfoNode * > > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__vectorT_infomap__PhysData_std__allocatorT_infomap__PhysData_t_t = {"_p_std__vectorT_infomap__PhysData_std__allocatorT_infomap__PhysData_t_t", "std::vector< infomap::PhysData,std::allocator< infomap::PhysData > > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__vectorT_infomap__detail__PerLevelStat_std__allocatorT_infomap__detail__PerLevelStat_t_t = {"_p_std__vectorT_infomap__detail__PerLevelStat_std__allocatorT_infomap__detail__PerLevelStat_t_t", "std::vector< infomap::detail::PerLevelStat,std::allocator< infomap::detail::PerLevelStat > > *", 0, 0, (void*)0, 0};
@@ -58200,6 +58212,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_IterWrapperT_InfomapChildIteratorT_infomap__InfoNode_p_t_t,
   &_swigt__p_IterWrapperT_TreeIteratorT_infomap__InfoNode_const_p_t_t,
   &_swigt__p_IterWrapperT_TreeIteratorT_infomap__InfoNode_p_t_t,
+  &_swigt__p_IterWrapperT_infomap__OwnedEdgePtrIteratorT_std__vectorT_std__unique_ptrT_infomap__InfoEdge_t_std__allocatorT_std__unique_ptrT_infomap__InfoEdge_t_t_t__iterator_t_t,
   &_swigt__p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t,
   &_swigt__p_LeafModuleIteratorT_infomap__InfoNode_p_t,
   &_swigt__p_LeafNodeIteratorT_infomap__InfoNode_p_t,
@@ -58219,6 +58232,8 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_const_child_iterator_wrapper,
   &_swigt__p_const_edge_iterator,
   &_swigt__p_const_edge_iterator_wrapper,
+  &_swigt__p_const_in_edge_iterator,
+  &_swigt__p_const_in_edge_iterator_wrapper,
   &_swigt__p_const_infomap_child_iterator,
   &_swigt__p_const_infomap_child_iterator_wrapper,
   &_swigt__p_const_infomap_iterator_wrapper,
@@ -58230,6 +58245,8 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_edge_iterator,
   &_swigt__p_edge_iterator_wrapper,
   &_swigt__p_first_type,
+  &_swigt__p_in_edge_iterator,
+  &_swigt__p_in_edge_iterator_wrapper,
   &_swigt__p_infomap__Config,
   &_swigt__p_infomap__DeltaFlow,
   &_swigt__p_infomap__EdgeData,
@@ -58251,6 +58268,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_infomap__LayerNode,
   &_swigt__p_infomap__MemDeltaFlow,
   &_swigt__p_infomap__Network,
+  &_swigt__p_infomap__OwnedEdgePtrIteratorT_std__vectorT_std__unique_ptrT_infomap__InfoEdge_t_std__allocatorT_std__unique_ptrT_infomap__InfoEdge_t_t_t__iterator_t,
   &_swigt__p_infomap__PhysData,
   &_swigt__p_infomap__StateNetwork,
   &_swigt__p_infomap__StateNetwork__PhysNode,
@@ -58318,6 +58336,7 @@ static swig_cast_info _swigc__p_IterWrapperT_InfomapChildIteratorT_infomap__Info
 static swig_cast_info _swigc__p_IterWrapperT_InfomapChildIteratorT_infomap__InfoNode_p_t_t[] = {  {&_swigt__p_IterWrapperT_InfomapChildIteratorT_infomap__InfoNode_p_t_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_IterWrapperT_TreeIteratorT_infomap__InfoNode_const_p_t_t[] = {  {&_swigt__p_IterWrapperT_TreeIteratorT_infomap__InfoNode_const_p_t_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_IterWrapperT_TreeIteratorT_infomap__InfoNode_p_t_t[] = {  {&_swigt__p_IterWrapperT_TreeIteratorT_infomap__InfoNode_p_t_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_IterWrapperT_infomap__OwnedEdgePtrIteratorT_std__vectorT_std__unique_ptrT_infomap__InfoEdge_t_std__allocatorT_std__unique_ptrT_infomap__InfoEdge_t_t_t__iterator_t_t[] = {  {&_swigt__p_IterWrapperT_infomap__OwnedEdgePtrIteratorT_std__vectorT_std__unique_ptrT_infomap__InfoEdge_t_std__allocatorT_std__unique_ptrT_infomap__InfoEdge_t_t_t__iterator_t_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t[] = {  {&_swigt__p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_LeafModuleIteratorT_infomap__InfoNode_p_t[] = {  {&_swigt__p_LeafModuleIteratorT_infomap__InfoNode_p_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_LeafNodeIteratorT_infomap__InfoNode_p_t[] = {  {&_swigt__p_LeafNodeIteratorT_infomap__InfoNode_p_t, 0, 0, 0},{0, 0, 0, 0}};
@@ -58337,6 +58356,8 @@ static swig_cast_info _swigc__p_const_child_iterator[] = {  {&_swigt__p_const_ch
 static swig_cast_info _swigc__p_const_child_iterator_wrapper[] = {  {&_swigt__p_const_child_iterator_wrapper, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_const_edge_iterator[] = {  {&_swigt__p_const_edge_iterator, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_const_edge_iterator_wrapper[] = {  {&_swigt__p_const_edge_iterator_wrapper, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_const_in_edge_iterator[] = {  {&_swigt__p_const_in_edge_iterator, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_const_in_edge_iterator_wrapper[] = {  {&_swigt__p_const_in_edge_iterator_wrapper, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_const_infomap_child_iterator[] = {  {&_swigt__p_const_infomap_child_iterator, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_const_infomap_child_iterator_wrapper[] = {  {&_swigt__p_const_infomap_child_iterator_wrapper, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_const_infomap_iterator_wrapper[] = {  {&_swigt__p_const_infomap_iterator_wrapper, 0, 0, 0},{0, 0, 0, 0}};
@@ -58348,6 +58369,8 @@ static swig_cast_info _swigc__p_difference_type[] = {  {&_swigt__p_difference_ty
 static swig_cast_info _swigc__p_edge_iterator[] = {  {&_swigt__p_edge_iterator, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_edge_iterator_wrapper[] = {  {&_swigt__p_edge_iterator_wrapper, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_first_type[] = {  {&_swigt__p_first_type, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_in_edge_iterator[] = {  {&_swigt__p_in_edge_iterator, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_in_edge_iterator_wrapper[] = {  {&_swigt__p_in_edge_iterator_wrapper, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_infomap__Config[] = {  {&_swigt__p_infomap__Config, 0, 0, 0},  {&_swigt__p_infomap__InfomapBase, _p_infomap__InfomapBaseTo_p_infomap__Config, 0, 0},  {&_swigt__p_infomap__InfomapConfigT_infomap__InfomapBase_t, _p_infomap__InfomapConfigT_infomap__InfomapBase_tTo_p_infomap__Config, 0, 0},  {&_swigt__p_infomap__InfomapWrapper, _p_infomap__InfomapWrapperTo_p_infomap__Config, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_infomap__DeltaFlow[] = {  {&_swigt__p_infomap__DeltaFlow, 0, 0, 0},  {&_swigt__p_infomap__MemDeltaFlow, _p_infomap__MemDeltaFlowTo_p_infomap__DeltaFlow, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_infomap__EdgeData[] = {  {&_swigt__p_infomap__EdgeData, 0, 0, 0},{0, 0, 0, 0}};
@@ -58369,6 +58392,7 @@ static swig_cast_info _swigc__p_infomap__InfomapWrapper[] = {  {&_swigt__p_infom
 static swig_cast_info _swigc__p_infomap__LayerNode[] = {  {&_swigt__p_infomap__LayerNode, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_infomap__MemDeltaFlow[] = {  {&_swigt__p_infomap__MemDeltaFlow, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_infomap__Network[] = {  {&_swigt__p_infomap__Network, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_infomap__OwnedEdgePtrIteratorT_std__vectorT_std__unique_ptrT_infomap__InfoEdge_t_std__allocatorT_std__unique_ptrT_infomap__InfoEdge_t_t_t__iterator_t[] = {  {&_swigt__p_infomap__OwnedEdgePtrIteratorT_std__vectorT_std__unique_ptrT_infomap__InfoEdge_t_std__allocatorT_std__unique_ptrT_infomap__InfoEdge_t_t_t__iterator_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_infomap__PhysData[] = {  {&_swigt__p_infomap__PhysData, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_infomap__StateNetwork[] = {  {&_swigt__p_infomap__StateNetwork, 0, 0, 0},  {&_swigt__p_infomap__Network, _p_infomap__NetworkTo_p_infomap__StateNetwork, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_infomap__StateNetwork__PhysNode[] = {  {&_swigt__p_infomap__StateNetwork__PhysNode, 0, 0, 0},{0, 0, 0, 0}};
@@ -58436,6 +58460,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_IterWrapperT_InfomapChildIteratorT_infomap__InfoNode_p_t_t,
   _swigc__p_IterWrapperT_TreeIteratorT_infomap__InfoNode_const_p_t_t,
   _swigc__p_IterWrapperT_TreeIteratorT_infomap__InfoNode_p_t_t,
+  _swigc__p_IterWrapperT_infomap__OwnedEdgePtrIteratorT_std__vectorT_std__unique_ptrT_infomap__InfoEdge_t_std__allocatorT_std__unique_ptrT_infomap__InfoEdge_t_t_t__iterator_t_t,
   _swigc__p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t,
   _swigc__p_LeafModuleIteratorT_infomap__InfoNode_p_t,
   _swigc__p_LeafNodeIteratorT_infomap__InfoNode_p_t,
@@ -58455,6 +58480,8 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_const_child_iterator_wrapper,
   _swigc__p_const_edge_iterator,
   _swigc__p_const_edge_iterator_wrapper,
+  _swigc__p_const_in_edge_iterator,
+  _swigc__p_const_in_edge_iterator_wrapper,
   _swigc__p_const_infomap_child_iterator,
   _swigc__p_const_infomap_child_iterator_wrapper,
   _swigc__p_const_infomap_iterator_wrapper,
@@ -58466,6 +58493,8 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_edge_iterator,
   _swigc__p_edge_iterator_wrapper,
   _swigc__p_first_type,
+  _swigc__p_in_edge_iterator,
+  _swigc__p_in_edge_iterator_wrapper,
   _swigc__p_infomap__Config,
   _swigc__p_infomap__DeltaFlow,
   _swigc__p_infomap__EdgeData,
@@ -58487,6 +58516,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_infomap__LayerNode,
   _swigc__p_infomap__MemDeltaFlow,
   _swigc__p_infomap__Network,
+  _swigc__p_infomap__OwnedEdgePtrIteratorT_std__vectorT_std__unique_ptrT_infomap__InfoEdge_t_std__allocatorT_std__unique_ptrT_infomap__InfoEdge_t_t_t__iterator_t,
   _swigc__p_infomap__PhysData,
   _swigc__p_infomap__StateNetwork,
   _swigc__p_infomap__StateNetwork__PhysNode,

--- a/src/core/InfoNode.cpp
+++ b/src/core/InfoNode.cpp
@@ -33,13 +33,7 @@ InfoNode::~InfoNode() noexcept
       parent->lastChild = previous;
   }
 
-  // Delete outgoing edges.
-  // TODO: Renders ingoing edges invalid. Assume or assert that all nodes on the same level are deleted?
-  for (edge_iterator outEdgeIt(begin_outEdge());
-       outEdgeIt != end_outEdge();
-       ++outEdgeIt) {
-    delete *outEdgeIt;
-  }
+  // Incoming edge pointers on other nodes become dangling non-owning back-references.
 }
 
 InfomapBase& InfoNode::setInfomap(InfomapBase* infomap)

--- a/src/core/InfoNode.h
+++ b/src/core/InfoNode.h
@@ -30,6 +30,25 @@ struct InfomapBaseDeleter {
   void operator()(InfomapBase* infomap) const noexcept;
 };
 
+template <typename Iter>
+class OwnedEdgePtrIterator {
+  Iter m_current;
+
+public:
+  explicit OwnedEdgePtrIterator(Iter current) : m_current(current) { }
+
+  InfoEdge* operator*() const noexcept { return m_current->get(); }
+
+  OwnedEdgePtrIterator& operator++() noexcept
+  {
+    ++m_current;
+    return *this;
+  }
+
+  bool operator==(const OwnedEdgePtrIterator& other) const noexcept { return m_current == other.m_current; }
+  bool operator!=(const OwnedEdgePtrIterator& other) const noexcept { return m_current != other.m_current; }
+};
+
 /**
  * Tree node with raw-pointer ownership.
  *
@@ -38,8 +57,8 @@ struct InfomapBaseDeleter {
  * collapsedLastChild. Destruction deletes both chains. releaseChildren() only
  * detaches the active chain from this parent; the caller must reattach or delete
  * those nodes. Reparenting helpers detach children before deleting the removed
- * intermediate node. An InfoNode also owns its sub-Infomap through a unique_ptr
- * and owns outgoing InfoEdge objects; incoming edge pointers are non-owning
+ * intermediate node. An InfoNode also owns its sub-Infomap and outgoing
+ * InfoEdge objects through unique_ptr; incoming edge pointers are non-owning
  * back-references.
  */
 class InfoNode {
@@ -60,11 +79,15 @@ public:
   using post_depth_first_iterator = DepthFirstIterator<InfoNode*, false>;
   using const_post_depth_first_iterator = DepthFirstIterator<InfoNode const*, false>;
 
-  using edge_iterator = std::vector<InfoEdge*>::iterator;
-  using const_edge_iterator = std::vector<InfoEdge*>::const_iterator;
+  using edge_iterator = OwnedEdgePtrIterator<std::vector<std::unique_ptr<InfoEdge>>::iterator>;
+  using const_edge_iterator = OwnedEdgePtrIterator<std::vector<std::unique_ptr<InfoEdge>>::const_iterator>;
+  using in_edge_iterator = std::vector<InfoEdge*>::iterator;
+  using const_in_edge_iterator = std::vector<InfoEdge*>::const_iterator;
 
   using edge_iterator_wrapper = IterWrapper<edge_iterator>;
   using const_edge_iterator_wrapper = IterWrapper<const_edge_iterator>;
+  using in_edge_iterator_wrapper = IterWrapper<in_edge_iterator>;
+  using const_in_edge_iterator_wrapper = IterWrapper<const_in_edge_iterator>;
 
   using infomap_iterator_wrapper = IterWrapper<tree_iterator>;
   using const_infomap_iterator_wrapper = IterWrapper<const_tree_iterator>;
@@ -103,7 +126,7 @@ private:
   bool m_childrenChanged = false;
   unsigned int m_numLeafMembers = 0;
 
-  std::vector<InfoEdge*> m_outEdges;
+  std::vector<std::unique_ptr<InfoEdge>> m_outEdges;
   std::vector<InfoEdge*> m_inEdges;
 
   std::unique_ptr<InfomapBase, InfomapBaseDeleter> m_infomap;
@@ -251,17 +274,17 @@ public:
 
   // ---------------------------- Graph iterators ----------------------------
 
-  edge_iterator begin_outEdge() noexcept { return m_outEdges.begin(); }
+  edge_iterator begin_outEdge() noexcept { return edge_iterator(m_outEdges.begin()); }
 
-  edge_iterator end_outEdge() noexcept { return m_outEdges.end(); }
+  edge_iterator end_outEdge() noexcept { return edge_iterator(m_outEdges.end()); }
 
-  edge_iterator begin_inEdge() noexcept { return m_inEdges.begin(); }
+  in_edge_iterator begin_inEdge() noexcept { return m_inEdges.begin(); }
 
-  edge_iterator end_inEdge() noexcept { return m_inEdges.end(); }
+  in_edge_iterator end_inEdge() noexcept { return m_inEdges.end(); }
 
-  edge_iterator_wrapper outEdges() noexcept { return { m_outEdges }; }
+  edge_iterator_wrapper outEdges() noexcept { return { begin_outEdge(), end_outEdge() }; }
 
-  edge_iterator_wrapper inEdges() noexcept { return { m_inEdges }; }
+  in_edge_iterator_wrapper inEdges() noexcept { return { m_inEdges }; }
 
   // ---------------------------- Capacity ----------------------------
 
@@ -397,9 +420,10 @@ public:
 
   void addOutEdge(InfoNode& target, double weight, double flow = 0.0) noexcept
   {
-    auto* edge = new InfoEdge(*this, target, weight, flow);
-    m_outEdges.push_back(edge);
-    target.m_inEdges.push_back(edge);
+    auto edge = std::make_unique<InfoEdge>(*this, target, weight, flow);
+    auto* edgePtr = edge.get();
+    m_outEdges.push_back(std::move(edge));
+    target.m_inEdges.push_back(edgePtr);
   }
 
 private:

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -523,7 +523,7 @@ InfomapBase& InfomapBase::initTree(const NodePaths& tree)
     ++numNodesWithoutClusterInfo;
     if (assignToNeighbouringModule) {
       // Take first neighbour that has a module assigned
-      for (auto& edge : leafNode->outEdges()) {
+      for (auto* edge : leafNode->outEdges()) {
         if (edge->target->parent != nullptr) {
           edge->target->parent->addChild(leafNode);
           ++numNodesAddedToNeighbouringModules;
@@ -532,7 +532,7 @@ InfomapBase& InfomapBase::initTree(const NodePaths& tree)
       }
       // Check incoming links if still orphan
       if (leafNode->parent == nullptr) {
-        for (auto& edge : leafNode->inEdges()) {
+        for (auto* edge : leafNode->inEdges()) {
           if (edge->source->parent != nullptr) {
             edge->source->parent->addChild(leafNode);
             ++numNodesAddedToNeighbouringModules;
@@ -628,7 +628,7 @@ InfomapBase& InfomapBase::initPartition(const std::map<unsigned int, unsigned in
       if (selectedNodes[i] == 0) {
         // Check out edges greedily for connected modules
         auto& node = *m_leafNodes[i];
-        for (auto& e : node.outEdges()) {
+        for (auto* e : node.outEdges()) {
           auto& edge = *e;
           auto targetNodeIndex = nodeIdToIndex[edge.target->stateId];
           if (selectedNodes[targetNodeIndex] != 0) {
@@ -639,7 +639,7 @@ InfomapBase& InfomapBase::initPartition(const std::map<unsigned int, unsigned in
         }
         if (selectedNodes[i] == 0) {
           // Check in edges greedily for connected modules
-          for (auto& e : node.inEdges()) {
+          for (auto* e : node.inEdges()) {
             auto& edge = *e;
             auto sourceNodeIndex = nodeIdToIndex[edge.source->stateId];
             if (selectedNodes[sourceNodeIndex] != 0) {

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -206,7 +206,7 @@ bool InfomapOptimizer<Objective>::moveNodeToPredefinedModule(InfoNode& current, 
   DeltaFlowDataType newModuleDelta(newM, 0.0, 0.0);
 
   // For all outlinks
-  for (auto& e : current.outEdges()) {
+  for (auto* e : current.outEdges()) {
     auto& edge = *e;
     unsigned int otherModule = edge.target->index;
     if (otherModule == oldM) {
@@ -216,7 +216,7 @@ bool InfomapOptimizer<Objective>::moveNodeToPredefinedModule(InfoNode& current, 
     }
   }
   // For all inlinks
-  for (auto& e : current.inEdges()) {
+  for (auto* e : current.inEdges()) {
     auto& edge = *e;
     unsigned int otherModule = edge.source->index;
     if (otherModule == oldM) {
@@ -317,13 +317,13 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModule()
     deltaFlow.startRound();
 
     // For all outlinks
-    for (auto& e : current.outEdges()) {
+    for (auto* e : current.outEdges()) {
       auto& edge = *e;
       InfoNode* neighbour = edge.target;
       deltaFlow.add(neighbour->index, DeltaFlowDataType(neighbour->index, edge.data.flow, 0.0));
     }
     // For all inlinks
-    for (auto& e : current.inEdges()) {
+    for (auto* e : current.inEdges()) {
       auto& edge = *e;
       InfoNode* neighbour = edge.source;
       deltaFlow.add(neighbour->index, DeltaFlowDataType(neighbour->index, 0.0, edge.data.flow));
@@ -426,14 +426,14 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModule()
       InfoNode* nodeInOldModule = &current;
       unsigned int numLinkedNodesInOldModule = 0;
       // Mark neighbours as dirty
-      for (auto& e : current.outEdges()) {
+      for (auto* e : current.outEdges()) {
         e->target->dirty = true;
         if (e->target->index == oldModuleIndex) {
           nodeInOldModule = e->target;
           ++numLinkedNodesInOldModule;
         }
       }
-      for (auto& e : current.inEdges()) {
+      for (auto* e : current.inEdges()) {
         e->source->dirty = true;
         if (e->source->index == oldModuleIndex) {
           nodeInOldModule = e->source;
@@ -447,9 +447,9 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModule()
         ++numMoved;
         // Mark neighbours as dirty
         if (nodeInOldModule->degree() > 1) {
-          for (auto& e : nodeInOldModule->outEdges())
+          for (auto* e : nodeInOldModule->outEdges())
             e->target->dirty = true;
-          for (auto& e : nodeInOldModule->inEdges())
+          for (auto* e : nodeInOldModule->inEdges())
             e->source->dirty = true;
         }
       }
@@ -502,13 +502,13 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleInParalle
     VectorMap<DeltaFlowDataType> deltaFlow(numNodes);
 
     // For all outlinks
-    for (auto& e : current.outEdges()) {
+    for (auto* e : current.outEdges()) {
       auto& edge = *e;
       InfoNode* neighbour = edge.target;
       deltaFlow.add(neighbour->index, DeltaFlowDataType(neighbour->index, edge.data.flow, 0.0));
     }
     // For all inlinks
-    for (auto& e : current.inEdges()) {
+    for (auto* e : current.inEdges()) {
       auto& edge = *e;
       InfoNode* neighbour = edge.source;
       deltaFlow.add(neighbour->index, DeltaFlowDataType(neighbour->index, 0.0, edge.data.flow));
@@ -595,7 +595,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleInParalle
           DeltaFlowDataType newModuleDelta(bestModuleIndex, 0.0, 0.0);
 
           // For all outlinks
-          for (auto& e : current.outEdges()) {
+          for (auto* e : current.outEdges()) {
             auto& edge = *e;
             unsigned int otherModule = edge.target->index;
             if (otherModule == oldModuleIndex)
@@ -604,7 +604,7 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleInParalle
               newModuleDelta.deltaExit += edge.data.flow;
           }
           // For all inlinks
-          for (auto& e : current.inEdges()) {
+          for (auto* e : current.inEdges()) {
             auto& edge = *e;
             unsigned int otherModule = edge.source->index;
             if (otherModule == oldModuleIndex)
@@ -641,9 +641,9 @@ unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestModuleInParalle
             ++numMoved;
 
             // Mark neighbours as dirty
-            for (auto& e : current.outEdges())
+            for (auto* e : current.outEdges())
               e->target->dirty = true;
-            for (auto& e : current.inEdges())
+            for (auto* e : current.inEdges())
               e->source->dirty = true;
           } else {
             ++numInvalidMoves;
@@ -695,7 +695,7 @@ inline void InfomapOptimizer<Objective>::consolidateModules(bool replaceExisting
 
   for (auto& node : network) {
     unsigned int module1 = node->index;
-    for (auto& e : node->outEdges()) {
+    for (auto* e : node->outEdges()) {
       InfoEdge& edge = *e;
       unsigned int module2 = edge.target->index;
       if (module1 != module2) {

--- a/src/io/Output.cpp
+++ b/src/io/Output.cpp
@@ -204,7 +204,7 @@ std::map<std::string, LinkMap> aggregateModuleLinks(InfomapBase& im, bool states
   std::map<std::string, LinkMap> moduleLinks;
 
   for (auto& leaf : im.leafNodes()) {
-    for (auto& link : leaf->outEdges()) {
+    for (auto* link : leaf->outEdges()) {
       double flow = link->data.flow;
       InfoNode* sourceParent = stateIdToParent[link->source->stateId];
       InfoNode* targetParent = stateIdToParent[link->target->stateId];

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -397,6 +397,7 @@ TEST_CASE("InfoNode owns outgoing edges while incoming edges are non-owning refe
 
   CHECK(source->outDegree() == 1);
   CHECK(target.inDegree() == 1);
+  CHECK(*source->outEdges().begin() == *target.inEdges().begin());
 
   delete source;
 


### PR DESCRIPTION
## Summary

- Stack this PR on #444 (`fix/infonode-infomap-unique-ptr`).
- Move `InfoNode` outgoing edge ownership from manual `new`/`delete` to `std::unique_ptr`.
- Keep public edge iteration pointer-based and leave child-chain ownership unchanged.

## Verification

- `make test-native CTEST_ARGS='-R infomap_cpp_partition_tests --output-on-failure'`
- `make test-native`
- `make test-sanitizers`

## Notes

- Incoming edge pointers remain non-owning back-references and retain the current dangling-after-source-delete contract.
- Call sites were mechanically adjusted from pointer references to raw pointer iteration where needed.
