### PR TITLE
Refactor InfoNode child links behind accessors

### DIFF
--- a/src/core/InfoNode.cpp
+++ b/src/core/InfoNode.cpp
@@ -13,9 +13,28 @@
 
 namespace infomap {
 
-namespace {
+void InfomapBaseDeleter::operator()(InfomapBase* infomap) const noexcept
+{
+  delete infomap;
+}
 
-bool chainContains(InfoNode* first, const InfoNode* node) noexcept
+std::unique_ptr<InfoNode> InfoNode::DetachedChildChain::take(InfoNode* child) noexcept
+{
+  for (auto it = m_children.begin(); it != m_children.end(); ++it) {
+    if (it->get() == child) {
+      InfoNode::unlinkFromChain(*child, m_first, m_last);
+      auto ownedChild = std::move(*it);
+      m_children.erase(it);
+      if (m_childDegree > 0)
+        --m_childDegree;
+      child->parent = nullptr;
+      return ownedChild;
+    }
+  }
+  return nullptr;
+}
+
+bool InfoNode::chainContains(InfoNode* first, const InfoNode* node) noexcept
 {
   for (auto* child = first; child != nullptr; child = child->next) {
     if (child == node)
@@ -24,7 +43,7 @@ bool chainContains(InfoNode* first, const InfoNode* node) noexcept
   return false;
 }
 
-void unlinkFromChain(InfoNode& node, InfoNode*& first, InfoNode*& last) noexcept
+void InfoNode::unlinkFromChain(InfoNode& node, InfoNode*& first, InfoNode*& last) noexcept
 {
   if (node.next != nullptr)
     node.next->previous = node.previous;
@@ -39,7 +58,7 @@ void unlinkFromChain(InfoNode& node, InfoNode*& first, InfoNode*& last) noexcept
   node.next = nullptr;
 }
 
-void unlinkFromParentAndSiblings(InfoNode& node) noexcept
+void InfoNode::unlinkFromParentAndSiblings(InfoNode& node) noexcept
 {
   if (node.parent != nullptr) {
     unlinkFromChain(node, node.parent->firstChild, node.parent->lastChild);
@@ -51,29 +70,6 @@ void unlinkFromParentAndSiblings(InfoNode& node) noexcept
   // Preserve current destructor/remove semantics: unlinking updates links but
   // does not update the parent's cached child degree.
   node.parent = nullptr;
-}
-
-} // namespace
-
-void InfomapBaseDeleter::operator()(InfomapBase* infomap) const noexcept
-{
-  delete infomap;
-}
-
-std::unique_ptr<InfoNode> InfoNode::DetachedChildChain::take(InfoNode* child) noexcept
-{
-  for (auto it = m_children.begin(); it != m_children.end(); ++it) {
-    if (it->get() == child) {
-      unlinkFromChain(*child, m_first, m_last);
-      auto ownedChild = std::move(*it);
-      m_children.erase(it);
-      if (m_childDegree > 0)
-        --m_childDegree;
-      child->parent = nullptr;
-      return ownedChild;
-    }
-  }
-  return nullptr;
 }
 
 InfoNode::InfoNode(const InfoNode& other)
@@ -352,6 +348,18 @@ void InfoNode::adoptChildren(DetachedChildChain children) noexcept
     child->next = nullptr;
     appendOwnedChild(std::move(child));
   }
+}
+
+void InfoNode::clearDetachedLinks() noexcept
+{
+  parent = nullptr;
+  previous = nullptr;
+  next = nullptr;
+}
+
+void InfoNode::setParentLink(InfoNode* parentNode) noexcept
+{
+  parent = parentNode;
 }
 
 unsigned int InfoNode::replaceChildWithChildren(InfoNode& child) noexcept

--- a/src/core/InfoNode.h
+++ b/src/core/InfoNode.h
@@ -55,7 +55,9 @@ public:
  *
  * An InfoNode owns active and collapsed children through private unique_ptr
  * storage. firstChild/lastChild, collapsedFirstChild/collapsedLastChild, and
- * sibling links are non-owning raw iteration links kept for compatibility.
+ * sibling links are non-owning raw iteration links kept as private native
+ * compatibility caches. They remain visible to SWIG/Python builds to preserve
+ * the existing generated wrapper ABI until that public API can be removed.
  * detachChildren() returns an owning move-only handle until the chain is
  * adopted by another parent or dropped. releaseChildren() is a legacy wrapper
  * that gives up ownership and leaves the caller responsible for reattach/delete.
@@ -155,6 +157,9 @@ public:
   std::vector<int> metaData; // Categorical value for each meta data dimension
 
   InfoNode* owner = nullptr; // Infomap owner (if this is an Infomap root)
+#if !defined(SWIG) && !defined(PYTHON)
+private:
+#endif
   InfoNode* parent = nullptr;
   InfoNode* previous = nullptr; // sibling
   InfoNode* next = nullptr; // sibling
@@ -162,6 +167,9 @@ public:
   InfoNode* lastChild = nullptr;
   InfoNode* collapsedFirstChild = nullptr;
   InfoNode* collapsedLastChild = nullptr;
+#if !defined(SWIG) && !defined(PYTHON)
+public:
+#endif
   double codelength = 0.0; // TODO: Better design for hierarchical stuff!?
   bool dirty = false;
 
@@ -334,6 +342,29 @@ public:
 
   unsigned int id() const noexcept { return stateId; }
 
+#ifndef SWIG
+  InfoNode* parentNode() noexcept { return parent; }
+  const InfoNode* parentNode() const noexcept { return parent; }
+
+  InfoNode* previousSibling() noexcept { return previous; }
+  const InfoNode* previousSibling() const noexcept { return previous; }
+
+  InfoNode* nextSibling() noexcept { return next; }
+  const InfoNode* nextSibling() const noexcept { return next; }
+
+  InfoNode* firstChildNode() noexcept { return firstChild; }
+  const InfoNode* firstChildNode() const noexcept { return firstChild; }
+
+  InfoNode* lastChildNode() noexcept { return lastChild; }
+  const InfoNode* lastChildNode() const noexcept { return lastChild; }
+
+  InfoNode* collapsedFirstChildNode() noexcept { return collapsedFirstChild; }
+  const InfoNode* collapsedFirstChildNode() const noexcept { return collapsedFirstChild; }
+
+  InfoNode* collapsedLastChildNode() noexcept { return collapsedLastChild; }
+  const InfoNode* collapsedLastChildNode() const noexcept { return collapsedLastChild; }
+#endif
+
   // ---------------------------- Operators ----------------------------
 
   bool operator==(const InfoNode& rhs) const noexcept { return this == &rhs; }
@@ -413,6 +444,16 @@ public:
   void adoptChildren(DetachedChildChain children) noexcept;
 
   /**
+   * Clear stale raw links on nodes intentionally detached through legacy APIs.
+   */
+  void clearDetachedLinks() noexcept;
+
+  /**
+   * Preserve parent context on detached value copies used by physical iterators.
+   */
+  void setParentLink(InfoNode* parentNode) noexcept;
+
+  /**
    * Replace an active child module with its active child chain. The parent owns
    * the mutation and destroys the removed module after reparenting children.
    */
@@ -477,6 +518,12 @@ private:
   void appendLinkedChild(InfoNode* child) noexcept;
 
   std::unique_ptr<InfoNode> takeChildOwnership(InfoNode* child) noexcept;
+
+  static bool chainContains(InfoNode* first, const InfoNode* node) noexcept;
+
+  static void unlinkFromChain(InfoNode& node, InfoNode*& first, InfoNode*& last) noexcept;
+
+  static void unlinkFromParentAndSiblings(InfoNode& node) noexcept;
 };
 
 } // namespace infomap

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -73,10 +73,10 @@ unsigned int InfomapBase::numLevels() const
 {
   // TODO: Make sure this is not called unless tree is guaranteed to have even depth!
   unsigned int depth = 0;
-  InfoNode* n = m_root.firstChild;
+  const InfoNode* n = m_root.firstChildNode();
   while (n != nullptr) {
     ++depth;
-    n = n->firstChild;
+    n = n->firstChildNode();
   }
   return depth;
 }
@@ -386,7 +386,7 @@ InfomapBase& InfomapBase::initNetwork(Network& network)
     throw std::domain_error("No nodes in network");
   // A fresh network init invalidates any previous hard-partition restore buffer.
   m_originalLeafNodes.clear();
