### PR TITLE
refactor: InfoNode child-chain cleanup

### DIFF
--- a/src/core/InfoNode.cpp
+++ b/src/core/InfoNode.cpp
@@ -13,6 +13,146 @@
 
 namespace infomap {
 
+namespace {
+
+class DetachedChildChain {
+public:
+  DetachedChildChain() = default;
+
+  DetachedChildChain(InfoNode* first, InfoNode* last) noexcept
+      : m_first(first),
+        m_last(last) { }
+
+  DetachedChildChain(const DetachedChildChain&) = delete;
+  DetachedChildChain& operator=(const DetachedChildChain&) = delete;
+
+  DetachedChildChain(DetachedChildChain&& other) noexcept
+      : m_first(other.m_first),
+        m_last(other.m_last)
+  {
+    other.m_first = nullptr;
+    other.m_last = nullptr;
+  }
+
+  DetachedChildChain& operator=(DetachedChildChain&& other) noexcept
+  {
+    if (this != &other) {
+      reset();
+      m_first = other.m_first;
+      m_last = other.m_last;
+      other.m_first = nullptr;
+      other.m_last = nullptr;
+    }
+    return *this;
+  }
+
+  ~DetachedChildChain() noexcept
+  {
+    reset();
+  }
+
+  InfoNode* first() const noexcept { return m_first; }
+
+  InfoNode* last() const noexcept { return m_last; }
+
+  bool empty() const noexcept { return m_first == nullptr; }
+
+  void release() noexcept
+  {
+    m_first = nullptr;
+    m_last = nullptr;
+  }
+
+  void reset() noexcept
+  {
+    InfoNode* node = m_first;
+    m_first = nullptr;
+    m_last = nullptr;
+    while (node != nullptr) {
+      InfoNode* next = node->next;
+      delete node;
+      node = next;
+    }
+  }
+
+private:
+  InfoNode* m_first = nullptr;
+  InfoNode* m_last = nullptr;
+};
+
+void spliceChildrenIntoParentBeforeDelete(InfoNode& node) noexcept
+{
+  InfoNode* parent = node.parent;
+  InfoNode* previous = node.previous;
+  InfoNode* next = node.next;
+  InfoNode* firstChild = node.firstChild;
+  InfoNode* lastChild = node.lastChild;
+
+  unsigned int childCount = 0;
+  for (InfoNode* child = firstChild; child != nullptr; child = child->next) {
+    child->parent = parent;
+    ++childCount;
+  }
+
+  parent->setChildDegree(parent->childDegree() + childCount - 1); // -1 as this node is deleted.
+
+  firstChild->previous = previous;
+  lastChild->next = next;
+
+  if (parent->firstChild == &node) {
+    parent->firstChild = firstChild;
+  } else {
+    previous->next = firstChild;
+  }
+
+  if (parent->lastChild == &node) {
+    parent->lastChild = lastChild;
+  } else {
+    next->previous = lastChild;
+  }
+
+  // Detach before self-delete so the destructor does not delete the reparented
+  // child chain or reconnect sibling links that were already spliced.
+  node.firstChild = nullptr;
+  node.lastChild = nullptr;
+  node.next = nullptr;
+  node.previous = nullptr;
+  node.parent = nullptr;
+  node.setChildDegree(0);
+}
+
+void prepareForSelfDelete(InfoNode& node, bool detachChildren) noexcept
+{
+  if (!detachChildren)
+    return;
+
+  node.firstChild = nullptr;
+  node.lastChild = nullptr;
+  node.setChildDegree(0);
+}
+
+void unlinkFromParentAndSiblings(InfoNode& node) noexcept
+{
+  if (node.next != nullptr)
+    node.next->previous = node.previous;
+  if (node.previous != nullptr)
+    node.previous->next = node.next;
+  if (node.parent != nullptr) {
+    if (node.parent->firstChild == &node)
+      node.parent->firstChild = node.next;
+    if (node.parent->lastChild == &node)
+      node.parent->lastChild = node.previous;
+  }
+
+  // Preserve current destructor/remove semantics: unlinking updates links but
+  // does not update the parent's cached child degree.
+  node.parent = nullptr;
+  node.previous = nullptr;
+  node.next = nullptr;
+}
+
+} // namespace
+
 void InfomapBaseDeleter::operator()(InfomapBase* infomap) const noexcept
 {
   delete infomap;
@@ -39,17 +179,7 @@ InfoNode& InfoNode::operator=(const InfoNode& other)
 InfoNode::~InfoNode() noexcept
 {
   deleteChildren();
-
-  if (next != nullptr)
-    next->previous = previous;
-  if (previous != nullptr)
-    previous->next = next;
-  if (parent != nullptr) {
-    if (parent->firstChild == this)
-      parent->firstChild = next;
-    if (parent->lastChild == this)
-      parent->lastChild = previous;
-  }
+  unlinkFromParentAndSiblings(*this);
 
   // Incoming edge pointers on other nodes become dangling non-owning back-references.
 }
@@ -199,9 +329,11 @@ InfoNode& InfoNode::addChild(std::unique_ptr<InfoNode> child) noexcept
 
 void InfoNode::releaseChildren() noexcept
 {
+  DetachedChildChain detached(firstChild, lastChild);
   firstChild = nullptr;
   lastChild = nullptr;
   m_childDegree = 0;
+  detached.release();
 }
 
 InfoNode& InfoNode::replaceChildrenWithOneNode()
@@ -223,8 +355,12 @@ InfoNode& InfoNode::replaceChildrenWithOneNode()
     middleNodePtr->addChild(n);
   } while (--numOriginalChildrenLeft != 0);
 
-  releaseChildren();
+  auto detachedChildren = DetachedChildChain(firstChild, lastChild);
+  firstChild = nullptr;
+  lastChild = nullptr;
+  m_childDegree = 0;
   addChild(std::move(middleNode));
+  detachedChildren.release();
   auto d1 = middleNodePtr->replaceChildrenWithGrandChildren();
   if (d1 != d0)
     throw std::logic_error("replaceChildrenWithOneNode replaced different number of children as having before");
@@ -251,37 +387,7 @@ unsigned int InfoNode::replaceWithChildren() noexcept
   if (isLeaf() || isRoot())
     return 0;
 
-  // Re-parent children
-  unsigned int deltaChildDegree = 0;
-  InfoNode* child = firstChild;
-  do {
-    child->parent = parent;
-    child = child->next;
-    ++deltaChildDegree;
-  } while (child != nullptr);
-  parent->m_childDegree += deltaChildDegree - 1; // -1 as this node is deleted
-
-  firstChild->previous = previous;
-  lastChild->next = next;
-
-  if (parent->firstChild == this) {
-    parent->firstChild = firstChild;
-  } else {
-    previous->next = firstChild;
-  }
-
-  if (parent->lastChild == this) {
-    parent->lastChild = lastChild;
-  } else {
-    next->previous = lastChild;
-  }
-
-  // Release connected nodes before delete, otherwise children are deleted and neighbours are reconnected.
-  firstChild = nullptr;
-  lastChild = nullptr;
-  next = nullptr;
-  previous = nullptr;
-  parent = nullptr;
+  spliceChildrenIntoParentBeforeDelete(*this);
   delete this;
   return 1;
 }
