### PR TITLE
build(ci): correct release publish metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,7 +264,9 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
 
       - name: Download npm package artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -273,7 +275,7 @@ jobs:
           path: dist/npm
 
       - name: Publish npm package
-        run: npm publish --provenance --access public dist/npm/*.tgz
+        run: npm publish --access public dist/npm/*.tgz
 
   notify-homebrew-infomap:
     name: Notify homebrew-infomap
@@ -285,7 +287,7 @@ jobs:
       - name: Dispatch homebrew-infomap update workflow
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_INFOMAP_REPO_DISPATCH_TOKEN }}
-          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
 
@@ -306,7 +308,7 @@ jobs:
       - name: Dispatch infomap-online update workflow
         env:
           GH_TOKEN: ${{ secrets.INFOMAP_ONLINE_REPO_DISPATCH_TOKEN }}
-          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,10 +27,12 @@ Configure these integrations before the first release:
 
 1. Create the GitHub environments `pypi-release` and `npm-release`.
 2. Add the required reviewers to both environments.
-3. Configure PyPI trusted publishing for this repository and
-   `.github/workflows/release.yml`.
-4. Configure npm trusted publishing for this repository and
-   `.github/workflows/release.yml`.
+3. Configure PyPI trusted publishing for project `infomap` with owner
+   `mapequation`, repository `infomap`, workflow `release.yml`, and
+   environment `pypi-release`.
+4. Configure npm trusted publishing for package `@mapequation/infomap` with
+   owner `mapequation`, repository `infomap`, workflow `release.yml`, and
+   environment `npm-release`.
 5. Remove legacy registry secrets after trusted publishing is confirmed:
    - `PYPI_USERNAME`
    - `PYPI_PASSWORD`
@@ -100,10 +102,9 @@ Configure these integrations before the first release:
    The R package is also continuously published by r-universe from
    `master`; the release workflow does not push to r-universe directly.
 
-   `workflow_dispatch` for `.github/workflows/release.yml` is intentionally a
-   partial recovery path. It rebuilds and re-attaches GitHub Release assets and
-   republishes GHCR images for an existing tag, but PyPI, npm, Homebrew, and
-   `infomap-online` publishing are gated to tag `push` events.
+   `workflow_dispatch` for `.github/workflows/release.yml` rebuilds and
+   republishes an existing tag. Use it only after confirming the target version
+   has not already been published to a registry that rejects duplicate uploads.
 
 ## R Package Publishing
 
@@ -203,9 +204,13 @@ If a release only partially succeeds:
   `workflow_dispatch` for the same tag to rebuild and re-attach the GitHub
   Release assets before approving registry publishing.
 - If PyPI fails before any successful publish, fix the configuration problem and
-  rerun `publish-pypi` in the original tag-triggered release workflow.
+  rerun `.github/workflows/release.yml` with `workflow_dispatch` for the same
+  tag, or rerun `publish-pypi` in the original workflow if its artifacts are
+  still available.
 - If npm fails before any successful publish, fix the configuration problem and
-  rerun `publish-npm` in the original tag-triggered release workflow.
+  rerun `.github/workflows/release.yml` with `workflow_dispatch` for the same
+  tag, or rerun `publish-npm` in the original workflow if its artifacts are
+  still available.
 - If GHCR publishing fails before any successful publish, fix the configuration
   problem and rerun `.github/workflows/release.yml` with `workflow_dispatch`
   for the same tag. If any GHCR tags already published, inspect the registry


### PR DESCRIPTION
## Summary

- run npm publish with Node 24 and npm trusted-publishing registry setup
- use the requested release tag, not `github.ref_name`, when dispatching downstream workflows from manual release runs
- document the exact PyPI/npm trusted publisher claims and current `workflow_dispatch` recovery behavior

## Why

The v2.10.0 recovery run used `workflow_dispatch`, so `github.ref_name` was `master`. That sent `master` as the Homebrew `version` and `release_tag`.

The npm publish job had `id-token: write`, but it used Node 20/npm 10 and no registry setup, so `npm publish --provenance` fell back to token auth and failed with `ENEEDAUTH`. npm trusted publishing requires npm 11.5.1+ and Node 22.14.0+; Node 24 satisfies that and provenance is generated automatically for trusted publishes.

PyPI failed because PyPI rejected the OIDC claims for `mapequation/infomap`, workflow `release.yml`, environment `pypi-release`. That is a PyPI trusted publisher configuration mismatch, so the repo-side fix is documentation of the exact required config.

## Verification

- `actionlint .github/workflows/release.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts ".github/workflows/release.yml parses"'`\n- `node --version && npm --version` locally confirms installed npm is new enough, but the workflow runner will install Node 24 through `actions/setup-node`\n\nNot verified: live npm/PyPI publish; requires registry trusted-publisher configuration and protected release environments.