### PR TITLE
chore: improve C++ dev workflow

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -20,6 +20,7 @@ ReflowComments: true
 SortIncludes: Never
 SortUsingDeclarations: true
 Standard: c++14
+SpaceInEmptyBlock: false
 UseTab: Never
 IndentWidth: 2
 BraceWrapping:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,19 @@
+---
+Checks: >
+  -*,
+  bugprone-*,
+  -bugprone-crtp-constructor-accessibility,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-exception-escape,
+  -bugprone-narrowing-conversions,
+  -bugprone-switch-missing-default-case,
+  -bugprone-unhandled-exception-at-new,
+  -bugprone-unused-local-non-trivial-variable,
+  performance-*,
+  modernize-use-nullptr,
+  modernize-use-override,
+  readability-container-size-empty,
+  readability-redundant-member-init
+HeaderFilterRegex: '^.*/src/.*'
+FormatStyle: file
+...

--- a/.codex-bin/pip
+++ b/.codex-bin/pip
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec "$(cd "$(dirname "$0")/.." && pwd)/.venv/bin/pip" "$@"

--- a/.codex-bin/pip
+++ b/.codex-bin/pip
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec "$(cd "$(dirname "$0")/.." && pwd)/.venv/bin/pip" "$@"

--- a/.codex-bin/python
+++ b/.codex-bin/python
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec "$(cd "$(dirname "$0")/.." && pwd)/.venv/bin/python" "$@"

--- a/.codex-bin/python
+++ b/.codex-bin/python
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec "$(cd "$(dirname "$0")/.." && pwd)/.venv/bin/python" "$@"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
               - "scripts/check_cpp_stream_policy.py"
               - ".github/workflows/ci.yml"
             native:
+              - ".clang-format"
+              - ".clang-tidy"
+              - "CMakePresets.json"
               - "CMakeLists.txt"
               - "Makefile"
               - "mk/**"
@@ -115,6 +118,26 @@ jobs:
       - name: Check runtime stream policy
         run: make test-cpp-stream-policy PYTHON=python3
 
+  cxx-format:
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.native == 'true' || needs.changes.outputs.policy == 'true'
+    name: C++ formatting
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format
+        shell: bash
+
+      - name: Check C++ formatting
+        run: make format-native-check
+
   native:
     needs: changes
     if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.native == 'true'
@@ -146,7 +169,7 @@ jobs:
 
   ci-summary:
     name: CI Summary
-    needs: [changes, policy, native, python, javascript, r]
+    needs: [changes, policy, cxx-format, native, python, javascript, r]
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 10

--- a/.github/workflows/nightly-quality.yml
+++ b/.github/workflows/nightly-quality.yml
@@ -118,6 +118,25 @@ jobs:
           ASAN_OPTIONS: detect_leaks=1:strict_string_checks=1
           UBSAN_OPTIONS: print_stacktrace=1
 
+  linux-clang-tidy:
+    name: Linux clang-tidy
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install clang-tidy toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-tidy ninja-build
+        shell: bash
+
+      - name: Run clang-tidy
+        run: make tidy-native CMAKE_DEV_GENERATOR=Ninja
+        shell: bash
+
   python-benchmarks:
     name: Python benchmarks
     runs-on: ubuntu-24.04

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ callgrind.*
 
 /Infomap
 /build/
+/compile_commands.json
 /dist/
 /include/
 /lib/

--- a/BUILD.md
+++ b/BUILD.md
@@ -50,6 +50,55 @@ make build-native
 
 The compiled binary is written to `./Infomap`.
 
+## C++ development
+
+For editor and agent workflows, configure a clangd-friendly CMake build:
+
+```bash
+make configure-cpp-dev
+```
+
+This writes CMake output under `build/cmake-dev/` and links
+`compile_commands.json` in the repository root. The default dev configuration
+uses `INFOMAP_MODE=debug` and disables OpenMP for simpler local setup. Use
+`CMAKE_DEV_OPENMP=1` when you need OpenMP in the dev build.
+
+Run the fast C++ feedback path with:
+
+```bash
+make dev-cpp-check
+```
+
+Format C++ sources or verify formatting without rewriting files:
+
+```bash
+make format-native
+make format-native-check
+```
+
+Run the opt-in clang-tidy profile with:
+
+```bash
+make tidy-native
+```
+
+On macOS with Homebrew LLVM, use the matching compiler if `clang-tidy` cannot
+resolve the standard library from the default AppleClang compile database:
+
+```bash
+make tidy-native CMAKE_DEV_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++
+```
+
+The same dev build is available through CMake Presets:
+
+```bash
+cmake --preset dev
+cmake --build --preset dev
+ctest --preset dev
+```
+
+Use `dev-openmp` instead of `dev` for an OpenMP-enabled preset.
+
 ## Python package
 
 `make build-python` uses the same shared `MODE`/`OPENMP` policy as

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,63 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "dev",
+      "displayName": "C++ dev",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/cmake-dev",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "INFOMAP_MODE": "debug",
+        "INFOMAP_USE_OPENMP": "OFF"
+      }
+    },
+    {
+      "name": "dev-openmp",
+      "displayName": "C++ dev with OpenMP",
+      "inherits": "dev",
+      "binaryDir": "${sourceDir}/build/cmake-dev-openmp",
+      "cacheVariables": {
+        "INFOMAP_USE_OPENMP": "ON"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "dev",
+      "configurePreset": "dev",
+      "targets": [
+        "infomap_cpp_tests"
+      ]
+    },
+    {
+      "name": "dev-openmp",
+      "configurePreset": "dev-openmp",
+      "targets": [
+        "infomap_cpp_tests"
+      ]
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "dev",
+      "configurePreset": "dev",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "dev-openmp",
+      "configurePreset": "dev-openmp",
+      "output": {
+        "outputOnFailure": true
+      }
+    }
+  ]
+}

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -30,6 +30,10 @@ SPHINX_BUILD_BIN := $(shell command -v sphinx-build 2>/dev/null || true)
 SPHINX_BUILD ?= $(if $(SPHINX_BUILD_BIN),$(SPHINX_BUILD_BIN),$(PYTHON) -m sphinx)
 CMAKE ?= $(shell command -v cmake 2>/dev/null || command -v /opt/homebrew/bin/cmake 2>/dev/null || echo cmake)
 CTEST ?= $(shell command -v ctest 2>/dev/null || command -v /opt/homebrew/bin/ctest 2>/dev/null || echo ctest)
+CLANG_FORMAT ?= $(shell command -v clang-format 2>/dev/null || command -v /opt/homebrew/bin/clang-format 2>/dev/null || command -v /opt/homebrew/opt/llvm/bin/clang-format 2>/dev/null || echo clang-format)
+CLANG_TIDY ?= $(shell command -v clang-tidy 2>/dev/null || command -v /opt/homebrew/bin/clang-tidy 2>/dev/null || command -v /opt/homebrew/opt/llvm/bin/clang-tidy 2>/dev/null || echo clang-tidy)
+CLANGD ?= $(shell command -v clangd 2>/dev/null || command -v /opt/homebrew/bin/clangd 2>/dev/null || command -v /opt/homebrew/opt/llvm/bin/clangd 2>/dev/null || echo clangd)
+NINJA ?= $(shell command -v ninja 2>/dev/null || command -v /opt/homebrew/bin/ninja 2>/dev/null || echo ninja)
 
 MODE ?= release
 OPENMP ?= 1
@@ -110,6 +114,11 @@ help:
 		"Dev" \
 		"  help                  Show this guide." \
 		"  doctor                Inspect tool availability and active build flags." \
+		"  configure-cpp-dev     Configure a clangd-friendly CMake dev build." \
+		"  format-native         Rewrite C++ sources with clang-format." \
+		"  format-native-check   Verify C++ sources are clang-format clean." \
+		"  tidy-native           Run clang-tidy over C++ source files." \
+		"  dev-cpp-check         Run the fast C++ developer feedback suite." \
 		"  dev-bootstrap         Install Python dev dependencies and run npm ci." \
 		"  dev-python-install    Install the built Python package in editable mode." \
 		"  clean                 Remove native, Python, and JS build outputs." \
