### PR TITLE
refactor: InfoNode remove self-delete

### DIFF
--- a/src/core/InfoNode.cpp
+++ b/src/core/InfoNode.cpp
@@ -119,7 +119,16 @@ void spliceChildrenIntoParentBeforeDelete(InfoNode& node) noexcept
   node.previous = nullptr;
   node.parent = nullptr;
   node.setChildDegree(0);
+}
 
+void prepareForSelfDelete(InfoNode& node, bool detachChildren) noexcept
+{
+  if (!detachChildren)
+    return;
+
+  node.firstChild = nullptr;
+  node.lastChild = nullptr;
+  node.setChildDegree(0);
 }
 
 } // namespace
@@ -397,7 +406,7 @@ void InfoNode::replaceWithChildrenDebug() noexcept
 
 void InfoNode::remove(bool removeChildren) noexcept
 {
-  firstChild = removeChildren ? nullptr : firstChild;
+  prepareForSelfDelete(*this, removeChildren);
   delete this;
 }
 

--- a/src/core/InfoNode.h
+++ b/src/core/InfoNode.h
@@ -377,8 +377,9 @@ public:
    * Delete this node.
    *
    * removeChildren=false leaves firstChild intact, so the destructor deletes the
-   * active child chain. removeChildren=true clears firstChild before deletion,
-   * leaving the previous child chain for the caller to reattach or delete.
+   * active child chain. removeChildren=true detaches this node from active child
+   * chain ownership before deletion, leaving the previous child chain for the
+   * caller to reattach or delete.
    */
   void remove(bool removeChildren) noexcept;
 

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -27,6 +27,27 @@ std::vector<unsigned int> childStateIds(const InfoNode& node)
   return ids;
 }
 
+std::vector<unsigned int> childChainStateIds(const InfoNode* firstChild)
+{
+  std::vector<unsigned int> ids;
+  for (const auto* child = firstChild; child != nullptr; child = child->next) {
+    ids.push_back(child->stateId);
+  }
+  return ids;
+}
+
+void deleteDetachedChildChain(InfoNode* firstChild)
+{
+  while (firstChild != nullptr) {
+    auto* next = firstChild->next;
+    firstChild->parent = nullptr;
+    firstChild->previous = nullptr;
+    firstChild->next = nullptr;
+    delete firstChild;
+    firstChild = next;
+  }
+}
+
 void checkLinkedChildOrder(InfoNode& parent, const std::vector<unsigned int>& expectedStateIds)
 {
   CHECK(childStateIds(parent) == expectedStateIds);
@@ -627,6 +648,7 @@ TEST_CASE("InfoNode remove documents current child-chain ownership semantics [fa
   InfoNode deleteRoot;
   auto* deletingParent = new InfoNode({}, 10);
   deletingParent->addChild(std::make_unique<InfoNode>(FlowData {}, 11));
+  deletingParent->addChild(std::make_unique<InfoNode>(FlowData {}, 12));
   deleteRoot.addChild(deletingParent);
 
   deletingParent->remove(false);
@@ -637,19 +659,59 @@ TEST_CASE("InfoNode remove documents current child-chain ownership semantics [fa
   InfoNode detachRoot;
   auto* detachingParent = new InfoNode({}, 20);
   auto* detachedChild = new InfoNode({}, 21);
+  auto* detachedSibling = new InfoNode({}, 22);
   detachingParent->addChild(detachedChild);
+  detachingParent->addChild(detachedSibling);
   detachRoot.addChild(detachingParent);
 
   detachingParent->remove(true);
 
   CHECK(detachRoot.firstChild == nullptr);
   CHECK(detachRoot.lastChild == nullptr);
-  CHECK(detachedChild->stateId == 21);
+  CHECK(childChainStateIds(detachedChild) == std::vector<unsigned int> { 21, 22 });
+  CHECK(detachedChild->previous == nullptr);
+  CHECK(detachedChild->next == detachedSibling);
+  CHECK(detachedSibling->previous == detachedChild);
+  CHECK(detachedSibling->next == nullptr);
 
-  detachedChild->parent = nullptr;
-  detachedChild->previous = nullptr;
-  detachedChild->next = nullptr;
-  delete detachedChild;
+  deleteDetachedChildChain(detachedChild);
+}
+
+TEST_CASE("InfoNode remove true unlinks first and last child modules while detaching their children [fast][core][partition][tree][ownership]")
+{
+  InfoNode firstRoot;
+  auto* firstModule = new InfoNode({}, 10);
+  auto* firstSibling = new InfoNode({}, 20);
+  auto* firstDetachedChild = new InfoNode({}, 11);
+  firstModule->addChild(firstDetachedChild);
+  firstRoot.addChild(firstModule);
+  firstRoot.addChild(firstSibling);
+
+  firstModule->remove(true);
+
+  CHECK(childStateIds(firstRoot) == std::vector<unsigned int> { 20 });
+  CHECK(firstRoot.firstChild == firstSibling);
+  CHECK(firstRoot.lastChild == firstSibling);
+  CHECK(firstSibling->previous == nullptr);
+  CHECK(firstSibling->next == nullptr);
+  deleteDetachedChildChain(firstDetachedChild);
+
+  InfoNode lastRoot;
+  auto* lastSibling = new InfoNode({}, 30);
+  auto* lastModule = new InfoNode({}, 40);
+  auto* lastDetachedChild = new InfoNode({}, 41);
+  lastModule->addChild(lastDetachedChild);
+  lastRoot.addChild(lastSibling);
+  lastRoot.addChild(lastModule);
+
+  lastModule->remove(true);
+
+  CHECK(childStateIds(lastRoot) == std::vector<unsigned int> { 30 });
+  CHECK(lastRoot.firstChild == lastSibling);
+  CHECK(lastRoot.lastChild == lastSibling);
+  CHECK(lastSibling->previous == nullptr);
+  CHECK(lastSibling->next == nullptr);
+  deleteDetachedChildChain(lastDetachedChild);
 }
 
 TEST_CASE("InfoNode owns outgoing edges while incoming edges are non-owning references [fast][core][partition][tree][ownership]")


### PR DESCRIPTION
## Summary
- stack on #449 / `fix/infonode-reparent-helper`
- isolate `InfoNode::remove(bool)` pre-delete child detach handling into an internal helper in `src/core/InfoNode.cpp`
- expand `test/cpp/test_partition.cpp` coverage for `remove(false)` subtree deletion and `remove(true)` child-chain detach/unlink behavior

## Public Interfaces
- no C++, Python, JS, or SWIG API changes
- child storage remains the existing raw linked list model
- `remove(false)` and `remove(true)` keep their current observable contracts

## Test Plan
- [x] `make test-native CTEST_ARGS='-R infomap_cpp_partition_tests --output-on-failure'`\n- [x] `make test-native`\n- [x] `make test-sanitizers`\n- [x] `make test-python-swig-freshness`\n\n## Notes\n- no SWIG/generated/docs output changed\n