### PR TITLE
refactor: add infonode child handoff

### DIFF
--- a/src/core/InfoNode.cpp
+++ b/src/core/InfoNode.cpp
@@ -145,6 +145,14 @@ void InfoNode::addChild(InfoNode* child) noexcept
   ++m_childDegree;
 }
 
+InfoNode& InfoNode::addChild(std::unique_ptr<InfoNode> child) noexcept
+{
+  auto* childPtr = child.get();
+  addChild(childPtr);
+  child.release();
+  return *childPtr;
+}
+
 void InfoNode::releaseChildren() noexcept
 {
   firstChild = nullptr;
@@ -160,22 +168,23 @@ InfoNode& InfoNode::replaceChildrenWithOneNode()
     throw std::logic_error("replaceChildrenWithOneNode called on a node without any children.");
   if (firstChild->firstChild == nullptr)
     throw std::logic_error("replaceChildrenWithOneNode called on a node without any grandchildren.");
-  auto* middleNode = new InfoNode();
+  auto middleNode = std::make_unique<InfoNode>();
+  auto* middleNodePtr = middleNode.get();
   InfoNode::child_iterator nodeIt = begin_child();
   unsigned int numOriginalChildrenLeft = m_childDegree;
   auto d0 = m_childDegree;
   do {
     InfoNode* n = nodeIt.current();
     ++nodeIt;
-    middleNode->addChild(n);
+    middleNodePtr->addChild(n);
   } while (--numOriginalChildrenLeft != 0);
 
   releaseChildren();
-  addChild(middleNode);
-  auto d1 = middleNode->replaceChildrenWithGrandChildren();
+  addChild(std::move(middleNode));
+  auto d1 = middleNodePtr->replaceChildrenWithGrandChildren();
   if (d1 != d0)
     throw std::logic_error("replaceChildrenWithOneNode replaced different number of children as having before");
-  return *middleNode;
+  return *middleNodePtr;
 }
 
 unsigned int InfoNode::replaceChildrenWithGrandChildren() noexcept

--- a/src/core/InfoNode.h
+++ b/src/core/InfoNode.h
@@ -54,12 +54,13 @@ public:
  *
  * An InfoNode owns the active child chain reachable through firstChild/lastChild
  * and the collapsed child chain reachable through collapsedFirstChild/
