### PR TITLE
fix: sync matchable multilayer ids for python input

### DIFF
--- a/interfaces/R/generated/infomap.R
+++ b/interfaces/R/generated/infomap.R
@@ -17476,6 +17476,20 @@ attr(`delete_Network`, 'returnType') = 'void'
 attr(`delete_Network`, "inputTypes") = c('_p_infomap__Network')
 class(`delete_Network`) = c("SWIGFunction", class('delete_Network'))
 
+# Start of Network_setConfig
+
+`Network_setConfig` = function(self, config)
+{
+  if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
+  if (inherits(config, "ExternalReference")) config = slot(config,"ref"); 
+  ;.Call('R_swig_Network_setConfig', self, config, PACKAGE='infomap');
+  
+}
+
+attr(`Network_setConfig`, 'returnType') = 'void'
+attr(`Network_setConfig`, "inputTypes") = c('_p_infomap__Network', '_p_infomap__Config')
+class(`Network_setConfig`) = c("SWIGFunction", class('Network_setConfig'))
+
 # Start of Network_clear
 
 `Network_clear` = function(self)
@@ -18049,7 +18063,7 @@ class(`Network_addMetaData__SWIG_1`) = c("SWIGFunction", class('Network_addMetaD
 setMethod('$', '_p_infomap__Network', function(x, name)
 
 {
-  accessorFuns = list('clear' = Network_clear, 'readInputData' = Network_readInputData, 'readMetaData' = Network_readMetaData, 'numMetaDataColumns' = Network_numMetaDataColumns, 'metaData' = Network_metaData, 'isMultilayerNetwork' = Network_isMultilayerNetwork, 'layerNodeToStateId' = Network_layerNodeToStateId, 'postProcessInputData' = Network_postProcessInputData, 'generateStateNetworkFromMultilayer' = Network_generateStateNetworkFromMultilayer, 'generateStateNetworkFromMultilayerWithInterLinks' = Network_generateStateNetworkFromMultilayerWithInterLinks, 'generateStateNetworkFromMultilayerWithSimulatedInterLinks' = Network_generateStateNetworkFromMultilayerWithSimulatedInterLinks, 'simulateInterLayerLinks' = Network_simulateInterLayerLinks, 'addMultilayerNode' = Network_addMultilayerNode, 'addMultilayerLink' = Network_addMultilayerLink, 'addMultilayerIntraLink' = Network_addMultilayerIntraLink, 'addMultilayerInterLink' = Network_addMultilayerInterLink, 'addMetaData' = Network_addMetaData);
+  accessorFuns = list('setConfig' = Network_setConfig, 'clear' = Network_clear, 'readInputData' = Network_readInputData, 'readMetaData' = Network_readMetaData, 'numMetaDataColumns' = Network_numMetaDataColumns, 'metaData' = Network_metaData, 'isMultilayerNetwork' = Network_isMultilayerNetwork, 'layerNodeToStateId' = Network_layerNodeToStateId, 'postProcessInputData' = Network_postProcessInputData, 'generateStateNetworkFromMultilayer' = Network_generateStateNetworkFromMultilayer, 'generateStateNetworkFromMultilayerWithInterLinks' = Network_generateStateNetworkFromMultilayerWithInterLinks, 'generateStateNetworkFromMultilayerWithSimulatedInterLinks' = Network_generateStateNetworkFromMultilayerWithSimulatedInterLinks, 'simulateInterLayerLinks' = Network_simulateInterLayerLinks, 'addMultilayerNode' = Network_addMultilayerNode, 'addMultilayerLink' = Network_addMultilayerLink, 'addMultilayerIntraLink' = Network_addMultilayerIntraLink, 'addMultilayerInterLink' = Network_addMultilayerInterLink, 'addMetaData' = Network_addMetaData);
   ;        idx = pmatch(name, names(accessorFuns));
   if(is.na(idx)) 
   return(callNextMethod(x, name));

--- a/interfaces/R/generated/infomap_wrap.cpp
+++ b/interfaces/R/generated/infomap_wrap.cpp
@@ -35389,6 +35389,52 @@ R_swig_delete_Network ( SEXP self)
 
 
 SWIGEXPORT SEXP
+R_swig_Network_setConfig ( SEXP self, SEXP config)
+{
+  {
+    infomap::Network *arg1 = 0 ;
+    infomap::Config *arg2 = 0 ;
+    void *argp1 = 0 ;
+    int res1 = 0 ;
+    void *argp2 = 0 ;
+    int res2 = 0 ;
+    unsigned int r_nprotect = 0;
+    SEXP r_ans = R_NilValue ;
+    VMAXTYPE r_vmax = vmaxget() ;
+    
+    res1 = SWIG_R_ConvertPtr(self, &argp1, SWIGTYPE_p_infomap__Network, 0 |  0 );
+    if (!SWIG_IsOK(res1)) {
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Network_setConfig" "', argument " "1"" of type '" "infomap::Network *""'"); 
+    }
+    arg1 = reinterpret_cast< infomap::Network * >(argp1);
+    res2 = SWIG_R_ConvertPtr(config, &argp2, SWIGTYPE_p_infomap__Config,  0 );
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Network_setConfig" "', argument " "2"" of type '" "infomap::Config const &""'"); 
+    }
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "Network_setConfig" "', argument " "2"" of type '" "infomap::Config const &""'"); 
+    }
+    arg2 = reinterpret_cast< infomap::Config * >(argp2);
+    {
+      try {
+        (arg1)->setConfig((infomap::Config const &)*arg2);
+      } catch (const std::exception& e) {
+        SWIG_exception(SWIG_RuntimeError, e.what());
+      }
+    }
+    r_ans = R_NilValue;
+    vmaxset(r_vmax);
+    if(r_nprotect)  Rf_unprotect(r_nprotect);
+    
+    return r_ans;
+    fail: SWIGUNUSED;
+  }
+  Rf_error("%s %s", SWIG_ErrorType(SWIG_lasterror_code), SWIG_lasterror_msg);
+  return R_NilValue;
+}
+
+
+SWIGEXPORT SEXP
 R_swig_Network_clear ( SEXP self)
 {
   {
@@ -47840,6 +47886,7 @@ SWIGINTERN R_CallMethodDef CallEntries[] = {
    {"R_swig_InfoNode_begin_leaf_modules", (DL_FUNC) &R_swig_InfoNode_begin_leaf_modules, 2},
    {"R_swig_InfomapIterator_copy", (DL_FUNC) &R_swig_InfomapIterator_copy, 2},
    {"R_swig_new_map_uint_vector_uint__SWIG_0", (DL_FUNC) &R_swig_new_map_uint_vector_uint__SWIG_0, 1},
+   {"R_swig_Network_setConfig", (DL_FUNC) &R_swig_Network_setConfig, 2},
    {"R_swig_new_map_uint_vector_uint__SWIG_1", (DL_FUNC) &R_swig_new_map_uint_vector_uint__SWIG_1, 0},
    {"R_swig_InfomapIterator_begin_leaf_modules", (DL_FUNC) &R_swig_InfomapIterator_begin_leaf_modules, 2},
    {"R_swig_InfomapIteratorPhysical_childIndex", (DL_FUNC) &R_swig_InfomapIteratorPhysical_childIndex, 2},

--- a/interfaces/python/generated/infomap_wrap.cpp
+++ b/interfaces/python/generated/infomap_wrap.cpp
@@ -41283,6 +41283,45 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_Network_setConfig(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  infomap::Network *arg1 = 0 ;
+  infomap::Config *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject *swig_obj[2] ;
+  
+  (void)self;
+  if (!SWIG_Python_UnpackTuple(args, "Network_setConfig", 2, 2, swig_obj)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__Network, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Network_setConfig" "', argument " "1"" of type '" "infomap::Network *""'"); 
+  }
+  arg1 = reinterpret_cast< infomap::Network * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_infomap__Config,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Network_setConfig" "', argument " "2"" of type '" "infomap::Config const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "Network_setConfig" "', argument " "2"" of type '" "infomap::Config const &""'"); 
+  }
+  arg2 = reinterpret_cast< infomap::Config * >(argp2);
+  {
+    try {
+      (arg1)->setConfig((infomap::Config const &)*arg2);
+    } catch (const std::exception& e) {
+      SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_Network_clear(PyObject *self, PyObject *args) {
   PyObject *resultobj = 0;
   infomap::Network *arg1 = 0 ;
@@ -57770,6 +57809,7 @@ static PyMethodDef SwigMethods[] = {
 	 { "StateNetwork_swigregister", StateNetwork_swigregister, METH_O, NULL},
 	 { "new_Network", _wrap_new_Network, METH_VARARGS, NULL},
 	 { "delete_Network", _wrap_delete_Network, METH_O, NULL},
+	 { "Network_setConfig", _wrap_Network_setConfig, METH_VARARGS, NULL},
 	 { "Network_clear", _wrap_Network_clear, METH_O, NULL},
 	 { "Network_readInputData", _wrap_Network_readInputData, METH_VARARGS, NULL},
 	 { "Network_readMetaData", _wrap_Network_readMetaData, METH_VARARGS, NULL},

--- a/interfaces/python/src/infomap/_swig.py
+++ b/interfaces/python/src/infomap/_swig.py
@@ -2165,6 +2165,9 @@ class Network(StateNetwork):
         _infomap.Network_swiginit(self, _infomap.new_Network(*args))
     __swig_destroy__ = _infomap.delete_Network
 
+    def setConfig(self, config):
+        return _infomap.Network_setConfig(self, config)
+
     def clear(self):
         return _infomap.Network_clear(self)
 

--- a/src/io/Network.cpp
+++ b/src/io/Network.cpp
@@ -22,6 +22,11 @@ using std::make_pair;
 void Network::init()
 {
   initValidHeadings();
+  updateDerivedConfig();
+}
+
+void Network::updateDerivedConfig()
+{
   m_multilayerStateIdBitShift = m_config.matchableMultilayerIds == 0
       ? 0
       : static_cast<unsigned int>(std::ceil(std::log2(m_config.matchableMultilayerIds)));

--- a/src/io/Network.h
+++ b/src/io/Network.h
@@ -70,6 +70,12 @@ public:
   Network(Network&&) = delete;
   Network& operator=(Network&&) = delete;
 
+  void setConfig(const Config& config)
+  {
+    StateNetwork::setConfig(config);
+    updateDerivedConfig();
+  }
+
   void clear() override;
 
   /**
@@ -132,6 +138,7 @@ public:
 
 private:
   void init();
+  void updateDerivedConfig();
   void initValidHeadings();
 
   void parseNetwork(const std::string& filename);

--- a/test/python/test_multilayer.py
+++ b/test/python/test_multilayer.py
@@ -1,0 +1,17 @@
+def test_matchable_multilayer_ids_with_python_read_file(make_infomap, example_network_path):
+    im = make_infomap(no_infomap=True, matchable_multilayer_ids=3)
+    im.read_file(str(example_network_path("multilayer.net")))
+    im.run()
+
+    nodes = sorted((node.state_id, node.node_id, node.layer_id) for node in im.nodes)
+
+    assert im.num_nodes == 6
+    assert im.num_physical_nodes == 5
+    assert nodes == [
+        (9, 1, 1),
+        (10, 1, 2),
+        (18, 2, 2),
+        (26, 3, 2),
+        (33, 4, 1),
+        (41, 5, 1),
+    ]


### PR DESCRIPTION
## Issue

Closes #311.

## Summary

- recompute Network derived multilayer state-id config after setConfig()
- keep Python read_file() multilayer parsing aligned with CLI matchable state ids
- add a Python regression test based on the linked discussion example

## Verification

- Regression test failed before rebuilding the extension with the current fix
- PATH="/opt/homebrew/bin:$PATH" PYTHON=.venv/bin/python PIP=".venv/bin/python -m pip" make build-python dev-python-install
- .venv/bin/python -m pytest test/python/test_multilayer.py::test_matchable_multilayer_ids_with_python_read_file -q
- PATH="/opt/homebrew/bin:$PATH" make build-native

## Risk

Low. The change only keeps Network derived config synchronized when Infomap updates Network config before reading Python file input.