### PR TITLE
refactor: guard infonode child chains

### DIFF
--- a/src/core/InfoNode.cpp
+++ b/src/core/InfoNode.cpp
@@ -13,6 +13,75 @@
 
 namespace infomap {
 
+namespace {
+
+class DetachedChildChain {
+public:
+  DetachedChildChain() = default;
+
+  DetachedChildChain(InfoNode* first, InfoNode* last) noexcept
+      : m_first(first),
+        m_last(last) { }
+
+  DetachedChildChain(const DetachedChildChain&) = delete;
+  DetachedChildChain& operator=(const DetachedChildChain&) = delete;
+
+  DetachedChildChain(DetachedChildChain&& other) noexcept
+      : m_first(other.m_first),
+        m_last(other.m_last)
+  {
+    other.m_first = nullptr;
+    other.m_last = nullptr;
+  }
+
+  DetachedChildChain& operator=(DetachedChildChain&& other) noexcept
+  {
+    if (this != &other) {
+      reset();
+      m_first = other.m_first;
+      m_last = other.m_last;
+      other.m_first = nullptr;
+      other.m_last = nullptr;
+    }
+    return *this;
+  }
+
+  ~DetachedChildChain() noexcept
+  {
+    reset();
+  }
+
+  InfoNode* first() const noexcept { return m_first; }
+
+  InfoNode* last() const noexcept { return m_last; }
+
+  bool empty() const noexcept { return m_first == nullptr; }
+
+  void release() noexcept
+  {
+    m_first = nullptr;
+    m_last = nullptr;
+  }
+
+  void reset() noexcept
+  {
+    InfoNode* node = m_first;
+    m_first = nullptr;
+    m_last = nullptr;
+    while (node != nullptr) {
+      InfoNode* next = node->next;
+      delete node;
+      node = next;
+    }
+  }
+
+private:
+  InfoNode* m_first = nullptr;
+  InfoNode* m_last = nullptr;
+};
+
+} // namespace
+
 void InfomapBaseDeleter::operator()(InfomapBase* infomap) const noexcept
 {
   delete infomap;
@@ -199,9 +268,11 @@ InfoNode& InfoNode::addChild(std::unique_ptr<InfoNode> child) noexcept
 
 void InfoNode::releaseChildren() noexcept
 {
+  DetachedChildChain detached(firstChild, lastChild);
   firstChild = nullptr;
   lastChild = nullptr;
   m_childDegree = 0;
+  detached.release();
 }
 
 InfoNode& InfoNode::replaceChildrenWithOneNode()
@@ -223,8 +294,12 @@ InfoNode& InfoNode::replaceChildrenWithOneNode()
     middleNodePtr->addChild(n);
   } while (--numOriginalChildrenLeft != 0);
 
-  releaseChildren();
+  auto detachedChildren = DetachedChildChain(firstChild, lastChild);
+  firstChild = nullptr;
+  lastChild = nullptr;
+  m_childDegree = 0;
   addChild(std::move(middleNode));
+  detachedChildren.release();
   auto d1 = middleNodePtr->replaceChildrenWithGrandChildren();
   if (d1 != d0)
     throw std::logic_error("replaceChildrenWithOneNode replaced different number of children as having before");
@@ -346,23 +421,12 @@ void InfoNode::remove(bool removeChildren) noexcept
 
 void InfoNode::deleteChildren() noexcept
 {
-  auto delete_child_chain = [](InfoNode*& first, InfoNode*& last) {
-    if (first == nullptr)
-      return;
-
-    InfoNode* node = first;
-    while (node != nullptr) {
-      InfoNode* next_node = node->next;
-      delete node;
-      node = next_node;
-    }
-
-    first = nullptr;
-    last = nullptr;
-  };
-
-  delete_child_chain(firstChild, lastChild);
-  delete_child_chain(collapsedFirstChild, collapsedLastChild);
+  DetachedChildChain activeChildren(firstChild, lastChild);
+  firstChild = nullptr;
+  lastChild = nullptr;
+  DetachedChildChain collapsedChildren(collapsedFirstChild, collapsedLastChild);
+  collapsedFirstChild = nullptr;
+  collapsedLastChild = nullptr;
   m_childDegree = 0;
 }
 
@@ -418,10 +482,14 @@ void InfoNode::sortChildrenOnFlow(bool recurse) noexcept
     std::sort(nodes.begin(), nodes.end(), [](const InfoNode* a, const InfoNode* b) {
       return b->data.flow < a->data.flow;
     });
-    releaseChildren();
+    auto detachedChildren = DetachedChildChain(firstChild, lastChild);
+    firstChild = nullptr;
+    lastChild = nullptr;
+    m_childDegree = 0;
     for (auto node : nodes) {
       addChild(node);
     }
+    detachedChildren.release();
   }
   if (recurse) {
     for (InfoNode& child : children()) {
@@ -434,10 +502,14 @@ void InfoNode::sortChildrenOnFlow(bool recurse) noexcept
 
 unsigned int InfoNode::collapseChildren() noexcept
 {
-  std::swap(collapsedFirstChild, firstChild);
-  std::swap(collapsedLastChild, lastChild);
+  auto activeChildren = DetachedChildChain(firstChild, lastChild);
   unsigned int numCollapsedChildren = childDegree();
-  releaseChildren();
+  firstChild = nullptr;
+  lastChild = nullptr;
+  m_childDegree = 0;
+  collapsedFirstChild = activeChildren.first();
+  collapsedLastChild = activeChildren.last();
+  activeChildren.release();
   return numCollapsedChildren;
 }
 

--- a/src/core/InfoNode.h
+++ b/src/core/InfoNode.h
@@ -55,12 +55,13 @@ public:
  * An InfoNode owns the active child chain reachable through firstChild/lastChild
  * and the collapsed child chain reachable through collapsedFirstChild/
  * collapsedLastChild. Child storage remains a raw linked list; the unique_ptr
- * addChild() overload is only a safe handoff helper for newly allocated nodes.
- * Destruction deletes both chains. releaseChildren() only detaches the active
- * chain from this parent; the caller must reattach or delete those nodes.
- * Reparenting helpers detach children before deleting the removed intermediate
- * node. An InfoNode also owns its sub-Infomap and outgoing InfoEdge objects
- * through unique_ptr; incoming edge pointers are non-owning back-references.
+ * addChild() overload is only a safe handoff helper for newly allocated nodes,
+ * while internal detach/delete paths use an RAII guard. Destruction deletes both
+ * chains. releaseChildren() only detaches the active chain from this parent; the
+ * caller must reattach or delete those nodes. Reparenting helpers detach
+ * children before deleting the removed intermediate node. An InfoNode also owns
+ * its sub-Infomap and outgoing InfoEdge objects through unique_ptr; incoming
+ * edge pointers are non-owning back-references.
  */
 class InfoNode {
 public:

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -428,6 +428,60 @@ TEST_CASE("InfoNode initClean remains an explicit reset helper [fast][core][part
   CHECK(source.collapsedLastChild == nullptr);
 }
 
+TEST_CASE("InfoNode replaceChildrenWithOneNode preserves children through guarded detach [fast][core][partition][tree][ownership]")
+{
+  InfoNode root;
+  auto* moduleA = new InfoNode({}, 100);
+  auto* moduleB = new InfoNode({}, 200);
+  root.addChild(moduleA);
+  root.addChild(moduleB);
+  moduleA->addChild(std::make_unique<InfoNode>(FlowData {}, 1));
+  moduleA->addChild(std::make_unique<InfoNode>(FlowData {}, 2));
+  moduleB->addChild(std::make_unique<InfoNode>(FlowData {}, 3));
+  moduleB->addChild(std::make_unique<InfoNode>(FlowData {}, 4));
+
+  InfoNode& middle = root.replaceChildrenWithOneNode();
+
+  CHECK(root.childDegree() == 1);
+  CHECK(root.firstChild == &middle);
+  CHECK(root.lastChild == &middle);
+  CHECK(middle.parent == &root);
+  CHECK(middle.previous == nullptr);
+  CHECK(middle.next == nullptr);
+  CHECK(middle.childDegree() == 4);
+  CHECK(childStateIds(middle) == std::vector<unsigned int> { 1, 2, 3, 4 });
+  for (auto& child : middle.children()) {
+    CHECK(child.parent == &middle);
+  }
+}
+
+TEST_CASE("InfoNode sortChildrenOnFlow preserves links through guarded detach [fast][core][partition][tree][ownership]")
+{
+  InfoNode root;
+  auto childA = std::make_unique<InfoNode>(FlowData {}, 10);
+  auto childB = std::make_unique<InfoNode>(FlowData {}, 20);
+  auto childC = std::make_unique<InfoNode>(FlowData {}, 30);
+  childA->data.flow = 0.1;
+  childB->data.flow = 0.7;
+  childC->data.flow = 0.4;
+
+  root.addChild(std::move(childA));
+  root.addChild(std::move(childB));
+  root.addChild(std::move(childC));
+
+  root.sortChildrenOnFlow(false);
+
+  CHECK(root.childDegree() == 3);
+  CHECK(childStateIds(root) == std::vector<unsigned int> { 20, 30, 10 });
+  CHECK(root.firstChild->previous == nullptr);
+  CHECK(root.firstChild->parent == &root);
+  CHECK(root.firstChild->next->parent == &root);
+  CHECK(root.lastChild->parent == &root);
+  CHECK(root.lastChild->next == nullptr);
+  CHECK(root.firstChild->next->previous == root.firstChild);
+  CHECK(root.lastChild->previous == root.firstChild->next);
+}
+
 TEST_CASE("InfoNode replace mutations preserve flattened tree structure [fast][core][partition][tree]")
 {
   InfoNode root;


### PR DESCRIPTION
## Summary
- Stackad ovanpå `fix/infonode-detached-copy` / #447.
- Inför en intern move-only RAII-guard för detachade `InfoNode` child chains.
- Behåller publik child-chain-modell med `firstChild`/`lastChild` och sibling-länkar oförändrad.

## Changes
- Lägger `DetachedChildChain` i anonym namespace i `src/core/InfoNode.cpp`.
- Låter `deleteChildren()` och interna detach/reattach-flöden använda guarden.
- Bevarar `releaseChildren()`-kontraktet genom att släppa guardens ownership efter detach.
- Lägger fokuserade tester för guarded `replaceChildrenWithOneNode()` och `sortChildrenOnFlow()`.

## Verification
- `make test-native CTEST_ARGS='-R infomap_cpp_partition_tests --output-on-failure'`
- `make test-native`
- `make test-sanitizers`
- `make test-python-swig-freshness`

## Notes
- Ingen SWIG/generated-output ändras; freshness-checken passerar.
- PR:n byter inte child storage till smart pointers och ändrar inte `remove()`-semantik.