-  if (m_root.firstChild != nullptr || m_root.collapsedFirstChild != nullptr) {
+  if (m_root.firstChildNode() != nullptr || m_root.collapsedFirstChildNode() != nullptr) {
     m_root.deleteChildren();
     m_leafNodes.clear();
   }
@@ -463,9 +463,9 @@ InfomapBase& InfomapBase::initTree(const NodePaths& tree)
   std::vector<InfoNode::DetachedChildChain> detachedLeafParents;
   for (auto& leafNode : m_leafNodes) {
     // Also detach leaf nodes to delete all modules, safe to call multiple times
-    detachedLeafParents.push_back(leafNode->parent->detachChildren());
+    detachedLeafParents.push_back(leafNode->parentNode()->detachChildren());
     // Set parent to nullptr to be able to collect any orphaned nodes in the end
-    leafNode->parent = nullptr;
+    leafNode->clearDetachedLinks();
     nodeIdToIndex[leafNode->stateId] = leafIndex;
     ++leafIndex;
   }
@@ -510,7 +510,7 @@ InfomapBase& InfomapBase::initTree(const NodePaths& tree)
         }
       }
 
-      node = node->lastChild;
+      node = node->lastChildNode();
       ++depth;
     }
     maxDepth = std::max(maxDepth, depth);
