### PR TITLE
build(ci): fail perf check on regressions

### DIFF
--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -91,14 +91,18 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          comparison_status=0
           python "$GITHUB_WORKSPACE/head/scripts/benchmarks/compare_native_benchmarks.py" \
             --base "$GITHUB_WORKSPACE/artifacts/base-native-benchmarks.json" \
             --head "$GITHUB_WORKSPACE/artifacts/head-native-benchmarks.json" \
             --markdown-out "$GITHUB_WORKSPACE/artifacts/perf-summary.md" \
-            --json-out "$GITHUB_WORKSPACE/artifacts/perf-comparison.json"
+            --json-out "$GITHUB_WORKSPACE/artifacts/perf-comparison.json" \
+            --fail-on-regression || comparison_status=$?
           cat "$GITHUB_WORKSPACE/artifacts/perf-summary.md" >> "$GITHUB_STEP_SUMMARY"
+          exit "$comparison_status"
 
       - name: Upload comparison artifacts
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pr-native-perf

--- a/scripts/benchmarks/compare_native_benchmarks.py
+++ b/scripts/benchmarks/compare_native_benchmarks.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import sys
 from pathlib import Path
 
 RELATIVE_REGRESSION_THRESHOLD = 0.15
@@ -108,14 +109,13 @@ def compare_reports(base_report: dict[str, object], head_report: dict[str, objec
 
     manual_review = [case for case in cases if case["status"] == "manual_review"]
     regressions = [case for case in cases if case["status"] == "regression"]
-    severe_regressions = [case for case in regressions if case["severe"]]
     inconclusive = [case for case in cases if case["status"] == "inconclusive"]
     improvements = [case for case in cases if case["status"] == "improvement"]
 
     if manual_review:
         overall_status = "manual_review"
         summary = "manual review needed"
-    elif len(regressions) >= 2 or severe_regressions:
+    elif regressions:
         overall_status = "possible_regression"
         summary = "possible regression"
     else:
@@ -198,12 +198,17 @@ def render_markdown(result: dict[str, object]) -> str:
     return "\n".join(lines)
 
 
-def main() -> None:
+def main() -> int:
     parser = argparse.ArgumentParser(description="Compare native benchmark reports for PR perf regression detection.")
     parser.add_argument("--base", type=Path, required=True, help="Path to the base benchmark JSON report.")
     parser.add_argument("--head", type=Path, required=True, help="Path to the head benchmark JSON report.")
     parser.add_argument("--markdown-out", type=Path, default=None, help="Optional Markdown summary output path.")
     parser.add_argument("--json-out", type=Path, default=None, help="Optional JSON comparison output path.")
+    parser.add_argument(
+        "--fail-on-regression",
+        action="store_true",
+        help="Exit with status 1 when any benchmark case is classified as a regression.",
+    )
     args = parser.parse_args()
 
     result = compare_reports(load_report(args.base), load_report(args.head))
@@ -218,7 +223,10 @@ def main() -> None:
         args.json_out.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
 
     print(markdown)
+    if args.fail_on_regression and result["counts"]["regression"]:
+        return 1
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/test/python/test_compare_native_benchmarks.py
+++ b/test/python/test_compare_native_benchmarks.py
@@ -58,7 +58,7 @@ def test_compare_reports_marks_stable_regression():
 
     assert result["cases"][0]["status"] == "regression"
     assert result["cases"][0]["reason"] == "regression"
-    assert result["overall_status"] == "no_regression"
+    assert result["overall_status"] == "possible_regression"
 
 
 def test_compare_reports_ignores_small_delta():
@@ -142,7 +142,7 @@ def test_main_writes_markdown_and_json(tmp_path: Path, capsys: pytest.CaptureFix
         str(json_path),
     ]
     try:
-        compare_module.main()
+        assert compare_module.main() == 0
     finally:
         sys.argv = old_argv
 
@@ -150,3 +150,36 @@ def test_main_writes_markdown_and_json(tmp_path: Path, capsys: pytest.CaptureFix
     assert "PR Native Benchmark Comparison" in captured.out
     assert "possible regression" in markdown_path.read_text(encoding="utf-8")
     assert json.loads(json_path.read_text(encoding="utf-8"))["overall_status"] == "possible_regression"
+
+
+def test_main_can_fail_after_writing_reports_for_regression(tmp_path: Path):
+    compare_module = _load_compare_module()
+    base_path = tmp_path / "base.json"
+    head_path = tmp_path / "head.json"
+    markdown_path = tmp_path / "summary.md"
+    json_path = tmp_path / "comparison.json"
+    base_path.write_text(json.dumps({"benchmarks": [_case("ring", median_run_sec=1.00)]}) + "\n", encoding="utf-8")
+    head_path.write_text(json.dumps({"benchmarks": [_case("ring", median_run_sec=1.20)]}) + "\n", encoding="utf-8")
+
+    import sys
+
+    old_argv = sys.argv
+    sys.argv = [
+        "compare_native_benchmarks.py",
+        "--base",
+        str(base_path),
+        "--head",
+        str(head_path),
+        "--markdown-out",
+        str(markdown_path),
+        "--json-out",
+        str(json_path),
+        "--fail-on-regression",
+    ]
+    try:
+        assert compare_module.main() == 1
+    finally:
+        sys.argv = old_argv
+
+    assert "possible regression" in markdown_path.read_text(encoding="utf-8")
+    assert json.loads(json_path.read_text(encoding="utf-8"))["counts"]["regression"] == 1


### PR DESCRIPTION
## Summary

- Make `scripts/benchmarks/compare_native_benchmarks.py` report any detected benchmark regression as `possible_regression`.
- Add `--fail-on-regression` so the comparison command can return a non-zero exit status after writing Markdown and JSON reports.
- Update `.github/workflows/perf-pr.yml` to use the fail flag while still appending the summary and uploading comparison artifacts.

## Root cause

The comparison script classified individual benchmark cases as regressions, but it still exited successfully. A single non-severe regression could also leave the overall status as `no_regression`, so the PR performance workflow stayed green even when a regression was detected.

## Verification

- `python3 -m pytest test/python/test_compare_native_benchmarks.py`