### PR TITLE
refactor: InfoNode unlink cleanup

### DIFF
--- a/src/core/InfoNode.cpp
+++ b/src/core/InfoNode.cpp
@@ -131,6 +131,26 @@ void prepareForSelfDelete(InfoNode& node, bool detachChildren) noexcept
   node.setChildDegree(0);
 }
 
+void unlinkFromParentAndSiblings(InfoNode& node) noexcept
+{
+  if (node.next != nullptr)
+    node.next->previous = node.previous;
+  if (node.previous != nullptr)
+    node.previous->next = node.next;
+  if (node.parent != nullptr) {
+    if (node.parent->firstChild == &node)
+      node.parent->firstChild = node.next;
+    if (node.parent->lastChild == &node)
+      node.parent->lastChild = node.previous;
+  }
+
+  // Preserve current destructor/remove semantics: unlinking updates links but
+  // does not update the parent's cached child degree.
+  node.parent = nullptr;
+  node.previous = nullptr;
+  node.next = nullptr;
+}
+
 } // namespace
 
 void InfomapBaseDeleter::operator()(InfomapBase* infomap) const noexcept
@@ -159,17 +179,7 @@ InfoNode& InfoNode::operator=(const InfoNode& other)
 InfoNode::~InfoNode() noexcept
 {
   deleteChildren();
-
-  if (next != nullptr)
-    next->previous = previous;
-  if (previous != nullptr)
-    previous->next = next;
-  if (parent != nullptr) {
-    if (parent->firstChild == this)
-      parent->firstChild = next;
-    if (parent->lastChild == this)
-      parent->lastChild = previous;
-  }
+  unlinkFromParentAndSiblings(*this);
 
   // Incoming edge pointers on other nodes become dangling non-owning back-references.
 }

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -714,6 +714,66 @@ TEST_CASE("InfoNode remove true unlinks first and last child modules while detac
   deleteDetachedChildChain(lastDetachedChild);
 }
 
+TEST_CASE("InfoNode destructor unlinks parent and sibling pointers without updating cached child degree [fast][core][partition][tree][ownership]")
+{
+  InfoNode root;
+  auto* first = new InfoNode({}, 10);
+  auto* middle = new InfoNode({}, 20);
+  auto* last = new InfoNode({}, 30);
+  root.addChild(first);
+  root.addChild(middle);
+  root.addChild(last);
+
+  delete middle;
+
+  CHECK(childStateIds(root) == std::vector<unsigned int> { 10, 30 });
+  CHECK(root.firstChild == first);
+  CHECK(root.lastChild == last);
+  CHECK(first->previous == nullptr);
+  CHECK(first->next == last);
+  CHECK(last->previous == first);
+  CHECK(last->next == nullptr);
+  // Existing destructor/remove semantics preserve the cached degree until a
+  // caller explicitly recalculates or overwrites it.
+  CHECK(root.childDegree() == 3);
+
+  root.calcChildDegree();
+  CHECK(root.childDegree() == 2);
+}
+
+TEST_CASE("InfoNode destructor unlinks first and last children without changing cached child degree [fast][core][partition][tree][ownership]")
+{
+  InfoNode firstRoot;
+  auto* first = new InfoNode({}, 10);
+  auto* second = new InfoNode({}, 20);
+  firstRoot.addChild(first);
+  firstRoot.addChild(second);
+
+  delete first;
+
+  CHECK(childStateIds(firstRoot) == std::vector<unsigned int> { 20 });
+  CHECK(firstRoot.firstChild == second);
+  CHECK(firstRoot.lastChild == second);
+  CHECK(second->previous == nullptr);
+  CHECK(second->next == nullptr);
+  CHECK(firstRoot.childDegree() == 2);
+
+  InfoNode lastRoot;
+  auto* beforeLast = new InfoNode({}, 30);
+  auto* last = new InfoNode({}, 40);
+  lastRoot.addChild(beforeLast);
+  lastRoot.addChild(last);
+
+  delete last;
+
+  CHECK(childStateIds(lastRoot) == std::vector<unsigned int> { 30 });
+  CHECK(lastRoot.firstChild == beforeLast);
+  CHECK(lastRoot.lastChild == beforeLast);
+  CHECK(beforeLast->previous == nullptr);
+  CHECK(beforeLast->next == nullptr);
+  CHECK(lastRoot.childDegree() == 2);
+}
+
 TEST_CASE("InfoNode owns outgoing edges while incoming edges are non-owning references [fast][core][partition][tree][ownership]")
 {
   auto* source = new InfoNode({}, 10);


### PR DESCRIPTION
## Summary
- stack on #450 / `fix/infonode-remove-helper`
- isolate `InfoNode` destructor parent/sibling unlinking into an internal helper in `src/core/InfoNode.cpp`
- add focused tests in `test/cpp/test_partition.cpp` for first, middle, and last child unlink behavior

## Public Interfaces
- no C++, Python, JS, or SWIG API changes
- child storage remains the existing raw linked list model
- cached parent `childDegree()` behavior is intentionally unchanged

## Test Plan
- [x] `make test-native CTEST_ARGS='-R infomap_cpp_partition_tests --output-on-failure'`\n- [x] `make test-native`\n- [x] `make test-sanitizers`\n- [x] `make test-python-swig-freshness`\n\n## Notes\n- no SWIG/generated/docs output changed\n- child-degree consistency remains a separate behavior change if we choose to tackle it later\n