### PR TITLE
ci: temporarily disable cxx-format job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
   cxx-format:
     needs: changes
     # Temporarily disabled while compilation warnings are being addressed (see #479).
+    # if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.native == 'true' || needs.changes.outputs.policy == 'true'
     if: false
     name: C++ formatting
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,8 @@ jobs:
 
   cxx-format:
     needs: changes
-    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.native == 'true' || needs.changes.outputs.policy == 'true'
+    # Temporarily disabled while compilation warnings are being addressed (see #479).
+    if: false
     name: C++ formatting
     runs-on: ubuntu-24.04
     timeout-minutes: 10


### PR DESCRIPTION
## Summary

- Disable the `cxx-format` job in `.github/workflows/ci.yml` (added in #478) by setting `if: false`. This is the `C++ formatting` job that runs `make format-native-check`.
