### PR TITLE
chore: silence compilation warnings

### DIFF
--- a/src/io/Network.cpp
+++ b/src/io/Network.cpp
@@ -529,7 +529,7 @@ void Network::addMultilayerLink(unsigned int layer1, unsigned int n1, unsigned i
   addMultilayerLink(stateId1, layer1, n1, stateId2, layer2, n2, weight);
 }
 
-void Network::addMultilayerLink(unsigned int stateId1, unsigned int layer1, unsigned int n1, unsigned int stateId2, unsigned int layer2, unsigned int n2, double weight)
+void Network::addMultilayerLink(unsigned int stateId1, unsigned int layer1, unsigned int n1, unsigned int stateId2, unsigned int layer2, unsigned int, double weight)
 {
   // if (stateId1 == stateId2) {
   // TODO: Handle self-links?

--- a/src/io/ProgramInterface.h
+++ b/src/io/ProgramInterface.h
@@ -43,13 +43,13 @@ struct ArgType {
 };
 
 struct Option {
-  Option(char shortName, std::string longName, std::string desc, std::string group, bool isAdvanced, bool requireArgument = false, std::string argName = "")
-      : shortName(shortName),
-        longName(std::move(longName)),
+  Option(char shortName_, std::string longName_, std::string desc, std::string group_, bool isAdvanced_, bool requireArgument_ = false, std::string argName = "")
+      : shortName(shortName_),
+        longName(std::move(longName_)),
         description(std::move(desc)),
-        group(std::move(group)),
-        isAdvanced(isAdvanced),
-        requireArgument(requireArgument),
+        group(std::move(group_)),
+        isAdvanced(isAdvanced_),
+        requireArgument(requireArgument_),
         incrementalArgument(false),
         argumentName(std::move(argName)) {}
 
@@ -106,8 +106,8 @@ struct Option {
 };
 
 struct IncrementalOption : Option {
-  IncrementalOption(unsigned int& target, char shortName, std::string longName, std::string desc, std::string group, bool isAdvanced)
-      : Option(shortName, std::move(longName), std::move(desc), std::move(group), isAdvanced, false), target(target)
+  IncrementalOption(unsigned int& target_, char shortName_, std::string longName_, std::string desc, std::string group_, bool isAdvanced_)
+      : Option(shortName_, std::move(longName_), std::move(desc), std::move(group_), isAdvanced_, false), target(target_)
   {
     incrementalArgument = true;
   }
@@ -136,8 +136,8 @@ struct IncrementalOption : Option {
 
 template <typename T>
 struct ArgumentOption : Option {
-  ArgumentOption(T& target, char shortName, std::string longName, std::string desc, std::string group, bool isAdvanced, std::string argName)
-      : Option(shortName, std::move(longName), std::move(desc), std::move(group), isAdvanced, true, std::move(argName)), target(target) {}
+  ArgumentOption(T& target_, char shortName_, std::string longName_, std::string desc, std::string group_, bool isAdvanced_, std::string argName)
+      : Option(shortName_, std::move(longName_), std::move(desc), std::move(group_), isAdvanced_, true, std::move(argName)), target(target_) {}
 
   bool parse(std::string const& value) override
   {
@@ -154,8 +154,8 @@ struct ArgumentOption : Option {
 
 template <typename T>
 struct LowerBoundArgumentOption : ArgumentOption<T> {
-  LowerBoundArgumentOption(T& target, char shortName, std::string longName, std::string desc, std::string group, bool isAdvanced, std::string argName, T minValue)
-      : ArgumentOption<T>(target, shortName, std::move(longName), std::move(desc), std::move(group), isAdvanced, std::move(argName)), minValue(minValue) {}
+  LowerBoundArgumentOption(T& target_, char shortName_, std::string longName_, std::string desc, std::string group_, bool isAdvanced_, std::string argName, T minValue_)
+      : ArgumentOption<T>(target_, shortName_, std::move(longName_), std::move(desc), std::move(group_), isAdvanced_, std::move(argName)), minValue(minValue_) {}
 
   bool parse(std::string const& value) override
   {
@@ -169,8 +169,8 @@ struct LowerBoundArgumentOption : ArgumentOption<T> {
 
 template <typename T>
 struct LowerUpperBoundArgumentOption : LowerBoundArgumentOption<T> {
-  LowerUpperBoundArgumentOption(T& target, char shortName, std::string longName, std::string desc, std::string group, bool isAdvanced, std::string argName, T minValue, T maxValue)
-      : LowerBoundArgumentOption<T>(target, shortName, std::move(longName), std::move(desc), std::move(group), isAdvanced, std::move(argName), minValue), maxValue(maxValue) {}
+  LowerUpperBoundArgumentOption(T& target_, char shortName_, std::string longName_, std::string desc, std::string group_, bool isAdvanced_, std::string argName, T minValue_, T maxValue_)
+      : LowerBoundArgumentOption<T>(target_, shortName_, std::move(longName_), std::move(desc), std::move(group_), isAdvanced_, std::move(argName), minValue_), maxValue(maxValue_) {}
 
   bool parse(std::string const& value) override
   {
@@ -184,8 +184,8 @@ struct LowerUpperBoundArgumentOption : LowerBoundArgumentOption<T> {
 
 template <>
 struct ArgumentOption<bool> : Option {
-  ArgumentOption(bool& target, char shortName, std::string longName, std::string desc, std::string group, bool isAdvanced)
-      : Option(shortName, std::move(longName), std::move(desc), std::move(group), isAdvanced, false), target(target) {}
+  ArgumentOption(bool& target_, char shortName_, std::string longName_, std::string desc, std::string group_, bool isAdvanced_)
+      : Option(shortName_, std::move(longName_), std::move(desc), std::move(group_), isAdvanced_, false), target(target_) {}
 
   bool parse(std::string const& value) override
   {
@@ -242,8 +242,8 @@ struct ParsedOption {
 };
 
 struct TargetBase {
-  TargetBase(std::string variableName, std::string desc, std::string group, bool isAdvanced)
-      : variableName(std::move(variableName)), description(std::move(desc)), group(std::move(group)), isOptionalVector(false), isAdvanced(isAdvanced) {}
+  TargetBase(std::string variableName_, std::string desc, std::string group_, bool isAdvanced_)
+      : variableName(std::move(variableName_)), description(std::move(desc)), group(std::move(group_)), isOptionalVector(false), isAdvanced(isAdvanced_) {}
 
   virtual ~TargetBase() = default;
 
@@ -263,8 +263,8 @@ struct TargetBase {
 
 template <typename T>
 struct Target : TargetBase {
-  Target(T& target, std::string variableName, std::string desc, std::string group, bool isAdvanced)
-      : TargetBase(std::move(variableName), std::move(desc), std::move(group), isAdvanced), target(target) {}
+  Target(T& target_, std::string variableName_, std::string desc, std::string group_, bool isAdvanced_)
+      : TargetBase(std::move(variableName_), std::move(desc), std::move(group_), isAdvanced_), target(target_) {}
 
   bool parse(std::string const& value) override
   {

--- a/src/utils/FlowCalculator.cpp
+++ b/src/utils/FlowCalculator.cpp
@@ -241,7 +241,7 @@ void FlowCalculator::calcRawdirFlow() noexcept
   }
 }
 
-void FlowCalculator::usePrecomputedFlow(const StateNetwork& network, const Config& config)
+void FlowCalculator::usePrecomputedFlow(const StateNetwork& network, const Config&)
 {
   Log() << "\n  -> Using directed links with precomputed flow from input data.";
   Log() << "\n  -> Total link flow: " << sumLinkWeight << ".";


### PR DESCRIPTION
## Summary
- Rename shadowing constructor parameters in `src/io/ProgramInterface.h`.
- Leave unused implementation-only parameters unnamed in `src/io/Network.cpp` and `src/utils/FlowCalculator.cpp`.

## Why
Issue #479 tracks removing compilation warnings without lowering warning levels or masking diagnostics. These changes address the warning sources in hand-written C++ code while keeping the patch limited to the affected source files.

## Verification
- `make build-native` -> 0 compiler warnings
- `make build-python PYTHON=.venv/bin/python` -> 0 compiler warnings; only GNU make jobserver output matched `warning:`
- `make build-r` -> 0 warnings
- `make dev-r-install` -> 0 compiler warnings
- `make build-js` -> 0 warnings
- `make test-native` -> passed
- `make test-python PYTHON=/Users/anton/kod/infomap/.venv/bin/python PYTEST='/Users/anton/kod/infomap/.venv/bin/python -m pytest' RUFF='/Users/anton/kod/infomap/.venv/bin/python -m ruff'` -> passed
- `make test-r-examples` -> passed
- `make test-js` -> passed

## Notes
- `make test-r` ran R CMD check but failed because the local environment is missing `checkbashisms` and `pandoc`; it also reports the existing CRAN incoming NOTE `New submission`. The R package compilation step itself produced 0 compiler warnings.