@@ -304,65 +410,24 @@ void InfoNode::replaceWithChildrenDebug() noexcept
   if (isLeaf() || isRoot())
     return;
 
-  // Re-parent children
-  unsigned int deltaChildDegree = 0;
-  InfoNode* child = firstChild;
-  do {
-    child->parent = parent;
-    child = child->next;
-    ++deltaChildDegree;
-  } while (child != nullptr);
-  parent->m_childDegree += deltaChildDegree - 1; // -1 as this node is deleted
-
-  if (parent->firstChild == this) {
-    parent->firstChild = firstChild;
-  } else {
-    previous->next = firstChild;
-    firstChild->previous = previous;
-  }
-
-  if (parent->lastChild == this) {
-    parent->lastChild = lastChild;
-  } else {
-    next->previous = lastChild;
-    lastChild->next = next;
-  }
-
-  // Release connected nodes before delete, otherwise children are deleted and neighbours are reconnected.
-  firstChild = nullptr;
-  lastChild = nullptr;
-  next = nullptr;
-  previous = nullptr;
-  parent = nullptr;
-
+  spliceChildrenIntoParentBeforeDelete(*this);
   delete this;
 }
 
 void InfoNode::remove(bool removeChildren) noexcept
 {
-  firstChild = removeChildren ? nullptr : firstChild;
+  prepareForSelfDelete(*this, removeChildren);
   delete this;
 }
 
 void InfoNode::deleteChildren() noexcept
 {
-  auto delete_child_chain = [](InfoNode*& first, InfoNode*& last) {
-    if (first == nullptr)
-      return;
-
-    InfoNode* node = first;
-    while (node != nullptr) {
-      InfoNode* next_node = node->next;
-      delete node;
-      node = next_node;
-    }
-
-    first = nullptr;
-    last = nullptr;
-  };
-
-  delete_child_chain(firstChild, lastChild);
-  delete_child_chain(collapsedFirstChild, collapsedLastChild);
+  DetachedChildChain activeChildren(firstChild, lastChild);
+  firstChild = nullptr;
+  lastChild = nullptr;
+  DetachedChildChain collapsedChildren(collapsedFirstChild, collapsedLastChild);
+  collapsedFirstChild = nullptr;
+  collapsedLastChild = nullptr;
   m_childDegree = 0;
 }
 
