### PR TITLE
refactor: detach infonode copies

### DIFF
--- a/src/core/InfoNode.cpp
+++ b/src/core/InfoNode.cpp
@@ -18,6 +18,24 @@ void InfomapBaseDeleter::operator()(InfomapBase* infomap) const noexcept
   delete infomap;
 }
 
+InfoNode::InfoNode(const InfoNode& other)
+{
+  copyDetachedValueStateFrom(other);
+}
+
+InfoNode& InfoNode::operator=(const InfoNode& other)
+{
+  if (this == &other)
+    return *this;
+
+  deleteChildren();
+  m_outEdges.clear();
+  m_inEdges.clear();
+  m_infomap.reset();
+  copyDetachedValueStateFrom(other);
+  return *this;
+}
+
 InfoNode::~InfoNode() noexcept
 {
   deleteChildren();
@@ -34,6 +52,32 @@ InfoNode::~InfoNode() noexcept
   }
 
   // Incoming edge pointers on other nodes become dangling non-owning back-references.
+}
+
+void InfoNode::copyDetachedValueStateFrom(const InfoNode& other)
+{
+  data = other.data;
+  index = other.index;
+  stateId = other.stateId;
+  physicalId = other.physicalId;
+  layerId = other.layerId;
+  metaData = other.metaData;
+  owner = nullptr;
+  parent = nullptr;
+  previous = nullptr;
+  next = nullptr;
+  firstChild = nullptr;
+  lastChild = nullptr;
+  collapsedFirstChild = nullptr;
+  collapsedLastChild = nullptr;
+  codelength = other.codelength;
+  dirty = other.dirty;
+  physicalNodes = other.physicalNodes;
+  metaCollection = other.metaCollection;
+  stateNodes = other.stateNodes;
+  m_childDegree = 0;
+  m_childrenChanged = false;
+  m_numLeafMembers = other.m_numLeafMembers;
 }
 
 InfomapBase& InfoNode::setInfomap(InfomapBase* infomap)

--- a/src/core/InfoNode.h
+++ b/src/core/InfoNode.h
@@ -148,52 +148,11 @@ public:
 
   InfoNode() = default;
 
-  InfoNode(const InfoNode& other)
-      : data(other.data),
-        index(other.index),
-        stateId(other.stateId),
-        physicalId(other.physicalId),
-        layerId(other.layerId),
-        metaData(other.metaData),
-        parent(other.parent),
-        previous(other.previous),
-        next(other.next),
-        firstChild(other.firstChild),
-        lastChild(other.lastChild),
-        collapsedFirstChild(other.collapsedFirstChild),
-        collapsedLastChild(other.collapsedLastChild),
-        codelength(other.codelength),
-        dirty(other.dirty),
-        metaCollection(other.metaCollection),
-        m_childDegree(other.m_childDegree),
-        m_childrenChanged(other.m_childrenChanged),
-        m_numLeafMembers(other.m_numLeafMembers) { }
+  InfoNode(const InfoNode& other);
 
   ~InfoNode() noexcept;
 
-  InfoNode& operator=(const InfoNode& other)
-  {
-    data = other.data;
-    index = other.index;
-    stateId = other.stateId;
-    physicalId = other.physicalId;
-    layerId = other.layerId;
-    metaData = other.metaData;
-    parent = other.parent;
-    previous = other.previous;
-    next = other.next;
-    firstChild = other.firstChild;
-    lastChild = other.lastChild;
-    collapsedFirstChild = other.collapsedFirstChild;
-    collapsedLastChild = other.collapsedLastChild;
-    codelength = other.codelength;
-    dirty = other.dirty;
-    metaCollection = other.metaCollection;
-    m_childDegree = other.m_childDegree;
-    m_childrenChanged = other.m_childrenChanged;
-    m_numLeafMembers = other.m_numLeafMembers;
-    return *this;
-  }
+  InfoNode& operator=(const InfoNode& other);
 
   // ---------------------------- Getters ----------------------------
 
@@ -436,6 +395,8 @@ public:
   }
 
 private:
