### PR TITLE
fix(ci): enforce low-noise clang-tidy checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
         shell: bash
 
       - name: Run clang-tidy
-        run: make tidy-native CMAKE_DEV_GENERATOR=Ninja
+        run: make tidy-native CMAKE_DEV_GENERATOR=Ninja CLANG_TIDY_WARNINGS_AS_ERRORS='readability-*,performance-*,modernize-use-override,bugprone-branch-clone'
         shell: bash
 
   native:

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -4,6 +4,7 @@ CMAKE_DEV_GENERATOR ?= Ninja
 CMAKE_DEV_OPENMP ?= 0
 CMAKE_DEV_CXX_COMPILER ?=
 CMAKE_DEV_OSX_SYSROOT ?= $(if $(filter Darwin,$(UNAME_S)),$(shell xcrun --show-sdk-path 2>/dev/null || true),)
+CLANG_TIDY_WARNINGS_AS_ERRORS ?=
 SANITIZER_BUILD_DIR ?= build/cmake-sanitizers
 DEFAULT_CMAKE_BUILD_TYPE := $(if $(filter debug,$(MODE)),Debug,RelWithDebInfo)
 CMAKE_BUILD_TYPE ?= $(DEFAULT_CMAKE_BUILD_TYPE)
@@ -50,7 +51,7 @@ configure-cpp-dev:
 	@ln -sfn $(CMAKE_DEV_BUILD_DIR)/compile_commands.json compile_commands.json
 
 tidy-native: configure-cpp-dev
-	$(CLANG_TIDY) --quiet -p $(CMAKE_DEV_BUILD_DIR) $(SOURCES)
+	$(CLANG_TIDY) --quiet $(if $(CLANG_TIDY_WARNINGS_AS_ERRORS),--warnings-as-errors=$(CLANG_TIDY_WARNINGS_AS_ERRORS),) -p $(CMAKE_DEV_BUILD_DIR) $(SOURCES)
 
 dev-cpp-check: format-native-check test-cpp-stream-policy
 	@$(MAKE) test-native MODE=debug OPENMP=0 CMAKE_GENERATOR="$(CMAKE_DEV_GENERATOR)" CMAKE_TEST_BUILD_DIR=$(CMAKE_DEV_BUILD_DIR) CMAKE_BUILD_TYPE=Debug