@@ -418,10 +483,14 @@ void InfoNode::sortChildrenOnFlow(bool recurse) noexcept
     std::sort(nodes.begin(), nodes.end(), [](const InfoNode* a, const InfoNode* b) {
       return b->data.flow < a->data.flow;
     });
-    releaseChildren();
+    auto detachedChildren = DetachedChildChain(firstChild, lastChild);
+    firstChild = nullptr;
+    lastChild = nullptr;
+    m_childDegree = 0;
     for (auto node : nodes) {
       addChild(node);
     }
+    detachedChildren.release();
   }
   if (recurse) {
     for (InfoNode& child : children()) {
@@ -434,10 +503,14 @@ void InfoNode::sortChildrenOnFlow(bool recurse) noexcept
 
 unsigned int InfoNode::collapseChildren() noexcept
 {
-  std::swap(collapsedFirstChild, firstChild);
-  std::swap(collapsedLastChild, lastChild);
+  auto activeChildren = DetachedChildChain(firstChild, lastChild);
   unsigned int numCollapsedChildren = childDegree();
-  releaseChildren();
+  firstChild = nullptr;
+  lastChild = nullptr;
+  m_childDegree = 0;
+  collapsedFirstChild = activeChildren.first();
+  collapsedLastChild = activeChildren.last();
+  activeChildren.release();
   return numCollapsedChildren;
 }
 

--- a/src/core/InfoNode.h
+++ b/src/core/InfoNode.h
@@ -55,12 +55,13 @@ public:
  * An InfoNode owns the active child chain reachable through firstChild/lastChild
  * and the collapsed child chain reachable through collapsedFirstChild/
  * collapsedLastChild. Child storage remains a raw linked list; the unique_ptr
- * addChild() overload is only a safe handoff helper for newly allocated nodes.
- * Destruction deletes both chains. releaseChildren() only detaches the active
- * chain from this parent; the caller must reattach or delete those nodes.
- * Reparenting helpers detach children before deleting the removed intermediate
- * node. An InfoNode also owns its sub-Infomap and outgoing InfoEdge objects
- * through unique_ptr; incoming edge pointers are non-owning back-references.
+ * addChild() overload is only a safe handoff helper for newly allocated nodes,
+ * while internal detach/delete paths use an RAII guard. Destruction deletes both
+ * chains. releaseChildren() only detaches the active chain from this parent; the
+ * caller must reattach or delete those nodes. Reparenting helpers detach
+ * children before deleting the removed intermediate node. An InfoNode also owns
+ * its sub-Infomap and outgoing InfoEdge objects through unique_ptr; incoming
+ * edge pointers are non-owning back-references.
  */
 class InfoNode {
 public:
@@ -376,8 +377,9 @@ public:
    * Delete this node.
    *
    * removeChildren=false leaves firstChild intact, so the destructor deletes the
-   * active child chain. removeChildren=true clears firstChild before deletion,
-   * leaving the previous child chain for the caller to reattach or delete.
+   * active child chain. removeChildren=true detaches this node from active child
+   * chain ownership before deletion, leaving the previous child chain for the
+   * caller to reattach or delete.
    */
   void remove(bool removeChildren) noexcept;
 

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -27,6 +27,55 @@ std::vector<unsigned int> childStateIds(const InfoNode& node)
   return ids;
 }
 
+std::vector<unsigned int> childChainStateIds(const InfoNode* firstChild)
+{
+  std::vector<unsigned int> ids;
+  for (const auto* child = firstChild; child != nullptr; child = child->next) {
+    ids.push_back(child->stateId);
+  }
+  return ids;
+}
+
+void deleteDetachedChildChain(InfoNode* firstChild)
+{
+  while (firstChild != nullptr) {
+    auto* next = firstChild->next;
+    firstChild->parent = nullptr;
+    firstChild->previous = nullptr;
+    firstChild->next = nullptr;
+    delete firstChild;
+    firstChild = next;
+  }
+}
+
+void checkLinkedChildOrder(InfoNode& parent, const std::vector<unsigned int>& expectedStateIds)
+{
+  CHECK(childStateIds(parent) == expectedStateIds);
+  CHECK(parent.childDegree() == expectedStateIds.size());
+
+  InfoNode* previous = nullptr;
+  InfoNode* child = parent.firstChild;
+  std::size_t index = 0;
+  while (child != nullptr) {
+    REQUIRE(index < expectedStateIds.size());
+    CHECK(child->stateId == expectedStateIds[index]);
+    CHECK(child->parent == &parent);
+    CHECK(child->previous == previous);
+    if (previous != nullptr) {
+      CHECK(previous->next == child);
+    }
+    previous = child;
+    child = child->next;
+    ++index;
+  }
+
+  CHECK(index == expectedStateIds.size());
+  CHECK(parent.lastChild == previous);
+  if (previous != nullptr) {
+    CHECK(previous->next == nullptr);
+  }
+}
+
 std::map<EdgeKey, double> aggregatedInterModuleFlow(std::vector<InfoNode*>& nodes, bool undirected)
 {
   std::map<EdgeKey, double> flows;
@@ -428,6 +477,60 @@ TEST_CASE("InfoNode initClean remains an explicit reset helper [fast][core][part
   CHECK(source.collapsedLastChild == nullptr);
 }
 
+TEST_CASE("InfoNode replaceChildrenWithOneNode preserves children through guarded detach [fast][core][partition][tree][ownership]")
+{
+  InfoNode root;
+  auto* moduleA = new InfoNode({}, 100);
+  auto* moduleB = new InfoNode({}, 200);
+  root.addChild(moduleA);
+  root.addChild(moduleB);
+  moduleA->addChild(std::make_unique<InfoNode>(FlowData {}, 1));
+  moduleA->addChild(std::make_unique<InfoNode>(FlowData {}, 2));
+  moduleB->addChild(std::make_unique<InfoNode>(FlowData {}, 3));
+  moduleB->addChild(std::make_unique<InfoNode>(FlowData {}, 4));
+
+  InfoNode& middle = root.replaceChildrenWithOneNode();
+
+  CHECK(root.childDegree() == 1);
+  CHECK(root.firstChild == &middle);
+  CHECK(root.lastChild == &middle);
+  CHECK(middle.parent == &root);
+  CHECK(middle.previous == nullptr);
+  CHECK(middle.next == nullptr);
+  CHECK(middle.childDegree() == 4);
+  CHECK(childStateIds(middle) == std::vector<unsigned int> { 1, 2, 3, 4 });
+  for (auto& child : middle.children()) {
+    CHECK(child.parent == &middle);
+  }
+}
+
+TEST_CASE("InfoNode sortChildrenOnFlow preserves links through guarded detach [fast][core][partition][tree][ownership]")
+{
+  InfoNode root;
+  auto childA = std::make_unique<InfoNode>(FlowData {}, 10);
+  auto childB = std::make_unique<InfoNode>(FlowData {}, 20);
+  auto childC = std::make_unique<InfoNode>(FlowData {}, 30);
+  childA->data.flow = 0.1;
+  childB->data.flow = 0.7;
+  childC->data.flow = 0.4;
+
+  root.addChild(std::move(childA));
+  root.addChild(std::move(childB));
+  root.addChild(std::move(childC));
+
+  root.sortChildrenOnFlow(false);
+
+  CHECK(root.childDegree() == 3);
+  CHECK(childStateIds(root) == std::vector<unsigned int> { 20, 30, 10 });
+  CHECK(root.firstChild->previous == nullptr);
+  CHECK(root.firstChild->parent == &root);
+  CHECK(root.firstChild->next->parent == &root);
+  CHECK(root.lastChild->parent == &root);
+  CHECK(root.lastChild->next == nullptr);
+  CHECK(root.firstChild->next->previous == root.firstChild);
+  CHECK(root.lastChild->previous == root.firstChild->next);
+}
+
 TEST_CASE("InfoNode replace mutations preserve flattened tree structure [fast][core][partition][tree]")
 {
   InfoNode root;
@@ -460,6 +563,42 @@ TEST_CASE("InfoNode replace mutations preserve flattened tree structure [fast][c
   }
 }
 
+TEST_CASE("InfoNode replaceWithChildren reparents a first child chain before deleting the module [fast][core][partition][tree][ownership]")
+{
+  InfoNode root;
+  auto* module = new InfoNode({}, 20);
+  auto* after = new InfoNode({}, 30);
+  root.addChild(module);
+  root.addChild(after);
+  module->addChild(std::make_unique<InfoNode>(FlowData {}, 1));
+  module->addChild(std::make_unique<InfoNode>(FlowData {}, 2));
+
+  CHECK(module->replaceWithChildren() == 1);
+
+  checkLinkedChildOrder(root, { 1, 2, 30 });
+  CHECK(root.firstChild->previous == nullptr);
+  CHECK(root.lastChild == after);
+  CHECK(after->previous->stateId == 2);
+}
+
+TEST_CASE("InfoNode replaceWithChildren reparents a last child chain before deleting the module [fast][core][partition][tree][ownership]")
+{
+  InfoNode root;
+  auto* before = new InfoNode({}, 10);
+  auto* module = new InfoNode({}, 20);
+  root.addChild(before);
+  root.addChild(module);
+  module->addChild(std::make_unique<InfoNode>(FlowData {}, 1));
+  module->addChild(std::make_unique<InfoNode>(FlowData {}, 2));
+
+  CHECK(module->replaceWithChildren() == 1);
+
+  checkLinkedChildOrder(root, { 10, 1, 2 });
+  CHECK(root.firstChild == before);
+  CHECK(root.lastChild->stateId == 2);
+  CHECK(root.lastChild->next == nullptr);
+}
+
 TEST_CASE("InfoNode replaceWithChildren reparents a middle child chain before deleting the module [fast][core][partition][tree][ownership]")
 {
   InfoNode root;
@@ -474,7 +613,7 @@ TEST_CASE("InfoNode replaceWithChildren reparents a middle child chain before de
 
   CHECK(module->replaceWithChildren() == 1);
 
-  CHECK(childStateIds(root) == std::vector<unsigned int> { 10, 1, 2, 30 });
+  checkLinkedChildOrder(root, { 10, 1, 2, 30 });
   CHECK(root.firstChild == before);
   CHECK(root.lastChild == after);
   CHECK(before->next->stateId == 1);
@@ -485,11 +624,31 @@ TEST_CASE("InfoNode replaceWithChildren reparents a middle child chain before de
   CHECK(after->previous->stateId == 2);
 }
 
+TEST_CASE("InfoNode replaceWithChildrenDebug uses the same reparent splice path [fast][core][partition][tree][ownership]")
+{
+  InfoNode root;
+  auto* before = new InfoNode({}, 10);
+  auto* module = new InfoNode({}, 20);
+  auto* after = new InfoNode({}, 30);
+  root.addChild(before);
+  root.addChild(module);
+  root.addChild(after);
+  module->addChild(std::make_unique<InfoNode>(FlowData {}, 1));
+  module->addChild(std::make_unique<InfoNode>(FlowData {}, 2));
+
+  module->replaceWithChildrenDebug();
+
+  checkLinkedChildOrder(root, { 10, 1, 2, 30 });
+  CHECK(root.firstChild == before);
+  CHECK(root.lastChild == after);
+}
+
 TEST_CASE("InfoNode remove documents current child-chain ownership semantics [fast][core][partition][tree][ownership]")
 {
   InfoNode deleteRoot;
   auto* deletingParent = new InfoNode({}, 10);
   deletingParent->addChild(std::make_unique<InfoNode>(FlowData {}, 11));
+  deletingParent->addChild(std::make_unique<InfoNode>(FlowData {}, 12));
   deleteRoot.addChild(deletingParent);
 
   deletingParent->remove(false);
@@ -500,19 +659,119 @@ TEST_CASE("InfoNode remove documents current child-chain ownership semantics [fa
   InfoNode detachRoot;
   auto* detachingParent = new InfoNode({}, 20);
   auto* detachedChild = new InfoNode({}, 21);
+  auto* detachedSibling = new InfoNode({}, 22);
   detachingParent->addChild(detachedChild);
+  detachingParent->addChild(detachedSibling);
   detachRoot.addChild(detachingParent);
 
   detachingParent->remove(true);
 
   CHECK(detachRoot.firstChild == nullptr);
   CHECK(detachRoot.lastChild == nullptr);
-  CHECK(detachedChild->stateId == 21);
+  CHECK(childChainStateIds(detachedChild) == std::vector<unsigned int> { 21, 22 });
+  CHECK(detachedChild->previous == nullptr);
+  CHECK(detachedChild->next == detachedSibling);
+  CHECK(detachedSibling->previous == detachedChild);
+  CHECK(detachedSibling->next == nullptr);
 
-  detachedChild->parent = nullptr;
-  detachedChild->previous = nullptr;
-  detachedChild->next = nullptr;
-  delete detachedChild;
+  deleteDetachedChildChain(detachedChild);
+}
+
+TEST_CASE("InfoNode remove true unlinks first and last child modules while detaching their children [fast][core][partition][tree][ownership]")
+{
+  InfoNode firstRoot;
+  auto* firstModule = new InfoNode({}, 10);
+  auto* firstSibling = new InfoNode({}, 20);
+  auto* firstDetachedChild = new InfoNode({}, 11);
+  firstModule->addChild(firstDetachedChild);
+  firstRoot.addChild(firstModule);
+  firstRoot.addChild(firstSibling);
+
+  firstModule->remove(true);
+
+  CHECK(childStateIds(firstRoot) == std::vector<unsigned int> { 20 });
+  CHECK(firstRoot.firstChild == firstSibling);
+  CHECK(firstRoot.lastChild == firstSibling);
+  CHECK(firstSibling->previous == nullptr);
+  CHECK(firstSibling->next == nullptr);
+  deleteDetachedChildChain(firstDetachedChild);
+
+  InfoNode lastRoot;
+  auto* lastSibling = new InfoNode({}, 30);
+  auto* lastModule = new InfoNode({}, 40);
+  auto* lastDetachedChild = new InfoNode({}, 41);
+  lastModule->addChild(lastDetachedChild);
+  lastRoot.addChild(lastSibling);
+  lastRoot.addChild(lastModule);
+
+  lastModule->remove(true);
+
+  CHECK(childStateIds(lastRoot) == std::vector<unsigned int> { 30 });
+  CHECK(lastRoot.firstChild == lastSibling);
+  CHECK(lastRoot.lastChild == lastSibling);
+  CHECK(lastSibling->previous == nullptr);
+  CHECK(lastSibling->next == nullptr);
+  deleteDetachedChildChain(lastDetachedChild);
+}
+
+TEST_CASE("InfoNode destructor unlinks parent and sibling pointers without updating cached child degree [fast][core][partition][tree][ownership]")
+{
+  InfoNode root;
+  auto* first = new InfoNode({}, 10);
+  auto* middle = new InfoNode({}, 20);
+  auto* last = new InfoNode({}, 30);
+  root.addChild(first);
+  root.addChild(middle);
+  root.addChild(last);
+
+  delete middle;
+
+  CHECK(childStateIds(root) == std::vector<unsigned int> { 10, 30 });
+  CHECK(root.firstChild == first);
+  CHECK(root.lastChild == last);
+  CHECK(first->previous == nullptr);
+  CHECK(first->next == last);
+  CHECK(last->previous == first);
+  CHECK(last->next == nullptr);
+  // Existing destructor/remove semantics preserve the cached degree until a
+  // caller explicitly recalculates or overwrites it.
+  CHECK(root.childDegree() == 3);
+
+  root.calcChildDegree();
+  CHECK(root.childDegree() == 2);
+}
+
+TEST_CASE("InfoNode destructor unlinks first and last children without changing cached child degree [fast][core][partition][tree][ownership]")
+{
+  InfoNode firstRoot;
+  auto* first = new InfoNode({}, 10);
+  auto* second = new InfoNode({}, 20);
+  firstRoot.addChild(first);
+  firstRoot.addChild(second);
+
+  delete first;
+
+  CHECK(childStateIds(firstRoot) == std::vector<unsigned int> { 20 });
+  CHECK(firstRoot.firstChild == second);
+  CHECK(firstRoot.lastChild == second);
+  CHECK(second->previous == nullptr);
+  CHECK(second->next == nullptr);
+  CHECK(firstRoot.childDegree() == 2);
+
+  InfoNode lastRoot;
+  auto* beforeLast = new InfoNode({}, 30);
+  auto* last = new InfoNode({}, 40);
+  lastRoot.addChild(beforeLast);
+  lastRoot.addChild(last);
+
+  delete last;
+
+  CHECK(childStateIds(lastRoot) == std::vector<unsigned int> { 30 });
+  CHECK(lastRoot.firstChild == beforeLast);
+  CHECK(lastRoot.lastChild == beforeLast);
+  CHECK(beforeLast->previous == nullptr);
+  CHECK(beforeLast->next == nullptr);
+  CHECK(lastRoot.childDegree() == 2);
 }
 
 TEST_CASE("InfoNode owns outgoing edges while incoming edges are non-owning references [fast][core][partition][tree][ownership]")


### PR DESCRIPTION
## Summary
- Consolidates the previous child-chain cleanup slices into one review unit.
- Includes the internal detached-chain guard, replace/reparent cleanup, remove cleanup, and unlink cleanup changes that were previously split across #448-#451.
- Keeps the resulting tree identical to the old `fix/infonode-unlink-helper` stack tip.

## Replaces
- Supersedes #448.
- Supersedes #449.
- Supersedes #450.
- Supersedes #451.

## Stack
- Base branch: `fix/infonode-detached-copy` / #447.
- Follow-up branch #452 is retargeted to this branch.

## Verification
- This is a squash/consolidation PR only; the resulting tree matches the previous #451 tip.
- Previous verification for the included changes: native partition tests, full native tests, sanitizer tests, and SWIG freshness.
