### PR TITLE
refactor: InfoNode reparent splice

### DIFF
--- a/src/core/InfoNode.cpp
+++ b/src/core/InfoNode.cpp
@@ -80,6 +80,48 @@ private:
   InfoNode* m_last = nullptr;
 };
 
+void spliceChildrenIntoParentBeforeDelete(InfoNode& node) noexcept
+{
+  InfoNode* parent = node.parent;
+  InfoNode* previous = node.previous;
+  InfoNode* next = node.next;
+  InfoNode* firstChild = node.firstChild;
+  InfoNode* lastChild = node.lastChild;
+
+  unsigned int childCount = 0;
+  for (InfoNode* child = firstChild; child != nullptr; child = child->next) {
+    child->parent = parent;
+    ++childCount;
+  }
+
+  parent->setChildDegree(parent->childDegree() + childCount - 1); // -1 as this node is deleted.
+
+  firstChild->previous = previous;
+  lastChild->next = next;
+
+  if (parent->firstChild == &node) {
+    parent->firstChild = firstChild;
+  } else {
+    previous->next = firstChild;
+  }
+
+  if (parent->lastChild == &node) {
+    parent->lastChild = lastChild;
+  } else {
+    next->previous = lastChild;
+  }
+
+  // Detach before self-delete so the destructor does not delete the reparented
+  // child chain or reconnect sibling links that were already spliced.
+  node.firstChild = nullptr;
+  node.lastChild = nullptr;
+  node.next = nullptr;
+  node.previous = nullptr;
+  node.parent = nullptr;
+  node.setChildDegree(0);
+
+}
+
 } // namespace
 
 void InfomapBaseDeleter::operator()(InfomapBase* infomap) const noexcept
@@ -326,37 +368,7 @@ unsigned int InfoNode::replaceWithChildren() noexcept
   if (isLeaf() || isRoot())
     return 0;
 
-  // Re-parent children
-  unsigned int deltaChildDegree = 0;
-  InfoNode* child = firstChild;
-  do {
-    child->parent = parent;
-    child = child->next;
-    ++deltaChildDegree;
-  } while (child != nullptr);
-  parent->m_childDegree += deltaChildDegree - 1; // -1 as this node is deleted
-
-  firstChild->previous = previous;
-  lastChild->next = next;
-
-  if (parent->firstChild == this) {
-    parent->firstChild = firstChild;
-  } else {
-    previous->next = firstChild;
-  }
-
-  if (parent->lastChild == this) {
-    parent->lastChild = lastChild;
-  } else {
-    next->previous = lastChild;
-  }
-
-  // Release connected nodes before delete, otherwise children are deleted and neighbours are reconnected.
-  firstChild = nullptr;
-  lastChild = nullptr;
-  next = nullptr;
-  previous = nullptr;
-  parent = nullptr;
+  spliceChildrenIntoParentBeforeDelete(*this);
   delete this;
   return 1;
 }
@@ -379,37 +391,7 @@ void InfoNode::replaceWithChildrenDebug() noexcept
   if (isLeaf() || isRoot())
     return;
 
-  // Re-parent children
-  unsigned int deltaChildDegree = 0;
-  InfoNode* child = firstChild;
-  do {
-    child->parent = parent;
-    child = child->next;
-    ++deltaChildDegree;
-  } while (child != nullptr);
-  parent->m_childDegree += deltaChildDegree - 1; // -1 as this node is deleted
-
-  if (parent->firstChild == this) {
-    parent->firstChild = firstChild;
-  } else {
-    previous->next = firstChild;
-    firstChild->previous = previous;
-  }
-
-  if (parent->lastChild == this) {
-    parent->lastChild = lastChild;
-  } else {
-    next->previous = lastChild;
-    lastChild->next = next;
-  }
-
-  // Release connected nodes before delete, otherwise children are deleted and neighbours are reconnected.
-  firstChild = nullptr;
-  lastChild = nullptr;
-  next = nullptr;
-  previous = nullptr;
-  parent = nullptr;
-
+  spliceChildrenIntoParentBeforeDelete(*this);
   delete this;
 }
 

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -27,6 +27,34 @@ std::vector<unsigned int> childStateIds(const InfoNode& node)
   return ids;
 }
 
+void checkLinkedChildOrder(InfoNode& parent, const std::vector<unsigned int>& expectedStateIds)
+{
+  CHECK(childStateIds(parent) == expectedStateIds);
+  CHECK(parent.childDegree() == expectedStateIds.size());
+
+  InfoNode* previous = nullptr;
+  InfoNode* child = parent.firstChild;
+  std::size_t index = 0;
+  while (child != nullptr) {
+    REQUIRE(index < expectedStateIds.size());
+    CHECK(child->stateId == expectedStateIds[index]);
+    CHECK(child->parent == &parent);
+    CHECK(child->previous == previous);
+    if (previous != nullptr) {
+      CHECK(previous->next == child);
+    }
+    previous = child;
+    child = child->next;
+    ++index;
+  }
+
+  CHECK(index == expectedStateIds.size());
+  CHECK(parent.lastChild == previous);
+  if (previous != nullptr) {
+    CHECK(previous->next == nullptr);
+  }
+}
+
 std::map<EdgeKey, double> aggregatedInterModuleFlow(std::vector<InfoNode*>& nodes, bool undirected)
 {
   std::map<EdgeKey, double> flows;
@@ -514,6 +542,42 @@ TEST_CASE("InfoNode replace mutations preserve flattened tree structure [fast][c
   }
 }
 
