### PR TITLE
refactor: InfoNode removals through parent ownership

### DIFF
--- a/src/core/InfoNode.cpp
+++ b/src/core/InfoNode.cpp
@@ -39,47 +39,6 @@ void unlinkFromChain(InfoNode& node, InfoNode*& first, InfoNode*& last) noexcept
   node.next = nullptr;
 }
 
-void spliceChildrenIntoParentBeforeDelete(InfoNode& node) noexcept
-{
-  InfoNode* parent = node.parent;
-  InfoNode* previous = node.previous;
-  InfoNode* next = node.next;
-  InfoNode* firstChild = node.firstChild;
-  InfoNode* lastChild = node.lastChild;
-
-  unsigned int childCount = 0;
-  for (InfoNode* child = firstChild; child != nullptr; child = child->next) {
-    child->parent = parent;
-    ++childCount;
-  }
-
-  parent->setChildDegree(parent->childDegree() + childCount - 1); // -1 as this node is deleted.
-
-  firstChild->previous = previous;
-  lastChild->next = next;
-
-  if (parent->firstChild == &node) {
-    parent->firstChild = firstChild;
-  } else {
-    previous->next = firstChild;
-  }
-
-  if (parent->lastChild == &node) {
-    parent->lastChild = lastChild;
-  } else {
-    next->previous = lastChild;
-  }
-
-  // Detach before self-delete so the destructor does not delete the reparented
-  // child chain or reconnect sibling links that were already spliced.
-  node.firstChild = nullptr;
-  node.lastChild = nullptr;
-  node.next = nullptr;
-  node.previous = nullptr;
-  node.parent = nullptr;
-  node.setChildDegree(0);
-}
-
 void unlinkFromParentAndSiblings(InfoNode& node) noexcept
 {
   if (node.parent != nullptr) {
@@ -139,10 +98,6 @@ InfoNode& InfoNode::operator=(const InfoNode& other)
 
 InfoNode::~InfoNode() noexcept
 {
-  if (parent != nullptr) {
-    auto selfOwnership = parent->takeChildOwnership(this);
-    selfOwnership.release();
-  }
   deleteChildren();
   unlinkFromParentAndSiblings(*this);
 
@@ -311,14 +266,6 @@ std::unique_ptr<InfoNode> InfoNode::takeChildOwnership(InfoNode* child) noexcept
   return takeFrom(m_collapsedChildren);
 }
 
-void InfoNode::moveActiveChildOwnershipTo(InfoNode& newParent)
-{
-  for (auto& child : m_children) {
-    newParent.m_children.push_back(std::move(child));
-  }
-  m_children.clear();
-}
-
 void InfoNode::addChild(InfoNode* child) noexcept
 {
   std::unique_ptr<InfoNode> ownedChild;
@@ -407,6 +354,89 @@ void InfoNode::adoptChildren(DetachedChildChain children) noexcept
   }
 }
 
+unsigned int InfoNode::replaceChildWithChildren(InfoNode& child) noexcept
+{
+  if (child.parent != this || child.isLeaf())
+    return 0;
+
+  auto childIt = std::find_if(m_children.begin(), m_children.end(), [&child](const auto& ownedChild) {
+    return ownedChild.get() == &child;
+  });
+  if (childIt == m_children.end())
+    return 0;
+
+  auto replacementChildren = child.detachChildren();
+  if (replacementChildren.empty())
+    return 0;
+
+  auto* previousSibling = child.previous;
+  auto* nextSibling = child.next;
+  auto* replacementFirst = replacementChildren.first();
+  auto* replacementLast = replacementChildren.last();
+  const auto replacementCount = replacementChildren.size();
+
+  for (auto* replacement = replacementFirst; replacement != nullptr; replacement = replacement->next) {
+    replacement->parent = this;
+  }
+
+  replacementFirst->previous = previousSibling;
+  replacementLast->next = nextSibling;
+
+  if (firstChild == &child) {
+    firstChild = replacementFirst;
+  } else if (previousSibling != nullptr) {
+    previousSibling->next = replacementFirst;
+  }
+
+  if (lastChild == &child) {
+    lastChild = replacementLast;
+  } else if (nextSibling != nullptr) {
+    nextSibling->previous = replacementLast;
+  }
+
+  child.parent = nullptr;
+  child.previous = nullptr;
+  child.next = nullptr;
+  child.setChildDegree(0);
+
+  auto removedChild = std::move(*childIt);
+  auto insertPos = m_children.erase(childIt);
+  m_children.insert(
+      insertPos,
+      std::make_move_iterator(replacementChildren.m_children.begin()),
+      std::make_move_iterator(replacementChildren.m_children.end()));
+
+  setChildDegree(childDegree() + replacementCount - 1);
+  return 1;
+}
+
+void InfoNode::removeChild(InfoNode& child, RemoveChildrenPolicy policy) noexcept
+{
+  if (child.parent != this)
+    return;
+
+  auto childIt = std::find_if(m_children.begin(), m_children.end(), [&child](const auto& ownedChild) {
+    return ownedChild.get() == &child;
+  });
+  if (childIt == m_children.end())
+    return;
+
+  InfoNode::DetachedChildChain detachedChildren;
+  if (policy == RemoveChildrenPolicy::DetachChildren) {
+    detachedChildren = child.detachChildren();
+    for (auto& detachedChild : detachedChildren.m_children) {
+      detachedChild.release();
+    }
+  }
+
+  unlinkFromChain(child, firstChild, lastChild);
+  child.parent = nullptr;
+  if (m_childDegree > 0)
+    setChildDegree(m_childDegree - 1);
+
+  m_children.erase(childIt);
+}
+
 InfoNode& InfoNode::replaceChildrenWithOneNode()
 {
   if (childDegree() == 1)
@@ -456,7 +486,7 @@ unsigned int InfoNode::replaceChildrenWithGrandChildren() noexcept
   do {
     InfoNode* n = nodeIt.current();
     ++nodeIt;
-    numChildrenReplaced += n->replaceWithChildren();
+    numChildrenReplaced += replaceChildWithChildren(*n);
   } while (--numOriginalChildrenLeft != 0);
   return numChildrenReplaced;
 }
@@ -466,13 +496,7 @@ unsigned int InfoNode::replaceWithChildren() noexcept
   if (isLeaf() || isRoot())
     return 0;
 
-  InfoNode* oldParent = parent;
-  moveActiveChildOwnershipTo(*oldParent);
-  auto selfOwnership = oldParent->takeChildOwnership(this);
-  selfOwnership.release();
-  spliceChildrenIntoParentBeforeDelete(*this);
-  delete this;
-  return 1;
+  return parent->replaceChildWithChildren(*this);
 }
 
 void InfoNode::replaceChildrenWithGrandChildrenDebug() noexcept
