### PR TITLE
build(ci): set up release artifact verification without checkout

### DIFF
--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -258,8 +258,6 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
-          cache: pip
-          cache-dependency-path: pyproject.toml
 
       - name: Download sdist
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
## Summary

- remove pip cache configuration from the Python release artifact verification job

## Why

`verify-release-artifacts` does not check out the repository; it only downloads and smoke-tests artifacts produced by earlier jobs. With `cache-dependency-path: pyproject.toml`, `actions/setup-python` fails before artifact download because there is no `pyproject.toml` in the empty workspace.

Keeping this job checkout-free also avoids coupling manual release dispatch recovery to files from the checked-out release tag.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/_python-package.yml"); puts ".github/workflows/_python-package.yml parses"'`\n- `actionlint .github/workflows/_python-package.yml .github/workflows/release.yml`\n\nNot verified: full release workflow; requires GitHub Actions release environment and artifacts from a live run.