+TEST_CASE("InfoNode replaceWithChildren reparents a first child chain before deleting the module [fast][core][partition][tree][ownership]")
+{
+  InfoNode root;
+  auto* module = new InfoNode({}, 20);
+  auto* after = new InfoNode({}, 30);
+  root.addChild(module);
+  root.addChild(after);
+  module->addChild(std::make_unique<InfoNode>(FlowData {}, 1));
+  module->addChild(std::make_unique<InfoNode>(FlowData {}, 2));
+
+  CHECK(module->replaceWithChildren() == 1);
+
+  checkLinkedChildOrder(root, { 1, 2, 30 });
+  CHECK(root.firstChild->previous == nullptr);
+  CHECK(root.lastChild == after);
+  CHECK(after->previous->stateId == 2);
+}
+
+TEST_CASE("InfoNode replaceWithChildren reparents a last child chain before deleting the module [fast][core][partition][tree][ownership]")
+{
+  InfoNode root;
+  auto* before = new InfoNode({}, 10);
+  auto* module = new InfoNode({}, 20);
+  root.addChild(before);
+  root.addChild(module);
+  module->addChild(std::make_unique<InfoNode>(FlowData {}, 1));
+  module->addChild(std::make_unique<InfoNode>(FlowData {}, 2));
+
+  CHECK(module->replaceWithChildren() == 1);
+
+  checkLinkedChildOrder(root, { 10, 1, 2 });
+  CHECK(root.firstChild == before);
+  CHECK(root.lastChild->stateId == 2);
+  CHECK(root.lastChild->next == nullptr);
+}
+
 TEST_CASE("InfoNode replaceWithChildren reparents a middle child chain before deleting the module [fast][core][partition][tree][ownership]")
 {
   InfoNode root;
@@ -528,7 +592,7 @@ TEST_CASE("InfoNode replaceWithChildren reparents a middle child chain before de
 
   CHECK(module->replaceWithChildren() == 1);
 
-  CHECK(childStateIds(root) == std::vector<unsigned int> { 10, 1, 2, 30 });
+  checkLinkedChildOrder(root, { 10, 1, 2, 30 });
   CHECK(root.firstChild == before);
   CHECK(root.lastChild == after);
   CHECK(before->next->stateId == 1);
@@ -537,6 +601,25 @@ TEST_CASE("InfoNode replaceWithChildren reparents a middle child chain before de
   CHECK(before->next->next->parent == &root);
   CHECK(before->next->next->next == after);
   CHECK(after->previous->stateId == 2);
+}
+
+TEST_CASE("InfoNode replaceWithChildrenDebug uses the same reparent splice path [fast][core][partition][tree][ownership]")
+{
+  InfoNode root;
+  auto* before = new InfoNode({}, 10);
+  auto* module = new InfoNode({}, 20);
+  auto* after = new InfoNode({}, 30);
+  root.addChild(before);
+  root.addChild(module);
+  root.addChild(after);
+  module->addChild(std::make_unique<InfoNode>(FlowData {}, 1));
+  module->addChild(std::make_unique<InfoNode>(FlowData {}, 2));
+
+  module->replaceWithChildrenDebug();
+
+  checkLinkedChildOrder(root, { 10, 1, 2, 30 });
+  CHECK(root.firstChild == before);
+  CHECK(root.lastChild == after);
 }
 
 TEST_CASE("InfoNode remove documents current child-chain ownership semantics [fast][core][partition][tree][ownership]")


### PR DESCRIPTION
## Summary
- stack on #448 / `fix/infonode-child-chain-guard`
- isolate `InfoNode::replaceWithChildren()` and `InfoNode::replaceWithChildrenDebug()` reparent-before-self-delete logic into an internal helper in `src/core/InfoNode.cpp`
- add focused child-chain link tests in `test/cpp/test_partition.cpp` for first, middle, last, and debug splice paths

## Public Interfaces
- no C++, Python, JS, or SWIG API changes
- child storage remains the existing raw linked list model
- `remove(bool)` and child-chain storage semantics are unchanged

## Test Plan
- [x] `make test-native CTEST_ARGS='-R infomap_cpp_partition_tests --output-on-failure'`\n- [x] `make test-native`\n- [x] `make test-sanitizers`\n- [x] `make test-python-swig-freshness`\n\n## Notes\n- no SWIG/generated/docs output changed\n