@@ -181,6 +190,11 @@ doctor:
 	@printf "sphinx (%s): %s\n" "$(SPHINX_BUILD)" "$(if $(SPHINX_BUILD_BIN),$(SPHINX_BUILD_BIN),python -m sphinx)"
 	@printf "cmake (%s): %s\n" "$(CMAKE)" "$$(command -v $(CMAKE) 2>/dev/null || echo missing)"
 	@printf "ctest (%s): %s\n" "$(CTEST)" "$$(command -v $(CTEST) 2>/dev/null || echo missing)"
+	@printf "clang-format (%s): %s\n" "$(CLANG_FORMAT)" "$$(command -v $(CLANG_FORMAT) 2>/dev/null || echo missing)"
+	@printf "clang-tidy (%s): %s\n" "$(CLANG_TIDY)" "$$(command -v $(CLANG_TIDY) 2>/dev/null || echo missing)"
+	@printf "clangd (%s): %s\n" "$(CLANGD)" "$$(command -v $(CLANGD) 2>/dev/null || echo missing)"
+	@printf "ninja (%s): %s\n" "$(NINJA)" "$$(command -v $(NINJA) 2>/dev/null || echo missing)"
+	@printf "compile_commands.json: %s\n" "$$([ -e compile_commands.json ] && printf present || printf missing)"
 	@printf "em++ (%s): %s\n" "$(EMXX)" "$$(command -v $(EMXX) 2>/dev/null || echo missing)"
 	@printf "NATIVE_CXXFLAGS=%s\n" "$(NATIVE_CXXFLAGS)"
 	@printf "NATIVE_LDFLAGS=%s\n" "$(NATIVE_LDFLAGS)"

--- a/mk/native.mk
+++ b/mk/native.mk
@@ -8,7 +8,7 @@ NATIVE_OBJECTS := $(SOURCES:src/%.cpp=$(NATIVE_OBJECT_DIR)/%.o)
 LIB_OBJECTS := $(SOURCES:src/%.cpp=$(LIB_OBJECT_DIR)/%.o)
 LIB_HEADERS := $(HEADERS:src/%.h=$(PUBLIC_INCLUDE_DIR)/%.h)
 
-.PHONY: build-native build-lib clean-native format-native
+.PHONY: build-native build-lib clean-native format-native format-native-check
 
 build-native: $(NATIVE_BINARY)
 	@printf "Built %s (MODE=%s OPENMP=%s)\n" "$(NATIVE_BINARY)" "$(MODE)" "$(OPENMP)"
@@ -39,7 +39,10 @@ $(LIB_OBJECT_DIR)/%.o: src/%.cpp $(HEADERS) $(MK_FILES) Makefile
 	$(CXX_COMPILE) $(NATIVE_CXXFLAGS) -DNS_INFOMAP -DAS_LIB -c $< -o $@
 
 format-native:
-	clang-format -i $(HEADERS) $(SOURCES)
+	$(CLANG_FORMAT) -i $(HEADERS) $(SOURCES)
+
+format-native-check:
+	$(CLANG_FORMAT) --dry-run --Werror $(HEADERS) $(SOURCES)
 
 clean-native:
 	$(RM) -r $(NATIVE_BINARY) build/native build/Infomap build/lib build/cmake build/cmake-sanitizers lib include

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -1,4 +1,9 @@
 CMAKE_TEST_BUILD_DIR ?= build/cmake
+CMAKE_DEV_BUILD_DIR ?= build/cmake-dev
+CMAKE_DEV_GENERATOR ?= Ninja
+CMAKE_DEV_OPENMP ?= 0
+CMAKE_DEV_CXX_COMPILER ?=
+CMAKE_DEV_OSX_SYSROOT ?= $(if $(filter Darwin,$(UNAME_S)),$(shell xcrun --show-sdk-path 2>/dev/null || true),)
 SANITIZER_BUILD_DIR ?= build/cmake-sanitizers
 DEFAULT_CMAKE_BUILD_TYPE := $(if $(filter debug,$(MODE)),Debug,RelWithDebInfo)
 CMAKE_BUILD_TYPE ?= $(DEFAULT_CMAKE_BUILD_TYPE)
@@ -27,7 +32,28 @@ define warn_cmake_build_type_mismatch
 	fi
 endef
 
-.PHONY: test-cpp-stream-policy test-native test-binding-options-freshness test-fast test-sanitizers bench-python bench-native
+.PHONY: configure-cpp-dev tidy-native dev-cpp-check test-cpp-stream-policy test-native test-binding-options-freshness test-fast test-sanitizers bench-python bench-native
+
+configure-cpp-dev:
+	@generator_args=""; \
+	if [ -n "$(CMAKE_DEV_GENERATOR)" ]; then generator_args="-G $(CMAKE_DEV_GENERATOR)"; fi; \
+	"$(CMAKE)" -S . -B $(CMAKE_DEV_BUILD_DIR) $$generator_args \
+		-DCMAKE_BUILD_TYPE=Debug \
+		$(if $(CMAKE_DEV_CXX_COMPILER),-DCMAKE_CXX_COMPILER=$(CMAKE_DEV_CXX_COMPILER),) \
+		$(if $(CMAKE_DEV_OSX_SYSROOT),-DCMAKE_OSX_SYSROOT=$(CMAKE_DEV_OSX_SYSROOT),) \
+		-DINFOMAP_MODE=debug \
+		-DINFOMAP_USE_OPENMP=$(if $(filter 1,$(CMAKE_DEV_OPENMP)),ON,OFF) \
+		-DINFOMAP_EXTRA_CPPFLAGS="$(CPPFLAGS)" \
+		-DINFOMAP_EXTRA_CXX_FLAGS="$(CXXFLAGS)" \
+		-DINFOMAP_EXTRA_LINK_FLAGS="$(LDFLAGS)" \
+		-DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+	@ln -sfn $(CMAKE_DEV_BUILD_DIR)/compile_commands.json compile_commands.json
+
+tidy-native: configure-cpp-dev
+	$(CLANG_TIDY) --quiet -p $(CMAKE_DEV_BUILD_DIR) $(SOURCES)
+
+dev-cpp-check: format-native-check test-cpp-stream-policy
+	@$(MAKE) test-native MODE=debug OPENMP=0 CMAKE_GENERATOR="$(CMAKE_DEV_GENERATOR)" CMAKE_TEST_BUILD_DIR=$(CMAKE_DEV_BUILD_DIR) CMAKE_BUILD_TYPE=Debug
 
 test-cpp-stream-policy:
 	@$(PYTHON) scripts/check_cpp_stream_policy.py