--- a/src/Infomap.h
+++ b/src/Infomap.h
@@ -22,10 +22,10 @@ namespace infomap {
 // Wrapper class for the Python API
 struct InfomapWrapper : public InfomapBase {
 public:
-  InfomapWrapper() : InfomapBase() {}
+  InfomapWrapper() {}
   InfomapWrapper(const std::string& flags) : InfomapBase(flags) {}
   InfomapWrapper(const Config& conf) : InfomapBase(conf) {}
-  virtual ~InfomapWrapper() = default;
+  ~InfomapWrapper() override = default;
 
   // ===================================================
   // Wrapper methods

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -415,7 +415,7 @@ InfomapBase& InfomapBase::initPartition(const std::string& clusterDataFile, bool
   FileURI file(clusterDataFile);
   ClusterMap clusterMap;
   if (this->isMultilayerNetwork() && network != nullptr) {
-    auto map = network->layerNodeToStateId();
+    const auto& map = network->layerNodeToStateId();
     clusterMap.readClusterData(clusterDataFile, false, &map);
   } else {
     clusterMap.readClusterData(clusterDataFile);

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -46,7 +46,7 @@ class InfomapBase : public InfomapConfig<InfomapBase> {
 public:
   using PartitionQueue = detail::PartitionQueue;
 
-  InfomapBase() : InfomapConfig<InfomapBase>() { initOptimizer(); }
+  InfomapBase() { initOptimizer(); }
 
   explicit InfomapBase(const Config& conf) : InfomapConfig<InfomapBase>(conf), m_network(conf) { initOptimizer(); }
 
@@ -57,7 +57,7 @@ public:
     m_initialParameters = m_currentParameters = flags;
   }
 
-  virtual ~InfomapBase() = default;
+  ~InfomapBase() override = default;
 
   // ===================================================
   // Iterators
@@ -488,7 +488,7 @@ protected:
   std::vector<InfoNode*> m_originalLeafNodes;
 
   Network m_network;
-  InitialPartition m_initialPartition = {}; // nodeId -> moduleId
+  InitialPartition m_initialPartition; // nodeId -> moduleId
 
   const unsigned int SUPER_LEVEL_ADDITION = 1 << 20;
   bool m_isMain = true;

--- a/src/core/StateNetwork.h
+++ b/src/core/StateNetwork.h
@@ -115,7 +115,7 @@ protected:
   unsigned int m_bipartiteStartId = 0;
 
 public:
-  StateNetwork() : m_config(Config()) {}
+  StateNetwork() {}
   StateNetwork(Config config) : m_config(std::move(config)) {}
   virtual ~StateNetwork() = default;
 

--- a/src/core/iterators/InfomapIterator.h
+++ b/src/core/iterators/InfomapIterator.h
@@ -97,7 +97,7 @@ public:
 
 struct InfomapModuleIterator : public InfomapIterator {
 public:
-  InfomapModuleIterator() : InfomapIterator() {}
+  InfomapModuleIterator() {}
 
   InfomapModuleIterator(InfoNode* nodePointer, int moduleIndexLevel = -1) : InfomapIterator(nodePointer, moduleIndexLevel) {}
 
@@ -130,7 +130,7 @@ public:
 
 struct InfomapLeafModuleIterator : public InfomapIterator {
 public:
-  InfomapLeafModuleIterator() : InfomapIterator() {}
+  InfomapLeafModuleIterator() {}
 
   InfomapLeafModuleIterator(InfoNode* nodePointer, int moduleIndexLevel = -1)
       : InfomapIterator(nodePointer, moduleIndexLevel) { init(); }
@@ -169,7 +169,7 @@ public:
 
 struct InfomapLeafIterator : public InfomapIterator {
 public:
-  InfomapLeafIterator() : InfomapIterator() {}
+  InfomapLeafIterator() {}
 
   InfomapLeafIterator(InfoNode* nodePointer, int moduleIndexLevel = -1)
       : InfomapIterator(nodePointer, moduleIndexLevel) { init(); }
@@ -218,7 +218,7 @@ protected:
   InfomapIterator m_oldIter;
 
 public:
-  InfomapIteratorPhysical() : InfomapIterator() {}
+  InfomapIteratorPhysical() {}
 
   InfomapIteratorPhysical(InfoNode* nodePointer, int moduleIndexLevel = -1)
       : InfomapIterator(nodePointer, moduleIndexLevel) {}
@@ -267,7 +267,7 @@ public:
  */
 struct InfomapLeafIteratorPhysical : public InfomapIteratorPhysical {
 public:
-  InfomapLeafIteratorPhysical() : InfomapIteratorPhysical() {}
+  InfomapLeafIteratorPhysical() {}
 
   InfomapLeafIteratorPhysical(InfoNode* nodePointer, int moduleIndexLevel = -1)
       : InfomapIteratorPhysical(nodePointer, moduleIndexLevel) { init(); }

--- a/src/core/iterators/IterWrapper.h
+++ b/src/core/iterators/IterWrapper.h
@@ -20,7 +20,7 @@ class IterWrapper {
   Iter m_begin, m_end;
 
 public:
-  IterWrapper(Iter begin, Iter end) : m_begin(begin), m_end(end) {}
+  IterWrapper(const Iter& begin, const Iter& end) : m_begin(begin), m_end(end) {}
 
   // template <typename Container>
   template <typename Container,

--- a/src/io/ClusterMap.cpp
+++ b/src/io/ClusterMap.cpp
@@ -51,7 +51,7 @@ void ClusterMap::readTree(const std::string& filename, bool includeFlow, const s
 
   while (!std::getline(input, line).fail()) {
     ++lineNr;
-    if (line.length() == 0)
+    if (line.empty())
       continue;
     if (line[0] == '#') {
       continue;
@@ -137,7 +137,7 @@ void ClusterMap::readClu(const std::string& filename, bool includeFlow, const st
   std::map<unsigned int, unsigned int> clusterData;
 
   while (!std::getline(input, line).fail()) {
-    if (line.length() == 0 || line[0] == '#' || line[0] == '*')
+    if (line.empty() || line[0] == '#' || line[0] == '*')
       continue;
 
     lineStream.clear();

--- a/src/io/Network.cpp
+++ b/src/io/Network.cpp
@@ -125,36 +125,35 @@ void Network::parseNetwork(const std::string& filename, const InsensitiveStringS
   SafeInFile input(filename);
 
   // Parse standard links by default until possible heading is reached
-  std::string heading = startHeading.length() > 0 ? startHeading : parseLinks(input);
+  std::string heading = !startHeading.empty() ? startHeading : parseLinks(input);
 
-  while (heading.length() > 0 && heading[0] == '*') {
+  while (!heading.empty() && heading[0] == '*') {
     std::string headingLowerCase = io::tolower(io::firstWord(heading));
     if (validHeadings.count(headingLowerCase) == 0) {
       throw std::runtime_error(io::Str() << "Unrecognized heading in network file: '" << headingLowerCase << "'.");
     }
-    if (ignoreHeadings.count(headingLowerCase) > 0) {
-      heading = ignoreSection(input, headingLowerCase);
-    } else if (headingLowerCase == "*vertices") {
+    bool shouldIgnoreHeading = ignoreHeadings.count(headingLowerCase) > 0;
+    if (!shouldIgnoreHeading && headingLowerCase == "*vertices") {
       heading = parseVertices(input, heading);
-    } else if (headingLowerCase == "*states") {
+    } else if (!shouldIgnoreHeading && headingLowerCase == "*states") {
       heading = parseStateNodes(input, heading);
-    } else if (headingLowerCase == "*edges") {
+    } else if (!shouldIgnoreHeading && headingLowerCase == "*edges") {
       if (!m_config.isUndirectedFlow())
         Log() << "\n --> Notice: Links marked as undirected but parsed as directed.\n";
       heading = parseLinks(input);
-    } else if (headingLowerCase == "*arcs") {
+    } else if (!shouldIgnoreHeading && headingLowerCase == "*arcs") {
       if (m_config.isUndirectedFlow())
         Log() << "\n --> Notice: Links marked as directed but parsed as undirected.\n";
       heading = parseLinks(input);
-    } else if (headingLowerCase == "*links") {
+    } else if (!shouldIgnoreHeading && headingLowerCase == "*links") {
       heading = parseLinks(input);
-    } else if (headingLowerCase == "*multilayer" || headingLowerCase == "*multiplex") {
+    } else if (!shouldIgnoreHeading && (headingLowerCase == "*multilayer" || headingLowerCase == "*multiplex")) {
       heading = parseMultilayerLinks(input);
-    } else if (headingLowerCase == "*intra") {
+    } else if (!shouldIgnoreHeading && headingLowerCase == "*intra") {
       heading = parseMultilayerIntraLinks(input);
-    } else if (headingLowerCase == "*inter") {
+    } else if (!shouldIgnoreHeading && headingLowerCase == "*inter") {
       heading = parseMultilayerInterLinks(input);
-    } else if (headingLowerCase == "*bipartite") {
+    } else if (!shouldIgnoreHeading && headingLowerCase == "*bipartite") {
       heading = parseBipartiteLinks(input, heading);
     } else {
       heading = ignoreSection(input, headingLowerCase);
@@ -185,7 +184,7 @@ void Network::readMetaData(const std::string& filename)
   SafeInFile input(filename);
   std::string line;
   while (!std::getline(input, line).fail()) {
-    if (line.length() == 0 || line[0] == '#')
+    if (line.empty() || line[0] == '#')
       continue;
 
     if (line[0] == '*')
@@ -222,7 +221,7 @@ std::string Network::parseVertices(std::ifstream& file, const std::string& /*hea
         << std::flush;
   std::string line;
   while (!std::getline(file, line).fail()) {
-    if (line.length() == 0 || line[0] == '#')
+    if (line.empty() || line[0] == '#')
       continue;
 
     if (line[0] == '*')
@@ -267,7 +266,7 @@ std::string Network::parseStateNodes(std::ifstream& file, const std::string& /*h
         << std::flush;
   std::string line;
   while (!std::getline(file, line).fail()) {
-    if (line.length() == 0 || line[0] == '#')
+    if (line.empty() || line[0] == '#')
       continue;
 
     if (line[0] == '*')
@@ -291,7 +290,7 @@ std::string Network::parseLinks(std::ifstream& file)
   bool parsingLinks = false;
   std::string line;
   while (!std::getline(file, line).fail()) {
-    if (line.length() == 0 || line[0] == '#')
+    if (line.empty() || line[0] == '#')
       continue;
 
     if (line[0] == '*')
@@ -325,7 +324,7 @@ std::string Network::parseMultilayerLinks(std::ifstream& file)
 
   std::string line;
   while (!std::getline(file, line).fail()) {
-    if (line.length() == 0 || line[0] == '#')
+    if (line.empty() || line[0] == '#')
       continue;
 
     if (line[0] == '*')
@@ -355,7 +354,7 @@ std::string Network::parseMultilayerIntraLinks(std::ifstream& file)
 
   std::string line;
   while (!std::getline(file, line).fail()) {
-    if (line.length() == 0 || line[0] == '#')
+    if (line.empty() || line[0] == '#')
       continue;
 
     if (line[0] == '*')
@@ -377,7 +376,7 @@ std::string Network::parseMultilayerInterLinks(std::ifstream& file)
         << std::flush;
   std::string line;
   while (!std::getline(file, line).fail()) {
-    if (line.length() == 0 || line[0] == '#')
+    if (line.empty() || line[0] == '#')
       continue;
 
     if (line[0] == '*')
@@ -407,7 +406,7 @@ std::string Network::parseBipartiteLinks(std::ifstream& file, const std::string&
   m_config.bipartite = true;
   std::string line;
   while (!std::getline(file, line).fail()) {
-    if (line.length() == 0 || line[0] == '#')
+    if (line.empty() || line[0] == '#')
       continue;
 
     if (line[0] == '*')

--- a/src/io/Network.h
+++ b/src/io/Network.h
@@ -60,7 +60,7 @@ private:
   // };
 
 public:
-  Network() : StateNetwork() { init(); }
+  Network() { init(); }
   explicit Network(const Config& config) : StateNetwork(config) { init(); }
   explicit Network(const std::string& flags) : StateNetwork(Config(flags)) { init(); }
   ~Network() override = default;

--- a/src/io/ProgramInterface.cpp
+++ b/src/io/ProgramInterface.cpp
@@ -260,7 +260,7 @@ void ProgramInterface::exitWithError(const std::string& message) const
 #ifdef _OPENMP
   Log() << " compiled with OpenMP";
 #endif
-  Log() << std::endl;
+  Log() << '\n';
   Log() << "Usage: " << m_executableName;
   for (auto& nonOptionArgument : m_nonOptionArguments)
     if (!nonOptionArgument->isAdvanced)
@@ -334,7 +334,7 @@ void ProgramInterface::parseArgs(const std::string& args)
   try {
     for (unsigned int i = 0; i < flags.size(); ++i) {
       const std::string& arg = flags[i];
-      if (arg.length() == 0)
+      if (arg.empty())
         throw std::runtime_error("Illegal argument ''");
 
       if (arg[0] != '-') {

--- a/src/utils/FlowCalculator.cpp
+++ b/src/utils/FlowCalculator.cpp
@@ -248,11 +248,11 @@ void FlowCalculator::usePrecomputedFlow(const StateNetwork& network, const Confi
 
   if (network.haveFileInput()) {
     if (network.haveMemoryInput() && !network.haveStateNodeWeights()) {
-      Log() << std::endl;
+      Log() << '\n';
       throw std::runtime_error("Missing node flow in input data. Should be passed as a third field under a *States section.");
     }
     if (!network.haveMemoryInput() && !network.haveNodeWeights()) {
-      Log() << std::endl;
+      Log() << '\n';
       throw std::runtime_error("Missing node flow in input data. Should be passed as a third field under a *Vertices section.");
     }
   }

--- a/src/utils/VectorMap.h
+++ b/src/utils/VectorMap.h
@@ -37,7 +37,7 @@ public:
     }
   }
 
-  void add(unsigned int index, T value)
+  void add(unsigned int index, const T& value)
   {
     if (isSet(index)) {
       m_values[m_redirect[index] - m_offset] += value;

--- a/src/utils/convert.h
+++ b/src/utils/convert.h
@@ -107,7 +107,7 @@ namespace io {
     std::stringstream ss(s);
     std::string item;
     while (std::getline(ss, item, delim)) {
-      if (item.length() > 0) {
+      if (!item.empty()) {
         items.push_back(item);
       }
     }


### PR DESCRIPTION
## Summary

- Clean up current low-noise clang-tidy findings in C++ sources.
- Add a configurable `CLANG_TIDY_WARNINGS_AS_ERRORS` make variable.
- Make the CI clang-tidy job fail on selected low-noise checks while leaving broader bugprone findings informational.

## Verification

- `make tidy-native CMAKE_DEV_GENERATOR=Ninja CLANG_TIDY_WARNINGS_AS_ERRORS='readability-*,performance-*,modernize-use-override,bugprone-branch-clone'`
- `make build-native`
- `make format-native-check`
