### PR TITLE
build(ci): gate release publishing on package tests

### DIFF
--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -220,8 +220,8 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==3.3.1
+      - name: Install Python release tooling
+        run: python -m pip install --group release
 
       - name: Install macOS OpenMP runtime
         if: startsWith(matrix.os, 'macos')
@@ -232,29 +232,13 @@ jobs:
         env:
           CIBW_BUILD: "cp311-* cp312-* cp313-* cp314-*"
           CIBW_SKIP: "*-musllinux* pp*"
+          CIBW_TEST_COMMAND: >-
+            python -c "from infomap import Infomap; print(Infomap(silent=True).num_top_modules)"
           CIBW_ENVIRONMENT_MACOS: >-
             CXX=/usr/bin/clang++
             MACOSX_DEPLOYMENT_TARGET=15.0
             CPPFLAGS="-I$(brew --prefix libomp)/include"
             LDFLAGS="-L$(brew --prefix libomp)/lib"
-
-      - name: Smoke test representative wheel
-        run: |
-          python -m venv .venv-wheel
-          if [ "${{ runner.os }}" = "Windows" ]; then
-            venv_python=".venv-wheel/Scripts/python.exe"
-          else
-            venv_python=".venv-wheel/bin/python"
-          fi
-          wheel="$(find wheelhouse -maxdepth 1 -name '*cp314*.whl' | head -n 1)"
-          [ -n "$wheel" ]
-          "$venv_python" -m pip install --upgrade pip
-          "$venv_python" -m pip install "$wheel"
-          "$venv_python" - <<'PY'
-          from infomap import Infomap
-          print(Infomap(silent=True).num_top_modules)
-          PY
-        shell: bash
 
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/_r-package.yml
+++ b/.github/workflows/_r-package.yml
@@ -199,6 +199,11 @@ jobs:
         with:
           python-version: "3.14"
 
+      - name: Install R package dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          working-directory: interfaces/R/infomap
+
       - name: Download R source tarball
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
     uses: ./.github/workflows/_python-package.yml
     with:
       ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
-      run-tests: false
+      run-tests: true
       build-release-artifacts: true
 
   javascript:
@@ -43,7 +43,7 @@ jobs:
     uses: ./.github/workflows/_r-package.yml
     with:
       ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
-      run-tests: false
+      run-tests: true
       build-release-artifacts: true
 
   publish-github-release:
@@ -296,9 +296,9 @@ jobs:
           version="${RELEASE_TAG#v}"
           gh api repos/mapequation/homebrew-infomap/dispatches \
             -f event_type=infomap_release_published \
-            -F client_payload[version]="$version" \
-            -F client_payload[release_tag]="$RELEASE_TAG" \
-            -F client_payload[release_url]="https://github.com/${{ github.repository }}/releases/tag/$RELEASE_TAG"
+            -F "client_payload[version]=$version" \
+            -F "client_payload[release_tag]=$RELEASE_TAG" \
+            -F "client_payload[release_url]=https://github.com/${{ github.repository }}/releases/tag/$RELEASE_TAG"
 
   notify-infomap-online:
     name: Notify infomap-online
@@ -318,7 +318,7 @@ jobs:
           version="${RELEASE_TAG#v}"
           gh api repos/mapequation/infomap-online/dispatches \
             -f event_type=infomap_release_published \
-            -f client_payload[package]=@mapequation/infomap \
-            -F client_payload[version]="$version" \
-            -F client_payload[release_tag]="$RELEASE_TAG" \
-            -F client_payload[release_url]="https://github.com/${{ github.repository }}/releases/tag/$RELEASE_TAG"
+            -f "client_payload[package]=@mapequation/infomap" \
+            -F "client_payload[version]=$version" \
+            -F "client_payload[release_tag]=$RELEASE_TAG" \
+            -F "client_payload[release_url]=https://github.com/${{ github.repository }}/releases/tag/$RELEASE_TAG"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,14 @@ release = [
   "wheel",
 ]
 
+[dependency-groups]
+release = [
+  "build",
+  "cibuildwheel==3.3.1",
+  "twine",
+  "wheel",
+]
+
 [project.scripts]
 infomap = "infomap:main"
 


### PR DESCRIPTION
## Summary
- Run Python and R test jobs during tag-driven releases before publish jobs can proceed.
- Install Python release tooling with `python -m pip install --group release`, backed by a `pyproject.toml` dependency group, so the tooling source stays in `pyproject.toml` without installing `infomap` itself.
- Move Python wheel smoke testing into `cibuildwheel` via `CIBW_TEST_COMMAND`, so each wheel is tested in its matching Python/platform environment.
- Install R package dependencies from `interfaces/R/infomap/DESCRIPTION` before building R binary artifacts.
- Quote downstream dispatch payload fields so `actionlint`/shellcheck can validate the release workflow.

## Root cause
The first `v2.10.0` release workflow reached the tag-triggered release path, but failed before publishing. The Windows Python wheel smoke test selected the first `cp314` wheel, which could be `win32` on a 64-bit runner, and the R binary jobs tried to install the release tarball without installing runtime imports such as `R6`. Release also skipped Python/R test jobs because both reusable workflows were called with `run-tests: false`.

## Validation
- `ruby -e 'require "yaml"; %w[.github/workflows/release.yml .github/workflows/_python-package.yml .github/workflows/_r-package.yml].each { |f| YAML.load_file(f); puts "#{f} parses" }'`
- `actionlint .github/workflows/release.yml .github/workflows/_python-package.yml .github/workflows/_r-package.yml`
- `python -m pip install --dry-run --group release` in a temporary venv