### PR TITLE
test: enforce runtime stream policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     outputs:
+      policy: ${{ steps.filter.outputs.policy }}
       native: ${{ steps.filter.outputs.native }}
       python: ${{ steps.filter.outputs.python }}
       javascript: ${{ steps.filter.outputs.javascript }}
@@ -36,6 +37,14 @@ jobs:
         uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.2
         with:
           filters: |
+            policy:
+              - "Makefile"
+              - "mk/**"
+              - "src/**"
+              - "interfaces/swig/**"
+              - "interfaces/R/generated/**"
+              - "scripts/check_cpp_stream_policy.py"
+              - ".github/workflows/ci.yml"
             native:
               - "CMakeLists.txt"
               - "Makefile"
@@ -92,6 +101,20 @@ jobs:
               - ".github/workflows/ci.yml"
               - ".github/workflows/_r-package.yml"
 
+  policy:
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.policy == 'true'
+    name: C++ stream policy
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check runtime stream policy
+        run: make test-cpp-stream-policy PYTHON=python3
+
   native:
     needs: changes
     if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.native == 'true'
@@ -123,7 +146,7 @@ jobs:
 
   ci-summary:
     name: CI Summary
-    needs: [changes, native, python, javascript, r]
+    needs: [changes, policy, native, python, javascript, r]
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 10

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -86,6 +86,7 @@ help:
 		"  build-docs            Refresh the committed Python docs site in docs/." \
 		"" \
 		"Test" \
+		"  test-cpp-stream-policy  Verify runtime C++ does not use direct global std streams outside approved files." \
 		"  test-native           Configure, build, and run the C++ doctest suite via CMake/CTest." \
 		"  test-python           Run the full Python verification suite." \
 		"  test-python-unit      Run pytest for test/python." \

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -27,7 +27,10 @@ define warn_cmake_build_type_mismatch
 	fi
 endef
 
-.PHONY: test-native test-fast test-sanitizers bench-python bench-native
+.PHONY: test-cpp-stream-policy test-native test-fast test-sanitizers bench-python bench-native
+
+test-cpp-stream-policy:
+	@$(PYTHON) scripts/check_cpp_stream_policy.py
 
 test-native:
 	$(warn_cmake_build_type_mismatch)
@@ -46,7 +49,7 @@ test-native:
 	@"$(CMAKE)" --build $(CMAKE_TEST_BUILD_DIR) --target $(CMAKE_TEST_TARGET) --parallel $(JOBS)
 	@"$(CTEST)" --test-dir $(CMAKE_TEST_BUILD_DIR) --output-on-failure $(CTEST_ARGS)
 
-test-fast: test-native test-python-unit
+test-fast: test-cpp-stream-policy test-native test-python-unit
 	@true
 
 test-sanitizers:

--- a/scripts/check_cpp_stream_policy.py
+++ b/scripts/check_cpp_stream_policy.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Enforce the C++ runtime stream policy.
+
+Runtime code that is shared with bindings should not introduce direct global
+std stream usage. Keep CLI/error handling and central log routing explicit by
+allowing only src/main.cpp and src/utils/Log.cpp.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+DEFAULT_SCAN_PATTERNS = (
+    "src/**/*.h",
+    "src/**/*.cpp",
+    "interfaces/swig/**/*.i",
+)
+EXTRA_SCAN_FILES = ("interfaces/R/generated/infomap_wrap.cpp",)
+ALLOWED_FILES = {
+    Path("src/main.cpp"),
+    Path("src/utils/Log.cpp"),
+}
+STREAM_NAMES = ("cout", "cerr", "clog", "wcout", "wcerr", "wclog")
+FORBIDDEN_PATTERNS = (
+    ("include <iostream>", re.compile(r"^\s*#\s*include\s*<\s*iostream\s*>")),
+    (
+        "global std stream",
+        re.compile(r"\bstd\s*::\s*(?:" + "|".join(STREAM_NAMES) + r")\b"),
+    ),
+    (
+        "using global std stream",
+        re.compile(r"\busing\s+std\s*::\s*(?:" + "|".join(STREAM_NAMES) + r")\b"),
+    ),
+)
+
+
+def repo_relative(path: Path, root: Path) -> Path:
+    return path.resolve().relative_to(root)
+
+
+def iter_scan_files(root: Path) -> list[Path]:
+    files: set[Path] = set()
+    for pattern in DEFAULT_SCAN_PATTERNS:
+        files.update(path for path in root.glob(pattern) if path.is_file())
+    for relpath in EXTRA_SCAN_FILES:
+        path = root / relpath
+        if path.is_file():
+            files.add(path)
+    return sorted(files)
+
+
+def scan_file(path: Path, root: Path) -> tuple[list[str], list[str]]:
+    relpath = repo_relative(path, root)
+    findings: list[str] = []
+    allowed_hits: list[str] = []
+
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        for label, pattern in FORBIDDEN_PATTERNS:
+            if not pattern.search(line):
+                continue
+            message = f"{relpath}:{line_number}: forbidden {label}: {line.strip()}"
+            if relpath in ALLOWED_FILES:
+                allowed_hits.append(message)
+            else:
+                findings.append(message)
+
+    return findings, allowed_hits
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root to scan. Defaults to the parent of scripts/.",
+    )
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    findings: list[str] = []
+    allowed_hits: list[str] = []
+
+    for path in iter_scan_files(root):
+        file_findings, file_allowed_hits = scan_file(path, root)
+        findings.extend(file_findings)
+        allowed_hits.extend(file_allowed_hits)
+
+    if findings:
+        print("Forbidden direct C++ std stream usage found:\n", file=sys.stderr)
+        print("\n".join(findings), file=sys.stderr)
+        print(
+            "\nUse infomap::Log or an explicit caller-owned stream instead. "
+            "Only src/main.cpp and src/utils/Log.cpp may use <iostream> or "
+            "global std streams directly.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if allowed_hits:
+        print("Allowed std stream usage is confined to:")
+        for hit in allowed_hits:
+            print(f"  {hit}")
+    else:
+        print("No direct C++ std stream usage found.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a lightweight C++ stream policy check to prevent accidental direct use of global std streams in runtime code that can affect the R package.

The only allowed first-party C++ exceptions are:

- `src/main.cpp`, the CLI entrypoint
- `src/utils/Log.cpp`, the central log-routing fallback

Everywhere else, new output should go through `infomap::Log` or an explicit caller-owned stream.

## Why

Direct `#include <iostream>` or `std::cout` / `std::cerr` references in runtime code can reintroduce R CMD check issues and bypass the R console routing. This makes the policy explicit and CI-enforced.

## Verification

- `make test-cpp-stream-policy PYTHON=python3`
- negative temp-root smoke test for a forbidden `#include <iostream>` and `std::cout`
- `python3 -m py_compile scripts/check_cpp_stream_policy.py`
- `make build-native`
- `make test-native`
- `make test-r-swig-freshness PYTHON=python3`