- * collapsedLastChild. Destruction deletes both chains. releaseChildren() only
- * detaches the active chain from this parent; the caller must reattach or delete
- * those nodes. Reparenting helpers detach children before deleting the removed
- * intermediate node. An InfoNode also owns its sub-Infomap and outgoing
- * InfoEdge objects through unique_ptr; incoming edge pointers are non-owning
- * back-references.
+ * collapsedLastChild. Child storage remains a raw linked list; the unique_ptr
+ * addChild() overload is only a safe handoff helper for newly allocated nodes.
+ * Destruction deletes both chains. releaseChildren() only detaches the active
+ * chain from this parent; the caller must reattach or delete those nodes.
+ * Reparenting helpers detach children before deleting the removed intermediate
+ * node. An InfoNode also owns its sub-Infomap and outgoing InfoEdge objects
+ * through unique_ptr; incoming edge pointers are non-owning back-references.
  */
 class InfoNode {
 public:
@@ -375,6 +376,14 @@ public:
    * to this parent. The child must not still be owned by another active chain.
    */
   void addChild(InfoNode* child) noexcept;
+
+  /**
+   * Append a newly allocated child to this node and release unique_ptr ownership
+   * after the raw child-chain handoff succeeds.
+   */
+#ifndef SWIG
+  InfoNode& addChild(std::unique_ptr<InfoNode> child) noexcept;
+#endif
 
   /**
    * Detach this node from its active child chain without deleting any child.

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -496,9 +496,10 @@ InfomapBase& InfomapBase::initTree(const NodePaths& tree)
       if (node->childDegree() < childNumber) {
         InfoNode* child = leafNode;
         if (i + 1 < path.size()) {
-          child = new InfoNode();
+          child = &node->addChild(std::make_unique<InfoNode>());
+        } else {
+          node->addChild(child);
         }
-        node->addChild(child);
       }
 
       node = node->lastChild;
@@ -542,15 +543,13 @@ InfomapBase& InfomapBase::initTree(const NodePaths& tree)
       }
       // Set to own module if no neighbour module available
       if (leafNode->parent == nullptr) {
-        auto module = new InfoNode();
-        root().addChild(module);
-        module->addChild(leafNode);
+        auto& module = root().addChild(std::make_unique<InfoNode>());
+        module.addChild(leafNode);
       }
     } else {
       // Set to own module if no neighbour module available
-      auto module = new InfoNode();
-      root().addChild(module);
-      module->addChild(leafNode);
+      auto& module = root().addChild(std::make_unique<InfoNode>());
+      module.addChild(leafNode);
     }
   }
   if (numNodesWithoutClusterInfo > 0) {
@@ -756,7 +755,8 @@ void InfomapBase::generateSubNetwork(Network& network)
   std::map<unsigned int, unsigned int> nodeIndexMap;
   for (auto& nodeIt : network.nodes()) {
     auto& networkNode = nodeIt.second;
-    auto* node = new InfoNode(networkNode.flow, networkNode.id, networkNode.physicalId, networkNode.layerId);
+    auto ownedNode = std::make_unique<InfoNode>(networkNode.flow, networkNode.id, networkNode.physicalId, networkNode.layerId);
+    auto* node = ownedNode.get();
     node->data.teleportWeight = networkNode.weight;
     node->data.teleportFlow = networkNode.teleFlow;
     node->data.exitFlow = networkNode.exitFlow;
@@ -771,7 +771,7 @@ void InfomapBase::generateSubNetwork(Network& network)
     }
     sumNodeFlow += networkNode.flow;
     sumTeleFlow += networkNode.teleFlow;
-    m_root.addChild(node);
+    m_root.addChild(std::move(ownedNode));
     nodeIndexMap[networkNode.id] = m_leafNodes.size();
     m_leafNodes.push_back(node);
   }
@@ -888,9 +888,10 @@ void InfomapBase::generateSubNetwork(InfoNode& parent)
 
   unsigned int childIndex = 0;
   for (InfoNode& node : parent) {
-    auto* clonedNode = new InfoNode(node);
+    auto ownedClonedNode = std::make_unique<InfoNode>(node);
+    auto* clonedNode = ownedClonedNode.get();
     clonedNode->initClean();
-    m_root.addChild(clonedNode);
+    m_root.addChild(std::move(ownedClonedNode));
     node.index = childIndex; // Set index to its place in this subnetwork to be able to find edge target below
     m_leafNodes[childIndex] = clonedNode;
     ++childIndex;
@@ -991,9 +992,10 @@ void InfomapBase::hierarchicalPartition()
             InfoNode* leaf = leafs[j];
             unsigned int moduleIndex = modules[j];
             if (subModules[moduleIndex] == nullptr) {
-              subModules[moduleIndex] = new InfoNode(subInfomap.leafNodes()[j]->parent->data);
+              auto subModule = std::make_unique<InfoNode>(subInfomap.leafNodes()[j]->parent->data);
+              subModules[moduleIndex] = subModule.get();
               subModules[moduleIndex]->index = moduleIndex;
-              module.addChild(subModules[moduleIndex]);
+              module.addChild(std::move(subModule));
             }
             subModules[moduleIndex]->addChild(leaf);
           }

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -682,9 +682,10 @@ inline void InfomapOptimizer<Objective>::consolidateModules(bool replaceExisting
     InfoNode* node = network[i];
     unsigned int moduleIndex = node->index;
     if (modules[moduleIndex] == nullptr) {
-      modules[moduleIndex] = new InfoNode(m_moduleFlowData[moduleIndex]);
+      auto module = std::make_unique<InfoNode>(m_moduleFlowData[moduleIndex]);
+      modules[moduleIndex] = module.get();
       modules[moduleIndex]->index = moduleIndex;
-      node->parent->addChild(modules[moduleIndex]);
+      node->parent->addChild(std::move(module));
     }
     modules[moduleIndex]->addChild(node);
   }

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -5,6 +5,7 @@
 #include "TestUtils.h"
 
 #include <map>
+#include <memory>
 #include <set>
 #include <tuple>
 #include <vector>
@@ -12,6 +13,7 @@
 namespace {
 
 using infomap::InfomapWrapper;
+using infomap::FlowData;
 using infomap::InfoNode;
 
 using EdgeKey = std::pair<unsigned int, unsigned int>;
@@ -200,6 +202,37 @@ TEST_CASE("InfoNode hierarchy mutations preserve parentage and child order [fast
   CHECK(childStateIds(root) == std::vector<unsigned int> { 40, 50 });
 }
 
+TEST_CASE("InfoNode unique_ptr child handoff preserves raw child-chain semantics [fast][core][partition][tree][ownership]")
+{
+  InfoNode root;
+  auto childA = std::make_unique<InfoNode>(FlowData {}, 10);
+  auto childB = std::make_unique<InfoNode>(FlowData {}, 20);
+
+  auto* childAPtr = childA.get();
+  auto* childBPtr = childB.get();
+
+  InfoNode& returnedA = root.addChild(std::move(childA));
+  InfoNode& returnedB = root.addChild(std::move(childB));
+
+  CHECK(&returnedA == childAPtr);
+  CHECK(&returnedB == childBPtr);
+  CHECK(childA == nullptr);
+  CHECK(childB == nullptr);
+  CHECK(root.childDegree() == 2);
+  CHECK(root.firstChild == childAPtr);
+  CHECK(root.lastChild == childBPtr);
+  CHECK(childAPtr->parent == &root);
+  CHECK(childBPtr->parent == &root);
+  CHECK(childAPtr->previous == nullptr);
+  CHECK(childAPtr->next == childBPtr);
+  CHECK(childBPtr->previous == childAPtr);
+  CHECK(childBPtr->next == nullptr);
+  CHECK(childStateIds(root) == std::vector<unsigned int> { 10, 20 });
+
+  childAPtr->addChild(std::make_unique<InfoNode>(FlowData {}, 11));
+  CHECK(childAPtr->childDegree() == 1);
+}
+
 TEST_CASE("InfoNode releaseChildren detaches active children without deleting them [fast][core][partition][tree][ownership]")
 {
   InfoNode root;
@@ -244,8 +277,8 @@ TEST_CASE("Reinitializing a network clears collapsed root children [fast][core][
 TEST_CASE("InfoNode deleteChildren also clears collapsed children [fast][core][partition][tree]")
 {
   InfoNode root;
-  root.addChild(new InfoNode({}, 10));
-  root.addChild(new InfoNode({}, 20));
+  root.addChild(std::make_unique<InfoNode>(FlowData {}, 10));
+  root.addChild(std::make_unique<InfoNode>(FlowData {}, 20));
 
   CHECK(root.collapseChildren() == 2);
   CHECK(root.childDegree() == 0);
@@ -264,11 +297,11 @@ TEST_CASE("InfoNode deleteChildren also clears collapsed children [fast][core][p
 TEST_CASE("InfoNode deleteChildren clears both active and collapsed child chains [fast][core][partition][tree][ownership]")
 {
   InfoNode root;
-  root.addChild(new InfoNode({}, 10));
-  root.addChild(new InfoNode({}, 20));
+  root.addChild(std::make_unique<InfoNode>(FlowData {}, 10));
+  root.addChild(std::make_unique<InfoNode>(FlowData {}, 20));
 
   CHECK(root.collapseChildren() == 2);
-  root.addChild(new InfoNode({}, 30));
+  root.addChild(std::make_unique<InfoNode>(FlowData {}, 30));
 
   root.deleteChildren();
 
@@ -282,8 +315,8 @@ TEST_CASE("InfoNode deleteChildren clears both active and collapsed child chains
 TEST_CASE("InfoNode initClean clears inherited collapsed children on clones [fast][core][partition][tree]")
 {
   InfoNode source;
-  source.addChild(new InfoNode({}, 10));
-  source.addChild(new InfoNode({}, 20));
+  source.addChild(std::make_unique<InfoNode>(FlowData {}, 10));
+  source.addChild(std::make_unique<InfoNode>(FlowData {}, 20));
 
   CHECK(source.collapseChildren() == 2);
   CHECK(source.childDegree() == 0);
@@ -309,10 +342,10 @@ TEST_CASE("InfoNode replace mutations preserve flattened tree structure [fast][c
   auto* moduleB = new InfoNode({}, 200);
   root.addChild(moduleA);
   root.addChild(moduleB);
-  moduleA->addChild(new InfoNode({}, 1));
-  moduleA->addChild(new InfoNode({}, 2));
-  moduleB->addChild(new InfoNode({}, 3));
-  moduleB->addChild(new InfoNode({}, 4));
+  moduleA->addChild(std::make_unique<InfoNode>(FlowData {}, 1));
+  moduleA->addChild(std::make_unique<InfoNode>(FlowData {}, 2));
+  moduleB->addChild(std::make_unique<InfoNode>(FlowData {}, 3));
+  moduleB->addChild(std::make_unique<InfoNode>(FlowData {}, 4));
 
   CHECK(root.childDegree() == 2);
   CHECK(moduleA->childDegree() == 2);
@@ -343,8 +376,8 @@ TEST_CASE("InfoNode replaceWithChildren reparents a middle child chain before de
   root.addChild(before);
   root.addChild(module);
   root.addChild(after);
-  module->addChild(new InfoNode({}, 1));
-  module->addChild(new InfoNode({}, 2));
+  module->addChild(std::make_unique<InfoNode>(FlowData {}, 1));
+  module->addChild(std::make_unique<InfoNode>(FlowData {}, 2));
 
   CHECK(module->replaceWithChildren() == 1);
 
@@ -363,7 +396,7 @@ TEST_CASE("InfoNode remove documents current child-chain ownership semantics [fa
 {
   InfoNode deleteRoot;
   auto* deletingParent = new InfoNode({}, 10);
-  deletingParent->addChild(new InfoNode({}, 11));
+  deletingParent->addChild(std::make_unique<InfoNode>(FlowData {}, 11));
   deleteRoot.addChild(deletingParent);
 
   deletingParent->remove(false);


### PR DESCRIPTION
## Summary
- Stackad ovanpå `fix/infonode-edge-unique-ptr` / #445.
- Lägger till `InfoNode& addChild(std::unique_ptr<InfoNode>)` som säker handoff för nya barn.
- Behåller child-chain storage och reparenting-semantik med råpekare oförändrad.

## Changes
- Uppdaterar ownership-kommentaren och `addChild`-API:t i `src/core/InfoNode.h` och `src/core/InfoNode.cpp`.
- Byter direkta nya `InfoNode`-handoffs i `src/core/InfomapBase.cpp` och `src/core/InfomapOptimizer.h` till `std::make_unique`.
- Lägger fokuserad handoff-test och använder overloaden för direkta test-handoffs i `test/cpp/test_partition.cpp`.

## Verification
- `make test-native CTEST_ARGS='-R infomap_cpp_partition_tests --output-on-failure'`
- `make test-native`
- `make test-sanitizers`

## Notes
- Ingen SWIG/generated/docs-output ändras.
- PR:n byter inte child-chain storage till smart pointers; den nya overloaden är bara en säkrare handoff-väg för nyallokerade barn.