@@ -525,7 +525,7 @@ InfomapBase& InfomapBase::initTree(const NodePaths& tree)
 
   // Set orphaned nodes to their own or neighbouring module
   for (auto& leafNode : m_leafNodes) {
-    if (leafNode->parent != nullptr) {
+    if (leafNode->parentNode() != nullptr) {
       continue;
     }
 
@@ -533,24 +533,24 @@ InfomapBase& InfomapBase::initTree(const NodePaths& tree)
     if (assignToNeighbouringModule) {
       // Take first neighbour that has a module assigned
       for (auto* edge : leafNode->outEdges()) {
-        if (edge->target->parent != nullptr) {
-          edge->target->parent->addChild(takeDetachedLeaf(leafNode));
+        if (edge->target->parentNode() != nullptr) {
+          edge->target->parentNode()->addChild(takeDetachedLeaf(leafNode));
           ++numNodesAddedToNeighbouringModules;
           break;
         }
       }
       // Check incoming links if still orphan
-      if (leafNode->parent == nullptr) {
+      if (leafNode->parentNode() == nullptr) {
         for (auto* edge : leafNode->inEdges()) {
-          if (edge->source->parent != nullptr) {
-            edge->source->parent->addChild(takeDetachedLeaf(leafNode));
+          if (edge->source->parentNode() != nullptr) {
+            edge->source->parentNode()->addChild(takeDetachedLeaf(leafNode));
             ++numNodesAddedToNeighbouringModules;
             break;
           }
         }
       }
       // Set to own module if no neighbour module available
-      if (leafNode->parent == nullptr) {
+      if (leafNode->parentNode() == nullptr) {
         auto& module = root().addChild(std::make_unique<InfoNode>());
         module.addChild(takeDetachedLeaf(leafNode));
       }
@@ -910,7 +910,7 @@ void InfomapBase::generateSubNetwork(InfoNode& parent)
     for (InfoEdge* e : node.outEdges()) {
       InfoEdge& edge = *e;
       // If neighbour node is within the same module, add the link to this subnetwork.
-      if (edge.target->parent == parentPtr) {
+      if (edge.target->parentNode() == parentPtr) {
         m_leafNodes[edge.source->index]->addOutEdge(*m_leafNodes[edge.target->index], edge.data.weight, edge.data.flow);
       }
     }
@@ -956,7 +956,7 @@ void InfomapBase::hierarchicalPartition()
       double codelengthAfter = 0.0;
 
       for (InfoNode& module : m_root.infomapTree()) {
-        if (!module.isLeaf() && module.firstChild->isLeafModule()) {
+        if (!module.isLeaf() && module.firstChildNode()->isLeafModule()) {
           codelengthBefore += module.codelength;
           auto numLeafs = 0;
           for (auto& leafModule : module) {
@@ -999,7 +999,7 @@ void InfomapBase::hierarchicalPartition()
             InfoNode* leaf = leafs[j];
             unsigned int moduleIndex = modules[j];
             if (subModules[moduleIndex] == nullptr) {
-              auto subModule = std::make_unique<InfoNode>(subInfomap.leafNodes()[j]->parent->data);
+              auto subModule = std::make_unique<InfoNode>(subInfomap.leafNodes()[j]->parentNode()->data);
               subModules[moduleIndex] = subModule.get();
               subModules[moduleIndex]->index = moduleIndex;
               module.addChild(std::move(subModule));
@@ -1170,8 +1170,8 @@ void InfomapBase::restoreHardPartition()
   for (InfoNode* node : leafNodes) {
     ++numExpandedNodes;
     numExpandedChildren += node->expandChildren();
-    if (!node->isLeaf() && node->parent != nullptr)
-      node->parent->replaceChildWithChildren(*node);
+    if (!node->isLeaf() && node->parentNode() != nullptr)
+      node->parentNode()->replaceChildWithChildren(*node);
   }
 
   // Swap back original leaf nodes
@@ -1251,7 +1251,7 @@ void InfomapBase::aggregateFlowValuesFromLeafToRoot()
   for (auto it = root().begin_post_depth_first(); !it.isEnd(); ++it) {
     auto& node = *it;
     if (!node.isRoot())
-      node.parent->data += node.data;
+      node.parentNode()->data += node.data;
     // Don't aggregate enter and exit flow
     if (!node.isLeaf()) {
       node.index = it.depth(); // Use index to store the depth on modules
@@ -1274,8 +1274,8 @@ void InfomapBase::aggregateFlowValuesFromLeafToRoot()
       double linkFlow = edge.data.flow;
       double halfFlow = linkFlow / 2;
 
-      InfoNode* node1 = leafNodeSource.parent;
-      InfoNode* node2 = leafNodeTarget->parent;
+      InfoNode* node1 = leafNodeSource.parentNode();
+      InfoNode* node2 = leafNodeTarget->parentNode();
 
       if (node1 == node2)
         continue;
@@ -1288,7 +1288,7 @@ void InfomapBase::aggregateFlowValuesFromLeafToRoot()
         } else {
           node1->data.exitFlow += linkFlow;
         }
-        node1 = node1->parent;
+        node1 = node1->parentNode();
       }
       while (node2->index > node1->index) {
         if (isUndirectedClustering()) {
@@ -1297,7 +1297,7 @@ void InfomapBase::aggregateFlowValuesFromLeafToRoot()
         } else {
           node2->data.enterFlow += linkFlow;
         }
-        node2 = node2->parent;
+        node2 = node2->parentNode();
       }
 
       // Then aggregate link flow until equal parent
@@ -1311,8 +1311,8 @@ void InfomapBase::aggregateFlowValuesFromLeafToRoot()
           node1->data.exitFlow += linkFlow;
           node2->data.enterFlow += linkFlow;
         }
-        node1 = node1->parent;
-        node2 = node2->parent;
+        node1 = node1->parentNode();
+        node2 = node2->parentNode();
       }
     }
   }
@@ -1422,7 +1422,7 @@ unsigned int InfomapBase::fineTune()
   // Put leaf modules in existing modules
   std::vector<unsigned int> modules(numLeafNodes());
   for (unsigned int i = 0; i < numLeafNodes(); ++i) {
-    modules[i] = m_leafNodes[i]->parent->index;
+    modules[i] = m_leafNodes[i]->parentNode()->index;
   }
   moveActiveNodesToPredefinedModules(modules);
 
@@ -1738,10 +1738,10 @@ void InfomapBase::resetFlowOnModules()
   // Aggregate flow from leaf nodes up in the tree
   for (InfoNode* n : m_leafNodes) {
     double leafNodeFlow = n->data.flow;
-    InfoNode* module = n->parent;
+    InfoNode* module = n->parentNode();
     do {
       module->data.flow += leafNodeFlow;
-      module = module->parent;
+      module = module->parentNode();
     } while (module != nullptr);
   }
 }
@@ -2211,7 +2211,7 @@ void aggregatePerLevelCodelength(const InfoNode& parent, std::vector<detail::Per
   if (perLevelStat.size() < level + 1)
     perLevelStat.resize(level + 1);
 
-  if (parent.firstChild->isLeaf()) {
+  if (parent.firstChildNode()->isLeaf()) {
     perLevelStat[level].numLeafNodes += parent.childDegree();
     perLevelStat[level].leafLength += parent.codelength;
     return;

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -99,7 +99,7 @@ public:
 
   unsigned int numNonTrivialTopModules() const { return m_numNonTrivialTopModules; }
 
-  bool haveModules() const { return !m_root.isLeaf() && !m_root.firstChild->isLeaf(); }
+  bool haveModules() const { return !m_root.isLeaf() && !m_root.firstChildNode()->isLeaf(); }
 
   bool haveNonTrivialModules() const { return numNonTrivialTopModules() > 0; }
 

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -676,7 +676,7 @@ inline void InfomapOptimizer<Objective>::consolidateModules(bool replaceExisting
   // Detach active children from current parent(s) to put new modules between
   std::vector<InfoNode::DetachedChildChain> detachedParents;
   for (auto& n : network) {
-    detachedParents.push_back(n->parent->detachChildren()); // Safe to call multiple times
+    detachedParents.push_back(n->parentNode()->detachChildren()); // Safe to call multiple times
   }
 
   auto takeDetachedNode = [&detachedParents](InfoNode* node) {
@@ -695,7 +695,7 @@ inline void InfomapOptimizer<Objective>::consolidateModules(bool replaceExisting
       auto module = std::make_unique<InfoNode>(m_moduleFlowData[moduleIndex]);
       modules[moduleIndex] = module.get();
       modules[moduleIndex]->index = moduleIndex;
-      node->parent->addChild(std::move(module));
+      node->parentNode()->addChild(std::move(module));
     }
     modules[moduleIndex]->addChild(takeDetachedNode(node));
   }
@@ -733,7 +733,7 @@ inline void InfomapOptimizer<Objective>::consolidateModules(bool replaceExisting
     if (level == 1) {
       Log(4) << "Consolidated super modules, removing old modules...\n";
       for (auto& node : network)
-        node->parent->replaceChildWithChildren(*node);
+        node->parentNode()->replaceChildWithChildren(*node);
     } else if (level == 2) {
       Log(4) << "Consolidated sub-modules, removing modules...\n";
       unsigned int moduleIndex = 0;

--- a/src/core/MetaMapEquation.cpp
+++ b/src/core/MetaMapEquation.cpp
@@ -73,7 +73,7 @@ void MetaMapEquation::initPartition(std::vector<InfoNode*>& nodes)
 
 void MetaMapEquation::initMetaNodes(InfoNode& root)
 {
-  bool notInitiated = root.firstChild->metaCollection.empty();
+  bool notInitiated = root.firstChildNode()->metaCollection.empty();
   if (notInitiated) {
     Log(3) << "MetaMapEquation::initMetaNodes()...\n";
 
@@ -86,12 +86,12 @@ void MetaMapEquation::initMetaNodes(InfoNode& root)
         if (!node.metaData.empty()) {
           // TODO: Use flow here and move weightByFlow choice to metaCollection, using flowCount?
           double flow = weightByFlow ? node.data.flow : m_unweightedNodeFlow;
-          node.parent->metaCollection.add(node.metaData[0], flow);
+          node.parentNode()->metaCollection.add(node.metaData[0], flow);
         } else {
           throw std::length_error("A node is missing meta data using MetaMapEquation");
         }
       } else {
-        node.parent->metaCollection.add(node.metaCollection);
+        node.parentNode()->metaCollection.add(node.metaCollection);
       }
     }
   }

--- a/src/core/iterators/InfomapIterator.cpp
+++ b/src/core/iterators/InfomapIterator.cpp
@@ -19,8 +19,8 @@ InfomapIterator& InfomapIterator::operator++() noexcept
   const auto root = m_current->getInfomapRoot();
   auto current = root ? root : m_current;
 
-  if (current->firstChild) {
-    current = current->firstChild;
+  if (current->firstChildNode()) {
+    current = current->firstChildNode();
     ++m_depth;
     m_path.push_back(1);
   } else {
@@ -32,7 +32,7 @@ InfomapIterator& InfomapIterator::operator++() noexcept
     while (tryNext) {
       tryNext = false;
 
-      while (!current->next) {
+      while (!current->nextSibling()) {
         if (current->owner) {
           current = current->owner;
 
@@ -44,8 +44,8 @@ InfomapIterator& InfomapIterator::operator++() noexcept
           tryNext = true;
           break;
         }
-        if (current->parent) {
-          current = current->parent;
+        if (current->parentNode()) {
+          current = current->parentNode();
           --m_depth;
           m_path.pop_back();
 
@@ -60,7 +60,7 @@ InfomapIterator& InfomapIterator::operator++() noexcept
       }
     }
 
-    current = current->next;
+    current = current->nextSibling();
 
     if (!current->isLeaf() && (static_cast<unsigned int>(m_moduleIndexLevel) >= m_depth)) {
       ++m_moduleIndex;
@@ -75,12 +75,12 @@ InfomapIterator& InfomapIterator::operator++() noexcept
 
 double InfomapIterator::modularCentrality() const noexcept
 {
-  if (m_current->parent == nullptr) {
+  if (m_current->parentNode() == nullptr) {
     // The root node has no modular centrality
     return 0.0;
   }
 
-  const auto p_m = m_current->parent->data.flow;
+  const auto p_m = m_current->parentNode()->data.flow;
   const auto p_u = m_current->data.flow;
   const auto p_diff = p_m - p_u;
 
@@ -165,7 +165,7 @@ InfomapIterator& InfomapIteratorPhysical::operator++() noexcept
         auto& physNode = ret.first->second;
         if (ret.second) {
           // New physical node, use same parent as the state leaf node
-          physNode.parent = m_current->parent;
+          physNode.setParentLink(m_current->parentNode());
         } else {
           // Not inserted, add flow to existing physical node
           // TODO: If exitFlow should be correct, flow between memory nodes within same physical node should be subtracted.
@@ -228,7 +228,7 @@ InfomapIterator& InfomapLeafIteratorPhysical::operator++() noexcept
 
 InfomapParentIterator& InfomapParentIterator::operator++() noexcept
 {
-  m_current = m_current->parent;
+  m_current = m_current->parentNode();
   if (m_current != nullptr && m_current->owner != nullptr) {
     m_current = m_current->owner;
   }

--- a/src/core/iterators/infomapIterators.h
+++ b/src/core/iterators/infomapIterators.h
@@ -55,7 +55,7 @@ public:
         m_root = infomapRoot;
       }
     }
-    m_current = m_root == nullptr ? nullptr : m_root->firstChild;
+    m_current = m_root == nullptr ? nullptr : m_root->firstChildNode();
   }
 
   pointer current() const { return m_current; }
@@ -72,8 +72,8 @@ public:
 
   InfomapChildIterator& operator++()
   {
-    m_current = m_current->next;
-    if (m_current != nullptr && m_current->parent != m_root) {
+    m_current = m_current->nextSibling();
+    if (m_current != nullptr && m_current->parentNode() != m_root) {
       m_current = nullptr;
     }
     return *this;
@@ -88,8 +88,8 @@ public:
 
   InfomapChildIterator& operator--()
   {
-    m_current = m_current->previous;
-    if (m_current != nullptr && m_current->parent != m_root) {
+    m_current = m_current->previousSibling();
+    if (m_current != nullptr && m_current->parentNode() != m_root) {
       m_current = nullptr;
     }
     return *this;
@@ -154,16 +154,16 @@ public:
   {
     NodePointerType curr = Base::m_current;
 
-    if (curr->firstChild != nullptr) {
-      curr = curr->firstChild;
+    if (curr->firstChildNode() != nullptr) {
+      curr = curr->firstChildNode();
       ++m_depth;
     } else {
     // Current node is a leaf
     // Presupposes that the next pointer can't reach out from the current parent.
     tryNext:
-      while (curr->next == nullptr) {
-        if (curr->parent != nullptr) {
-          curr = curr->parent;
+      while (curr->nextSibling() == nullptr) {
+        if (curr->parentNode() != nullptr) {
+          curr = curr->parentNode();
           --m_depth;
           if (curr == Base::m_root) // Check if back to beginning
           {
@@ -192,7 +192,7 @@ public:
           }
         }
       }
-      curr = curr->next;
+      curr = curr->nextSibling();
     }
     m_current = curr;
     moveToInfomapRootIfExist();
@@ -286,17 +286,17 @@ public:
   {
     NodePointerType curr = Base::m_current;
 
-    if (curr->firstChild != nullptr) {
-      curr = curr->firstChild;
+    if (curr->firstChildNode() != nullptr) {
+      curr = curr->firstChildNode();
       ++m_depth;
       m_path.push_back(0);
     } else {
     // Current node is a leaf
     // Presupposes that the next pointer can't reach out from the current parent.
     tryNext:
-      while (curr->next == nullptr) {
-        if (curr->parent != nullptr) {
-          curr = curr->parent;
+      while (curr->nextSibling() == nullptr) {
+        if (curr->parentNode() != nullptr) {
+          curr = curr->parentNode();
           --m_depth;
           m_path.pop_back();
           if (curr == Base::m_root) // Check if back to beginning
@@ -326,7 +326,7 @@ public:
           }
         }
       }
-      curr = curr->next;
+      curr = curr->nextSibling();
       ++m_path.back();
     }
     m_current = curr;

--- a/src/core/iterators/treeIterators.h
+++ b/src/core/iterators/treeIterators.h
@@ -42,7 +42,7 @@ public:
   ChildIterator() = default;
 
   ChildIterator(const NodePointerType& nodePointer)
-      : m_root(nodePointer), m_current(nodePointer == nullptr ? nullptr : nodePointer->firstChild) { }
+      : m_root(nodePointer), m_current(nodePointer == nullptr ? nullptr : nodePointer->firstChildNode()) { }
 
   ChildIterator(const ChildIterator& other)
       : m_root(other.m_root), m_current(other.m_current) { }
@@ -68,8 +68,8 @@ public:
 
   ChildIterator& operator++()
   {
-    m_current = m_current->next;
-    if (m_current != nullptr && m_current->parent != m_root) {
+    m_current = m_current->nextSibling();
+    if (m_current != nullptr && m_current->parentNode() != m_root) {
       m_current = nullptr;
     }
     return *this;
@@ -84,8 +84,8 @@ public:
 
   ChildIterator& operator--()
   {
-    m_current = m_current->previous;
-    if (m_current != nullptr && m_current->parent != m_root) {
+    m_current = m_current->previousSibling();
+    if (m_current != nullptr && m_current->parentNode() != m_root) {
       m_current = nullptr;
     }
     return *this;
@@ -173,17 +173,17 @@ public:
       curr = infomapRoot;
     }
 
-    if (curr->firstChild != nullptr) {
-      curr = curr->firstChild;
+    if (curr->firstChildNode() != nullptr) {
+      curr = curr->firstChildNode();
       ++m_depth;
       m_path.push_back(0);
     } else {
     // Current node is a leaf
     // Presupposes that the next pointer can't reach out from the current parent.
     tryNext:
-      while (curr->next == nullptr) {
-        if (curr->parent != nullptr) {
-          curr = curr->parent;
+      while (curr->nextSibling() == nullptr) {
+        if (curr->parentNode() != nullptr) {
+          curr = curr->parentNode();
           --m_depth;
           m_path.pop_back();
           if (curr == m_root) // Check if back to beginning
@@ -213,7 +213,7 @@ public:
           }
         }
       }
-      curr = curr->next;
+      curr = curr->nextSibling();
       ++m_path.back();
     }
     m_current = curr;
@@ -327,13 +327,13 @@ public:
   DepthFirstIterator& operator++()
   {
     NodePointerType curr = Base::m_current;
-    if (curr->firstChild != nullptr) {
-      curr = curr->firstChild;
+    if (curr->firstChildNode() != nullptr) {
+      curr = curr->firstChildNode();
       ++Base::m_depth;
     } else {
       // Presupposes that the next pointer can't reach out from the current parent.
-      while (curr->next == nullptr) {
-        curr = curr->parent;
+      while (curr->nextSibling() == nullptr) {
+        curr = curr->parentNode();
         --Base::m_depth;
         if (curr == Base::m_root || curr == nullptr) // 0 if no children in first place
         {
@@ -341,7 +341,7 @@ public:
           return *this;
         }
       }
-      curr = curr->next;
+      curr = curr->nextSibling();
     }
     Base::m_current = curr;
     return *this;
@@ -386,8 +386,8 @@ public:
   void init()
   {
     if (Base::m_current != nullptr) {
-      while (Base::m_current->firstChild != nullptr) {
-        Base::m_current = Base::m_current->firstChild;
+      while (Base::m_current->firstChildNode() != nullptr) {
+        Base::m_current = Base::m_current->firstChildNode();
         ++Base::m_depth;
       }
     }
@@ -402,14 +402,14 @@ public:
     }
 
     NodePointerType curr = Base::m_current;
-    if (curr->next != nullptr) {
-      curr = curr->next;
-      while (curr->firstChild != nullptr) {
-        curr = curr->firstChild;
+    if (curr->nextSibling() != nullptr) {
+      curr = curr->nextSibling();
+      while (curr->firstChildNode() != nullptr) {
+        curr = curr->firstChildNode();
         ++Base::m_depth;
       }
     } else {
-      curr = curr->parent;
+      curr = curr->parentNode();
       --Base::m_depth;
     }
 
@@ -456,8 +456,8 @@ public:
   void init()
   {
     if (Base::m_current != nullptr) {
-      while (Base::m_current->firstChild != nullptr) {
-        Base::m_current = Base::m_current->firstChild;
+      while (Base::m_current->firstChildNode() != nullptr) {
+        Base::m_current = Base::m_current->firstChildNode();
         ++Base::m_depth;
       }
     }
@@ -466,18 +466,18 @@ public:
   LeafNodeIterator& operator++()
   {
     ASSERT(Base::m_current != nullptr);
-    while (Base::m_current->next == nullptr || Base::m_current->next->parent != Base::m_current->parent) {
-      Base::m_current = Base::m_current->parent;
+    while (Base::m_current->nextSibling() == nullptr || Base::m_current->nextSibling()->parentNode() != Base::m_current->parentNode()) {
+      Base::m_current = Base::m_current->parentNode();
       --Base::m_depth;
       if (Base::m_current == nullptr)
         return *this;
     }
 
-    Base::m_current = Base::m_current->next;
+    Base::m_current = Base::m_current->nextSibling();
 
     if (Base::m_current != nullptr) {
-      while (Base::m_current->firstChild != nullptr) {
-        Base::m_current = Base::m_current->firstChild;
+      while (Base::m_current->firstChildNode() != nullptr) {
+        Base::m_current = Base::m_current->firstChildNode();
         ++Base::m_depth;
       }
     }
@@ -522,11 +522,11 @@ public:
   void init()
   {
     if (Base::m_current != nullptr) {
-      if (Base::m_current->firstChild == nullptr) {
+      if (Base::m_current->firstChildNode() == nullptr) {
         Base::m_current = nullptr; // End directly if no module
       } else {
-        while (Base::m_current->firstChild->firstChild != nullptr) {
-          Base::m_current = Base::m_current->firstChild;
+        while (Base::m_current->firstChildNode()->firstChildNode() != nullptr) {
+          Base::m_current = Base::m_current->firstChildNode();
           ++Base::m_depth;
         }
       }
@@ -536,21 +536,21 @@ public:
   LeafModuleIterator& operator++()
   {
     ASSERT(Base::m_current != nullptr);
-    while (Base::m_current->next == nullptr || Base::m_current->next->parent != Base::m_current->parent) {
-      Base::m_current = Base::m_current->parent;
+    while (Base::m_current->nextSibling() == nullptr || Base::m_current->nextSibling()->parentNode() != Base::m_current->parentNode()) {
+      Base::m_current = Base::m_current->parentNode();
       --Base::m_depth;
       if (Base::m_current == nullptr)
         return *this;
     }
 
-    Base::m_current = Base::m_current->next;
+    Base::m_current = Base::m_current->nextSibling();
 
     if (Base::m_current != nullptr) {
-      if (Base::m_current->firstChild == nullptr) {
-        Base::m_current = Base::m_current->parent;
+      if (Base::m_current->firstChildNode() == nullptr) {
+        Base::m_current = Base::m_current->parentNode();
       } else {
-        while (Base::m_current->firstChild->firstChild != nullptr) {
-          Base::m_current = Base::m_current->firstChild;
+        while (Base::m_current->firstChildNode()->firstChildNode() != nullptr) {
+          Base::m_current = Base::m_current->firstChildNode();
           ++Base::m_depth;
         }
       }
@@ -597,7 +597,7 @@ public:
   SiblingIterator& operator++()
   {
     ASSERT(Base::m_current != nullptr);
-    Base::m_current = Base::m_current->next;
+    Base::m_current = Base::m_current->nextSibling();
     return *this;
   }
 
@@ -611,7 +611,7 @@ public:
   SiblingIterator& operator--()
   {
     ASSERT(Base::m_current != nullptr);
-    Base::m_current = Base::m_current->previous;
+    Base::m_current = Base::m_current->previousSibling();
     return *this;
   }
 

--- a/src/io/Output.cpp
+++ b/src/io/Output.cpp
@@ -187,7 +187,7 @@ std::map<std::string, LinkMap> aggregateModuleLinks(InfomapBase& im, bool states
     for (auto it(im.iterTreePhysical()); !it.isEnd(); ++it) {
       if (it->isLeaf()) {
         for (auto stateId : it->stateNodes) {
-          stateIdToParent[stateId] = it->parent;
+          stateIdToParent[stateId] = it->parentNode();
           stateIdToChildIndex[stateId] = it.childIndex();
         }
       }
@@ -195,7 +195,7 @@ std::map<std::string, LinkMap> aggregateModuleLinks(InfomapBase& im, bool states
   } else {
     for (auto it(im.iterTree()); !it.isEnd(); ++it) {
       if (it->isLeaf()) {
-        stateIdToParent[it->stateId] = it->parent;
+        stateIdToParent[it->stateId] = it->parentNode();
         stateIdToChildIndex[it->stateId] = it.childIndex();
       }
     }

--- a/test/cpp/test_infomap_wrapper.cpp
+++ b/test/cpp/test_infomap_wrapper.cpp
@@ -21,7 +21,7 @@ std::multiset<InternalEdge> internalEdgesForModule(infomap::InfoNode& module)
   std::multiset<InternalEdge> edges;
   for (auto& node : module) {
     for (auto* edge : node.outEdges()) {
-      if (edge->target->parent == &module) {
+      if (edge->target->parentNode() == &module) {
         edges.emplace(edge->source->stateId, edge->target->stateId, edge->data.weight, edge->data.flow);
       }
     }
@@ -275,7 +275,7 @@ TEST_CASE("Subnetwork reuse and dispose stay stable on the same parent module [f
   infomap::test::checkRunSanity(im);
   REQUIRE(im.numTopModules() == 2);
 
-  auto& module = *im.root().firstChild;
+  auto& module = *im.root().firstChildNode();
   const auto originalEdges = internalEdgesForModule(module);
   std::vector<unsigned int> expectedLeafIds;
   for (const auto& node : module) {
@@ -345,7 +345,7 @@ TEST_CASE("Subnetwork ownership replaces and disposes the module Infomap instanc
   infomap::test::checkRunSanity(im);
   REQUIRE(im.numTopModules() == 2);
 
-  auto& module = *im.root().firstChild;
+  auto& module = *im.root().firstChildNode();
 
   auto& firstSubInfomap = im.getSubInfomap(module).initNetwork(module);
   REQUIRE(module.getInfomapRoot() == &firstSubInfomap.root());
@@ -370,7 +370,7 @@ TEST_CASE("Higher-order subnetwork rebuild preserves state identities and intern
   infomap::test::checkRunSanity(im);
   REQUIRE(im.numTopModules() == 2);
 
-  auto& module = *im.root().firstChild;
+  auto& module = *im.root().firstChildNode();
   REQUIRE(module.childDegree() >= 2);
 
   const auto originalEdges = internalEdgesForModule(module);
@@ -411,7 +411,7 @@ TEST_CASE("Metadata-bearing subnetwork rebuild preserves leaf metadata [fast][co
   infomap::test::checkRunSanity(im);
   REQUIRE(im.numTopModules() == 2);
 
-  auto& module = *im.root().firstChild;
+  auto& module = *im.root().firstChildNode();
   const auto originalEdges = internalEdgesForModule(module);
   const auto originalIdentities = nodeIdentitiesForModule(module);
   REQUIRE_FALSE(originalIdentities.empty());
@@ -440,7 +440,7 @@ TEST_CASE("Higher-order metadata-bearing subnetwork rebuild stays stable [fast][
   infomap::test::checkRunSanity(im);
   REQUIRE(im.numTopModules() == 2);
 
-  auto& module = *im.root().firstChild;
+  auto& module = *im.root().firstChildNode();
   REQUIRE(module.childDegree() >= 2);
 
   const auto originalEdges = internalEdgesForModule(module);

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -30,7 +30,7 @@ std::vector<unsigned int> childStateIds(const InfoNode& node)
 std::vector<unsigned int> childChainStateIds(const InfoNode* firstChild)
 {
   std::vector<unsigned int> ids;
-  for (const auto* child = firstChild; child != nullptr; child = child->next) {
+  for (const auto* child = firstChild; child != nullptr; child = child->nextSibling()) {
     ids.push_back(child->stateId);
   }
   return ids;
@@ -39,10 +39,8 @@ std::vector<unsigned int> childChainStateIds(const InfoNode* firstChild)
 void deleteDetachedChildChain(InfoNode* firstChild)
 {
   while (firstChild != nullptr) {
-    auto* next = firstChild->next;
-    firstChild->parent = nullptr;
-    firstChild->previous = nullptr;
-    firstChild->next = nullptr;
+    auto* next = firstChild->nextSibling();
+    firstChild->clearDetachedLinks();
     delete firstChild;
     firstChild = next;
   }
@@ -54,25 +52,25 @@ void checkLinkedChildOrder(InfoNode& parent, const std::vector<unsigned int>& ex
   CHECK(parent.childDegree() == expectedStateIds.size());
 
   InfoNode* previous = nullptr;
-  InfoNode* child = parent.firstChild;
+  InfoNode* child = parent.firstChildNode();
   std::size_t index = 0;
   while (child != nullptr) {
     REQUIRE(index < expectedStateIds.size());
     CHECK(child->stateId == expectedStateIds[index]);
-    CHECK(child->parent == &parent);
-    CHECK(child->previous == previous);
+    CHECK(child->parentNode() == &parent);
+    CHECK(child->previousSibling() == previous);
     if (previous != nullptr) {
-      CHECK(previous->next == child);
+      CHECK(previous->nextSibling() == child);
     }
     previous = child;
-    child = child->next;
+    child = child->nextSibling();
     ++index;
   }
 
   CHECK(index == expectedStateIds.size());
-  CHECK(parent.lastChild == previous);
+  CHECK(parent.lastChildNode() == previous);
   if (previous != nullptr) {
-    CHECK(previous->next == nullptr);
+    CHECK(previous->nextSibling() == nullptr);
   }
 }
 
@@ -223,20 +221,20 @@ TEST_CASE("InfoNode hierarchy mutations preserve parentage and child order [fast
 
   CHECK(root.collapseChildren() == 3);
   CHECK(root.childDegree() == 0);
-  CHECK(root.firstChild == nullptr);
-  CHECK(root.lastChild == nullptr);
+  CHECK(root.firstChildNode() == nullptr);
+  CHECK(root.lastChildNode() == nullptr);
 
   CHECK(root.expandChildren() == 3);
   CHECK(root.childDegree() == 3);
   CHECK(childStateIds(root) == std::vector<unsigned int> { 10, 20, 30 });
-  CHECK(childA->parent == &root);
-  CHECK(childB->parent == &root);
-  CHECK(childC->parent == &root);
+  CHECK(childA->parentNode() == &root);
+  CHECK(childB->parentNode() == &root);
+  CHECK(childC->parentNode() == &root);
 
   root.releaseChildren();
   CHECK(root.childDegree() == 0);
-  CHECK(root.firstChild == nullptr);
-  CHECK(root.lastChild == nullptr);
+  CHECK(root.firstChildNode() == nullptr);
+  CHECK(root.lastChildNode() == nullptr);
 
   delete childA;
   delete childB;
@@ -268,14 +266,14 @@ TEST_CASE("InfoNode unique_ptr child handoff preserves raw child-chain semantics
   CHECK(childA == nullptr);
   CHECK(childB == nullptr);
   CHECK(root.childDegree() == 2);
-  CHECK(root.firstChild == childAPtr);
-  CHECK(root.lastChild == childBPtr);
-  CHECK(childAPtr->parent == &root);
-  CHECK(childBPtr->parent == &root);
-  CHECK(childAPtr->previous == nullptr);
-  CHECK(childAPtr->next == childBPtr);
-  CHECK(childBPtr->previous == childAPtr);
-  CHECK(childBPtr->next == nullptr);
+  CHECK(root.firstChildNode() == childAPtr);
+  CHECK(root.lastChildNode() == childBPtr);
+  CHECK(childAPtr->parentNode() == &root);
+  CHECK(childBPtr->parentNode() == &root);
+  CHECK(childAPtr->previousSibling() == nullptr);
+  CHECK(childAPtr->nextSibling() == childBPtr);
+  CHECK(childBPtr->previousSibling() == childAPtr);
+  CHECK(childBPtr->nextSibling() == nullptr);
   CHECK(childStateIds(root) == std::vector<unsigned int> { 10, 20 });
 
   childAPtr->addChild(std::make_unique<InfoNode>(FlowData {}, 11));
@@ -293,15 +291,15 @@ TEST_CASE("InfoNode raw addChild reparents child ownership between parents [fast
 
   CHECK(childStateIds(oldParent) == std::vector<unsigned int> { 20 });
   CHECK(childStateIds(newParent) == std::vector<unsigned int> { 10 });
-  CHECK(child->parent == &newParent);
-  CHECK(child->previous == nullptr);
-  CHECK(child->next == nullptr);
+  CHECK(child->parentNode() == &newParent);
+  CHECK(child->previousSibling() == nullptr);
+  CHECK(child->nextSibling() == nullptr);
 
   oldParent.deleteChildren();
 
   CHECK(child->stateId == 10);
-  CHECK(newParent.firstChild == child);
-  CHECK(newParent.lastChild == child);
+  CHECK(newParent.firstChildNode() == child);
+  CHECK(newParent.lastChildNode() == child);
 }
 
 TEST_CASE("InfoNode releaseChildren detaches active children without deleting them [fast][core][partition][tree][ownership]")
@@ -315,14 +313,14 @@ TEST_CASE("InfoNode releaseChildren detaches active children without deleting th
   root.releaseChildren();
 
   CHECK(root.childDegree() == 0);
-  CHECK(root.firstChild == nullptr);
-  CHECK(root.lastChild == nullptr);
+  CHECK(root.firstChildNode() == nullptr);
+  CHECK(root.lastChildNode() == nullptr);
   CHECK(childA->stateId == 10);
   CHECK(childB->stateId == 20);
-  CHECK(childA->parent == &root);
-  CHECK(childB->parent == &root);
-  CHECK(childA->next == childB);
-  CHECK(childB->previous == childA);
+  CHECK(childA->parentNode() == &root);
+  CHECK(childB->parentNode() == &root);
+  CHECK(childA->nextSibling() == childB);
+  CHECK(childB->previousSibling() == childA);
 
   delete childA;
   delete childB;
@@ -340,8 +338,8 @@ TEST_CASE("InfoNode reattaches released children under new unique_ptr ownership 
   newParent.addChild(childB);
 
   CHECK(oldParent.childDegree() == 0);
-  CHECK(oldParent.firstChild == nullptr);
-  CHECK(oldParent.lastChild == nullptr);
+  CHECK(oldParent.firstChildNode() == nullptr);
+  CHECK(oldParent.lastChildNode() == nullptr);
   checkLinkedChildOrder(newParent, { 10, 20 });
 }
 
@@ -364,8 +362,8 @@ TEST_CASE("InfoNode detached child handle adopts children in linked-list order [
   auto detachedChildren = oldParent.detachChildren();
 
   CHECK(oldParent.childDegree() == 0);
-  CHECK(oldParent.firstChild == nullptr);
-  CHECK(oldParent.lastChild == nullptr);
+  CHECK(oldParent.firstChildNode() == nullptr);
+  CHECK(oldParent.lastChildNode() == nullptr);
   CHECK(detachedChildren.size() == 3);
   CHECK(childChainStateIds(detachedChildren.first()) == std::vector<unsigned int> { 20, 30, 10 });
 
@@ -389,9 +387,9 @@ TEST_CASE("InfoNode detached child handle can move one child to another parent [
 
   checkLinkedChildOrder(firstNewParent, { 20 });
   checkLinkedChildOrder(secondNewParent, { 10, 30 });
-  CHECK(childA->parent == &secondNewParent);
-  CHECK(childB->parent == &firstNewParent);
-  CHECK(childC->parent == &secondNewParent);
+  CHECK(childA->parentNode() == &secondNewParent);
+  CHECK(childB->parentNode() == &firstNewParent);
+  CHECK(childC->parentNode() == &secondNewParent);
 }
 
 TEST_CASE("InfoNode adoptChildren appends without reordering existing children [fast][core][partition][tree][ownership]")
@@ -427,8 +425,8 @@ TEST_CASE("InfoNode detached child handle deletes dropped children [fast][core][
   }
 
   CHECK(oldParent.childDegree() == 0);
-  CHECK(oldParent.firstChild == nullptr);
-  CHECK(oldParent.lastChild == nullptr);
+  CHECK(oldParent.firstChildNode() == nullptr);
+  CHECK(oldParent.lastChildNode() == nullptr);
   oldParent.deleteChildren();
 }
 
@@ -445,8 +443,8 @@ TEST_CASE("Reinitializing a network clears collapsed root children [fast][core][
   im.initNetwork(im.network());
 
   CHECK(im.root().childDegree() == 6);
-  CHECK(im.root().collapsedFirstChild == nullptr);
-  CHECK(im.root().collapsedLastChild == nullptr);
+  CHECK(im.root().collapsedFirstChildNode() == nullptr);
+  CHECK(im.root().collapsedLastChildNode() == nullptr);
 }
 
 TEST_CASE("InfoNode deleteChildren also clears collapsed children [fast][core][partition][tree]")
@@ -457,16 +455,16 @@ TEST_CASE("InfoNode deleteChildren also clears collapsed children [fast][core][p
 
   CHECK(root.collapseChildren() == 2);
   CHECK(root.childDegree() == 0);
-  CHECK(root.firstChild == nullptr);
-  CHECK(root.collapsedFirstChild != nullptr);
+  CHECK(root.firstChildNode() == nullptr);
+  CHECK(root.collapsedFirstChildNode() != nullptr);
 
   root.deleteChildren();
 
   CHECK(root.childDegree() == 0);
-  CHECK(root.firstChild == nullptr);
-  CHECK(root.lastChild == nullptr);
-  CHECK(root.collapsedFirstChild == nullptr);
-  CHECK(root.collapsedLastChild == nullptr);
+  CHECK(root.firstChildNode() == nullptr);
+  CHECK(root.lastChildNode() == nullptr);
+  CHECK(root.collapsedFirstChildNode() == nullptr);
+  CHECK(root.collapsedLastChildNode() == nullptr);
 }
 
 TEST_CASE("InfoNode deleteChildren clears both active and collapsed child chains [fast][core][partition][tree][ownership]")
@@ -481,10 +479,10 @@ TEST_CASE("InfoNode deleteChildren clears both active and collapsed child chains
   root.deleteChildren();
 
   CHECK(root.childDegree() == 0);
-  CHECK(root.firstChild == nullptr);
-  CHECK(root.lastChild == nullptr);
-  CHECK(root.collapsedFirstChild == nullptr);
-  CHECK(root.collapsedLastChild == nullptr);
+  CHECK(root.firstChildNode() == nullptr);
+  CHECK(root.lastChildNode() == nullptr);
+  CHECK(root.collapsedFirstChildNode() == nullptr);
+  CHECK(root.collapsedLastChildNode() == nullptr);
 }
 
 TEST_CASE("InfoNode copy constructor creates detached shallow copies [fast][core][partition][tree][ownership]")
@@ -508,8 +506,8 @@ TEST_CASE("InfoNode copy constructor creates detached shallow copies [fast][core
 
   CHECK(source.collapseChildren() == 2);
   CHECK(source.childDegree() == 0);
-  CHECK(source.collapsedFirstChild != nullptr);
-  CHECK(source.collapsedLastChild != nullptr);
+  CHECK(source.collapsedFirstChildNode() != nullptr);
+  CHECK(source.collapsedLastChildNode() != nullptr);
 
   InfoNode clone(source);
 
@@ -526,16 +524,16 @@ TEST_CASE("InfoNode copy constructor creates detached shallow copies [fast][core
   CHECK(clone.outDegree() == 0);
   CHECK(clone.inDegree() == 0);
   CHECK(clone.owner == nullptr);
-  CHECK(clone.parent == nullptr);
-  CHECK(clone.previous == nullptr);
-  CHECK(clone.next == nullptr);
-  CHECK(clone.firstChild == nullptr);
-  CHECK(clone.lastChild == nullptr);
-  CHECK(clone.collapsedFirstChild == nullptr);
-  CHECK(clone.collapsedLastChild == nullptr);
+  CHECK(clone.parentNode() == nullptr);
+  CHECK(clone.previousSibling() == nullptr);
+  CHECK(clone.nextSibling() == nullptr);
+  CHECK(clone.firstChildNode() == nullptr);
+  CHECK(clone.lastChildNode() == nullptr);
+  CHECK(clone.collapsedFirstChildNode() == nullptr);
+  CHECK(clone.collapsedLastChildNode() == nullptr);
 
-  CHECK(source.collapsedFirstChild == activeChild);
-  CHECK(source.collapsedFirstChild->next->stateId == 20);
+  CHECK(source.collapsedFirstChildNode() == activeChild);
+  CHECK(source.collapsedFirstChildNode()->nextSibling()->stateId == 20);
 
   delete sourceEdgeTarget;
   source.deleteChildren();
@@ -554,7 +552,7 @@ TEST_CASE("InfoNode copy assignment clears destination ownership and detaches fr
   auto* destinationEdgeTarget = new InfoNode(FlowData {}, 12);
   destination.addOutEdge(*destinationEdgeTarget, 1.0, 0.5);
 
-  auto* sourceChild = source.firstChild;
+  auto* sourceChild = source.firstChildNode();
   destination = source;
 
   CHECK(destination.stateId == source.stateId);
@@ -564,43 +562,37 @@ TEST_CASE("InfoNode copy assignment clears destination ownership and detaches fr
   CHECK(destination.childDegree() == 0);
   CHECK(destination.outDegree() == 0);
   CHECK(destination.inDegree() == 0);
-  CHECK(destination.parent == nullptr);
-  CHECK(destination.previous == nullptr);
-  CHECK(destination.next == nullptr);
-  CHECK(destination.firstChild == nullptr);
-  CHECK(destination.lastChild == nullptr);
-  CHECK(destination.collapsedFirstChild == nullptr);
-  CHECK(destination.collapsedLastChild == nullptr);
+  CHECK(destination.parentNode() == nullptr);
+  CHECK(destination.previousSibling() == nullptr);
+  CHECK(destination.nextSibling() == nullptr);
+  CHECK(destination.firstChildNode() == nullptr);
+  CHECK(destination.lastChildNode() == nullptr);
+  CHECK(destination.collapsedFirstChildNode() == nullptr);
+  CHECK(destination.collapsedLastChildNode() == nullptr);
 
-  CHECK(source.firstChild == sourceChild);
-  CHECK(source.firstChild->parent == &source);
+  CHECK(source.firstChildNode() == sourceChild);
+  CHECK(source.firstChildNode()->parentNode() == &source);
 
   delete destinationEdgeTarget;
 }
 
 TEST_CASE("InfoNode initClean remains an explicit reset helper [fast][core][partition][tree]")
 {
-  InfoNode source;
   InfoNode parent;
-  InfoNode previous;
-  InfoNode next;
-  InfoNode collapsed;
-  source.parent = &parent;
-  source.previous = &previous;
-  source.next = &next;
-  source.collapsedFirstChild = &collapsed;
-  source.collapsedLastChild = &collapsed;
+  auto& source = parent.addChild(std::make_unique<InfoNode>());
+  source.addChild(std::make_unique<InfoNode>(FlowData {}, 10));
+  source.collapseChildren();
 
   source.initClean();
 
   CHECK(source.childDegree() == 0);
-  CHECK(source.parent == nullptr);
-  CHECK(source.previous == nullptr);
-  CHECK(source.next == nullptr);
-  CHECK(source.firstChild == nullptr);
-  CHECK(source.lastChild == nullptr);
-  CHECK(source.collapsedFirstChild == nullptr);
-  CHECK(source.collapsedLastChild == nullptr);
+  CHECK(source.parentNode() == nullptr);
+  CHECK(source.previousSibling() == nullptr);
+  CHECK(source.nextSibling() == nullptr);
+  CHECK(source.firstChildNode() == nullptr);
+  CHECK(source.lastChildNode() == nullptr);
+  CHECK(source.collapsedFirstChildNode() == nullptr);
+  CHECK(source.collapsedLastChildNode() == nullptr);
 }
 
 TEST_CASE("InfoNode replaceChildrenWithOneNode preserves children through guarded detach [fast][core][partition][tree][ownership]")
@@ -618,15 +610,15 @@ TEST_CASE("InfoNode replaceChildrenWithOneNode preserves children through guarde
   InfoNode& middle = root.replaceChildrenWithOneNode();
 
   CHECK(root.childDegree() == 1);
-  CHECK(root.firstChild == &middle);
-  CHECK(root.lastChild == &middle);
-  CHECK(middle.parent == &root);
-  CHECK(middle.previous == nullptr);
-  CHECK(middle.next == nullptr);
+  CHECK(root.firstChildNode() == &middle);
+  CHECK(root.lastChildNode() == &middle);
+  CHECK(middle.parentNode() == &root);
+  CHECK(middle.previousSibling() == nullptr);
+  CHECK(middle.nextSibling() == nullptr);
   CHECK(middle.childDegree() == 4);
   CHECK(childStateIds(middle) == std::vector<unsigned int> { 1, 2, 3, 4 });
   for (auto& child : middle.children()) {
-    CHECK(child.parent == &middle);
+    CHECK(child.parentNode() == &middle);
   }
 }
 
@@ -648,13 +640,13 @@ TEST_CASE("InfoNode sortChildrenOnFlow preserves links through guarded detach [f
 
   CHECK(root.childDegree() == 3);
   CHECK(childStateIds(root) == std::vector<unsigned int> { 20, 30, 10 });
-  CHECK(root.firstChild->previous == nullptr);
-  CHECK(root.firstChild->parent == &root);
-  CHECK(root.firstChild->next->parent == &root);
-  CHECK(root.lastChild->parent == &root);
-  CHECK(root.lastChild->next == nullptr);
-  CHECK(root.firstChild->next->previous == root.firstChild);
-  CHECK(root.lastChild->previous == root.firstChild->next);
+  CHECK(root.firstChildNode()->previousSibling() == nullptr);
+  CHECK(root.firstChildNode()->parentNode() == &root);
+  CHECK(root.firstChildNode()->nextSibling()->parentNode() == &root);
+  CHECK(root.lastChildNode()->parentNode() == &root);
+  CHECK(root.lastChildNode()->nextSibling() == nullptr);
+  CHECK(root.firstChildNode()->nextSibling()->previousSibling() == root.firstChildNode());
+  CHECK(root.lastChildNode()->previousSibling() == root.firstChildNode()->nextSibling());
 }
 
 TEST_CASE("InfoNode replace mutations preserve flattened tree structure [fast][core][partition][tree]")
@@ -676,15 +668,15 @@ TEST_CASE("InfoNode replace mutations preserve flattened tree structure [fast][c
   CHECK(moduleA->replaceWithChildren() == 1);
   CHECK(root.childDegree() == 3);
   CHECK(childStateIds(root) == std::vector<unsigned int> { 1, 2, 200 });
-  CHECK(root.firstChild->parent == &root);
-  CHECK(root.firstChild->next->parent == &root);
-  CHECK(root.lastChild == moduleB);
+  CHECK(root.firstChildNode()->parentNode() == &root);
+  CHECK(root.firstChildNode()->nextSibling()->parentNode() == &root);
+  CHECK(root.lastChildNode() == moduleB);
 
   CHECK(root.replaceChildrenWithGrandChildren() == 1);
   CHECK(root.childDegree() == 4);
   CHECK(childStateIds(root) == std::vector<unsigned int> { 1, 2, 3, 4 });
   for (const auto& child : root.children()) {
-    CHECK(child.parent == &root);
+    CHECK(child.parentNode() == &root);
     CHECK(child.isLeaf());
   }
 }
@@ -702,9 +694,9 @@ TEST_CASE("InfoNode replaceWithChildren reparents a first child chain before del
   CHECK(module->replaceWithChildren() == 1);
 
   checkLinkedChildOrder(root, { 1, 2, 30 });
-  CHECK(root.firstChild->previous == nullptr);
-  CHECK(root.lastChild == after);
-  CHECK(after->previous->stateId == 2);
+  CHECK(root.firstChildNode()->previousSibling() == nullptr);
+  CHECK(root.lastChildNode() == after);
+  CHECK(after->previousSibling()->stateId == 2);
 }
 
 TEST_CASE("InfoNode replaceWithChildren reparents a last child chain before deleting the module [fast][core][partition][tree][ownership]")
@@ -720,9 +712,9 @@ TEST_CASE("InfoNode replaceWithChildren reparents a last child chain before dele
   CHECK(module->replaceWithChildren() == 1);
 
   checkLinkedChildOrder(root, { 10, 1, 2 });
-  CHECK(root.firstChild == before);
-  CHECK(root.lastChild->stateId == 2);
-  CHECK(root.lastChild->next == nullptr);
+  CHECK(root.firstChildNode() == before);
+  CHECK(root.lastChildNode()->stateId == 2);
+  CHECK(root.lastChildNode()->nextSibling() == nullptr);
 }
 
 TEST_CASE("InfoNode replaceWithChildren reparents a middle child chain before deleting the module [fast][core][partition][tree][ownership]")
@@ -740,14 +732,14 @@ TEST_CASE("InfoNode replaceWithChildren reparents a middle child chain before de
   CHECK(module->replaceWithChildren() == 1);
 
   checkLinkedChildOrder(root, { 10, 1, 2, 30 });
-  CHECK(root.firstChild == before);
-  CHECK(root.lastChild == after);
-  CHECK(before->next->stateId == 1);
-  CHECK(before->next->parent == &root);
-  CHECK(before->next->next->stateId == 2);
-  CHECK(before->next->next->parent == &root);
-  CHECK(before->next->next->next == after);
-  CHECK(after->previous->stateId == 2);
+  CHECK(root.firstChildNode() == before);
+  CHECK(root.lastChildNode() == after);
+  CHECK(before->nextSibling()->stateId == 1);
+  CHECK(before->nextSibling()->parentNode() == &root);
+  CHECK(before->nextSibling()->nextSibling()->stateId == 2);
+  CHECK(before->nextSibling()->nextSibling()->parentNode() == &root);
+  CHECK(before->nextSibling()->nextSibling()->nextSibling() == after);
+  CHECK(after->previousSibling()->stateId == 2);
 }
 
 TEST_CASE("InfoNode replaceChildWithChildren performs parent-owned reparenting [fast][core][partition][tree][ownership]")
@@ -766,8 +758,8 @@ TEST_CASE("InfoNode replaceChildWithChildren performs parent-owned reparenting [
 
   checkLinkedChildOrder(root, { 10, 1, 2, 30 });
   CHECK(root.childDegree() == 4);
-  CHECK(before->next->stateId == 1);
-  CHECK(after->previous->stateId == 2);
+  CHECK(before->nextSibling()->stateId == 1);
+  CHECK(after->previousSibling()->stateId == 2);
 }
 
 TEST_CASE("InfoNode replaceWithChildrenDebug uses the same reparent splice path [fast][core][partition][tree][ownership]")
@@ -785,8 +777,8 @@ TEST_CASE("InfoNode replaceWithChildrenDebug uses the same reparent splice path 
   module->replaceWithChildrenDebug();
 
   checkLinkedChildOrder(root, { 10, 1, 2, 30 });
-  CHECK(root.firstChild == before);
-  CHECK(root.lastChild == after);
+  CHECK(root.firstChildNode() == before);
+  CHECK(root.lastChildNode() == after);
 }
 
 TEST_CASE("InfoNode remove documents current child-chain ownership semantics [fast][core][partition][tree][ownership]")
@@ -799,8 +791,8 @@ TEST_CASE("InfoNode remove documents current child-chain ownership semantics [fa
 
   deletingParent->remove(false);
 
-  CHECK(deleteRoot.firstChild == nullptr);
-  CHECK(deleteRoot.lastChild == nullptr);
+  CHECK(deleteRoot.firstChildNode() == nullptr);
+  CHECK(deleteRoot.lastChildNode() == nullptr);
 
   InfoNode detachRoot;
   auto* detachingParent = new InfoNode({}, 20);
@@ -812,13 +804,13 @@ TEST_CASE("InfoNode remove documents current child-chain ownership semantics [fa
 
   detachingParent->remove(true);
 
-  CHECK(detachRoot.firstChild == nullptr);
-  CHECK(detachRoot.lastChild == nullptr);
+  CHECK(detachRoot.firstChildNode() == nullptr);
+  CHECK(detachRoot.lastChildNode() == nullptr);
   CHECK(childChainStateIds(detachedChild) == std::vector<unsigned int> { 21, 22 });
-  CHECK(detachedChild->previous == nullptr);
-  CHECK(detachedChild->next == detachedSibling);
-  CHECK(detachedSibling->previous == detachedChild);
-  CHECK(detachedSibling->next == nullptr);
+  CHECK(detachedChild->previousSibling() == nullptr);
+  CHECK(detachedChild->nextSibling() == detachedSibling);
+  CHECK(detachedSibling->previousSibling() == detachedChild);
+  CHECK(detachedSibling->nextSibling() == nullptr);
 
   deleteDetachedChildChain(detachedChild);
 }
@@ -836,10 +828,10 @@ TEST_CASE("InfoNode remove true unlinks first and last child modules while detac
   firstModule->remove(true);
 
   CHECK(childStateIds(firstRoot) == std::vector<unsigned int> { 20 });
-  CHECK(firstRoot.firstChild == firstSibling);
-  CHECK(firstRoot.lastChild == firstSibling);
-  CHECK(firstSibling->previous == nullptr);
-  CHECK(firstSibling->next == nullptr);
+  CHECK(firstRoot.firstChildNode() == firstSibling);
+  CHECK(firstRoot.lastChildNode() == firstSibling);
+  CHECK(firstSibling->previousSibling() == nullptr);
+  CHECK(firstSibling->nextSibling() == nullptr);
   deleteDetachedChildChain(firstDetachedChild);
 
   InfoNode lastRoot;
@@ -853,10 +845,10 @@ TEST_CASE("InfoNode remove true unlinks first and last child modules while detac
   lastModule->remove(true);
 
   CHECK(childStateIds(lastRoot) == std::vector<unsigned int> { 30 });
-  CHECK(lastRoot.firstChild == lastSibling);
-  CHECK(lastRoot.lastChild == lastSibling);
-  CHECK(lastSibling->previous == nullptr);
-  CHECK(lastSibling->next == nullptr);
+  CHECK(lastRoot.firstChildNode() == lastSibling);
+  CHECK(lastRoot.lastChildNode() == lastSibling);
+  CHECK(lastSibling->previousSibling() == nullptr);
+  CHECK(lastSibling->nextSibling() == nullptr);
   deleteDetachedChildChain(lastDetachedChild);
 }
 
@@ -873,12 +865,12 @@ TEST_CASE("InfoNode removeChild unlinks parent and sibling pointers through owne
   root.removeChild(*middle, InfoNode::RemoveChildrenPolicy::DeleteSubtree);
 
   CHECK(childStateIds(root) == std::vector<unsigned int> { 10, 30 });
-  CHECK(root.firstChild == first);
-  CHECK(root.lastChild == last);
-  CHECK(first->previous == nullptr);
-  CHECK(first->next == last);
-  CHECK(last->previous == first);
-  CHECK(last->next == nullptr);
+  CHECK(root.firstChildNode() == first);
+  CHECK(root.lastChildNode() == last);
+  CHECK(first->previousSibling() == nullptr);
+  CHECK(first->nextSibling() == last);
+  CHECK(last->previousSibling() == first);
+  CHECK(last->nextSibling() == nullptr);
   CHECK(root.childDegree() == 2);
 }
 
@@ -893,10 +885,10 @@ TEST_CASE("InfoNode removeChild unlinks first and last children through owner AP
   firstRoot.removeChild(*first, InfoNode::RemoveChildrenPolicy::DeleteSubtree);
 
   CHECK(childStateIds(firstRoot) == std::vector<unsigned int> { 20 });
-  CHECK(firstRoot.firstChild == second);
-  CHECK(firstRoot.lastChild == second);
-  CHECK(second->previous == nullptr);
-  CHECK(second->next == nullptr);
+  CHECK(firstRoot.firstChildNode() == second);
+  CHECK(firstRoot.lastChildNode() == second);
+  CHECK(second->previousSibling() == nullptr);
+  CHECK(second->nextSibling() == nullptr);
   CHECK(firstRoot.childDegree() == 1);
 
   InfoNode lastRoot;
@@ -908,10 +900,10 @@ TEST_CASE("InfoNode removeChild unlinks first and last children through owner AP
   lastRoot.removeChild(*last, InfoNode::RemoveChildrenPolicy::DeleteSubtree);
 
   CHECK(childStateIds(lastRoot) == std::vector<unsigned int> { 30 });
-  CHECK(lastRoot.firstChild == beforeLast);
-  CHECK(lastRoot.lastChild == beforeLast);
-  CHECK(beforeLast->previous == nullptr);
-  CHECK(beforeLast->next == nullptr);
+  CHECK(lastRoot.firstChildNode() == beforeLast);
+  CHECK(lastRoot.lastChildNode() == beforeLast);
+  CHECK(beforeLast->previousSibling() == nullptr);
+  CHECK(beforeLast->nextSibling() == nullptr);
   CHECK(lastRoot.childDegree() == 1);
 }
 


### PR DESCRIPTION
## Summary
- Make `InfoNode` parent/sibling/child raw links private for native C++ builds.
- Add C++-only read accessors for parent, siblings, active children, and collapsed children.
- Update core runtime, iterators, output code, and C++ tests to use accessors instead of direct raw-field access.
- Keep raw fields visible for SWIG/Python extension builds to preserve the existing generated wrapper ABI; no generated wrapper diff is needed.

## Stack
- Stacked on #454 / `fix/infonode-parent-owned-mutations`.
- Base branch: `fix/infonode-parent-owned-mutations`.

## Verification
- `make test-native CTEST_ARGS='-R infomap_cpp_partition_tests --output-on-failure'`
- `make test-native`
- `make test-sanitizers`
- `make test-python-swig-freshness`
- `PYTHON=<temp-venv>/bin/python make build-python`
- `rg -n -g '!src/core/InfoNode.cpp' -g '!src/core/InfoNode.h' -- '->(parent|previous|next|firstChild|lastChild|collapsedFirstChild|collapsedLastChild)\\b|\\.(parent|previous|next|firstChild|lastChild|collapsedFirstChild|collapsedLastChild)\\b' src test/cpp` returned no matches.

## Notes
- This completes the planned ownership/RAII roadmap after #452-#454: internal native code no longer mutates child links directly outside `InfoNode`.
- SWIG/Python compatibility is intentionally transitional: the raw fields remain visible when compiling the generated wrapper because the tracked wrapper still exposes them.
