### PR TITLE
ci: add native perf warmup runs

### DIFF
--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -77,6 +77,7 @@ jobs:
             --binary "$GITHUB_WORKSPACE/base/build/cmake/infomap_native_benchmark" \
             --profile pr \
             --repeats 3 \
+            --warmup-runs 1 \
             --iterations 1 \
             --output "$GITHUB_WORKSPACE/artifacts/base-native-benchmarks.json"
 
@@ -84,6 +85,7 @@ jobs:
             --binary "$GITHUB_WORKSPACE/head/build/cmake/infomap_native_benchmark" \
             --profile pr \
             --repeats 3 \
+            --warmup-runs 1 \
             --iterations 1 \
             --output "$GITHUB_WORKSPACE/artifacts/head-native-benchmarks.json"
 

--- a/scripts/benchmarks/run_native_benchmarks.py
+++ b/scripts/benchmarks/run_native_benchmarks.py
@@ -165,24 +165,35 @@ def benchmark_case(
     name: str,
     network_path: Path,
     repeats: int,
+    warmup_runs: int,
     iterations: int,
     flags: str,
 ) -> dict[str, object]:
     samples: list[dict[str, object]] = []
     run_samples: list[dict[str, object]] = []
+
+    command = [
+        str(binary),
+        "--input",
+        str(network_path),
+        "--name",
+        name,
+        "--flags",
+        flags,
+        "--iterations",
+        str(iterations),
+    ]
+    for _ in range(warmup_runs):
+        subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
     for repeat in range(repeats):
         completed = subprocess.run(
-            [
-                str(binary),
-                "--input",
-                str(network_path),
-                "--name",
-                name,
-                "--flags",
-                flags,
-                "--iterations",
-                str(iterations),
-            ],
+            command,
             check=True,
             capture_output=True,
             text=True,
@@ -255,6 +266,7 @@ def benchmark_case(
         "name": name,
         "path": str(network_path),
         "repeats": repeats,
+        "warmup_runs": warmup_runs,
         "iterations": iterations,
         "flags": samples[0]["flags"],
         "samples": samples,
@@ -342,6 +354,7 @@ def main() -> None:
     parser.add_argument("--output", type=Path, required=True, help="Path to write the JSON benchmark report.")
     parser.add_argument("--summary", type=Path, default=None, help="Optional Markdown summary output.")
     parser.add_argument("--repeats", type=int, default=3, help="Number of runs per case.")
+    parser.add_argument("--warmup-runs", type=int, default=0, help="Number of unmeasured warmup runs per case.")
     parser.add_argument("--iterations", type=int, default=1, help="Number of in-process iterations per benchmark run.")
     parser.add_argument(
         "--profile",
@@ -358,6 +371,10 @@ def main() -> None:
 
     if args.iterations < 1:
         parser.error("--iterations must be at least 1")
+    if args.repeats < 1:
+        parser.error("--repeats must be at least 1")
+    if args.warmup_runs < 0:
+        parser.error("--warmup-runs must be at least 0")
 
     repo_root = Path(__file__).resolve().parents[2]
     if not args.binary.is_file():
@@ -372,6 +389,7 @@ def main() -> None:
                 str(case["name"]),
                 Path(case["path"]),
                 args.repeats,
+                args.warmup_runs,
                 args.iterations,
                 " ".join(part for part in (args.flags, str(case["flags"])) if part).strip(),
             )
@@ -381,6 +399,7 @@ def main() -> None:
     report = {
         "profile": args.profile,
         "repeats": args.repeats,
+        "warmup_runs": args.warmup_runs,
         "iterations": args.iterations,
         "binary": str(args.binary),
         "benchmarks": results,

--- a/test/python/test_native_benchmark_script.py
+++ b/test/python/test_native_benchmark_script.py
@@ -70,6 +70,7 @@ def test_benchmark_case_tolerates_missing_rebuild_metrics(monkeypatch, tmp_path:
         name="toy",
         network_path=tmp_path / "toy.net",
         repeats=1,
+        warmup_runs=0,
         iterations=1,
         flags="--silent",
     )
@@ -139,12 +140,71 @@ def test_benchmark_case_collects_dynamic_rebuild_bucket_labels(monkeypatch, tmp_
         name="toy",
         network_path=tmp_path / "toy.net",
         repeats=1,
+        warmup_runs=0,
         iterations=1,
         flags="--silent",
     )
 
     assert result["rebuild"]["mean_total_sec"] == pytest.approx(0.05)
     assert result["rebuild"]["module_size_buckets"]["33-64"]["mean_sec"] == pytest.approx(0.03)
+
+
+def test_benchmark_case_discards_warmup_samples(monkeypatch, tmp_path: Path):
+    benchmark_module = _load_benchmark_module()
+
+    def payload(run_sec: float) -> dict[str, object]:
+        return {
+            "flags": "--silent --no-file-output --num-trials 1 --seed 123",
+            "total_sec": run_sec + 0.1,
+            "read_input_sec": 0.1,
+            "run_sec": run_sec,
+            "peak_rss_bytes": 4096,
+            "node_size_bytes": 32,
+            "edge_size_bytes": 16,
+            "num_nodes": 5,
+            "num_links": 4,
+            "num_top_modules": 2,
+            "num_levels": 1,
+            "codelength": 1.5,
+            "higher_order_input": False,
+            "directed_input": False,
+            "runs": [
+                {
+                    "iteration": 1,
+                    "read_input_sec": 0.0,
+                    "run_sec": run_sec,
+                    "total_sec": run_sec,
+                    "peak_rss_bytes": 4096,
+                    "num_top_modules": 2,
+                    "num_levels": 1,
+                    "codelength": 1.5,
+                }
+            ],
+        }
+
+    payloads = [payload(99.0), payload(1.0), payload(3.0)]
+
+    def fake_run(*args, **kwargs):
+        return benchmark_module.subprocess.CompletedProcess(args[0], 0, stdout=json.dumps(payloads.pop(0)), stderr="")
+
+    monkeypatch.setattr(benchmark_module.subprocess, "run", fake_run)
+
+    result = benchmark_module.benchmark_case(
+        binary=tmp_path / "infomap_native_benchmark",
+        name="toy",
+        network_path=tmp_path / "toy.net",
+        repeats=2,
+        warmup_runs=1,
+        iterations=1,
+        flags="--silent",
+    )
+
+    assert payloads == []
+    assert result["warmup_runs"] == 1
+    assert len(result["samples"]) == 2
+    assert [sample["run_sec"] for sample in result["samples"]] == [1.0, 3.0]
+    assert result["median_run_sec"] == pytest.approx(2.0)
+    assert [sample["repeat"] for sample in result["run_samples"]] == [1, 2]
 
 
 def test_build_benchmark_cases_pr_profile_focuses_on_stable_cases(monkeypatch, tmp_path: Path):
@@ -191,3 +251,27 @@ def test_build_benchmark_cases_smoke_skips_100k_generation(monkeypatch, tmp_path
     benchmark_module.build_benchmark_cases("smoke", repo_root, tmp_path)
 
     assert calls == [10_000]
+
+
+def test_main_rejects_negative_warmup_runs(monkeypatch):
+    benchmark_module = _load_benchmark_module()
+
+    import sys
+
+    old_argv = sys.argv
+    sys.argv = [
+        "run_native_benchmarks.py",
+        "--binary",
+        "missing-binary",
+        "--output",
+        "missing-output.json",
+        "--warmup-runs",
+        "-1",
+    ]
+    try:
+        with pytest.raises(SystemExit) as exc_info:
+            benchmark_module.main()
+    finally:
+        sys.argv = old_argv
+
+    assert exc_info.value.code == 2


### PR DESCRIPTION
## Summary

- Add `--warmup-runs` support to `scripts/benchmarks/run_native_benchmarks.py`.
- Discard warmup runs from measured samples, run samples, medians, CVs, and comparison inputs.
- Run one warmup pass for both base and head in the PR native performance workflow.

## Details

The benchmark report now records `warmup_runs` at the top level and per benchmark case so artifacts show how many unmeasured warmup executions were used. The default remains `0` for non-PR callers unless they opt in.

## Verification

- `python3 -m pytest test/python/test_native_benchmark_script.py`
- `python3 -m pytest test/python/test_compare_native_benchmarks.py`
- `/opt/homebrew/bin/actionlint .github/workflows/perf-pr.yml`
- `git diff --check`