+  void copyDetachedValueStateFrom(const InfoNode& other);
+
   void calcChildDegree() noexcept;
 };
 

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -890,7 +890,6 @@ void InfomapBase::generateSubNetwork(InfoNode& parent)
   for (InfoNode& node : parent) {
     auto ownedClonedNode = std::make_unique<InfoNode>(node);
     auto* clonedNode = ownedClonedNode.get();
-    clonedNode->initClean();
     m_root.addChild(std::move(ownedClonedNode));
     node.index = childIndex; // Set index to its place in this subnetwork to be able to find edge target below
     m_leafNodes[childIndex] = clonedNode;

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -312,10 +312,23 @@ TEST_CASE("InfoNode deleteChildren clears both active and collapsed child chains
   CHECK(root.collapsedLastChild == nullptr);
 }
 
-TEST_CASE("InfoNode initClean clears inherited collapsed children on clones [fast][core][partition][tree]")
+TEST_CASE("InfoNode copy constructor creates detached shallow copies [fast][core][partition][tree][ownership]")
 {
   InfoNode source;
-  source.addChild(std::make_unique<InfoNode>(FlowData {}, 10));
+  source.index = 7;
+  source.stateId = 100;
+  source.physicalId = 200;
+  source.layerId = 3;
+  source.metaData = { 1, 2 };
+  source.codelength = 1.25;
+  source.dirty = true;
+  source.stateNodes = { 100, 101 };
+  source.setNumLeafNodes(2);
+  auto* sourceEdgeTarget = new InfoNode(FlowData {}, 99);
+  source.addOutEdge(*sourceEdgeTarget, 1.0, 0.5);
+
+  auto* activeChild = new InfoNode({}, 10);
+  source.addChild(activeChild);
   source.addChild(std::make_unique<InfoNode>(FlowData {}, 20));
 
   CHECK(source.collapseChildren() == 2);
@@ -324,15 +337,95 @@ TEST_CASE("InfoNode initClean clears inherited collapsed children on clones [fas
   CHECK(source.collapsedLastChild != nullptr);
 
   InfoNode clone(source);
-  clone.initClean();
 
+  CHECK(clone.index == source.index);
+  CHECK(clone.stateId == source.stateId);
+  CHECK(clone.physicalId == source.physicalId);
+  CHECK(clone.layerId == source.layerId);
+  CHECK(clone.metaData == source.metaData);
+  CHECK(clone.codelength == doctest::Approx(source.codelength));
+  CHECK(clone.dirty == source.dirty);
+  CHECK(clone.stateNodes == source.stateNodes);
+  CHECK(clone.numLeafMembers() == source.numLeafMembers());
   CHECK(clone.childDegree() == 0);
+  CHECK(clone.outDegree() == 0);
+  CHECK(clone.inDegree() == 0);
+  CHECK(clone.owner == nullptr);
+  CHECK(clone.parent == nullptr);
+  CHECK(clone.previous == nullptr);
+  CHECK(clone.next == nullptr);
   CHECK(clone.firstChild == nullptr);
   CHECK(clone.lastChild == nullptr);
   CHECK(clone.collapsedFirstChild == nullptr);
   CHECK(clone.collapsedLastChild == nullptr);
 
+  CHECK(source.collapsedFirstChild == activeChild);
+  CHECK(source.collapsedFirstChild->next->stateId == 20);
+
+  delete sourceEdgeTarget;
   source.deleteChildren();
+}
+
+TEST_CASE("InfoNode copy assignment clears destination ownership and detaches from source [fast][core][partition][tree][ownership]")
+{
+  InfoNode source({}, 40);
+  source.index = 12;
+  source.codelength = 2.5;
+  source.setNumLeafNodes(3);
+  source.addChild(std::make_unique<InfoNode>(FlowData {}, 41));
+
+  InfoNode destination({}, 10);
+  destination.addChild(std::make_unique<InfoNode>(FlowData {}, 11));
+  auto* destinationEdgeTarget = new InfoNode(FlowData {}, 12);
+  destination.addOutEdge(*destinationEdgeTarget, 1.0, 0.5);
+
+  auto* sourceChild = source.firstChild;
+  destination = source;
+
+  CHECK(destination.stateId == source.stateId);
+  CHECK(destination.index == source.index);
+  CHECK(destination.codelength == doctest::Approx(source.codelength));
+  CHECK(destination.numLeafMembers() == source.numLeafMembers());
+  CHECK(destination.childDegree() == 0);
+  CHECK(destination.outDegree() == 0);
+  CHECK(destination.inDegree() == 0);
+  CHECK(destination.parent == nullptr);
+  CHECK(destination.previous == nullptr);
+  CHECK(destination.next == nullptr);
+  CHECK(destination.firstChild == nullptr);
+  CHECK(destination.lastChild == nullptr);
+  CHECK(destination.collapsedFirstChild == nullptr);
+  CHECK(destination.collapsedLastChild == nullptr);
+
+  CHECK(source.firstChild == sourceChild);
+  CHECK(source.firstChild->parent == &source);
+
+  delete destinationEdgeTarget;
+}
+
+TEST_CASE("InfoNode initClean remains an explicit reset helper [fast][core][partition][tree]")
+{
+  InfoNode source;
+  InfoNode parent;
+  InfoNode previous;
+  InfoNode next;
+  InfoNode collapsed;
+  source.parent = &parent;
+  source.previous = &previous;
+  source.next = &next;
+  source.collapsedFirstChild = &collapsed;
+  source.collapsedLastChild = &collapsed;
+
+  source.initClean();
+
+  CHECK(source.childDegree() == 0);
+  CHECK(source.parent == nullptr);
+  CHECK(source.previous == nullptr);
+  CHECK(source.next == nullptr);
+  CHECK(source.firstChild == nullptr);
+  CHECK(source.lastChild == nullptr);
+  CHECK(source.collapsedFirstChild == nullptr);
+  CHECK(source.collapsedLastChild == nullptr);
 }
 
 TEST_CASE("InfoNode replace mutations preserve flattened tree structure [fast][core][partition][tree]")


### PR DESCRIPTION
## Summary
- Stackad ovanpå `fix/infonode-child-handoff` / #446.
- Gör `InfoNode` copy constructor och copy assignment till detached shallow copies.
- Behåller befintliga copy-signaturer, men kopior får inte längre barnkedjor, sibling-/parent-länkar, edges eller sub-Infomap ownership från källan.

## Changes
- Flyttar `InfoNode` copy/assignment till `src/core/InfoNode.cpp` och delar värdekopiering via en intern helper.
- Rensar destinationens befintliga owned state vid copy assignment innan detached value state skrivs.
- Tar bort `copy + initClean()`-beroendet i subnetwork-kloning.
- Lägger ownership-tester för copy constructor, copy assignment och kvarvarande explicit `initClean()`-reset.

## Verification
- `make test-native CTEST_ARGS='-R infomap_cpp_partition_tests --output-on-failure'`
- `make test-native`
- `make test-sanitizers`
- `make test-python-swig-freshness`
- `make build-python`

## Notes
- Ingen SWIG/generated-output ändras; freshness-checken passerar.
- Child-chain storage och reparenting-semantik lämnas oförändrade.
