### PR TITLE
test: add portable random integer mapping for testing

### DIFF
--- a/src/utils/Random.h
+++ b/src/utils/Random.h
@@ -10,21 +10,49 @@
 #ifndef RANDOM_H_
 #define RANDOM_H_
 
-#include <vector>
+#include <cstdint>
 #include <random>
 #include <utility>
+#include <vector>
 
 namespace infomap {
 using RandGen = std::mt19937;
-using uniform_uint_dist = std::uniform_int_distribution<unsigned int>;
-using uniform_param_t = uniform_uint_dist::param_type;
+using StdUniformUIntDistribution = std::uniform_int_distribution<unsigned int>;
 
-class Random {
+class PortableUniformUIntDistribution {
+public:
+  struct param_type {
+    param_type(unsigned int minValue, unsigned int maxValue) : min(minValue), max(maxValue) {}
+
+    unsigned int min;
+    unsigned int max;
+  };
+
+  // Portable unbiased bounded integer mapping, independent of std::uniform_int_distribution internals.
+  unsigned int operator()(RandGen& randGen, const param_type& params)
+  {
+    const auto min = params.min;
+    const auto max = params.max;
+    const std::uint64_t range = static_cast<std::uint64_t>(max) - min + 1u;
+    const std::uint64_t generatorRange = static_cast<std::uint64_t>(RandGen::max()) - RandGen::min() + 1u;
+    const std::uint64_t limit = generatorRange - (generatorRange % range);
+
+    std::uint64_t value = 0;
+    do {
+      value = static_cast<std::uint64_t>(randGen()) - RandGen::min();
+    } while (value >= limit);
+
+    return min + static_cast<unsigned int>(value % range);
+  }
+};
+
+template <typename UniformUIntDistribution>
+class BasicRandom {
   RandGen m_randGen;
-  uniform_uint_dist uniform;
+  UniformUIntDistribution m_uniform;
 
 public:
-  Random(unsigned int seed = 123) : m_randGen(seed) {}
+  BasicRandom(unsigned int seed = 123) : m_randGen(seed) {}
 
   void seed(unsigned int seedValue)
   {
@@ -33,7 +61,7 @@ public:
 
   unsigned int randInt(unsigned int min, unsigned int max)
   {
-    return uniform(m_randGen, uniform_param_t(min, max));
+    return m_uniform(m_randGen, typename UniformUIntDistribution::param_type(min, max));
   }
 
   /**
@@ -48,6 +76,10 @@ public:
       std::swap(randomOrder[i], randomOrder[i + randInt(0, size - i - 1)]);
   }
 };
+
+using StdRandom = BasicRandom<StdUniformUIntDistribution>;
+using PortableRandom = BasicRandom<PortableUniformUIntDistribution>;
+using Random = StdRandom;
 } // namespace infomap
 
 #endif // RANDOM_H_

--- a/test/cpp/test_utils_io.cpp
+++ b/test/cpp/test_utils_io.cpp
@@ -2,6 +2,7 @@
 
 #include "io/SafeFile.h"
 #include "utils/FileURI.h"
+#include "utils/Random.h"
 #include "utils/convert.h"
 
 #include <cerrno>
@@ -138,6 +139,40 @@ TEST_CASE("convert helpers preserve current tokenization behavior [fast][core][u
   CHECK(infomap::io::stringify(parts, "|") == "alpha|beta|gamma");
   CHECK(infomap::io::tolower("MiXeD") == "mixed");
   CHECK(infomap::io::InsensitiveCompare {}("abc", "ABD"));
+}
+
+TEST_CASE("PortableRandom maps integers portably [fast][core][utils]")
+{
+  infomap::PortableRandom random(2501);
+  CHECK(random.randInt(0, 10) == 9u);
+  CHECK(random.randInt(1, 3) == 3u);
+  CHECK(random.randInt(7, 19) == 14u);
+  CHECK(random.randInt(0, 1) == 1u);
+  CHECK(random.randInt(42, 42) == 42u);
+  CHECK(random.randInt(0, 999) == 695u);
+  CHECK(random.randInt(0, std::numeric_limits<unsigned int>::max()) == 3859750371u);
+  CHECK(random.randInt(100, 100000) == 3169u);
+}
+
+TEST_CASE("PortableRandom index vectors are portable [fast][core][utils]")
+{
+  infomap::PortableRandom random(2501);
+  std::vector<unsigned int> order(16);
+  random.getRandomizedIndexVector(order);
+
+  CHECK(order == std::vector<unsigned int> { 9, 0, 5, 14, 7, 15, 4, 12, 3, 8, 10, 11, 13, 2, 1, 6 });
+}
+
+TEST_CASE("Random keeps the standard library distribution by default [fast][core][utils]")
+{
+  infomap::Random random(2501);
+  CHECK(random.randInt(42, 42) == 42u);
+
+  for (unsigned int i = 0; i < 32; ++i) {
+    const auto value = random.randInt(7, 19);
+    CHECK(value >= 7u);
+    CHECK(value <= 19u);
+  }
 }
 
 TEST_CASE("FileURI splits valid paths and rejects invalid ones [fast][core][utils][io]")


### PR DESCRIPTION
## Summary

- Introduce `BasicRandom<UniformUIntDistribution>` in `src/utils/Random.h` so the bounded integer distribution can be swapped in one local alias.
- Keep the current runtime default unchanged with `using Random = StdRandom`, where `StdRandom` uses `std::uniform_int_distribution<unsigned int>`.
- Add `PortableRandom` with an explicit rejection-sampling integer mapping and C++ regression coverage for its seed `2501` integer sequence and randomized index vector.

## Why

Issue #342 reports different results for the same `--seed` across binary and locally compiled builds. `std::mt19937` is deterministic, but `std::uniform_int_distribution` does not guarantee the same interval mapping across standard library implementations. That can change node permutations and lead to different optimization paths even with the same seed.

This keeps the discussion contained to `Random.h`: the existing `Random` alias preserves current behavior, while `PortableRandom` makes the standard-library-independent mapping available for focused testing and review before deciding whether to change the default.

## Validation

- `make test-native CMAKE_TEST_TARGET=infomap_cpp_utils_io_tests CTEST_ARGS='-R infomap_cpp_utils_io_tests'`
- `make build-native`