### PR TITLE
refactor: InfoNode detached child handoff

### DIFF
--- a/src/core/InfoNode.cpp
+++ b/src/core/InfoNode.cpp
@@ -101,6 +101,22 @@ void InfomapBaseDeleter::operator()(InfomapBase* infomap) const noexcept
   delete infomap;
 }
 
+std::unique_ptr<InfoNode> InfoNode::DetachedChildChain::take(InfoNode* child) noexcept
+{
+  for (auto it = m_children.begin(); it != m_children.end(); ++it) {
+    if (it->get() == child) {
+      unlinkFromChain(*child, m_first, m_last);
+      auto ownedChild = std::move(*it);
+      m_children.erase(it);
+      if (m_childDegree > 0)
+        --m_childDegree;
+      child->parent = nullptr;
+      return ownedChild;
+    }
+  }
+  return nullptr;
+}
+
 InfoNode::InfoNode(const InfoNode& other)
 {
   copyDetachedValueStateFrom(other);
@@ -338,13 +354,57 @@ InfoNode& InfoNode::addChild(std::unique_ptr<InfoNode> child) noexcept
 
 void InfoNode::releaseChildren() noexcept
 {
-  for (auto& child : m_children) {
+  auto detachedChildren = detachChildren();
+  for (auto& child : detachedChildren.m_children) {
     child.release();
   }
-  m_children.clear();
+}
+
+InfoNode::DetachedChildChain InfoNode::detachChildren() noexcept
+{
+  auto unorderedChildren = std::move(m_children);
+  std::vector<std::unique_ptr<InfoNode>> orderedChildren;
+  orderedChildren.reserve(unorderedChildren.size());
+
+  auto takeFromUnorderedChildren = [&unorderedChildren](InfoNode* child) {
+    for (auto it = unorderedChildren.begin(); it != unorderedChildren.end(); ++it) {
+      if (it->get() == child) {
+        auto ownedChild = std::move(*it);
+        unorderedChildren.erase(it);
+        return ownedChild;
+      }
+    }
+    return std::unique_ptr<InfoNode>();
+  };
+
+  for (auto* child = firstChild; child != nullptr; child = child->next) {
+    if (auto ownedChild = takeFromUnorderedChildren(child))
+      orderedChildren.push_back(std::move(ownedChild));
+  }
+
+  for (auto& child : unorderedChildren) {
+    if (child != nullptr)
+      orderedChildren.push_back(std::move(child));
+  }
+
+  auto* detachedFirstChild = firstChild;
+  auto* detachedLastChild = lastChild;
+  auto detachedChildDegree = m_childDegree;
+
   firstChild = nullptr;
   lastChild = nullptr;
   m_childDegree = 0;
+
+  return { std::move(orderedChildren), detachedFirstChild, detachedLastChild, detachedChildDegree };
+}
+
+void InfoNode::adoptChildren(DetachedChildChain children) noexcept
+{
+  for (auto& child : children.m_children) {
+    child->previous = nullptr;
+    child->next = nullptr;
+    appendOwnedChild(std::move(child));
+  }
 }
 
 InfoNode& InfoNode::replaceChildrenWithOneNode()

--- a/src/core/InfoNode.h
+++ b/src/core/InfoNode.h
@@ -55,11 +55,13 @@ public:
  * An InfoNode owns active and collapsed children through private unique_ptr
  * storage. firstChild/lastChild, collapsedFirstChild/collapsedLastChild, and
  * sibling links are non-owning raw iteration links kept for compatibility.
- * releaseChildren() only detaches the active chain from this parent; the caller
- * must reattach or delete those nodes. Reparenting helpers transfer child
- * ownership before deleting the removed intermediate node. An InfoNode also
- * owns its sub-Infomap and outgoing InfoEdge objects through unique_ptr;
- * incoming edge pointers are non-owning back-references.
+ * detachChildren() returns an owning move-only handle until the chain is
+ * adopted by another parent or dropped. releaseChildren() is a legacy wrapper
+ * that gives up ownership and leaves the caller responsible for reattach/delete.
+ * Reparenting helpers transfer child ownership before deleting the removed
+ * intermediate node. An InfoNode also owns its sub-Infomap and outgoing
+ * InfoEdge objects through unique_ptr; incoming edge pointers are non-owning
+ * back-references.
  */
 class InfoNode {
 public:
@@ -97,6 +99,46 @@ public:
 
   using infomap_child_iterator_wrapper = IterWrapper<infomap_child_iterator>;
   using const_infomap_child_iterator_wrapper = IterWrapper<const_infomap_child_iterator>;
+
+#ifndef SWIG
+  /**
+   * Owning temporary for an active child chain detached from a parent.
+   * The raw first/last/sibling links preserve child order while unique_ptr
+   * storage keeps lifetime explicit until adoption or destruction.
+   */
+  class DetachedChildChain {
+  public:
+    DetachedChildChain() = default;
+    DetachedChildChain(const DetachedChildChain&) = delete;
+    DetachedChildChain& operator=(const DetachedChildChain&) = delete;
+    DetachedChildChain(DetachedChildChain&&) noexcept = default;
+    DetachedChildChain& operator=(DetachedChildChain&&) noexcept = default;
+
+    InfoNode* first() const noexcept { return m_first; }
+    InfoNode* last() const noexcept { return m_last; }
+    bool empty() const noexcept { return m_children.empty(); }
+    unsigned int size() const noexcept { return m_childDegree; }
+    std::unique_ptr<InfoNode> take(InfoNode* child) noexcept;
+
+  private:
+    friend class InfoNode;
+
+    DetachedChildChain(
+        std::vector<std::unique_ptr<InfoNode>> children,
+        InfoNode* first,
+        InfoNode* last,
+        unsigned int childDegree) noexcept
+        : m_children(std::move(children)),
+          m_first(first),
+          m_last(last),
+          m_childDegree(childDegree) { }
+
+    std::vector<std::unique_ptr<InfoNode>> m_children;
+    InfoNode* m_first = nullptr;
+    InfoNode* m_last = nullptr;
+    unsigned int m_childDegree = 0;
+  };
+#endif
 
 public:
   FlowData data;
@@ -351,6 +393,19 @@ public:
    * delete the detached chain before those stale links can be observed.
    */
   void releaseChildren() noexcept;
+
+#ifndef SWIG
+  /**
+   * Detach the active child chain into an owning temporary. The handle preserves
+   * linked-list order even when private storage has a different order.
+   */
+  DetachedChildChain detachChildren() noexcept;
+
+  /**
+   * Append all children from a detached handle to this node's active child chain.
+   */
+  void adoptChildren(DetachedChildChain children) noexcept;
+#endif
 
   /**
    * If not already having a single child, replace children

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -460,15 +460,24 @@ InfomapBase& InfomapBase::initTree(const NodePaths& tree)
 
   std::map<unsigned int, unsigned int> nodeIdToIndex;
   auto leafIndex = 0;
+  std::vector<InfoNode::DetachedChildChain> detachedLeafParents;
   for (auto& leafNode : m_leafNodes) {
     // Also detach leaf nodes to delete all modules, safe to call multiple times
-    leafNode->parent->releaseChildren();
+    detachedLeafParents.push_back(leafNode->parent->detachChildren());
     // Set parent to nullptr to be able to collect any orphaned nodes in the end
     leafNode->parent = nullptr;
     nodeIdToIndex[leafNode->stateId] = leafIndex;
     ++leafIndex;
   }
   m_root.deleteChildren();
+
+  auto takeDetachedLeaf = [&detachedLeafParents](InfoNode* leafNode) {
+    for (auto& detachedParent : detachedLeafParents) {
+      if (auto ownedLeaf = detachedParent.take(leafNode))
+        return ownedLeaf;
+    }
+    throw std::logic_error("Detached leaf node ownership not found.");
+  };
 
   auto numNodesFound = 0;
   auto numNodesNotInNetwork = 0;
@@ -494,11 +503,10 @@ InfomapBase& InfomapBase::initTree(const NodePaths& tree)
       // Create new node if path doesn't exist
       // TODO: Check correct tree indexing?
       if (node->childDegree() < childNumber) {
-        InfoNode* child = leafNode;
         if (i + 1 < path.size()) {
-          child = &node->addChild(std::make_unique<InfoNode>());
+          node->addChild(std::make_unique<InfoNode>());
         } else {
-          node->addChild(child);
+          node->addChild(takeDetachedLeaf(leafNode));
         }
       }
 
@@ -526,7 +534,7 @@ InfomapBase& InfomapBase::initTree(const NodePaths& tree)
       // Take first neighbour that has a module assigned
       for (auto* edge : leafNode->outEdges()) {
         if (edge->target->parent != nullptr) {
-          edge->target->parent->addChild(leafNode);
+          edge->target->parent->addChild(takeDetachedLeaf(leafNode));
           ++numNodesAddedToNeighbouringModules;
           break;
         }
@@ -535,7 +543,7 @@ InfomapBase& InfomapBase::initTree(const NodePaths& tree)
       if (leafNode->parent == nullptr) {
         for (auto* edge : leafNode->inEdges()) {
           if (edge->source->parent != nullptr) {
-            edge->source->parent->addChild(leafNode);
+            edge->source->parent->addChild(takeDetachedLeaf(leafNode));
             ++numNodesAddedToNeighbouringModules;
             break;
           }
@@ -544,12 +552,12 @@ InfomapBase& InfomapBase::initTree(const NodePaths& tree)
       // Set to own module if no neighbour module available
       if (leafNode->parent == nullptr) {
         auto& module = root().addChild(std::make_unique<InfoNode>());
-        module.addChild(leafNode);
+        module.addChild(takeDetachedLeaf(leafNode));
       }
     } else {
       // Set to own module if no neighbour module available
       auto& module = root().addChild(std::make_unique<InfoNode>());
-      module.addChild(leafNode);
+      module.addChild(takeDetachedLeaf(leafNode));
     }
   }
   if (numNodesWithoutClusterInfo > 0) {
@@ -985,7 +993,7 @@ void InfomapBase::hierarchicalPartition()
 
           // Create new sub modules
           std::vector<InfoNode*> subModules(numLeafs, nullptr);
-          module.releaseChildren();
+          auto detachedChildren = module.detachChildren();
 
           for (auto j = 0; j < numLeafs; ++j) {
             InfoNode* leaf = leafs[j];
@@ -996,7 +1004,10 @@ void InfomapBase::hierarchicalPartition()
               subModules[moduleIndex]->index = moduleIndex;
               module.addChild(std::move(subModule));
             }
-            subModules[moduleIndex]->addChild(leaf);
+            auto ownedLeaf = detachedChildren.take(leaf);
+            if (ownedLeaf == nullptr)
+              throw std::logic_error("Detached submodule leaf ownership not found.");
+            subModules[moduleIndex]->addChild(std::move(ownedLeaf));
           }
           module.disposeInfomap();
           module.codelength = calcCodelength(module);

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -17,6 +17,7 @@
 #include "InfoNode.h"
 #include "FlowData.h"
 
+#include <stdexcept>
 #include <set>
 #include <utility>
 
@@ -672,10 +673,19 @@ inline void InfomapOptimizer<Objective>::consolidateModules(bool replaceExisting
   if (leafLevel == 1)
     replaceExistingModules = false;
 
-  // Release children pointers on current parent(s) to put new modules between
+  // Detach active children from current parent(s) to put new modules between
+  std::vector<InfoNode::DetachedChildChain> detachedParents;
   for (auto& n : network) {
-    n->parent->releaseChildren(); // Safe to call multiple times
+    detachedParents.push_back(n->parent->detachChildren()); // Safe to call multiple times
   }
+
+  auto takeDetachedNode = [&detachedParents](InfoNode* node) {
+    for (auto& detachedParent : detachedParents) {
+      if (auto ownedNode = detachedParent.take(node))
+        return ownedNode;
+    }
+    throw std::logic_error("Detached active node ownership not found.");
+  };
 
   // Create the new module nodes and re-parent the active network from its common parent to the new module level
   for (unsigned int i = 0; i < numNodes; ++i) {
@@ -687,7 +697,7 @@ inline void InfomapOptimizer<Objective>::consolidateModules(bool replaceExisting
       modules[moduleIndex]->index = moduleIndex;
       node->parent->addChild(std::move(module));
     }
-    modules[moduleIndex]->addChild(node);
+    modules[moduleIndex]->addChild(takeDetachedNode(node));
   }
 
   using NodePair = std::pair<unsigned int, unsigned int>;

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -345,6 +345,93 @@ TEST_CASE("InfoNode reattaches released children under new unique_ptr ownership 
   checkLinkedChildOrder(newParent, { 10, 20 });
 }
 
+TEST_CASE("InfoNode detached child handle adopts children in linked-list order [fast][core][partition][tree][ownership]")
+{
+  InfoNode oldParent;
+  InfoNode newParent;
+  auto childA = std::make_unique<InfoNode>(FlowData {}, 10);
+  auto childB = std::make_unique<InfoNode>(FlowData {}, 20);
+  auto childC = std::make_unique<InfoNode>(FlowData {}, 30);
+  childA->data.flow = 0.1;
+  childB->data.flow = 0.7;
+  childC->data.flow = 0.4;
+
+  oldParent.addChild(std::move(childA));
+  oldParent.addChild(std::move(childB));
+  oldParent.addChild(std::move(childC));
+  oldParent.sortChildrenOnFlow(false);
+
+  auto detachedChildren = oldParent.detachChildren();
+
+  CHECK(oldParent.childDegree() == 0);
+  CHECK(oldParent.firstChild == nullptr);
+  CHECK(oldParent.lastChild == nullptr);
+  CHECK(detachedChildren.size() == 3);
+  CHECK(childChainStateIds(detachedChildren.first()) == std::vector<unsigned int> { 20, 30, 10 });
+
+  newParent.adoptChildren(std::move(detachedChildren));
+
+  checkLinkedChildOrder(newParent, { 20, 30, 10 });
+}
+
+TEST_CASE("InfoNode detached child handle can move one child to another parent [fast][core][partition][tree][ownership]")
+{
+  InfoNode oldParent;
+  InfoNode firstNewParent;
+  InfoNode secondNewParent;
+  auto* childA = &oldParent.addChild(std::make_unique<InfoNode>(FlowData {}, 10));
+  auto* childB = &oldParent.addChild(std::make_unique<InfoNode>(FlowData {}, 20));
+  auto* childC = &oldParent.addChild(std::make_unique<InfoNode>(FlowData {}, 30));
+
+  auto detachedChildren = oldParent.detachChildren();
+  firstNewParent.addChild(detachedChildren.take(childB));
+  secondNewParent.adoptChildren(std::move(detachedChildren));
+
+  checkLinkedChildOrder(firstNewParent, { 20 });
+  checkLinkedChildOrder(secondNewParent, { 10, 30 });
+  CHECK(childA->parent == &secondNewParent);
+  CHECK(childB->parent == &firstNewParent);
+  CHECK(childC->parent == &secondNewParent);
+}
+
+TEST_CASE("InfoNode adoptChildren appends without reordering existing children [fast][core][partition][tree][ownership]")
+{
+  InfoNode oldParent;
+  InfoNode newParent;
+  auto existingA = std::make_unique<InfoNode>(FlowData {}, 10);
+  auto existingB = std::make_unique<InfoNode>(FlowData {}, 20);
+  existingA->data.flow = 0.1;
+  existingB->data.flow = 0.7;
+  newParent.addChild(std::move(existingA));
+  newParent.addChild(std::move(existingB));
+  newParent.sortChildrenOnFlow(false);
+
+  oldParent.addChild(std::make_unique<InfoNode>(FlowData {}, 30));
+  oldParent.addChild(std::make_unique<InfoNode>(FlowData {}, 40));
+
+  newParent.adoptChildren(oldParent.detachChildren());
+
+  checkLinkedChildOrder(newParent, { 20, 10, 30, 40 });
+}
+
+TEST_CASE("InfoNode detached child handle deletes dropped children [fast][core][partition][tree][ownership]")
+{
+  InfoNode oldParent;
+  oldParent.addChild(std::make_unique<InfoNode>(FlowData {}, 10));
+  oldParent.addChild(std::make_unique<InfoNode>(FlowData {}, 20));
+
+  {
+    auto detachedChildren = oldParent.detachChildren();
+    CHECK(detachedChildren.size() == 2);
+    CHECK(oldParent.childDegree() == 0);
+  }
+
+  CHECK(oldParent.childDegree() == 0);
+  CHECK(oldParent.firstChild == nullptr);
+  CHECK(oldParent.lastChild == nullptr);
+  oldParent.deleteChildren();
+}
+
 TEST_CASE("Reinitializing a network clears collapsed root children [fast][core][partition][tree]")
 {
   InfomapWrapper im(infomap::test::defaultFlags());


### PR DESCRIPTION
## Summary
- Add an internal move-only `InfoNode::DetachedChildChain` handle for active child-chain detach/adopt flows.
- Keep `releaseChildren()` as a legacy compatibility wrapper that releases ownership after detaching.
- Replace runtime raw reattach flows in `src/core/InfomapBase.cpp` and `src/core/InfomapOptimizer.h` with explicit handle ownership transfer.
- Add focused C++ ownership tests for adopt order, partial take, append behavior, and dropped detached chains.

## Stack
- Stacked on #452 / `fix/infonode-child-storage`.
- Base branch: `fix/infonode-child-storage`.

## Verification
- `make test-native CTEST_ARGS='-R infomap_cpp_partition_tests --output-on-failure'`
- `make test-native`
- `make test-sanitizers`
- `make test-python-swig-freshness`
- `PYTHON=<temp-venv>/bin/python make build-python`

## Notes
- `make build-python` with the default local `python3.14` failed because that environment cannot execute `python -m build`; the same make target passed with a temporary venv containing a clean `build` install.
- No SWIG/generated/docs output changed.
