### PR TITLE
build(ci): install python cibuildwheel directly in release.yml

### DIFF
--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -221,7 +221,7 @@ jobs:
           python-version: "3.14"
 
       - name: Install Python release tooling
-        run: python -m pip install --group release
+        run: python -m pip install build cibuildwheel==3.3.1 twine wheel
 
       - name: Install macOS OpenMP runtime
         if: startsWith(matrix.os, 'macos')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,14 +61,6 @@ release = [
   "wheel",
 ]
 
-[dependency-groups]
-release = [
-  "build",
-  "cibuildwheel==3.3.1",
-  "twine",
-  "wheel",
-]
-
 [project.scripts]
 infomap = "infomap:main"
 


### PR DESCRIPTION
## Summary

- install Python release build tools directly in `.github/workflows/_python-package.yml`
- remove the duplicate `[dependency-groups]` release tooling metadata from `pyproject.toml`

## Why

Manual `workflow_dispatch` release runs can use the current workflow from `master` while checking out an older release tag for the package sources. That means release tooling bootstrap cannot rely on metadata that only exists in newer tagged source trees. The existing `project.optional-dependencies.release` extra remains for local developer setup, but the workflow now bootstraps its own tools explicitly.

## Verification

- `ruby -e 'require "yaml"; %w[.github/workflows/release.yml .github/workflows/_python-package.yml .github/workflows/_r-package.yml].each { |f| YAML.load_file(f); puts "#{f} parses" }'`\n- `actionlint .github/workflows/release.yml .github/workflows/_python-package.yml .github/workflows/_r-package.yml`\n- `python3 -m venv ...` plus `python -m pip install --dry-run build cibuildwheel==3.3.1 twine wheel`\n\nNot verified: full release workflow, because publishing requires GitHub Actions environments and release secrets.