### PR TITLE
fix: use release token for release-please tags

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,9 +22,18 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Create release app token
+        id: release-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
+
       - name: Create or update release PR
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Release Please creates the version tag that triggers release.yml.
+          # GITHUB_TOKEN-created tag events do not start follow-up workflows.
+          token: ${{ steps.release-token.outputs.token }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -41,10 +41,19 @@ Configure these integrations before the first release:
    `infomap-v2.9.2`. If Release Please is allowed to add the component
    prefix, the first release PR after the migration can re-include already
    released commits and generate an overlapping `CHANGELOG.md`.
-7. Confirm that GitHub Actions can publish this repository's package to GHCR.
+7. Confirm the Release Please GitHub App is configured through these
+   repository secrets:
+   - `RELEASE_PLEASE_APP_ID`
+   - `RELEASE_PLEASE_PRIVATE_KEY`
+
+   The app needs repository permissions for contents, pull requests, and
+   issues. Do not use the default `GITHUB_TOKEN` for Release Please: tags
+   created with `GITHUB_TOKEN` do not trigger the follow-up `release.yml`
+   workflow that publishes packages.
+8. Confirm that GitHub Actions can publish this repository's package to GHCR.
    The release workflow uses `GITHUB_TOKEN` with `packages: write` permission
    and publishes `ghcr.io/mapequation/infomap`.
-8. Add repository dispatch tokens for downstream update workflows:
+9. Add repository dispatch tokens for downstream update workflows:
    - `HOMEBREW_INFOMAP_REPO_DISPATCH_TOKEN`
    - `INFOMAP_ONLINE_REPO_DISPATCH_TOKEN`
 
@@ -90,6 +99,11 @@ Configure these integrations before the first release:
 
    The R package is also continuously published by r-universe from
    `master`; the release workflow does not push to r-universe directly.
+
+   `workflow_dispatch` for `.github/workflows/release.yml` is intentionally a
+   partial recovery path. It rebuilds and re-attaches GitHub Release assets and
+   republishes GHCR images for an existing tag, but PyPI, npm, Homebrew, and
+   `infomap-online` publishing are gated to tag `push` events.
 
 ## R Package Publishing
 


### PR DESCRIPTION
## Summary
- Create a GitHub App installation token for Release Please using `actions/create-github-app-token`.
- Pass that App token to Release Please instead of `secrets.GITHUB_TOKEN`.
- Document why the release tag must be created by a non-default token so `.github/workflows/release.yml` can run on the tag push.
- Update `RELEASING.md` with the required App secrets, permission check, and the limits of manual `workflow_dispatch` recovery.

## Root cause
Release Please creates the `vX.Y.Z` tag that is supposed to trigger `.github/workflows/release.yml`. Tags created with the default `GITHUB_TOKEN` do not start follow-up GitHub Actions workflows, so merging the release PR would create the release tag without running the package publishing workflow.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-please.yml"); puts "release-please.yml parses"'`
- `actionlint .github/workflows/release-please.yml`

## Deployment note
Before merging the next Release Please PR, confirm these repository secrets are configured for the existing Release Please GitHub App:

- `RELEASE_PLEASE_APP_ID`
- `RELEASE_PLEASE_PRIVATE_KEY`

The app needs repository permissions for contents, pull requests, and issues.