@@ -484,7 +508,7 @@ void InfoNode::replaceChildrenWithGrandChildrenDebug() noexcept
   do {
     InfoNode* n = nodeIt.current();
     ++nodeIt;
-    n->replaceWithChildrenDebug();
+    replaceChildWithChildren(*n);
   } while (--numOriginalChildrenLeft != 0);
 }
 
@@ -493,22 +517,18 @@ void InfoNode::replaceWithChildrenDebug() noexcept
   if (isLeaf() || isRoot())
     return;
 
-  InfoNode* oldParent = parent;
-  moveActiveChildOwnershipTo(*oldParent);
-  auto selfOwnership = oldParent->takeChildOwnership(this);
-  selfOwnership.release();
-  spliceChildrenIntoParentBeforeDelete(*this);
-  delete this;
+  parent->replaceChildWithChildren(*this);
 }
 
 void InfoNode::remove(bool removeChildren) noexcept
 {
-  std::unique_ptr<InfoNode> selfOwnership;
   if (parent != nullptr) {
-    selfOwnership = parent->takeChildOwnership(this);
-    selfOwnership.release();
+    parent->removeChild(*this, removeChildren ? RemoveChildrenPolicy::DetachChildren : RemoveChildrenPolicy::DeleteSubtree);
+    return;
   }
 
+  // Legacy detached-node compatibility. Internally, parent-owned nodes are
+  // removed through removeChild().
   if (removeChildren) {
     for (auto& child : m_children) {
       child.release();
@@ -518,7 +538,7 @@ void InfoNode::remove(bool removeChildren) noexcept
     lastChild = nullptr;
     setChildDegree(0);
   }
-  delete this;
+  std::unique_ptr<InfoNode> self(this);
 }
 
 void InfoNode::deleteChildren() noexcept

--- a/src/core/InfoNode.h
+++ b/src/core/InfoNode.h
@@ -19,6 +19,7 @@
 #include <stdexcept>
 #include <memory>
 #include <iostream>
+#include <iterator>
 #include <vector>
 #include <limits>
 
@@ -101,6 +102,11 @@ public:
   using const_infomap_child_iterator_wrapper = IterWrapper<const_infomap_child_iterator>;
 
 #ifndef SWIG
+  enum class RemoveChildrenPolicy {
+    DeleteSubtree,
+    DetachChildren
+  };
+
   /**
    * Owning temporary for an active child chain detached from a parent.
    * The raw first/last/sibling links preserve child order while unique_ptr
@@ -405,6 +411,17 @@ public:
    * Append all children from a detached handle to this node's active child chain.
    */
   void adoptChildren(DetachedChildChain children) noexcept;
+
+  /**
+   * Replace an active child module with its active child chain. The parent owns
+   * the mutation and destroys the removed module after reparenting children.
+   */
+  unsigned int replaceChildWithChildren(InfoNode& child) noexcept;
+
+  /**
+   * Remove an active child owned by this parent.
+   */
+  void removeChild(InfoNode& child, RemoveChildrenPolicy policy) noexcept;
 #endif
 
   /**
@@ -429,12 +446,11 @@ public:
   void replaceChildrenWithGrandChildrenDebug() noexcept;
 
   /**
-   * Delete this node.
+   * Remove this node through its parent-owned child storage.
    *
-   * removeChildren=false leaves firstChild intact, so the destructor deletes the
-   * active child chain. removeChildren=true detaches this node from active child
-   * chain ownership before deletion, leaving the previous child chain for the
-   * caller to reattach or delete.
+   * removeChildren=false deletes the active child subtree. removeChildren=true
+   * detaches this node's active child chain before removing the node, leaving the
+   * previous child chain for the caller to reattach or delete.
    */
   void remove(bool removeChildren) noexcept;
 
@@ -461,8 +477,6 @@ private:
   void appendLinkedChild(InfoNode* child) noexcept;
 
   std::unique_ptr<InfoNode> takeChildOwnership(InfoNode* child) noexcept;
-
-  void moveActiveChildOwnershipTo(InfoNode& newParent);
 };
 
 } // namespace infomap

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1170,7 +1170,8 @@ void InfomapBase::restoreHardPartition()
   for (InfoNode* node : leafNodes) {
     ++numExpandedNodes;
     numExpandedChildren += node->expandChildren();
-    node->replaceWithChildren();
+    if (!node->isLeaf() && node->parent != nullptr)
+      node->parent->replaceChildWithChildren(*node);
   }
 
   // Swap back original leaf nodes

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -733,7 +733,7 @@ inline void InfomapOptimizer<Objective>::consolidateModules(bool replaceExisting
     if (level == 1) {
       Log(4) << "Consolidated super modules, removing old modules...\n";
       for (auto& node : network)
-        node->replaceWithChildren();
+        node->parent->replaceChildWithChildren(*node);
     } else if (level == 2) {
       Log(4) << "Consolidated sub-modules, removing modules...\n";
       unsigned int moduleIndex = 0;

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -750,6 +750,26 @@ TEST_CASE("InfoNode replaceWithChildren reparents a middle child chain before de
   CHECK(after->previous->stateId == 2);
 }
 
+TEST_CASE("InfoNode replaceChildWithChildren performs parent-owned reparenting [fast][core][partition][tree][ownership]")
+{
+  InfoNode root;
+  auto* before = new InfoNode({}, 10);
+  auto* module = new InfoNode({}, 20);
+  auto* after = new InfoNode({}, 30);
+  root.addChild(before);
+  root.addChild(module);
+  root.addChild(after);
+  module->addChild(std::make_unique<InfoNode>(FlowData {}, 1));
+  module->addChild(std::make_unique<InfoNode>(FlowData {}, 2));
+
+  CHECK(root.replaceChildWithChildren(*module) == 1);
+
+  checkLinkedChildOrder(root, { 10, 1, 2, 30 });
+  CHECK(root.childDegree() == 4);
+  CHECK(before->next->stateId == 1);
+  CHECK(after->previous->stateId == 2);
+}
+
 TEST_CASE("InfoNode replaceWithChildrenDebug uses the same reparent splice path [fast][core][partition][tree][ownership]")
 {
   InfoNode root;
@@ -840,7 +860,7 @@ TEST_CASE("InfoNode remove true unlinks first and last child modules while detac
   deleteDetachedChildChain(lastDetachedChild);
 }
 
-TEST_CASE("InfoNode destructor unlinks parent and sibling pointers without updating cached child degree [fast][core][partition][tree][ownership]")
+TEST_CASE("InfoNode removeChild unlinks parent and sibling pointers through owner API [fast][core][partition][tree][ownership]")
 {
   InfoNode root;
   auto* first = new InfoNode({}, 10);
@@ -850,7 +870,7 @@ TEST_CASE("InfoNode destructor unlinks parent and sibling pointers without updat
   root.addChild(middle);
   root.addChild(last);
 
-  delete middle;
+  root.removeChild(*middle, InfoNode::RemoveChildrenPolicy::DeleteSubtree);
 
   CHECK(childStateIds(root) == std::vector<unsigned int> { 10, 30 });
   CHECK(root.firstChild == first);
@@ -859,15 +879,10 @@ TEST_CASE("InfoNode destructor unlinks parent and sibling pointers without updat
   CHECK(first->next == last);
   CHECK(last->previous == first);
   CHECK(last->next == nullptr);
-  // Existing destructor/remove semantics preserve the cached degree until a
-  // caller explicitly recalculates or overwrites it.
-  CHECK(root.childDegree() == 3);
-
-  root.calcChildDegree();
   CHECK(root.childDegree() == 2);
 }
 
-TEST_CASE("InfoNode destructor unlinks first and last children without changing cached child degree [fast][core][partition][tree][ownership]")
+TEST_CASE("InfoNode removeChild unlinks first and last children through owner API [fast][core][partition][tree][ownership]")
 {
   InfoNode firstRoot;
   auto* first = new InfoNode({}, 10);
@@ -875,14 +890,14 @@ TEST_CASE("InfoNode destructor unlinks first and last children without changing 
   firstRoot.addChild(first);
   firstRoot.addChild(second);
 
-  delete first;
+  firstRoot.removeChild(*first, InfoNode::RemoveChildrenPolicy::DeleteSubtree);
 
   CHECK(childStateIds(firstRoot) == std::vector<unsigned int> { 20 });
   CHECK(firstRoot.firstChild == second);
   CHECK(firstRoot.lastChild == second);
   CHECK(second->previous == nullptr);
   CHECK(second->next == nullptr);
-  CHECK(firstRoot.childDegree() == 2);
+  CHECK(firstRoot.childDegree() == 1);
 
   InfoNode lastRoot;
   auto* beforeLast = new InfoNode({}, 30);
@@ -890,14 +905,14 @@ TEST_CASE("InfoNode destructor unlinks first and last children without changing 
   lastRoot.addChild(beforeLast);
   lastRoot.addChild(last);
 
-  delete last;
+  lastRoot.removeChild(*last, InfoNode::RemoveChildrenPolicy::DeleteSubtree);
 
   CHECK(childStateIds(lastRoot) == std::vector<unsigned int> { 30 });
   CHECK(lastRoot.firstChild == beforeLast);
   CHECK(lastRoot.lastChild == beforeLast);
   CHECK(beforeLast->previous == nullptr);
   CHECK(beforeLast->next == nullptr);
-  CHECK(lastRoot.childDegree() == 2);
+  CHECK(lastRoot.childDegree() == 1);
 }
 
 TEST_CASE("InfoNode owns outgoing edges while incoming edges are non-owning references [fast][core][partition][tree][ownership]")


### PR DESCRIPTION
## Summary
- Add parent-owned `InfoNode::replaceChildWithChildren()` and `InfoNode::removeChild()` operations.
- Route `replaceWithChildren*()` and `remove(bool)` through parent-owned storage instead of `delete this`.
- Stop destructor repair of parent child-storage ownership; parent-owned removals now erase the owning `unique_ptr` directly.
- Update internal runtime call sites in `src/core/InfomapBase.cpp` and `src/core/InfomapOptimizer.h` to use the parent-owned replace path.
- Update C++ ownership tests so parent-owned nodes are removed through owner APIs instead of direct `delete`.

## Stack
- Stacked on #453 / `fix/infonode-detached-chain-api`.
- Base branch: `fix/infonode-detached-chain-api`.

## Verification
- `make test-native CTEST_ARGS='-R infomap_cpp_partition_tests --output-on-failure'`
- `make test-native`
- `make test-sanitizers`
- `make test-python-swig-freshness`
- `PYTHON=<temp-venv>/bin/python make build-python`

## Notes
- The new parent-owned APIs are hidden from SWIG with `#ifndef SWIG`; tracked SWIG outputs stayed fresh.
- `make build-python` was run with a temporary venv for the same local `python3.14` build-module issue noted in the previous stacked PR.
