### PR TITLE
fix: speed up bulk multilayer link loading

### DIFF
--- a/docs/python/infomap.html
+++ b/docs/python/infomap.html
@@ -259,7 +259,10 @@ and directed links. Infomap will not make any changes to the network.</p>
 <dl class="field-list simple">
 <dt class="field-odd">Parameters<span class="colon">:</span></dt>
 <dd class="field-odd"><p><strong>links</strong> (<em>iterable</em><em> of </em><em>tuples</em>) – Iterable of tuples of the form
-<code class="docutils literal notranslate"><span class="pre">(source_node,</span> <span class="pre">target_node,</span> <span class="pre">[weight])</span></code></p>
+<code class="docutils literal notranslate"><span class="pre">(source_node,</span> <span class="pre">target_node,</span> <span class="pre">[weight])</span></code>. NumPy arrays must be
+2-dimensional with 4 or 5 columns of the form
+<code class="docutils literal notranslate"><span class="pre">(source_layer_id,</span> <span class="pre">source_node_id,</span> <span class="pre">target_layer_id,</span>
+<span class="pre">target_node_id,</span> <span class="pre">[weight])</span></code>.</p>
 </dd>
 </dl>
 </dd></dl>

--- a/interfaces/R/generated/infomap.R
+++ b/interfaces/R/generated/infomap.R
@@ -17929,6 +17929,24 @@ class(`Network_addMultilayerLink__SWIG_1`) = c("SWIGFunction", class('Network_ad
 }
 
 # Dispatch function
+# Start of Network_addMultilayerLinks
+
+`Network_addMultilayerLinks` = function(self, sourceLayerIds, sourceNodeIds, targetLayerIds, targetNodeIds, weights)
+{
+  if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
+  sourceLayerIds = as.integer(sourceLayerIds);
+  sourceNodeIds = as.integer(sourceNodeIds);
+  targetLayerIds = as.integer(targetLayerIds);
+  targetNodeIds = as.integer(targetNodeIds);
+  weights = as.numeric(weights);
+  ;.Call('R_swig_Network_addMultilayerLinks', self, sourceLayerIds, sourceNodeIds, targetLayerIds, targetNodeIds, weights, PACKAGE='infomap');
+  
+}
+
+attr(`Network_addMultilayerLinks`, 'returnType') = 'void'
+attr(`Network_addMultilayerLinks`, "inputTypes") = c('_p_infomap__Network', 'integer', 'integer', 'integer', 'integer', '_p_std__vectorT_double_t')
+class(`Network_addMultilayerLinks`) = c("SWIGFunction", class('Network_addMultilayerLinks'))
+
 # Start of Network_addMultilayerIntraLink
 
 `Network_addMultilayerIntraLink` = function(self, layer, n1, n2, weight)
@@ -18063,7 +18081,7 @@ class(`Network_addMetaData__SWIG_1`) = c("SWIGFunction", class('Network_addMetaD
 setMethod('$', '_p_infomap__Network', function(x, name)
 
 {
-  accessorFuns = list('setConfig' = Network_setConfig, 'clear' = Network_clear, 'readInputData' = Network_readInputData, 'readMetaData' = Network_readMetaData, 'numMetaDataColumns' = Network_numMetaDataColumns, 'metaData' = Network_metaData, 'isMultilayerNetwork' = Network_isMultilayerNetwork, 'layerNodeToStateId' = Network_layerNodeToStateId, 'postProcessInputData' = Network_postProcessInputData, 'generateStateNetworkFromMultilayer' = Network_generateStateNetworkFromMultilayer, 'generateStateNetworkFromMultilayerWithInterLinks' = Network_generateStateNetworkFromMultilayerWithInterLinks, 'generateStateNetworkFromMultilayerWithSimulatedInterLinks' = Network_generateStateNetworkFromMultilayerWithSimulatedInterLinks, 'simulateInterLayerLinks' = Network_simulateInterLayerLinks, 'addMultilayerNode' = Network_addMultilayerNode, 'addMultilayerLink' = Network_addMultilayerLink, 'addMultilayerIntraLink' = Network_addMultilayerIntraLink, 'addMultilayerInterLink' = Network_addMultilayerInterLink, 'addMetaData' = Network_addMetaData);
+  accessorFuns = list('setConfig' = Network_setConfig, 'clear' = Network_clear, 'readInputData' = Network_readInputData, 'readMetaData' = Network_readMetaData, 'numMetaDataColumns' = Network_numMetaDataColumns, 'metaData' = Network_metaData, 'isMultilayerNetwork' = Network_isMultilayerNetwork, 'layerNodeToStateId' = Network_layerNodeToStateId, 'postProcessInputData' = Network_postProcessInputData, 'generateStateNetworkFromMultilayer' = Network_generateStateNetworkFromMultilayer, 'generateStateNetworkFromMultilayerWithInterLinks' = Network_generateStateNetworkFromMultilayerWithInterLinks, 'generateStateNetworkFromMultilayerWithSimulatedInterLinks' = Network_generateStateNetworkFromMultilayerWithSimulatedInterLinks, 'simulateInterLayerLinks' = Network_simulateInterLayerLinks, 'addMultilayerNode' = Network_addMultilayerNode, 'addMultilayerLink' = Network_addMultilayerLink, 'addMultilayerLinks' = Network_addMultilayerLinks, 'addMultilayerIntraLink' = Network_addMultilayerIntraLink, 'addMultilayerInterLink' = Network_addMultilayerInterLink, 'addMetaData' = Network_addMetaData);
   ;        idx = pmatch(name, names(accessorFuns));
   if(is.na(idx)) 
   return(callNextMethod(x, name));
@@ -22964,6 +22982,24 @@ class(`InfomapWrapper_addMultilayerLink__SWIG_1`) = c("SWIGFunction", class('Inf
 }
 
 # Dispatch function
+# Start of InfomapWrapper_addMultilayerLinks
+
+`InfomapWrapper_addMultilayerLinks` = function(self, sourceLayerIds, sourceNodeIds, targetLayerIds, targetNodeIds, weights)
+{
+  if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
+  sourceLayerIds = as.integer(sourceLayerIds);
+  sourceNodeIds = as.integer(sourceNodeIds);
+  targetLayerIds = as.integer(targetLayerIds);
+  targetNodeIds = as.integer(targetNodeIds);
+  weights = as.numeric(weights);
+  ;.Call('R_swig_InfomapWrapper_addMultilayerLinks', self, sourceLayerIds, sourceNodeIds, targetLayerIds, targetNodeIds, weights, PACKAGE='infomap');
+  
+}
+
+attr(`InfomapWrapper_addMultilayerLinks`, 'returnType') = 'void'
+attr(`InfomapWrapper_addMultilayerLinks`, "inputTypes") = c('_p_infomap__InfomapWrapper', 'integer', 'integer', 'integer', 'integer', '_p_std__vectorT_double_t')
+class(`InfomapWrapper_addMultilayerLinks`) = c("SWIGFunction", class('InfomapWrapper_addMultilayerLinks'))
+
 # Start of InfomapWrapper_addMultilayerIntraLink
 
 `InfomapWrapper_addMultilayerIntraLink` = function(self, layer, n1, n2, weight)
@@ -23432,7 +23468,7 @@ class(`InfomapWrapper_run__SWIG_2`) = c("SWIGFunction", class('InfomapWrapper_ru
 setMethod('$', '_p_infomap__InfomapWrapper', function(x, name)
 
 {
-  accessorFuns = list('readInputData' = InfomapWrapper_readInputData, 'addNode' = InfomapWrapper_addNode, 'addName' = InfomapWrapper_addName, 'getName' = InfomapWrapper_getName, 'getNames' = InfomapWrapper_getNames, 'addPhysicalNode' = InfomapWrapper_addPhysicalNode, 'addStateNode' = InfomapWrapper_addStateNode, 'addLink' = InfomapWrapper_addLink, 'addLinks' = InfomapWrapper_addLinks, 'addMultilayerLink' = InfomapWrapper_addMultilayerLink, 'addMultilayerIntraLink' = InfomapWrapper_addMultilayerIntraLink, 'addMultilayerInterLink' = InfomapWrapper_addMultilayerInterLink, 'setBipartiteStartId' = InfomapWrapper_setBipartiteStartId, 'getLinks' = InfomapWrapper_getLinks, 'getModules' = InfomapWrapper_getModules, 'codelength' = InfomapWrapper_codelength, 'getEntropyRate' = InfomapWrapper_getEntropyRate, 'getMultilevelModules' = InfomapWrapper_getMultilevelModules, 'iterLeafNodes' = InfomapWrapper_iterLeafNodes, 'iterTree' = InfomapWrapper_iterTree, 'run' = InfomapWrapper_run);
+  accessorFuns = list('readInputData' = InfomapWrapper_readInputData, 'addNode' = InfomapWrapper_addNode, 'addName' = InfomapWrapper_addName, 'getName' = InfomapWrapper_getName, 'getNames' = InfomapWrapper_getNames, 'addPhysicalNode' = InfomapWrapper_addPhysicalNode, 'addStateNode' = InfomapWrapper_addStateNode, 'addLink' = InfomapWrapper_addLink, 'addLinks' = InfomapWrapper_addLinks, 'addMultilayerLink' = InfomapWrapper_addMultilayerLink, 'addMultilayerLinks' = InfomapWrapper_addMultilayerLinks, 'addMultilayerIntraLink' = InfomapWrapper_addMultilayerIntraLink, 'addMultilayerInterLink' = InfomapWrapper_addMultilayerInterLink, 'setBipartiteStartId' = InfomapWrapper_setBipartiteStartId, 'getLinks' = InfomapWrapper_getLinks, 'getModules' = InfomapWrapper_getModules, 'codelength' = InfomapWrapper_codelength, 'getEntropyRate' = InfomapWrapper_getEntropyRate, 'getMultilevelModules' = InfomapWrapper_getMultilevelModules, 'iterLeafNodes' = InfomapWrapper_iterLeafNodes, 'iterTree' = InfomapWrapper_iterTree, 'run' = InfomapWrapper_run);
   ;        idx = pmatch(name, names(accessorFuns));
   if(is.na(idx)) 
   return(callNextMethod(x, name));

--- a/interfaces/R/generated/infomap_wrap.cpp
+++ b/interfaces/R/generated/infomap_wrap.cpp
@@ -36288,6 +36288,116 @@ R_swig_Network_addMultilayerLink__SWIG_1 ( SEXP self, SEXP stateId1, SEXP layer1
 
 
 SWIGEXPORT SEXP
+R_swig_Network_addMultilayerLinks ( SEXP self, SEXP sourceLayerIds, SEXP sourceNodeIds, SEXP targetLayerIds, SEXP targetNodeIds, SEXP weights)
+{
+  {
+    infomap::Network *arg1 = 0 ;
+    std::vector< unsigned int,std::allocator< unsigned int > > *arg2 = 0 ;
+    std::vector< unsigned int,std::allocator< unsigned int > > *arg3 = 0 ;
+    std::vector< unsigned int,std::allocator< unsigned int > > *arg4 = 0 ;
+    std::vector< unsigned int,std::allocator< unsigned int > > *arg5 = 0 ;
+    std::vector< double,std::allocator< double > > *arg6 = 0 ;
+    void *argp1 = 0 ;
+    int res1 = 0 ;
+    int res2 = SWIG_OLDOBJ ;
+    int res3 = SWIG_OLDOBJ ;
+    int res4 = SWIG_OLDOBJ ;
+    int res5 = SWIG_OLDOBJ ;
+    int res6 = SWIG_OLDOBJ ;
+    unsigned int r_nprotect = 0;
+    SEXP r_ans = R_NilValue ;
+    VMAXTYPE r_vmax = vmaxget() ;
+    
+    res1 = SWIG_R_ConvertPtr(self, &argp1, SWIGTYPE_p_infomap__Network, 0 |  0 );
+    if (!SWIG_IsOK(res1)) {
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Network_addMultilayerLinks" "', argument " "1"" of type '" "infomap::Network *""'"); 
+    }
+    arg1 = reinterpret_cast< infomap::Network * >(argp1);
+    {
+      std::vector< unsigned int,std::allocator< unsigned int > > *ptr = (std::vector< unsigned int,std::allocator< unsigned int > > *)0;
+      res2 = swig::asptr(sourceLayerIds, &ptr);
+      if (!SWIG_IsOK(res2)) {
+        SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Network_addMultilayerLinks" "', argument " "2"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+      }
+      if (!ptr) {
+        SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "Network_addMultilayerLinks" "', argument " "2"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+      }
+      arg2 = ptr;
+    }
+    {
+      std::vector< unsigned int,std::allocator< unsigned int > > *ptr = (std::vector< unsigned int,std::allocator< unsigned int > > *)0;
+      res3 = swig::asptr(sourceNodeIds, &ptr);
+      if (!SWIG_IsOK(res3)) {
+        SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "Network_addMultilayerLinks" "', argument " "3"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+      }
+      if (!ptr) {
+        SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "Network_addMultilayerLinks" "', argument " "3"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+      }
+      arg3 = ptr;
+    }
+    {
+      std::vector< unsigned int,std::allocator< unsigned int > > *ptr = (std::vector< unsigned int,std::allocator< unsigned int > > *)0;
+      res4 = swig::asptr(targetLayerIds, &ptr);
+      if (!SWIG_IsOK(res4)) {
+        SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "Network_addMultilayerLinks" "', argument " "4"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+      }
+      if (!ptr) {
+        SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "Network_addMultilayerLinks" "', argument " "4"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+      }
+      arg4 = ptr;
+    }
+    {
+      std::vector< unsigned int,std::allocator< unsigned int > > *ptr = (std::vector< unsigned int,std::allocator< unsigned int > > *)0;
+      res5 = swig::asptr(targetNodeIds, &ptr);
+      if (!SWIG_IsOK(res5)) {
+        SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "Network_addMultilayerLinks" "', argument " "5"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+      }
+      if (!ptr) {
+        SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "Network_addMultilayerLinks" "', argument " "5"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+      }
+      arg5 = ptr;
+    }
+    {
+      std::vector< double,std::allocator< double > > *ptr = (std::vector< double,std::allocator< double > > *)0;
+      res6 = swig::asptr(weights, &ptr);
+      if (!SWIG_IsOK(res6)) {
+        SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "Network_addMultilayerLinks" "', argument " "6"" of type '" "std::vector< double,std::allocator< double > > const &""'"); 
+      }
+      if (!ptr) {
+        SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "Network_addMultilayerLinks" "', argument " "6"" of type '" "std::vector< double,std::allocator< double > > const &""'"); 
+      }
+      arg6 = ptr;
+    }
+    {
+      try {
+        (arg1)->addMultilayerLinks((std::vector< unsigned int,std::allocator< unsigned int > > const &)*arg2,(std::vector< unsigned int,std::allocator< unsigned int > > const &)*arg3,(std::vector< unsigned int,std::allocator< unsigned int > > const &)*arg4,(std::vector< unsigned int,std::allocator< unsigned int > > const &)*arg5,(std::vector< double,std::allocator< double > > const &)*arg6);
+      } catch (const std::exception& e) {
+        SWIG_exception(SWIG_RuntimeError, e.what());
+      }
+    }
+    r_ans = R_NilValue;
+    if (SWIG_IsNewObj(res2)) delete arg2;
+    if (SWIG_IsNewObj(res3)) delete arg3;
+    if (SWIG_IsNewObj(res4)) delete arg4;
+    if (SWIG_IsNewObj(res5)) delete arg5;
+    if (SWIG_IsNewObj(res6)) delete arg6;
+    vmaxset(r_vmax);
+    if(r_nprotect)  Rf_unprotect(r_nprotect);
+    
+    return r_ans;
+    fail: SWIGUNUSED;
+    if (SWIG_IsNewObj(res2)) delete arg2;
+    if (SWIG_IsNewObj(res3)) delete arg3;
+    if (SWIG_IsNewObj(res4)) delete arg4;
+    if (SWIG_IsNewObj(res5)) delete arg5;
+    if (SWIG_IsNewObj(res6)) delete arg6;
+  }
+  Rf_error("%s %s", SWIG_ErrorType(SWIG_lasterror_code), SWIG_lasterror_msg);
+  return R_NilValue;
+}
+
+
+SWIGEXPORT SEXP
 R_swig_Network_addMultilayerIntraLink ( SEXP self, SEXP layer, SEXP n1, SEXP n2, SEXP weight)
 {
   {
@@ -45357,6 +45467,116 @@ R_swig_InfomapWrapper_addMultilayerLink__SWIG_1 ( SEXP self, SEXP layer1, SEXP n
 
 
 SWIGEXPORT SEXP
+R_swig_InfomapWrapper_addMultilayerLinks ( SEXP self, SEXP sourceLayerIds, SEXP sourceNodeIds, SEXP targetLayerIds, SEXP targetNodeIds, SEXP weights)
+{
+  {
+    infomap::InfomapWrapper *arg1 = 0 ;
+    std::vector< unsigned int,std::allocator< unsigned int > > *arg2 = 0 ;
+    std::vector< unsigned int,std::allocator< unsigned int > > *arg3 = 0 ;
+    std::vector< unsigned int,std::allocator< unsigned int > > *arg4 = 0 ;
+    std::vector< unsigned int,std::allocator< unsigned int > > *arg5 = 0 ;
+    std::vector< double,std::allocator< double > > *arg6 = 0 ;
+    void *argp1 = 0 ;
+    int res1 = 0 ;
+    int res2 = SWIG_OLDOBJ ;
+    int res3 = SWIG_OLDOBJ ;
+    int res4 = SWIG_OLDOBJ ;
+    int res5 = SWIG_OLDOBJ ;
+    int res6 = SWIG_OLDOBJ ;
+    unsigned int r_nprotect = 0;
+    SEXP r_ans = R_NilValue ;
+    VMAXTYPE r_vmax = vmaxget() ;
+    
+    res1 = SWIG_R_ConvertPtr(self, &argp1, SWIGTYPE_p_infomap__InfomapWrapper, 0 |  0 );
+    if (!SWIG_IsOK(res1)) {
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapWrapper_addMultilayerLinks" "', argument " "1"" of type '" "infomap::InfomapWrapper *""'"); 
+    }
+    arg1 = reinterpret_cast< infomap::InfomapWrapper * >(argp1);
+    {
+      std::vector< unsigned int,std::allocator< unsigned int > > *ptr = (std::vector< unsigned int,std::allocator< unsigned int > > *)0;
+      res2 = swig::asptr(sourceLayerIds, &ptr);
+      if (!SWIG_IsOK(res2)) {
+        SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "InfomapWrapper_addMultilayerLinks" "', argument " "2"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+      }
+      if (!ptr) {
+        SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "InfomapWrapper_addMultilayerLinks" "', argument " "2"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+      }
+      arg2 = ptr;
+    }
+    {
+      std::vector< unsigned int,std::allocator< unsigned int > > *ptr = (std::vector< unsigned int,std::allocator< unsigned int > > *)0;
+      res3 = swig::asptr(sourceNodeIds, &ptr);
+      if (!SWIG_IsOK(res3)) {
+        SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "InfomapWrapper_addMultilayerLinks" "', argument " "3"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+      }
+      if (!ptr) {
+        SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "InfomapWrapper_addMultilayerLinks" "', argument " "3"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+      }
+      arg3 = ptr;
+    }
+    {
+      std::vector< unsigned int,std::allocator< unsigned int > > *ptr = (std::vector< unsigned int,std::allocator< unsigned int > > *)0;
+      res4 = swig::asptr(targetLayerIds, &ptr);
+      if (!SWIG_IsOK(res4)) {
+        SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "InfomapWrapper_addMultilayerLinks" "', argument " "4"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+      }
+      if (!ptr) {
+        SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "InfomapWrapper_addMultilayerLinks" "', argument " "4"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+      }
+      arg4 = ptr;
+    }
+    {
+      std::vector< unsigned int,std::allocator< unsigned int > > *ptr = (std::vector< unsigned int,std::allocator< unsigned int > > *)0;
+      res5 = swig::asptr(targetNodeIds, &ptr);
+      if (!SWIG_IsOK(res5)) {
+        SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "InfomapWrapper_addMultilayerLinks" "', argument " "5"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+      }
+      if (!ptr) {
+        SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "InfomapWrapper_addMultilayerLinks" "', argument " "5"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+      }
+      arg5 = ptr;
+    }
+    {
+      std::vector< double,std::allocator< double > > *ptr = (std::vector< double,std::allocator< double > > *)0;
+      res6 = swig::asptr(weights, &ptr);
+      if (!SWIG_IsOK(res6)) {
+        SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "InfomapWrapper_addMultilayerLinks" "', argument " "6"" of type '" "std::vector< double,std::allocator< double > > const &""'"); 
+      }
+      if (!ptr) {
+        SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "InfomapWrapper_addMultilayerLinks" "', argument " "6"" of type '" "std::vector< double,std::allocator< double > > const &""'"); 
+      }
+      arg6 = ptr;
+    }
+    {
+      try {
+        (arg1)->addMultilayerLinks((std::vector< unsigned int,std::allocator< unsigned int > > const &)*arg2,(std::vector< unsigned int,std::allocator< unsigned int > > const &)*arg3,(std::vector< unsigned int,std::allocator< unsigned int > > const &)*arg4,(std::vector< unsigned int,std::allocator< unsigned int > > const &)*arg5,(std::vector< double,std::allocator< double > > const &)*arg6);
+      } catch (const std::exception& e) {
+        SWIG_exception(SWIG_RuntimeError, e.what());
+      }
+    }
+    r_ans = R_NilValue;
+    if (SWIG_IsNewObj(res2)) delete arg2;
+    if (SWIG_IsNewObj(res3)) delete arg3;
+    if (SWIG_IsNewObj(res4)) delete arg4;
+    if (SWIG_IsNewObj(res5)) delete arg5;
+    if (SWIG_IsNewObj(res6)) delete arg6;
+    vmaxset(r_vmax);
+    if(r_nprotect)  Rf_unprotect(r_nprotect);
+    
+    return r_ans;
+    fail: SWIGUNUSED;
+    if (SWIG_IsNewObj(res2)) delete arg2;
+    if (SWIG_IsNewObj(res3)) delete arg3;
+    if (SWIG_IsNewObj(res4)) delete arg4;
+    if (SWIG_IsNewObj(res5)) delete arg5;
+    if (SWIG_IsNewObj(res6)) delete arg6;
+  }
+  Rf_error("%s %s", SWIG_ErrorType(SWIG_lasterror_code), SWIG_lasterror_msg);
+  return R_NilValue;
+}
+
+
+SWIGEXPORT SEXP
 R_swig_InfomapWrapper_addMultilayerIntraLink ( SEXP self, SEXP layer, SEXP n1, SEXP n2, SEXP weight)
 {
   {
@@ -47651,6 +47871,7 @@ SWIGINTERN R_CallMethodDef CallEntries[] = {
    {"R_swig_InfomapIterator_collapsedLastChild_get", (DL_FUNC) &R_swig_InfomapIterator_collapsedLastChild_get, 1},
    {"R_swig_InfoNode_metaCollection_get", (DL_FUNC) &R_swig_InfoNode_metaCollection_get, 2},
    {"R_swig_Config_verbosity_get", (DL_FUNC) &R_swig_Config_verbosity_get, 2},
+   {"R_swig_Network_addMultilayerLinks", (DL_FUNC) &R_swig_Network_addMultilayerLinks, 6},
    {"R_swig_InfomapParentIterator_firstDepthBelow", (DL_FUNC) &R_swig_InfomapParentIterator_firstDepthBelow, 2},
    {"R_swig_InfomapIterator_metaCollection_get", (DL_FUNC) &R_swig_InfomapIterator_metaCollection_get, 2},
    {"R_swig_InfoNode_parent_set", (DL_FUNC) &R_swig_InfoNode_parent_set, 2},
@@ -47986,6 +48207,7 @@ SWIGINTERN R_CallMethodDef CallEntries[] = {
    {"R_swig_StateNetwork_addLink__SWIG_2", (DL_FUNC) &R_swig_StateNetwork_addLink__SWIG_2, 5},
    {"R_swig_Config_unweightedMetaData_set", (DL_FUNC) &R_swig_Config_unweightedMetaData_set, 2},
    {"R_swig_Config_coreLoopLimit_set", (DL_FUNC) &R_swig_Config_coreLoopLimit_set, 2},
+   {"R_swig_InfomapWrapper_addMultilayerLinks", (DL_FUNC) &R_swig_InfomapWrapper_addMultilayerLinks, 6},
    {"R_swig_Config_noInfomap_get", (DL_FUNC) &R_swig_Config_noInfomap_get, 2},
    {"R_swig_InfoNode_begin_outEdge", (DL_FUNC) &R_swig_InfoNode_begin_outEdge, 2},
    {"R_swig_Config_useNodeWeightsAsFlow_get", (DL_FUNC) &R_swig_Config_useNodeWeightsAsFlow_get, 2},

--- a/interfaces/R/infomap/R/Infomap.R
+++ b/interfaces/R/infomap/R/Infomap.R
@@ -333,13 +333,106 @@ InfomapClass <- R6::R6Class(
     },
 
     #' @description Add many multilayer links at once.
-    #' @param links A list of vectors, each
-    #'   `c(source_multilayer_node, target_multilayer_node, [weight])`.
+    #' @param links A list whose entries are
+    #'   `list(source_multilayer_node, target_multilayer_node, weight)`
+    #'   (weight optional), or a 4- or 5-column matrix / data.frame of
+    #'   `source_layer`, `source_node`, `target_layer`, `target_node`, and
+    #'   optional `weight`.
     add_multilayer_links = function(links) {
-      for (entry in links) {
-        weight <- if (length(entry) >= 3L) entry[[3L]] else 1.0
-        self$add_multilayer_link(entry[[1L]], entry[[2L]], weight)
+      if (is.matrix(links) || is.data.frame(links)) {
+        ncol_links <- ncol(links)
+        if (!ncol_links %in% c(4L, 5L)) {
+          stop("`links` matrix/data.frame must have 4 or 5 columns ",
+               "(source_layer, source_node, target_layer, target_node, [weight]).",
+               call. = FALSE)
+        }
+
+        source_layers <- if (is.matrix(links)) links[, 1L] else links[[1L]]
+        source_nodes <- if (is.matrix(links)) links[, 2L] else links[[2L]]
+        target_layers <- if (is.matrix(links)) links[, 3L] else links[[3L]]
+        target_nodes <- if (is.matrix(links)) links[, 4L] else links[[4L]]
+        id_columns <- list(source_layers, source_nodes, target_layers, target_nodes)
+        if (!all(vapply(id_columns, is.numeric, logical(1L)))) {
+          stop("`links` multilayer id columns must be numeric/integer.",
+               call. = FALSE)
+        }
+
+        weights <- if (ncol_links == 5L) {
+          w <- if (is.matrix(links)) links[, 5L] else links[[5L]]
+          if (!is.numeric(w)) {
+            stop("`links` weight column must be numeric.", call. = FALSE)
+          }
+          as.numeric(w)
+        } else {
+          rep(1.0, length(source_layers))
+        }
+      } else {
+        link_lengths <- vapply(links, length, integer(1L))
+        if (!all(link_lengths %in% c(2L, 3L))) {
+          stop("Each multilayer link must contain 2 or 3 values: ",
+               "source node, target node, and optional weight.",
+               call. = FALSE)
+        }
+
+        extract_node_value <- function(node, name, index) {
+          if (length(node) != 2L) {
+            stop("Each multilayer node must contain 2 values: layer id and node id.",
+                 call. = FALSE)
+          }
+          value <- node[[index]]
+          if (length(value) != 1L) {
+            stop("Each multilayer ", name, " value must be scalar.",
+                 call. = FALSE)
+          }
+          if (!is.numeric(value)) {
+            stop("Multilayer layer/node values must be numeric/integer.",
+                 call. = FALSE)
+          }
+          value
+        }
+
+        source_layers <- vapply(
+          links,
+          function(entry) extract_node_value(entry[[1L]], "source layer", 1L),
+          numeric(1L)
+        )
+        source_nodes <- vapply(
+          links,
+          function(entry) extract_node_value(entry[[1L]], "source node", 2L),
+          numeric(1L)
+        )
+        target_layers <- vapply(
+          links,
+          function(entry) extract_node_value(entry[[2L]], "target layer", 1L),
+          numeric(1L)
+        )
+        target_nodes <- vapply(
+          links,
+          function(entry) extract_node_value(entry[[2L]], "target node", 2L),
+          numeric(1L)
+        )
+        weights <- vapply(
+          links,
+          function(entry) {
+            value <- if (length(entry) == 3L) entry[[3L]] else 1.0
+            if (length(value) != 1L) {
+              stop("Each multilayer link weight value must be scalar.",
+                   call. = FALSE)
+            }
+            if (!is.numeric(value)) {
+              stop("Multilayer link weight values must be numeric.",
+                   call. = FALSE)
+            }
+            value
+          },
+          numeric(1L)
+        )
       }
+
+      private$.swig$addMultilayerLinks(
+        as.integer(source_layers), as.integer(source_nodes),
+        as.integer(target_layers), as.integer(target_nodes), as.numeric(weights)
+      )
       invisible(self)
     },
 

--- a/interfaces/R/infomap/man/Infomap.Rd
+++ b/interfaces/R/infomap/man/Infomap.Rd
@@ -483,8 +483,11 @@ Add many multilayer links at once.
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{links}}{A list of vectors, each
-\verb{c(source_multilayer_node, target_multilayer_node, [weight])}.}
+\item{\code{links}}{A list whose entries are
+\code{list(source_multilayer_node, target_multilayer_node, weight)}
+(weight optional), or a 4- or 5-column matrix / data.frame of
+\code{source_layer}, \code{source_node}, \code{target_layer}, \code{target_node}, and
+optional \code{weight}.}
 }
 \if{html}{\out{</div>}}
 }

--- a/interfaces/R/infomap/tests/testthat/test-errors.R
+++ b/interfaces/R/infomap/tests/testthat/test-errors.R
@@ -32,6 +32,57 @@ test_that("add_links rejects malformed list entries", {
   expect_error(im$add_links(list(list(1, 2, c(3, 4)))), "weight value must be scalar")
 })
 
+test_that("add_multilayer_links rejects malformed matrix/data.frame input", {
+  im <- Infomap(silent = TRUE)
+
+  expect_error(
+    im$add_multilayer_links(matrix(c(1, 1, 2), ncol = 3L)),
+    "4 or 5 columns"
+  )
+  expect_error(
+    im$add_multilayer_links(data.frame(a = "x", b = 1, c = 2, d = 3)),
+    "numeric/integer"
+  )
+  expect_error(
+    im$add_multilayer_links(data.frame(a = 1, b = 1, c = 2, d = 2, w = "bad")),
+    "weight column must be numeric"
+  )
+})
+
+test_that("add_multilayer_links rejects malformed list entries", {
+  im <- Infomap(silent = TRUE)
+
+  expect_error(im$add_multilayer_links(list(list(c(1, 1)))), "2 or 3 values")
+  expect_error(
+    im$add_multilayer_links(list(list(c(1, 1), c(2, 2), 1, 2))),
+    "2 or 3 values"
+  )
+  expect_error(
+    im$add_multilayer_links(list(list(c(1), c(2, 2)))),
+    "node must contain 2 values"
+  )
+  expect_error(
+    im$add_multilayer_links(list(list(c(1, 1), c(2, 2, 3)))),
+    "node must contain 2 values"
+  )
+  expect_error(
+    im$add_multilayer_links(list(list(list(c(1, 2), 1), c(2, 2)))),
+    "source layer value must be scalar"
+  )
+  expect_error(
+    im$add_multilayer_links(list(list(c("a", 1), c(2, 2)))),
+    "numeric/integer"
+  )
+  expect_error(
+    im$add_multilayer_links(list(list(c(1, 1), c(2, 2), c(1, 2)))),
+    "weight value must be scalar"
+  )
+  expect_error(
+    im$add_multilayer_links(list(list(c(1, 1), c(2, 2), "bad"))),
+    "weight values must be numeric"
+  )
+})
+
 test_that("running twice in a row does not crash", {
   im <- Infomap(silent = TRUE)
   im$add_link(1, 2)

--- a/interfaces/R/infomap/tests/testthat/test-multilayer.R
+++ b/interfaces/R/infomap/tests/testthat/test-multilayer.R
@@ -19,6 +19,77 @@ test_that("multilayer intra/inter format clusters across layers", {
   expect_setequal(unique(df$layer_id), c(1L, 2L))
 })
 
+expect_same_multilayer_links <- function(actual, expected) {
+  expect_equal(actual$num_links, expected$num_links)
+  expect_equal(actual$num_nodes, expected$num_nodes)
+  expect_equal(actual$num_physical_nodes, expected$num_physical_nodes)
+}
+
+test_that("add_multilayer_links list input matches repeated add_multilayer_link", {
+  links <- list(
+    list(c(1, 1), c(1, 2), 2.0),
+    list(c(1, 2), c(1, 3), 2.0),
+    list(c(1, 3), c(2, 1), 1.0),
+    list(c(2, 1), c(2, 2), 3.0),
+    list(c(2, 2), c(2, 3), 3.0),
+    list(c(2, 3), c(1, 1), 1.0)
+  )
+
+  baseline <- Infomap(silent = TRUE, num_trials = 1L, two_level = TRUE)
+  for (link in links) {
+    baseline$add_multilayer_link(link[[1L]], link[[2L]], link[[3L]])
+  }
+
+  im <- Infomap(silent = TRUE, num_trials = 1L, two_level = TRUE)
+  im$add_multilayer_links(links)
+
+  expect_same_multilayer_links(im, baseline)
+
+  baseline$run()
+  im$run()
+  expect_equal(im$codelength, baseline$codelength, tolerance = 1e-10)
+})
+
+test_that("add_multilayer_links accepts matrix input through bulk path", {
+  links <- matrix(
+    c(1, 1, 1, 2, 2,
+      1, 2, 2, 1, 1,
+      2, 1, 2, 2, 3),
+    ncol = 5L,
+    byrow = TRUE
+  )
+
+  baseline <- Infomap(silent = TRUE)
+  for (i in seq_len(nrow(links))) {
+    baseline$add_multilayer_link(links[i, 1:2], links[i, 3:4], links[i, 5])
+  }
+
+  im <- Infomap(silent = TRUE)
+  im$add_multilayer_links(links)
+
+  expect_same_multilayer_links(im, baseline)
+})
+
+test_that("add_multilayer_links accepts unweighted matrix input", {
+  links <- matrix(
+    c(1, 1, 1, 2,
+      1, 2, 2, 1,
+      2, 1, 2, 2),
+    ncol = 4L,
+    byrow = TRUE
+  )
+
+  baseline <- Infomap(silent = TRUE)
+  for (i in seq_len(nrow(links))) {
+    baseline$add_multilayer_link(links[i, 1:2], links[i, 3:4])
+  }
+
+  im <- Infomap(silent = TRUE)
+  im$add_multilayer_links(links)
+
+  expect_same_multilayer_links(im, baseline)
+})
+
 test_that("add_igraph rejects diagonal multilayer links by default", {
   skip_if_not_installed("igraph")
 

--- a/interfaces/python/generated/infomap_wrap.cpp
+++ b/interfaces/python/generated/infomap_wrap.cpp
@@ -42342,6 +42342,109 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_Network_addMultilayerLinks(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  infomap::Network *arg1 = 0 ;
+  std::vector< unsigned int,std::allocator< unsigned int > > *arg2 = 0 ;
+  std::vector< unsigned int,std::allocator< unsigned int > > *arg3 = 0 ;
+  std::vector< unsigned int,std::allocator< unsigned int > > *arg4 = 0 ;
+  std::vector< unsigned int,std::allocator< unsigned int > > *arg5 = 0 ;
+  std::vector< double,std::allocator< double > > *arg6 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 = SWIG_OLDOBJ ;
+  int res3 = SWIG_OLDOBJ ;
+  int res4 = SWIG_OLDOBJ ;
+  int res5 = SWIG_OLDOBJ ;
+  int res6 = SWIG_OLDOBJ ;
+  PyObject *swig_obj[6] ;
+  
+  (void)self;
+  if (!SWIG_Python_UnpackTuple(args, "Network_addMultilayerLinks", 6, 6, swig_obj)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__Network, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Network_addMultilayerLinks" "', argument " "1"" of type '" "infomap::Network *""'"); 
+  }
+  arg1 = reinterpret_cast< infomap::Network * >(argp1);
+  {
+    std::vector< unsigned int,std::allocator< unsigned int > > *ptr = (std::vector< unsigned int,std::allocator< unsigned int > > *)0;
+    res2 = swig::asptr(swig_obj[1], &ptr);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Network_addMultilayerLinks" "', argument " "2"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "Network_addMultilayerLinks" "', argument " "2"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+    }
+    arg2 = ptr;
+  }
+  {
+    std::vector< unsigned int,std::allocator< unsigned int > > *ptr = (std::vector< unsigned int,std::allocator< unsigned int > > *)0;
+    res3 = swig::asptr(swig_obj[2], &ptr);
+    if (!SWIG_IsOK(res3)) {
+      SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "Network_addMultilayerLinks" "', argument " "3"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "Network_addMultilayerLinks" "', argument " "3"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+    }
+    arg3 = ptr;
+  }
+  {
+    std::vector< unsigned int,std::allocator< unsigned int > > *ptr = (std::vector< unsigned int,std::allocator< unsigned int > > *)0;
+    res4 = swig::asptr(swig_obj[3], &ptr);
+    if (!SWIG_IsOK(res4)) {
+      SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "Network_addMultilayerLinks" "', argument " "4"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "Network_addMultilayerLinks" "', argument " "4"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+    }
+    arg4 = ptr;
+  }
+  {
+    std::vector< unsigned int,std::allocator< unsigned int > > *ptr = (std::vector< unsigned int,std::allocator< unsigned int > > *)0;
+    res5 = swig::asptr(swig_obj[4], &ptr);
+    if (!SWIG_IsOK(res5)) {
+      SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "Network_addMultilayerLinks" "', argument " "5"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "Network_addMultilayerLinks" "', argument " "5"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+    }
+    arg5 = ptr;
+  }
+  {
+    std::vector< double,std::allocator< double > > *ptr = (std::vector< double,std::allocator< double > > *)0;
+    res6 = swig::asptr(swig_obj[5], &ptr);
+    if (!SWIG_IsOK(res6)) {
+      SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "Network_addMultilayerLinks" "', argument " "6"" of type '" "std::vector< double,std::allocator< double > > const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "Network_addMultilayerLinks" "', argument " "6"" of type '" "std::vector< double,std::allocator< double > > const &""'"); 
+    }
+    arg6 = ptr;
+  }
+  {
+    try {
+      (arg1)->addMultilayerLinks((std::vector< unsigned int,std::allocator< unsigned int > > const &)*arg2,(std::vector< unsigned int,std::allocator< unsigned int > > const &)*arg3,(std::vector< unsigned int,std::allocator< unsigned int > > const &)*arg4,(std::vector< unsigned int,std::allocator< unsigned int > > const &)*arg5,(std::vector< double,std::allocator< double > > const &)*arg6);
+    } catch (const std::exception& e) {
+      SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+  }
+  resultobj = SWIG_Py_Void();
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  if (SWIG_IsNewObj(res3)) delete arg3;
+  if (SWIG_IsNewObj(res4)) delete arg4;
+  if (SWIG_IsNewObj(res5)) delete arg5;
+  if (SWIG_IsNewObj(res6)) delete arg6;
+  return resultobj;
+fail:
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  if (SWIG_IsNewObj(res3)) delete arg3;
+  if (SWIG_IsNewObj(res4)) delete arg4;
+  if (SWIG_IsNewObj(res5)) delete arg5;
+  if (SWIG_IsNewObj(res6)) delete arg6;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_Network_addMultilayerIntraLink(PyObject *self, PyObject *args) {
   PyObject *resultobj = 0;
   infomap::Network *arg1 = 0 ;
@@ -56090,6 +56193,109 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_InfomapWrapper_addMultilayerLinks(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  infomap::InfomapWrapper *arg1 = 0 ;
+  std::vector< unsigned int,std::allocator< unsigned int > > *arg2 = 0 ;
+  std::vector< unsigned int,std::allocator< unsigned int > > *arg3 = 0 ;
+  std::vector< unsigned int,std::allocator< unsigned int > > *arg4 = 0 ;
+  std::vector< unsigned int,std::allocator< unsigned int > > *arg5 = 0 ;
+  std::vector< double,std::allocator< double > > *arg6 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 = SWIG_OLDOBJ ;
+  int res3 = SWIG_OLDOBJ ;
+  int res4 = SWIG_OLDOBJ ;
+  int res5 = SWIG_OLDOBJ ;
+  int res6 = SWIG_OLDOBJ ;
+  PyObject *swig_obj[6] ;
+  
+  (void)self;
+  if (!SWIG_Python_UnpackTuple(args, "InfomapWrapper_addMultilayerLinks", 6, 6, swig_obj)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__InfomapWrapper, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapWrapper_addMultilayerLinks" "', argument " "1"" of type '" "infomap::InfomapWrapper *""'"); 
+  }
+  arg1 = reinterpret_cast< infomap::InfomapWrapper * >(argp1);
+  {
+    std::vector< unsigned int,std::allocator< unsigned int > > *ptr = (std::vector< unsigned int,std::allocator< unsigned int > > *)0;
+    res2 = swig::asptr(swig_obj[1], &ptr);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "InfomapWrapper_addMultilayerLinks" "', argument " "2"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "InfomapWrapper_addMultilayerLinks" "', argument " "2"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+    }
+    arg2 = ptr;
+  }
+  {
+    std::vector< unsigned int,std::allocator< unsigned int > > *ptr = (std::vector< unsigned int,std::allocator< unsigned int > > *)0;
+    res3 = swig::asptr(swig_obj[2], &ptr);
+    if (!SWIG_IsOK(res3)) {
+      SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "InfomapWrapper_addMultilayerLinks" "', argument " "3"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "InfomapWrapper_addMultilayerLinks" "', argument " "3"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+    }
+    arg3 = ptr;
+  }
+  {
+    std::vector< unsigned int,std::allocator< unsigned int > > *ptr = (std::vector< unsigned int,std::allocator< unsigned int > > *)0;
+    res4 = swig::asptr(swig_obj[3], &ptr);
+    if (!SWIG_IsOK(res4)) {
+      SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "InfomapWrapper_addMultilayerLinks" "', argument " "4"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "InfomapWrapper_addMultilayerLinks" "', argument " "4"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+    }
+    arg4 = ptr;
+  }
+  {
+    std::vector< unsigned int,std::allocator< unsigned int > > *ptr = (std::vector< unsigned int,std::allocator< unsigned int > > *)0;
+    res5 = swig::asptr(swig_obj[4], &ptr);
+    if (!SWIG_IsOK(res5)) {
+      SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "InfomapWrapper_addMultilayerLinks" "', argument " "5"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "InfomapWrapper_addMultilayerLinks" "', argument " "5"" of type '" "std::vector< unsigned int,std::allocator< unsigned int > > const &""'"); 
+    }
+    arg5 = ptr;
+  }
+  {
+    std::vector< double,std::allocator< double > > *ptr = (std::vector< double,std::allocator< double > > *)0;
+    res6 = swig::asptr(swig_obj[5], &ptr);
+    if (!SWIG_IsOK(res6)) {
+      SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "InfomapWrapper_addMultilayerLinks" "', argument " "6"" of type '" "std::vector< double,std::allocator< double > > const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "InfomapWrapper_addMultilayerLinks" "', argument " "6"" of type '" "std::vector< double,std::allocator< double > > const &""'"); 
+    }
+    arg6 = ptr;
+  }
+  {
+    try {
+      (arg1)->addMultilayerLinks((std::vector< unsigned int,std::allocator< unsigned int > > const &)*arg2,(std::vector< unsigned int,std::allocator< unsigned int > > const &)*arg3,(std::vector< unsigned int,std::allocator< unsigned int > > const &)*arg4,(std::vector< unsigned int,std::allocator< unsigned int > > const &)*arg5,(std::vector< double,std::allocator< double > > const &)*arg6);
+    } catch (const std::exception& e) {
+      SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+  }
+  resultobj = SWIG_Py_Void();
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  if (SWIG_IsNewObj(res3)) delete arg3;
+  if (SWIG_IsNewObj(res4)) delete arg4;
+  if (SWIG_IsNewObj(res5)) delete arg5;
+  if (SWIG_IsNewObj(res6)) delete arg6;
+  return resultobj;
+fail:
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  if (SWIG_IsNewObj(res3)) delete arg3;
+  if (SWIG_IsNewObj(res4)) delete arg4;
+  if (SWIG_IsNewObj(res5)) delete arg5;
+  if (SWIG_IsNewObj(res6)) delete arg6;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_InfomapWrapper_addMultilayerIntraLink(PyObject *self, PyObject *args) {
   PyObject *resultobj = 0;
   infomap::InfomapWrapper *arg1 = 0 ;
@@ -57824,6 +58030,7 @@ static PyMethodDef SwigMethods[] = {
 	 { "Network_simulateInterLayerLinks", _wrap_Network_simulateInterLayerLinks, METH_O, NULL},
 	 { "Network_addMultilayerNode", _wrap_Network_addMultilayerNode, METH_VARARGS, NULL},
 	 { "Network_addMultilayerLink", _wrap_Network_addMultilayerLink, METH_VARARGS, NULL},
+	 { "Network_addMultilayerLinks", _wrap_Network_addMultilayerLinks, METH_VARARGS, NULL},
 	 { "Network_addMultilayerIntraLink", _wrap_Network_addMultilayerIntraLink, METH_VARARGS, NULL},
 	 { "Network_addMultilayerInterLink", _wrap_Network_addMultilayerInterLink, METH_VARARGS, NULL},
 	 { "Network_addMetaData", _wrap_Network_addMetaData, METH_VARARGS, NULL},
@@ -58096,6 +58303,7 @@ static PyMethodDef SwigMethods[] = {
 	 { "InfomapWrapper_addLink", _wrap_InfomapWrapper_addLink, METH_VARARGS, NULL},
 	 { "InfomapWrapper_addLinks", _wrap_InfomapWrapper_addLinks, METH_VARARGS, NULL},
 	 { "InfomapWrapper_addMultilayerLink", _wrap_InfomapWrapper_addMultilayerLink, METH_VARARGS, NULL},
+	 { "InfomapWrapper_addMultilayerLinks", _wrap_InfomapWrapper_addMultilayerLinks, METH_VARARGS, NULL},
 	 { "InfomapWrapper_addMultilayerIntraLink", _wrap_InfomapWrapper_addMultilayerIntraLink, METH_VARARGS, NULL},
 	 { "InfomapWrapper_addMultilayerInterLink", _wrap_InfomapWrapper_addMultilayerInterLink, METH_VARARGS, NULL},
 	 { "InfomapWrapper_setBipartiteStartId", _wrap_InfomapWrapper_setBipartiteStartId, METH_VARARGS, NULL},

--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -712,10 +712,92 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin, InfomapWrapper):  # no
         ----------
         links : iterable of tuples
             Iterable of tuples of the form
-            ``(source_node, target_node, [weight])``
+            ``(source_node, target_node, [weight])``. NumPy arrays must be
+            2-dimensional with 4 or 5 columns of the form
+            ``(source_layer_id, source_node_id, target_layer_id,
+            target_node_id, [weight])``.
         """
+        if links.__class__.__module__.startswith("numpy"):
+            try:
+                import numpy as np
+            except ImportError:
+                pass
+            else:
+                links_array = np.asarray(links)
+                if links_array.ndim != 2:
+                    raise ValueError(
+                        "Numpy multilayer link arrays must be 2D with 4 or 5 columns."
+                    )
+                if links_array.shape[1] not in (4, 5):
+                    raise ValueError(
+                        "Numpy multilayer link arrays must have 4 or 5 columns: "
+                        "(source_layer_id, source_node_id, target_layer_id, "
+                        "target_node_id, [weight])."
+                    )
+
+                source_layer_ids = links_array[:, 0].astype(np.uint32, copy=False).tolist()
+                source_node_ids = links_array[:, 1].astype(np.uint32, copy=False).tolist()
+                target_layer_ids = links_array[:, 2].astype(np.uint32, copy=False).tolist()
+                target_node_ids = links_array[:, 3].astype(np.uint32, copy=False).tolist()
+                if links_array.shape[1] == 5:
+                    weights = links_array[:, 4].astype(np.float64, copy=False).tolist()
+                else:
+                    weights = [1.0] * links_array.shape[0]
+
+                return super().addMultilayerLinks(
+                    source_layer_ids,
+                    source_node_ids,
+                    target_layer_ids,
+                    target_node_ids,
+                    weights,
+                )
+
+        source_layer_ids = []
+        source_node_ids = []
+        target_layer_ids = []
+        target_node_ids = []
+        weights = []
+
         for link in links:
-            self.add_multilayer_link(*link)
+            try:
+                link_length = len(link)
+            except TypeError as err:
+                raise ValueError(
+                    "Each multilayer link must be a sequence of 2 or 3 values."
+                ) from err
+
+            if link_length == 2:
+                source_node, target_node = link
+                weight = 1.0
+            elif link_length == 3:
+                source_node, target_node, weight = link
+            else:
+                raise ValueError(
+                    "Each multilayer link must contain 2 or 3 values: "
+                    "(source_node, target_node, [weight])."
+                )
+
+            try:
+                source_layer_id, source_node_id = source_node
+                target_layer_id, target_node_id = target_node
+            except (TypeError, ValueError) as err:
+                raise ValueError(
+                    "Each multilayer node must contain 2 values: (layer_id, node_id)."
+                ) from err
+
+            source_layer_ids.append(source_layer_id)
+            source_node_ids.append(source_node_id)
+            target_layer_ids.append(target_layer_id)
+            target_node_ids.append(target_node_id)
+            weights.append(weight)
+
+        return super().addMultilayerLinks(
+            source_layer_ids,
+            source_node_ids,
+            target_layer_ids,
+            target_node_ids,
+            weights,
+        )
 
     def remove_multilayer_link(self):
         raise NotImplementedError(

--- a/interfaces/python/src/infomap/_swig.py
+++ b/interfaces/python/src/infomap/_swig.py
@@ -2210,6 +2210,9 @@ class Network(StateNetwork):
     def addMultilayerLink(self, *args):
         return _infomap.Network_addMultilayerLink(self, *args)
 
+    def addMultilayerLinks(self, sourceLayerIds, sourceNodeIds, targetLayerIds, targetNodeIds, weights):
+        return _infomap.Network_addMultilayerLinks(self, sourceLayerIds, sourceNodeIds, targetLayerIds, targetNodeIds, weights)
+
     def addMultilayerIntraLink(self, layer, n1, n2, weight):
         return _infomap.Network_addMultilayerIntraLink(self, layer, n1, n2, weight)
 
@@ -3039,6 +3042,9 @@ class InfomapWrapper(InfomapBase):
 
     def addMultilayerLink(self, layer1, n1, layer2, n2, weight=1.0):
         return _infomap.InfomapWrapper_addMultilayerLink(self, layer1, n1, layer2, n2, weight)
+
+    def addMultilayerLinks(self, sourceLayerIds, sourceNodeIds, targetLayerIds, targetNodeIds, weights):
+        return _infomap.InfomapWrapper_addMultilayerLinks(self, sourceLayerIds, sourceNodeIds, targetLayerIds, targetNodeIds, weights)
 
     def addMultilayerIntraLink(self, layer, n1, n2, weight):
         return _infomap.InfomapWrapper_addMultilayerIntraLink(self, layer, n1, n2, weight)

--- a/src/Infomap.h
+++ b/src/Infomap.h
@@ -56,6 +56,15 @@ public:
   void addLink(unsigned int sourceId, unsigned int targetId, unsigned long weight) { m_network.addLink(sourceId, targetId, weight); }
   void addLinks(const std::vector<unsigned int>& sourceIds, const std::vector<unsigned int>& targetIds, const std::vector<double>& weights) { m_network.addLinks(sourceIds, targetIds, weights); }
   void addMultilayerLink(unsigned int layer1, unsigned int n1, unsigned int layer2, unsigned int n2, double weight = 1.0) { m_network.addMultilayerLink(layer1, n1, layer2, n2, weight); }
+  void addMultilayerLinks(const std::vector<unsigned int>& sourceLayerIds,
+                          const std::vector<unsigned int>& sourceNodeIds,
+                          const std::vector<unsigned int>& targetLayerIds,
+                          const std::vector<unsigned int>& targetNodeIds,
+                          const std::vector<double>& weights)
+  {
+    m_network.addMultilayerLinks(sourceLayerIds, sourceNodeIds, targetLayerIds, targetNodeIds,
+                                 weights);
+  }
   void addMultilayerIntraLink(unsigned int layer, unsigned int n1, unsigned int n2, double weight) { m_network.addMultilayerIntraLink(layer, n1, n2, weight); }
   void addMultilayerInterLink(unsigned int layer1, unsigned int n, unsigned int layer2, double interWeight) { m_network.addMultilayerInterLink(layer1, n, layer2, interWeight); }
 

--- a/src/io/Network.cpp
+++ b/src/io/Network.cpp
@@ -14,6 +14,7 @@
 
 #include <cmath>
 #include <algorithm>
+#include <stdexcept>
 
 namespace infomap {
 
@@ -547,6 +548,24 @@ void Network::addMultilayerLink(unsigned int stateId1, unsigned int layer1, unsi
   }
 
   addLink(stateId1, stateId2, weight);
+}
+
+void Network::addMultilayerLinks(const std::vector<unsigned int>& sourceLayerIds,
+                                 const std::vector<unsigned int>& sourceNodeIds,
+                                 const std::vector<unsigned int>& targetLayerIds,
+                                 const std::vector<unsigned int>& targetNodeIds,
+                                 const std::vector<double>& weights)
+{
+  if (sourceLayerIds.size() != sourceNodeIds.size() ||
+      sourceLayerIds.size() != targetLayerIds.size() ||
+      sourceLayerIds.size() != targetNodeIds.size() ||
+      sourceLayerIds.size() != weights.size()) {
+    throw std::invalid_argument("sourceLayerIds, sourceNodeIds, targetLayerIds, targetNodeIds, and weights must have the same length");
+  }
+
+  for (std::size_t i = 0; i < sourceLayerIds.size(); ++i) {
+    addMultilayerLink(sourceLayerIds[i], sourceNodeIds[i], targetLayerIds[i], targetNodeIds[i], weights[i]);
+  }
 }
 
 void Network::generateStateNetworkFromMultilayer()

--- a/src/io/Network.h
+++ b/src/io/Network.h
@@ -119,6 +119,11 @@ public:
 
   void addMultilayerLink(unsigned int layer1, unsigned int n1, unsigned int layer2, unsigned int n2, double weight);
   void addMultilayerLink(unsigned int stateId1, unsigned int layer1, unsigned int n1, unsigned int stateId2, unsigned int layer2, unsigned int n2, double weight);
+  void addMultilayerLinks(const std::vector<unsigned int>& sourceLayerIds,
+                          const std::vector<unsigned int>& sourceNodeIds,
+                          const std::vector<unsigned int>& targetLayerIds,
+                          const std::vector<unsigned int>& targetNodeIds,
+                          const std::vector<double>& weights);
 
   /**
    * Create an intra-layer link

--- a/test/python/test_add_multilayer_links.py
+++ b/test/python/test_add_multilayer_links.py
@@ -1,0 +1,109 @@
+import pytest
+from infomap import MultilayerNode
+
+
+pytestmark = pytest.mark.fast
+
+
+def assert_same_multilayer_links(actual, expected):
+    assert actual.num_links == expected.num_links
+    assert actual.num_nodes == expected.num_nodes
+    assert actual.num_physical_nodes == expected.num_physical_nodes
+    assert sorted(actual.get_links()) == sorted(expected.get_links())
+
+
+def test_add_multilayer_links_matches_repeated_add_multilayer_link(make_infomap):
+    links = [
+        ((0, 1), (1, 2), 1.5),
+        ((0, 3), (1, 2), 2.0),
+        (MultilayerNode(layer_id=1, node_id=2), MultilayerNode(layer_id=2, node_id=4), 3.0),
+    ]
+
+    baseline = make_infomap()
+    for link in links:
+        baseline.add_multilayer_link(*link)
+
+    im = make_infomap()
+    im.add_multilayer_links(links)
+
+    assert_same_multilayer_links(im, baseline)
+
+
+def test_add_multilayer_links_uses_default_weight(make_infomap):
+    links = [((0, 1), (1, 2)), ((0, 3), (1, 2))]
+
+    baseline = make_infomap()
+    for link in links:
+        baseline.add_multilayer_link(*link)
+
+    im = make_infomap()
+    im.add_multilayer_links(links)
+
+    assert_same_multilayer_links(im, baseline)
+
+
+def test_add_multilayer_links_accepts_weighted_numpy_array(make_infomap):
+    np = pytest.importorskip("numpy")
+    links = np.array(
+        [
+            [0, 1, 1, 2, 1.5],
+            [0, 3, 1, 2, 2.0],
+            [1, 2, 2, 4, 3.0],
+        ]
+    )
+
+    baseline = make_infomap()
+    for source_layer, source_node, target_layer, target_node, weight in links.tolist():
+        baseline.add_multilayer_link(
+            (source_layer, source_node), (target_layer, target_node), weight
+        )
+
+    im = make_infomap()
+    im.add_multilayer_links(links)
+
+    assert_same_multilayer_links(im, baseline)
+
+
+def test_add_multilayer_links_accepts_unweighted_numpy_array(make_infomap):
+    np = pytest.importorskip("numpy")
+    links = np.array([[0, 1, 1, 2], [0, 3, 1, 2]], dtype=np.uint32)
+
+    baseline = make_infomap()
+    for source_layer, source_node, target_layer, target_node in links.tolist():
+        baseline.add_multilayer_link((source_layer, source_node), (target_layer, target_node))
+
+    im = make_infomap()
+    im.add_multilayer_links(links)
+
+    assert_same_multilayer_links(im, baseline)
+
+
+def test_add_multilayer_links_rejects_invalid_link_lengths(make_infomap):
+    im = make_infomap()
+
+    with pytest.raises(ValueError, match="2 or 3 values"):
+        im.add_multilayer_links([((0, 1),)])
+
+    with pytest.raises(ValueError, match="2 or 3 values"):
+        im.add_multilayer_links([((0, 1), (1, 2), 1.0, 2.0)])
+
+
+def test_add_multilayer_links_rejects_invalid_node_lengths(make_infomap):
+    im = make_infomap()
+
+    with pytest.raises(ValueError, match="multilayer node.*2 values"):
+        im.add_multilayer_links([((0,), (1, 2))])
+
+    with pytest.raises(ValueError, match="multilayer node.*2 values"):
+        im.add_multilayer_links([((0, 1), (1, 2, 3))])
+
+
+def test_add_multilayer_links_rejects_invalid_numpy_shapes(make_infomap):
+    np = pytest.importorskip("numpy")
+    im = make_infomap()
+
+    with pytest.raises(ValueError, match="2D"):
+        im.add_multilayer_links(np.array([0, 1, 1, 2]))
+
+    with pytest.raises(ValueError, match="4 or 5 columns"):
+        im.add_multilayer_links(np.array([[0, 1, 1]]))


### PR DESCRIPTION
## Summary

Closes #495.

Adds a native bulk path for full multilayer links so Python and R `add_multilayer_links()` no longer call `add_multilayer_link()` once per link.

Changes:
- Add `Network::addMultilayerLinks(...)` and `InfomapWrapper::addMultilayerLinks(...)`.
- Expose the new bulk method through regenerated Python and R SWIG outputs.
- Update `interfaces/python/src/infomap/_facade.py` to batch tuple/list input and NumPy arrays with 4 or 5 columns.
- Update `interfaces/R/infomap/R/Infomap.R` to batch list input plus 4- or 5-column matrix/data.frame input.
- Add Python and R regression tests comparing bulk input with repeated `add_multilayer_link()` calls.
- Refresh generated Python docs and R Rd output.

## Benchmark

Local Python smoke benchmark on macOS, Python 3.14.3, 100k full multilayer links, best of 3 runs:

| Method | Best time | Speedup vs loop |
| --- | ---: | ---: |
| `add_multilayer_link` loop | 0.1226s | 1.00x |
| `add_multilayer_links` list | 0.0875s | 1.40x |
| `add_multilayer_links` NumPy | 0.0803s | 1.53x |

Local R smoke benchmark on macOS, R 4.6.0, 100k full multilayer links, best of 3 runs:

| Method | Best time | Speedup vs loop |
| --- | ---: | ---: |
| `add_multilayer_link` loop | 3.0790s | 1.00x |
| `add_multilayer_links` list | 0.6980s | 4.41x |
| `add_multilayer_links` matrix | 0.0710s | 43.37x |

Benchmark commands generated unique full multilayer links and asserted `num_links == 100000` after each run.

## Verification

- `make build-native`
- `make build-python-swig build-r-swig`
- `make test-python-swig-freshness test-r-swig-freshness`
- `make PYTHON=.venv/bin/python PIP=.venv/bin/pip PYTEST=.venv/bin/pytest build-python`
- `make PYTHON=.venv/bin/python PIP=.venv/bin/pip PYTEST=.venv/bin/pytest dev-python-install`
- `make PYTHON=.venv/bin/python PIP=.venv/bin/pip PYTEST=.venv/bin/pytest test-python-unit PYTEST_ARGS='test/python/test_add_multilayer_links.py'`
- `.venv/bin/ruff check interfaces/python/src/infomap/_facade.py test/python/test_add_multilayer_links.py`
- `Rscript -e 'roxygen2::roxygenise("interfaces/R/infomap")'`
- `make test-r-examples`
- `make PYTHON=.venv/bin/python PIP=.venv/bin/pip build-docs`
- `make PYTHON=.venv/bin/python PIP=.venv/bin/pip test-docs`

`make test-r` completed with 0 errors and testthat OK, but exits non-zero locally because this environment lacks `checkbashisms` and `pandoc`, producing the existing top-level-file warning plus the CRAN incoming note.