--- a/src/Infomap.h
+++ b/src/Infomap.h
@@ -22,9 +22,9 @@ namespace infomap {
 // Wrapper class for the Python API
 struct InfomapWrapper : public InfomapBase {
 public:
-  InfomapWrapper() : InfomapBase() { }
-  InfomapWrapper(const std::string& flags) : InfomapBase(flags) { }
-  InfomapWrapper(const Config& conf) : InfomapBase(conf) { }
+  InfomapWrapper() : InfomapBase() {}
+  InfomapWrapper(const std::string& flags) : InfomapBase(flags) {}
+  InfomapWrapper(const Config& conf) : InfomapBase(conf) {}
   virtual ~InfomapWrapper() = default;
 
   // ===================================================

--- a/src/core/BiasedMapEquation.h
+++ b/src/core/BiasedMapEquation.h
@@ -56,7 +56,7 @@ public:
 
   void init(const Config& config) override;
 
-  void initTree(InfoNode& /*root*/) override { }
+  void initTree(InfoNode& /*root*/) override {}
 
   void initNetwork(InfoNode& root) override;
 

--- a/src/core/FlowData.h
+++ b/src/core/FlowData.h
@@ -25,7 +25,7 @@ struct FlowData {
   double danglingFlow = 0.0;
 
   FlowData() = default;
-  FlowData(double flow) : flow(flow) { }
+  FlowData(double flow) : flow(flow) {}
 
   FlowData& operator+=(const FlowData& other)
   {
@@ -68,7 +68,7 @@ struct DeltaFlow {
   explicit DeltaFlow(unsigned int module, double deltaExit, double deltaEnter)
       : module(module),
         deltaExit(deltaExit),
-        deltaEnter(deltaEnter) { }
+        deltaEnter(deltaEnter) {}
 
   DeltaFlow() = default;
   DeltaFlow(const DeltaFlow&) = default;
@@ -117,7 +117,7 @@ struct MemDeltaFlow : DeltaFlow {
   explicit MemDeltaFlow(unsigned int module, double deltaExit, double deltaEnter, double sumDeltaPlogpPhysFlow = 0.0, double sumPlogpPhysFlow = 0.0)
       : DeltaFlow(module, deltaExit, deltaEnter),
         sumDeltaPlogpPhysFlow(sumDeltaPlogpPhysFlow),
-        sumPlogpPhysFlow(sumPlogpPhysFlow) { }
+        sumPlogpPhysFlow(sumPlogpPhysFlow) {}
 
   MemDeltaFlow& operator+=(const MemDeltaFlow& other)
   {
@@ -152,7 +152,7 @@ struct PhysData {
   double sumFlowFromM2Node; // The amount of flow from the memory node in this physical node
 
   explicit PhysData(unsigned int physNodeIndex, double sumFlowFromM2Node = 0.0)
-      : physNodeIndex(physNodeIndex), sumFlowFromM2Node(sumFlowFromM2Node) { }
+      : physNodeIndex(physNodeIndex), sumFlowFromM2Node(sumFlowFromM2Node) {}
 
   friend std::ostream& operator<<(std::ostream& out, const PhysData& data)
   {

--- a/src/core/InfoEdge.h
+++ b/src/core/InfoEdge.h
@@ -18,7 +18,7 @@ struct EdgeData {
 public:
   EdgeData() = default;
 
-  EdgeData(double weight, double flow) : weight(weight), flow(flow) { }
+  EdgeData(double weight, double flow) : weight(weight), flow(flow) {}
 
   double weight;
   double flow;
@@ -31,7 +31,7 @@ public:
   InfoEdge(InfoNode& source, InfoNode& target, double weight, double flow)
       : data(weight, flow),
         source(&source),
-        target(&target) { }
+        target(&target) {}
 
   InfoNode& other(InfoNode& node) const;
 

--- a/src/core/InfoNode.h
+++ b/src/core/InfoNode.h
@@ -105,17 +105,17 @@ private:
 
 public:
   InfoNode(const FlowData& flowData)
-      : data(flowData) {};
+      : data(flowData) { };
 
   // For first order nodes, physicalId equals stateId
   InfoNode(const FlowData& flowData, unsigned int stateId)
-      : data(flowData), stateId(stateId), physicalId(stateId) {};
+      : data(flowData), stateId(stateId), physicalId(stateId) { };
 
   InfoNode(const FlowData& flowData, unsigned int stateId, unsigned int physicalId)
-      : data(flowData), stateId(stateId), physicalId(physicalId) {};
+      : data(flowData), stateId(stateId), physicalId(physicalId) { };
 
   InfoNode(const FlowData& flowData, unsigned int stateId, unsigned int physicalId, unsigned int layerId)
-      : data(flowData), stateId(stateId), physicalId(physicalId), layerId(layerId) {};
+      : data(flowData), stateId(stateId), physicalId(physicalId), layerId(layerId) { };
 
   InfoNode() = default;
 

--- a/src/core/InfoNode.h
+++ b/src/core/InfoNode.h
@@ -105,17 +105,17 @@ private:
 
 public:
   InfoNode(const FlowData& flowData)
-      : data(flowData) { };
+      : data(flowData) {};
 
   // For first order nodes, physicalId equals stateId
   InfoNode(const FlowData& flowData, unsigned int stateId)
-      : data(flowData), stateId(stateId), physicalId(stateId) { };
+      : data(flowData), stateId(stateId), physicalId(stateId) {};
 
   InfoNode(const FlowData& flowData, unsigned int stateId, unsigned int physicalId)
-      : data(flowData), stateId(stateId), physicalId(physicalId) { };
+      : data(flowData), stateId(stateId), physicalId(physicalId) {};
 
   InfoNode(const FlowData& flowData, unsigned int stateId, unsigned int physicalId, unsigned int layerId)
-      : data(flowData), stateId(stateId), physicalId(physicalId), layerId(layerId) { };
+      : data(flowData), stateId(stateId), physicalId(physicalId), layerId(layerId) {};
 
   InfoNode() = default;
 
@@ -138,7 +138,7 @@ public:
         metaCollection(other.metaCollection),
         m_childDegree(other.m_childDegree),
         m_childrenChanged(other.m_childrenChanged),
-        m_numLeafMembers(other.m_numLeafMembers) { }
+        m_numLeafMembers(other.m_numLeafMembers) {}
 
   ~InfoNode() noexcept;
 

--- a/src/core/InfomapConfig.h
+++ b/src/core/InfomapConfig.h
@@ -22,7 +22,7 @@ class InfomapConfig : public Config {
 public:
   InfomapConfig() = default;
 
-  InfomapConfig(const std::string& flags, bool isCli = false) : InfomapConfig(Config(flags, isCli)) { }
+  InfomapConfig(const std::string& flags, bool isCli = false) : InfomapConfig(Config(flags, isCli)) {}
 
   InfomapConfig(const Config& conf) : Config(conf), m_rand(conf.seedToRandomNumberGenerator)
   {

--- a/src/core/MapEquation.h
+++ b/src/core/MapEquation.h
@@ -110,9 +110,9 @@ public:
     return parent.isLeafModule() ? ME::calcCodelengthOnModuleOfLeafNodes(parent) : ME::calcCodelengthOnModuleOfModules(parent);
   }
 
-  virtual void addMemoryContributions(InfoNode& /*current*/, DeltaFlowDataType& /*oldModuleDelta*/, DeltaFlowDataType& /*newModuleDelta*/) { }
+  virtual void addMemoryContributions(InfoNode& /*current*/, DeltaFlowDataType& /*oldModuleDelta*/, DeltaFlowDataType& /*newModuleDelta*/) {}
 
-  virtual void addMemoryContributions(InfoNode& /*current*/, DeltaFlowDataType& /*oldModuleDelta*/, VectorMap<DeltaFlowDataType>& /*moduleDeltaFlow*/) { }
+  virtual void addMemoryContributions(InfoNode& /*current*/, DeltaFlowDataType& /*oldModuleDelta*/, VectorMap<DeltaFlowDataType>& /*moduleDeltaFlow*/) {}
 
   virtual double getDeltaCodelengthOnMovingNode(InfoNode& current,
                                                 DeltaFlowDataType& oldModuleDelta,

--- a/src/core/MemMapEquation.h
+++ b/src/core/MemMapEquation.h
@@ -53,7 +53,7 @@ public:
 
   void init(const Config& config) override;
 
-  void initTree(InfoNode& /*root*/) override { }
+  void initTree(InfoNode& /*root*/) override {}
 
   void initNetwork(InfoNode& root) override;
 
@@ -162,7 +162,7 @@ private:
 };
 
 struct MemNodeSet {
-  MemNodeSet(unsigned int numMemNodes, double sumFlow) : numMemNodes(numMemNodes), sumFlow(sumFlow) { }
+  MemNodeSet(unsigned int numMemNodes, double sumFlow) : numMemNodes(numMemNodes), sumFlow(sumFlow) {}
   unsigned int numMemNodes; // use counter to check for zero to avoid round-off errors in sumFlow
   double sumFlow;
 };

--- a/src/core/StateNetwork.h
+++ b/src/core/StateNetwork.h
@@ -32,11 +32,11 @@ public:
     double exitFlow = 0.0;
     double teleFlow = 0.0;
 
-    StateNode(unsigned int id = 0) : id(id), physicalId(id) { }
+    StateNode(unsigned int id = 0) : id(id), physicalId(id) {}
 
-    StateNode(unsigned int id, unsigned int physicalId) : id(id), physicalId(physicalId) { }
+    StateNode(unsigned int id, unsigned int physicalId) : id(id), physicalId(physicalId) {}
 
-    StateNode(unsigned int id, unsigned int physicalId, std::string name) : id(id), physicalId(physicalId), name(std::move(name)) { }
+    StateNode(unsigned int id, unsigned int physicalId, std::string name) : id(id), physicalId(physicalId), name(std::move(name)) {}
 
     bool operator==(const StateNode& rhs) const { return id == rhs.id; }
     bool operator!=(const StateNode& rhs) const { return id != rhs.id; }
@@ -46,16 +46,16 @@ public:
   struct PhysNode {
     unsigned int physId = 0;
     double weight = 1.0;
-    PhysNode(unsigned int physId) : physId(physId) { }
-    PhysNode(unsigned int physId, double weight) : physId(physId), weight(weight) { }
-    PhysNode(double weight = 1.0) : weight(weight) { }
+    PhysNode(unsigned int physId) : physId(physId) {}
+    PhysNode(unsigned int physId, double weight) : physId(physId), weight(weight) {}
+    PhysNode(double weight = 1.0) : weight(weight) {}
   };
 
   struct LinkData {
     double weight = 1.0;
     double flow = 0.0;
 
-    LinkData(double weight = 1.0) : weight(weight) { }
+    LinkData(double weight = 1.0) : weight(weight) {}
 
     LinkData& operator+=(double w)
     {
@@ -69,7 +69,7 @@ public:
         : source(sourceIndex),
           target(targetIndex),
           weight(weight),
-          flow(weight) { }
+          flow(weight) {}
 
     unsigned int source;
     unsigned int target;
@@ -115,8 +115,8 @@ protected:
   unsigned int m_bipartiteStartId = 0;
 
 public:
-  StateNetwork() : m_config(Config()) { }
-  StateNetwork(Config config) : m_config(std::move(config)) { }
+  StateNetwork() : m_config(Config()) {}
+  StateNetwork(Config config) : m_config(std::move(config)) {}
   virtual ~StateNetwork() = default;
 
   StateNetwork(const StateNetwork&) = delete;

--- a/src/core/iterators/InfomapIterator.h
+++ b/src/core/iterators/InfomapIterator.h
@@ -36,7 +36,7 @@ public:
   InfomapIterator() = default;
 
   InfomapIterator(InfoNode* nodePointer, int moduleIndexLevel = -1)
-      : m_root(nodePointer), m_current(nodePointer), m_moduleIndexLevel(moduleIndexLevel) { }
+      : m_root(nodePointer), m_current(nodePointer), m_moduleIndexLevel(moduleIndexLevel) {}
 
   virtual ~InfomapIterator() = default;
   InfomapIterator(const InfomapIterator&) = default;
@@ -97,9 +97,9 @@ public:
 
 struct InfomapModuleIterator : public InfomapIterator {
 public:
-  InfomapModuleIterator() : InfomapIterator() { }
+  InfomapModuleIterator() : InfomapIterator() {}
 
-  InfomapModuleIterator(InfoNode* nodePointer, int moduleIndexLevel = -1) : InfomapIterator(nodePointer, moduleIndexLevel) { }
+  InfomapModuleIterator(InfoNode* nodePointer, int moduleIndexLevel = -1) : InfomapIterator(nodePointer, moduleIndexLevel) {}
 
   ~InfomapModuleIterator() override = default;
   InfomapModuleIterator(const InfomapModuleIterator&) = default;
@@ -130,7 +130,7 @@ public:
 
 struct InfomapLeafModuleIterator : public InfomapIterator {
 public:
-  InfomapLeafModuleIterator() : InfomapIterator() { }
+  InfomapLeafModuleIterator() : InfomapIterator() {}
 
   InfomapLeafModuleIterator(InfoNode* nodePointer, int moduleIndexLevel = -1)
       : InfomapIterator(nodePointer, moduleIndexLevel) { init(); }
@@ -169,7 +169,7 @@ public:
 
 struct InfomapLeafIterator : public InfomapIterator {
 public:
-  InfomapLeafIterator() : InfomapIterator() { }
+  InfomapLeafIterator() : InfomapIterator() {}
 
   InfomapLeafIterator(InfoNode* nodePointer, int moduleIndexLevel = -1)
       : InfomapIterator(nodePointer, moduleIndexLevel) { init(); }
@@ -218,14 +218,14 @@ protected:
   InfomapIterator m_oldIter;
 
 public:
-  InfomapIteratorPhysical() : InfomapIterator() { }
+  InfomapIteratorPhysical() : InfomapIterator() {}
 
   InfomapIteratorPhysical(InfoNode* nodePointer, int moduleIndexLevel = -1)
-      : InfomapIterator(nodePointer, moduleIndexLevel) { }
+      : InfomapIterator(nodePointer, moduleIndexLevel) {}
 
   ~InfomapIteratorPhysical() override = default;
   InfomapIteratorPhysical(const InfomapIteratorPhysical&) = default;
-  InfomapIteratorPhysical(const InfomapIterator& other) : InfomapIterator(other) { }
+  InfomapIteratorPhysical(const InfomapIterator& other) : InfomapIterator(other) {}
 
   InfomapIteratorPhysical(InfomapIteratorPhysical&&) = default;
   InfomapIteratorPhysical& operator=(const InfomapIteratorPhysical&) = default;
@@ -267,7 +267,7 @@ public:
  */
 struct InfomapLeafIteratorPhysical : public InfomapIteratorPhysical {
 public:
-  InfomapLeafIteratorPhysical() : InfomapIteratorPhysical() { }
+  InfomapLeafIteratorPhysical() : InfomapIteratorPhysical() {}
 
   InfomapLeafIteratorPhysical(InfoNode* nodePointer, int moduleIndexLevel = -1)
       : InfomapIteratorPhysical(nodePointer, moduleIndexLevel) { init(); }
@@ -320,7 +320,7 @@ protected:
 public:
   InfomapParentIterator() = default;
 
-  InfomapParentIterator(InfoNode* nodePointer) : m_current(nodePointer) { }
+  InfomapParentIterator(InfoNode* nodePointer) : m_current(nodePointer) {}
 
   ~InfomapParentIterator() = default;
 

--- a/src/core/iterators/IterWrapper.h
+++ b/src/core/iterators/IterWrapper.h
@@ -20,19 +20,19 @@ class IterWrapper {
   Iter m_begin, m_end;
 
 public:
-  IterWrapper(Iter begin, Iter end) : m_begin(begin), m_end(end) { }
+  IterWrapper(Iter begin, Iter end) : m_begin(begin), m_end(end) {}
 
   // template <typename Container>
   template <typename Container,
             typename = decltype(std::declval<Container>().begin()),
             typename = decltype(std::declval<Container>().end())>
-  IterWrapper(Container& container) : m_begin(container.begin()), m_end(container.end()) { }
+  IterWrapper(Container& container) : m_begin(container.begin()), m_end(container.end()) {}
 
   template <typename Container,
             typename std::enable_if<std::is_convertible<Container&, IterWrapper<Iter>&>::value, int>::type = 0>
   IterWrapper(Container& container)
       : m_begin(static_cast<IterWrapper<Iter>&>(container).begin()),
-        m_end(static_cast<IterWrapper<Iter>&>(container).end()) { }
+        m_end(static_cast<IterWrapper<Iter>&>(container).end()) {}
 
   Iter begin() noexcept { return m_begin; };
 

--- a/src/core/iterators/infomapIterators.h
+++ b/src/core/iterators/infomapIterators.h
@@ -38,7 +38,7 @@ public:
       : m_root(nodePointer), m_current(nodePointer) { init(); }
 
   InfomapChildIterator(const InfomapChildIterator& other)
-      : m_root(other.m_root), m_current(other.m_current) { }
+      : m_root(other.m_root), m_current(other.m_current) {}
 
   InfomapChildIterator& operator=(const InfomapChildIterator& other)
   {
@@ -119,7 +119,7 @@ protected:
   using Base::m_depth;
 
 public:
-  InfomapClusterIterator() : Base() { }
+  InfomapClusterIterator() : Base() {}
 
   InfomapClusterIterator(const NodePointerType& nodePointer, int moduleIndexLevel = -1)
       : Base(nodePointer), m_moduleIndexLevel(moduleIndexLevel)
@@ -128,7 +128,7 @@ public:
   }
 
   InfomapClusterIterator(const InfomapClusterIterator& other)
-      : Base(other), m_moduleIndex(other.m_moduleIndex), m_moduleIndexLevel(other.m_moduleIndexLevel) { }
+      : Base(other), m_moduleIndex(other.m_moduleIndex), m_moduleIndexLevel(other.m_moduleIndexLevel) {}
 
   virtual void init() { moveToInfomapRootIfExist(); }
 
@@ -241,7 +241,7 @@ protected:
   using Base::m_depth;
 
 public:
-  InfomapDepthFirstIterator() : Base() { }
+  InfomapDepthFirstIterator() : Base() {}
 
   InfomapDepthFirstIterator(const NodePointerType& nodePointer, int moduleIndexLevel = -1)
       : Base(nodePointer),

--- a/src/core/iterators/treeIterators.h
+++ b/src/core/iterators/treeIterators.h
@@ -42,10 +42,10 @@ public:
   ChildIterator() = default;
 
   ChildIterator(const NodePointerType& nodePointer)
-      : m_root(nodePointer), m_current(nodePointer == nullptr ? nullptr : nodePointer->firstChild) { }
+      : m_root(nodePointer), m_current(nodePointer == nullptr ? nullptr : nodePointer->firstChild) {}
 
   ChildIterator(const ChildIterator& other)
-      : m_root(other.m_root), m_current(other.m_current) { }
+      : m_root(other.m_root), m_current(other.m_current) {}
 
   ChildIterator& operator=(const ChildIterator& other)
   {
@@ -124,7 +124,7 @@ public:
   TreeIterator(NodePointerType nodePointer, int moduleIndexLevel = -1)
       : m_root(nodePointer),
         m_current(nodePointer),
-        m_moduleIndexLevel(moduleIndexLevel) { }
+        m_moduleIndexLevel(moduleIndexLevel) {}
 
   TreeIterator(const TreeIterator& other)
       : m_root(other.m_root),
@@ -132,7 +132,7 @@ public:
         m_moduleIndexLevel(other.m_moduleIndexLevel),
         m_moduleIndex(other.m_moduleIndex),
         m_path(other.m_path),
-        m_depth(other.m_depth) { }
+        m_depth(other.m_depth) {}
 
   virtual ~TreeIterator() = default;
 
@@ -245,11 +245,11 @@ struct node_iterator_base {
   using reference = typename iterator_traits<NodePointerType>::reference;
   using pointer = typename iterator_traits<NodePointerType>::pointer;
 
-  node_iterator_base() : m_current(nullptr) { }
+  node_iterator_base() : m_current(nullptr) {}
 
-  node_iterator_base(const NodePointerType& nodePointer) : m_current(nodePointer) { }
+  node_iterator_base(const NodePointerType& nodePointer) : m_current(nodePointer) {}
 
-  node_iterator_base(const node_iterator_base& other) : m_current(other.m_current) { }
+  node_iterator_base(const node_iterator_base& other) : m_current(other.m_current) {}
 
   node_iterator_base& operator=(const node_iterator_base& other)
   {
@@ -280,11 +280,11 @@ class DepthFirstIteratorBase : public node_iterator_base<NodePointerType> {
   using Base = node_iterator_base<NodePointerType>;
 
 public:
-  DepthFirstIteratorBase() : Base(), m_root(nullptr), m_depth(0) { }
+  DepthFirstIteratorBase() : Base(), m_root(nullptr), m_depth(0) {}
 
-  DepthFirstIteratorBase(const NodePointerType& nodePointer) : Base(nodePointer), m_root(nodePointer), m_depth(0) { }
+  DepthFirstIteratorBase(const NodePointerType& nodePointer) : Base(nodePointer), m_root(nodePointer), m_depth(0) {}
 
-  DepthFirstIteratorBase(const DepthFirstIteratorBase& other) : Base(other), m_root(other.m_root), m_depth(other.m_depth) { }
+  DepthFirstIteratorBase(const DepthFirstIteratorBase& other) : Base(other), m_root(other.m_root), m_depth(other.m_depth) {}
 
   DepthFirstIteratorBase& operator=(const DepthFirstIteratorBase& other)
   {
@@ -312,11 +312,11 @@ class DepthFirstIterator : public DepthFirstIteratorBase<NodePointerType> {
   using Base = DepthFirstIteratorBase<NodePointerType>;
 
 public:
-  DepthFirstIterator() : Base() { }
+  DepthFirstIterator() : Base() {}
 
-  DepthFirstIterator(const NodePointerType& nodePointer) : Base(nodePointer) { }
+  DepthFirstIterator(const NodePointerType& nodePointer) : Base(nodePointer) {}
 
-  DepthFirstIterator(const DepthFirstIterator& other) : Base(other) { }
+  DepthFirstIterator(const DepthFirstIterator& other) : Base(other) {}
 
   DepthFirstIterator& operator=(const DepthFirstIterator& other)
   {
@@ -371,11 +371,11 @@ class DepthFirstIterator<NodePointerType, false> : public DepthFirstIteratorBase
   using Base = DepthFirstIteratorBase<NodePointerType>;
 
 public:
-  DepthFirstIterator() : Base() { }
+  DepthFirstIterator() : Base() {}
 
   DepthFirstIterator(const NodePointerType& nodePointer) : Base(nodePointer) { init(); }
 
-  DepthFirstIterator(const DepthFirstIterator& other) : Base(other) { }
+  DepthFirstIterator(const DepthFirstIterator& other) : Base(other) {}
 
   DepthFirstIterator& operator=(const DepthFirstIterator& other)
   {
@@ -441,11 +441,11 @@ class LeafNodeIterator : public DepthFirstIteratorBase<NodePointerType> {
   using Base = DepthFirstIteratorBase<NodePointerType>;
 
 public:
-  LeafNodeIterator() : Base() { }
+  LeafNodeIterator() : Base() {}
 
   LeafNodeIterator(const NodePointerType& nodePointer) : Base(nodePointer) { init(); }
 
-  LeafNodeIterator(const LeafNodeIterator& other) : Base(other) { }
+  LeafNodeIterator(const LeafNodeIterator& other) : Base(other) {}
 
   LeafNodeIterator& operator=(const LeafNodeIterator& other)
   {
@@ -506,11 +506,11 @@ class LeafModuleIterator : public DepthFirstIteratorBase<NodePointerType> {
   using Base = DepthFirstIteratorBase<NodePointerType>;
 
 public:
-  LeafModuleIterator() : Base() { }
+  LeafModuleIterator() : Base() {}
 
   LeafModuleIterator(const NodePointerType& nodePointer) : Base(nodePointer) { init(); }
 
-  LeafModuleIterator(const LeafModuleIterator& other) : Base(other) { }
+  LeafModuleIterator(const LeafModuleIterator& other) : Base(other) {}
 
   LeafModuleIterator& operator=(const LeafModuleIterator& other)
   {
@@ -582,11 +582,11 @@ class SiblingIterator : public node_iterator_base<NodePointerType> {
 public:
   using self_type = SiblingIterator<NodePointerType>;
 
-  SiblingIterator() : Base() { }
+  SiblingIterator() : Base() {}
 
-  SiblingIterator(const NodePointerType& nodePointer) : Base(nodePointer) { }
+  SiblingIterator(const NodePointerType& nodePointer) : Base(nodePointer) {}
 
-  SiblingIterator(const SiblingIterator& other) : Base(other) { }
+  SiblingIterator(const SiblingIterator& other) : Base(other) {}
 
   SiblingIterator& operator=(const SiblingIterator& other)
   {

--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -26,39 +26,39 @@ constexpr int FlowModel::precomputed;
 
 namespace {
 
-void applyFlowModelSelection(Config& config, const std::string& flowModelArg)
-{
-  if (flowModelArg == "directed" || config.directed) {
-    config.setFlowModel(FlowModel::directed);
-  } else if (flowModelArg == "undirected") {
-    config.setFlowModel(FlowModel::undirected);
-  } else if (flowModelArg == "undirdir") {
-    config.setFlowModel(FlowModel::undirdir);
-  } else if (flowModelArg == "outdirdir") {
-    config.setFlowModel(FlowModel::outdirdir);
-  } else if (flowModelArg == "rawdir") {
-    config.setFlowModel(FlowModel::rawdir);
-  } else if (flowModelArg == "precomputed") {
-    config.setFlowModel(FlowModel::precomputed);
-  } else if (!flowModelArg.empty()) {
-    throw std::runtime_error(io::Str() << "Unrecognized flow model: '" << flowModelArg << "'");
+  void applyFlowModelSelection(Config& config, const std::string& flowModelArg)
+  {
+    if (flowModelArg == "directed" || config.directed) {
+      config.setFlowModel(FlowModel::directed);
+    } else if (flowModelArg == "undirected") {
+      config.setFlowModel(FlowModel::undirected);
+    } else if (flowModelArg == "undirdir") {
+      config.setFlowModel(FlowModel::undirdir);
+    } else if (flowModelArg == "outdirdir") {
+      config.setFlowModel(FlowModel::outdirdir);
+    } else if (flowModelArg == "rawdir") {
+      config.setFlowModel(FlowModel::rawdir);
+    } else if (flowModelArg == "precomputed") {
+      config.setFlowModel(FlowModel::precomputed);
+    } else if (!flowModelArg.empty()) {
+      throw std::runtime_error(io::Str() << "Unrecognized flow model: '" << flowModelArg << "'");
+    }
   }
-}
 
-void normalizeOutputDirectory(Config& config)
-{
-  if (!config.haveOutput() || config.outDirectory.empty())
-    return;
+  void normalizeOutputDirectory(Config& config)
+  {
+    if (!config.haveOutput() || config.outDirectory.empty())
+      return;
 
-  if (config.outDirectory.back() != '/')
-    config.outDirectory.push_back('/');
-}
+    if (config.outDirectory.back() != '/')
+      config.outDirectory.push_back('/');
+  }
 
-void validateOutputDirectory(const Config& config)
-{
-  if (config.haveOutput() && !isDirectoryWritable(config.outDirectory))
-    throw std::runtime_error(io::Str() << "Can't write to directory '" << config.outDirectory << "'. Check that the directory exists and that you have write permissions.");
-}
+  void validateOutputDirectory(const Config& config)
+  {
+    if (config.haveOutput() && !isDirectoryWritable(config.outDirectory))
+      throw std::runtime_error(io::Str() << "Can't write to directory '" << config.outDirectory << "'. Check that the directory exists and that you have write permissions.");
+  }
 
 } // namespace
 

--- a/src/io/Config.h
+++ b/src/io/Config.h
@@ -34,7 +34,7 @@ struct FlowModel {
 
   int value = 0;
 
-  FlowModel(int val) : value(val) { }
+  FlowModel(int val) : value(val) {}
   FlowModel& operator=(int val)
   {
     value = val;

--- a/src/io/Network.h
+++ b/src/io/Network.h
@@ -204,7 +204,7 @@ private:
 
 struct LayerNode {
   unsigned int layer, node;
-  explicit LayerNode(unsigned int layer = 0, unsigned int node = 0) : layer(layer), node(node) { }
+  explicit LayerNode(unsigned int layer = 0, unsigned int node = 0) : layer(layer), node(node) {}
 
   bool operator<(const LayerNode other) const
   {

--- a/src/io/ProgramInterface.cpp
+++ b/src/io/ProgramInterface.cpp
@@ -35,131 +35,131 @@ const std::unordered_map<std::string, char> ArgType::toShort = {
 
 namespace {
 
-using ShortOptionMap = std::map<char, Option*>;
-using LongOptionMap = std::map<std::string, Option*>;
-using NonOptionArguments = std::deque<std::unique_ptr<TargetBase>>;
+  using ShortOptionMap = std::map<char, Option*>;
+  using LongOptionMap = std::map<std::string, Option*>;
+  using NonOptionArguments = std::deque<std::unique_ptr<TargetBase>>;
 
-struct OptionLookup {
-  ShortOptionMap shortOptions;
-  LongOptionMap longOptions;
-};
+  struct OptionLookup {
+    ShortOptionMap shortOptions;
+    LongOptionMap longOptions;
+  };
 
-OptionLookup buildOptionLookup(std::deque<std::unique_ptr<Option>>& options)
-{
-  OptionLookup lookup;
-  for (auto& optionArgument : options) {
-    auto& opt = *optionArgument;
-    if (opt.shortName != '\0') {
-      auto inserted = lookup.shortOptions.insert(std::make_pair(opt.shortName, &opt));
+  OptionLookup buildOptionLookup(std::deque<std::unique_ptr<Option>>& options)
+  {
+    OptionLookup lookup;
+    for (auto& optionArgument : options) {
+      auto& opt = *optionArgument;
+      if (opt.shortName != '\0') {
+        auto inserted = lookup.shortOptions.insert(std::make_pair(opt.shortName, &opt));
+        if (!inserted.second)
+          throw std::runtime_error(io::Str() << "Duplication of option '" << opt.shortName << "'");
+      }
+
+      auto inserted = lookup.longOptions.insert(std::make_pair(opt.longName, &opt));
       if (!inserted.second)
-        throw std::runtime_error(io::Str() << "Duplication of option '" << opt.shortName << "'");
+        throw std::runtime_error(io::Str() << "Duplication of option \"" << opt.longName << "\"");
     }
-
-    auto inserted = lookup.longOptions.insert(std::make_pair(opt.longName, &opt));
-    if (!inserted.second)
-      throw std::runtime_error(io::Str() << "Duplication of option \"" << opt.longName << "\"");
+    return lookup;
   }
-  return lookup;
-}
 
-std::vector<std::string> tokenizeArgs(const std::string& args)
-{
-  std::vector<std::string> flags;
-  std::istringstream argStream(args);
-  std::string arg;
-  while (!(argStream >> arg).fail())
-    flags.push_back(arg);
-  return flags;
-}
+  std::vector<std::string> tokenizeArgs(const std::string& args)
+  {
+    std::vector<std::string> flags;
+    std::istringstream argStream(args);
+    std::string arg;
+    while (!(argStream >> arg).fail())
+      flags.push_back(arg);
+    return flags;
+  }
 
-void parseOptionValue(Option& opt, const std::string& value)
-{
-  if (!opt.parse(value))
-    throw std::runtime_error(io::Str() << "Cannot parse '" << value << "' as argument to option '" << opt.longName << "'. ");
-}
+  void parseOptionValue(Option& opt, const std::string& value)
+  {
+    if (!opt.parse(value))
+      throw std::runtime_error(io::Str() << "Cannot parse '" << value << "' as argument to option '" << opt.longName << "'. ");
+  }
 
-void parseLongOption(const std::string& arg, const LongOptionMap& longOptions, const std::vector<std::string>& flags, unsigned int& i)
-{
-  if (arg.length() < 3)
-    throw std::runtime_error("Illegal argument '--'");
+  void parseLongOption(const std::string& arg, const LongOptionMap& longOptions, const std::vector<std::string>& flags, unsigned int& i)
+  {
+    if (arg.length() < 3)
+      throw std::runtime_error("Illegal argument '--'");
 
-  std::string longOpt = arg.substr(2);
-  bool flagValue = true;
-  auto it = longOptions.find(longOpt);
-  if (it == longOptions.end()) {
-    // Unrecognized option, check if it negates a recognised option with the '--no-' prefix
-    if (longOpt.compare(0, 3, "no-") == 0 && longOptions.find(std::string(longOpt, 3)) != longOptions.end()) {
-      longOpt = std::string(longOpt, 3);
-      it = longOptions.find(longOpt);
-      flagValue = false;
-    } else {
-      throw std::runtime_error(io::Str() << "Unrecognized option: '--" << longOpt << "'");
+    std::string longOpt = arg.substr(2);
+    bool flagValue = true;
+    auto it = longOptions.find(longOpt);
+    if (it == longOptions.end()) {
+      // Unrecognized option, check if it negates a recognised option with the '--no-' prefix
+      if (longOpt.compare(0, 3, "no-") == 0 && longOptions.find(std::string(longOpt, 3)) != longOptions.end()) {
+        longOpt = std::string(longOpt, 3);
+        it = longOptions.find(longOpt);
+        flagValue = false;
+      } else {
+        throw std::runtime_error(io::Str() << "Unrecognized option: '--" << longOpt << "'");
+      }
     }
-  }
-
-  auto& opt = *it->second;
-  if (!opt.requireArgument || opt.incrementalArgument) {
-    opt.set(flagValue);
-    return;
-  }
-
-  const auto numArgsLeft = flags.size() - i - 1;
-  if (numArgsLeft == 0)
-    throw std::runtime_error(io::Str() << "Option '" << opt.longName << "' requires argument");
-
-  ++i;
-  parseOptionValue(opt, flags[i]);
-}
-
-void parseShortOptions(const std::string& arg, const ShortOptionMap& shortOptions, const std::vector<std::string>& flags, unsigned int& i)
-{
-  for (unsigned int j = 1; j < arg.length(); ++j) {
-    const auto optionName = arg[j];
-    const auto numCharsLeft = arg.length() - j - 1;
-    auto it = shortOptions.find(optionName);
-    if (it == shortOptions.end())
-      throw std::runtime_error(io::Str() << "Unrecognized option: '-" << optionName << "'");
 
     auto& opt = *it->second;
     if (!opt.requireArgument || opt.incrementalArgument) {
-      opt.set(true);
-      continue;
+      opt.set(flagValue);
+      return;
     }
 
-    std::string optArg;
     const auto numArgsLeft = flags.size() - i - 1;
-    if (numCharsLeft > 0) {
-      optArg = arg.substr(j + 1);
-      j = arg.length() - 1;
-    } else if (numArgsLeft > 0) {
-      ++i;
-      optArg = flags[i];
-    } else {
+    if (numArgsLeft == 0)
       throw std::runtime_error(io::Str() << "Option '" << opt.longName << "' requires argument");
+
+    ++i;
+    parseOptionValue(opt, flags[i]);
+  }
+
+  void parseShortOptions(const std::string& arg, const ShortOptionMap& shortOptions, const std::vector<std::string>& flags, unsigned int& i)
+  {
+    for (unsigned int j = 1; j < arg.length(); ++j) {
+      const auto optionName = arg[j];
+      const auto numCharsLeft = arg.length() - j - 1;
+      auto it = shortOptions.find(optionName);
+      if (it == shortOptions.end())
+        throw std::runtime_error(io::Str() << "Unrecognized option: '-" << optionName << "'");
+
+      auto& opt = *it->second;
+      if (!opt.requireArgument || opt.incrementalArgument) {
+        opt.set(true);
+        continue;
+      }
+
+      std::string optArg;
+      const auto numArgsLeft = flags.size() - i - 1;
+      if (numCharsLeft > 0) {
+        optArg = arg.substr(j + 1);
+        j = arg.length() - 1;
+      } else if (numArgsLeft > 0) {
+        ++i;
+        optArg = flags[i];
+      } else {
+        throw std::runtime_error(io::Str() << "Option '" << opt.longName << "' requires argument");
+      }
+
+      parseOptionValue(opt, optArg);
     }
-
-    parseOptionValue(opt, optArg);
   }
-}
 
-void parseNonOptionArguments(std::deque<std::string>& nonOpts, NonOptionArguments& nonOptionArguments, unsigned int numRequiredArguments)
-{
-  if (nonOpts.size() < numRequiredArguments)
-    throw std::runtime_error("Missing required arguments.");
+  void parseNonOptionArguments(std::deque<std::string>& nonOpts, NonOptionArguments& nonOptionArguments, unsigned int numRequiredArguments)
+  {
+    if (nonOpts.size() < numRequiredArguments)
+      throw std::runtime_error("Missing required arguments.");
 
-  unsigned int i = 0;
-  unsigned int numVectorArguments = nonOpts.size() - (nonOptionArguments.size() - 1);
-  while (!nonOpts.empty()) {
-    std::string arg = nonOpts.front();
-    nonOpts.pop_front();
-    if (nonOptionArguments[i]->isOptionalVector && numVectorArguments == 0)
-      ++i;
-    if (!nonOptionArguments[i]->parse(arg))
-      throw std::runtime_error("Argument error.");
-    if (!nonOptionArguments[i]->isOptionalVector || --numVectorArguments == 0)
-      ++i;
+    unsigned int i = 0;
+    unsigned int numVectorArguments = nonOpts.size() - (nonOptionArguments.size() - 1);
+    while (!nonOpts.empty()) {
+      std::string arg = nonOpts.front();
+      nonOpts.pop_front();
+      if (nonOptionArguments[i]->isOptionalVector && numVectorArguments == 0)
+        ++i;
+      if (!nonOptionArguments[i]->parse(arg))
+        throw std::runtime_error("Argument error.");
+      if (!nonOptionArguments[i]->isOptionalVector || --numVectorArguments == 0)
+        ++i;
+    }
   }
-}
 
 } // namespace
 
@@ -240,7 +240,7 @@ void ProgramInterface::exitWithUsage(bool showAdvanced) const
     }
   }
   Log() << '\n';
-  throw CleanExit{};
+  throw CleanExit {};
 }
 
 void ProgramInterface::exitWithVersionInformation() const
@@ -251,7 +251,7 @@ void ProgramInterface::exitWithVersionInformation() const
 #endif
   Log() << '\n';
   Log() << "See www.mapequation.org for terms of use.\n";
-  throw CleanExit{};
+  throw CleanExit {};
 }
 
 void ProgramInterface::exitWithError(const std::string& message) const
@@ -322,7 +322,7 @@ void ProgramInterface::exitWithJsonParameters() const
   }
   Log() << "  ]\n}";
 
-  throw CleanExit{};
+  throw CleanExit {};
 }
 
 void ProgramInterface::parseArgs(const std::string& args)

--- a/src/io/ProgramInterface.h
+++ b/src/io/ProgramInterface.h
@@ -29,7 +29,7 @@ namespace infomap {
 /// status 0; library callers (R/Python/JS bindings) never trigger these
 /// flags. Not derived from std::exception so the generic catch in
 /// infomap::run() does not treat it as an error.
-struct CleanExit { };
+struct CleanExit {};
 
 struct ArgType {
   static const std::string integer;
@@ -51,7 +51,7 @@ struct Option {
         isAdvanced(isAdvanced),
         requireArgument(requireArgument),
         incrementalArgument(false),
-        argumentName(std::move(argName)) { }
+        argumentName(std::move(argName)) {}
 
   virtual ~Option() = default;
 
@@ -137,7 +137,7 @@ struct IncrementalOption : Option {
 template <typename T>
 struct ArgumentOption : Option {
   ArgumentOption(T& target, char shortName, std::string longName, std::string desc, std::string group, bool isAdvanced, std::string argName)
-      : Option(shortName, std::move(longName), std::move(desc), std::move(group), isAdvanced, true, std::move(argName)), target(target) { }
+      : Option(shortName, std::move(longName), std::move(desc), std::move(group), isAdvanced, true, std::move(argName)), target(target) {}
 
   bool parse(std::string const& value) override
   {
@@ -155,7 +155,7 @@ struct ArgumentOption : Option {
 template <typename T>
 struct LowerBoundArgumentOption : ArgumentOption<T> {
   LowerBoundArgumentOption(T& target, char shortName, std::string longName, std::string desc, std::string group, bool isAdvanced, std::string argName, T minValue)
-      : ArgumentOption<T>(target, shortName, std::move(longName), std::move(desc), std::move(group), isAdvanced, std::move(argName)), minValue(minValue) { }
+      : ArgumentOption<T>(target, shortName, std::move(longName), std::move(desc), std::move(group), isAdvanced, std::move(argName)), minValue(minValue) {}
 
   bool parse(std::string const& value) override
   {
@@ -170,7 +170,7 @@ struct LowerBoundArgumentOption : ArgumentOption<T> {
 template <typename T>
 struct LowerUpperBoundArgumentOption : LowerBoundArgumentOption<T> {
   LowerUpperBoundArgumentOption(T& target, char shortName, std::string longName, std::string desc, std::string group, bool isAdvanced, std::string argName, T minValue, T maxValue)
-      : LowerBoundArgumentOption<T>(target, shortName, std::move(longName), std::move(desc), std::move(group), isAdvanced, std::move(argName), minValue), maxValue(maxValue) { }
+      : LowerBoundArgumentOption<T>(target, shortName, std::move(longName), std::move(desc), std::move(group), isAdvanced, std::move(argName), minValue), maxValue(maxValue) {}
 
   bool parse(std::string const& value) override
   {
@@ -185,7 +185,7 @@ struct LowerUpperBoundArgumentOption : LowerBoundArgumentOption<T> {
 template <>
 struct ArgumentOption<bool> : Option {
   ArgumentOption(bool& target, char shortName, std::string longName, std::string desc, std::string group, bool isAdvanced)
-      : Option(shortName, std::move(longName), std::move(desc), std::move(group), isAdvanced, false), target(target) { }
+      : Option(shortName, std::move(longName), std::move(desc), std::move(group), isAdvanced, false), target(target) {}
 
   bool parse(std::string const& value) override
   {
@@ -217,7 +217,7 @@ struct ParsedOption {
         incrementalArgument(opt.incrementalArgument),
         argumentName(opt.argumentName),
         negated(opt.negated),
-        value(opt.printValue()) { }
+        value(opt.printValue()) {}
 
   friend std::ostream& operator<<(std::ostream& out, const ParsedOption& option)
   {
@@ -243,7 +243,7 @@ struct ParsedOption {
 
 struct TargetBase {
   TargetBase(std::string variableName, std::string desc, std::string group, bool isAdvanced)
-      : variableName(std::move(variableName)), description(std::move(desc)), group(std::move(group)), isOptionalVector(false), isAdvanced(isAdvanced) { }
+      : variableName(std::move(variableName)), description(std::move(desc)), group(std::move(group)), isOptionalVector(false), isAdvanced(isAdvanced) {}
 
   virtual ~TargetBase() = default;
 
@@ -264,7 +264,7 @@ struct TargetBase {
 template <typename T>
 struct Target : TargetBase {
   Target(T& target, std::string variableName, std::string desc, std::string group, bool isAdvanced)
-      : TargetBase(std::move(variableName), std::move(desc), std::move(group), isAdvanced), target(target) { }
+      : TargetBase(std::move(variableName), std::move(desc), std::move(group), isAdvanced), target(target) {}
 
   bool parse(std::string const& value) override
   {

--- a/src/utils/Date.h
+++ b/src/utils/Date.h
@@ -18,7 +18,7 @@ namespace infomap {
 
 class ElapsedTime {
 public:
-  ElapsedTime(double elapsedTime = 0.0) : m_elapsedTime(elapsedTime) { }
+  ElapsedTime(double elapsedTime = 0.0) : m_elapsedTime(elapsedTime) {}
 
   double getSeconds() const { return m_elapsedTime; }
 

--- a/src/utils/FlowCalculator.cpp
+++ b/src/utils/FlowCalculator.cpp
@@ -30,7 +30,7 @@ inline void normalize(std::vector<T>& v, const T sum) noexcept
 template <typename T>
 inline void normalize(std::vector<T>& v) noexcept
 {
-  const auto sum = std::accumulate(cbegin(v), cend(v), T { });
+  const auto sum = std::accumulate(cbegin(v), cend(v), T {});
   normalize(v, sum);
 }
 

--- a/src/utils/Log.cpp
+++ b/src/utils/Log.cpp
@@ -17,10 +17,10 @@ namespace infomap {
 
 namespace {
 
-class NullStreambuf : public std::streambuf {
-protected:
-  int_type overflow(int_type c) override { return traits_type::not_eof(c); }
-};
+  class NullStreambuf : public std::streambuf {
+  protected:
+    int_type overflow(int_type c) override { return traits_type::not_eof(c); }
+  };
 
 } // namespace
 

--- a/src/utils/Log.h
+++ b/src/utils/Log.h
@@ -28,7 +28,7 @@ public:
    * and maxLevel is above or equal Log::verboseLevel()
    */
   explicit Log(unsigned int level = 0, unsigned int maxLevel = std::numeric_limits<int>::max())
-      : m_level(level), m_maxLevel(maxLevel), m_visible(isVisible(m_level, m_maxLevel)) { }
+      : m_level(level), m_maxLevel(maxLevel), m_visible(isVisible(m_level, m_maxLevel)) {}
 
   bool isVisible() const { return isVisible(m_level, m_maxLevel); }
 
@@ -113,7 +113,7 @@ private:
 };
 
 struct hideIf {
-  explicit hideIf(bool value) : hide(value) { }
+  explicit hideIf(bool value) : hide(value) {}
 
   friend Log& operator<<(Log& out, const hideIf& manip)
   {

--- a/src/utils/MetaCollection.h
+++ b/src/utils/MetaCollection.h
@@ -20,7 +20,7 @@ struct FlowCount {
   FlowCount() = default;
 
   explicit FlowCount(double flow)
-      : flow(flow), count(1) { }
+      : flow(flow), count(1) {}
 
   FlowCount& operator+=(const FlowCount& o)
   {

--- a/src/utils/Random.h
+++ b/src/utils/Random.h
@@ -24,7 +24,7 @@ class Random {
   uniform_uint_dist uniform;
 
 public:
-  Random(unsigned int seed = 123) : m_randGen(seed) { }
+  Random(unsigned int seed = 123) : m_randGen(seed) {}
 
   void seed(unsigned int seedValue)
   {

--- a/src/utils/VectorMap.h
+++ b/src/utils/VectorMap.h
@@ -23,7 +23,7 @@ public:
       : m_capacity(capacity),
         m_values(capacity),
         m_redirect(capacity, 0),
-        m_maxOffset(std::numeric_limits<unsigned int>::max() - 1 - capacity) { }
+        m_maxOffset(std::numeric_limits<unsigned int>::max() - 1 - capacity) {}
 
   void startRound()
   {

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}


### PR DESCRIPTION
## Summary
- add C++ dev Make targets for compile_commands.json, format checks, clang-tidy, and fast local feedback
- add CMake presets and a low-noise .clang-tidy profile
- wire C++ formatting into PR CI and clang-tidy into nightly quality
- document the C++ development workflow in BUILD.md

## Verification
- make -n format-native-check
- make configure-cpp-dev
- make format-native-check
- make tidy-native
- make dev-cpp-check CMAKE_DEV_GENERATOR=
- make test-native CMAKE_GENERATOR=
- cmake --list-presets
- cmake --build --preset dev
- ctest --preset dev
- make doctor
- actionlint .github/workflows/ci.yml .github/workflows/nightly-quality.yml
- git diff --check