### PR TITLE
perf: speed up large network input parsing

### DIFF
--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -27,6 +27,7 @@
 #include <limits>
 #include <map>
 #include <set>
+#include <unordered_map>
 #include <cstdlib>
 #include <algorithm>
 #include <cmath>
@@ -836,7 +837,8 @@ void InfomapBase::generateSubNetwork(Network& network)
   m_leafNodes.reserve(numNodes);
   double sumNodeFlow = 0.0;
   double sumTeleFlow = 0.0;
-  std::map<unsigned int, unsigned int> nodeIndexMap;
+  std::unordered_map<unsigned int, unsigned int> nodeIndexMap;
+  nodeIndexMap.reserve(numNodes);
   for (auto& nodeIt : network.nodes()) {
     auto& networkNode = nodeIt.second;
     auto* node = new InfoNode(networkNode.flow, networkNode.id, networkNode.physicalId, networkNode.layerId);

--- a/src/io/Network.cpp
+++ b/src/io/Network.cpp
@@ -14,11 +14,76 @@
 
 #include <cmath>
 #include <algorithm>
+#include <cstdlib>
+#include <limits>
 #include <stdexcept>
 
 namespace infomap {
 
 using std::make_pair;
+
+namespace {
+
+inline bool isInputWhitespace(char c)
+{
+  return c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '\f' || c == '\v';
+}
+
+inline bool isDigit(char c)
+{
+  return c >= '0' && c <= '9';
+}
+
+void skipWhitespace(const char*& p)
+{
+  while (isInputWhitespace(*p)) {
+    ++p;
+  }
+}
+
+bool parseUnsigned(const char*& p, unsigned int& value)
+{
+  skipWhitespace(p);
+  if (*p == '+') {
+    ++p;
+  }
+  if (!isDigit(*p)) {
+    return false;
+  }
+
+  unsigned long long result = 0;
+  const unsigned long long maxValue = std::numeric_limits<unsigned int>::max();
+  do {
+    result = result * 10 + static_cast<unsigned long long>(*p - '0');
+    if (result > maxValue) {
+      return false;
+    }
+    ++p;
+  } while (isDigit(*p));
+
+  value = static_cast<unsigned int>(result);
+  return true;
+}
+
+bool parseOptionalDouble(const char*& p, double& value)
+{
+  skipWhitespace(p);
+  if (*p == '\0' || *p == '#') {
+    return false;
+  }
+
+  char* end = nullptr;
+  const double parsed = std::strtod(p, &end);
+  if (end == p) {
+    return false;
+  }
+
+  value = parsed;
+  p = end;
+  return true;
+}
+
+} // namespace
 
 void Network::init()
 {
@@ -444,20 +509,19 @@ std::string Network::ignoreSection(std::ifstream& file, const std::string& headi
 
 void Network::parseStateNode(const std::string& line, StateNetwork::StateNode& stateNode)
 {
-  m_extractor.clear();
-  m_extractor.str(line);
-  if (!(m_extractor >> stateNode.id >> stateNode.physicalId))
+  const char* p = line.c_str();
+  if (!parseUnsigned(p, stateNode.id) || !parseUnsigned(p, stateNode.physicalId))
     throw std::runtime_error(io::Str() << "Can't parse any state node from line '" << line << "'");
 
   // Optional name enclosed in double quotes
-  auto nameStart = line.find_first_of('\"', m_extractor.tellg());
+  auto nameStart = line.find_first_of('\"', static_cast<std::size_t>(p - line.c_str()));
   auto nameEnd = line.find_last_of('\"');
   if (nameStart < nameEnd) {
     stateNode.name = std::string(line.begin() + nameStart + 1, line.begin() + nameEnd);
-    m_extractor.seekg(nameEnd + 1);
+    p = line.c_str() + nameEnd + 1;
   }
   // Optional weight, default to 1.0
-  if ((m_extractor >> stateNode.weight)) {
+  if (parseOptionalDouble(p, stateNode.weight)) {
     m_haveStateNodeWeights = true;
     if (stateNode.weight < 0)
       throw std::runtime_error(io::Str() << "Negative state node weight (" << stateNode.weight << ") from line '" << line << "'");
@@ -466,38 +530,42 @@ void Network::parseStateNode(const std::string& line, StateNetwork::StateNode& s
 
 void Network::parseLink(const std::string& line, unsigned int& n1, unsigned int& n2, double& weight)
 {
-  m_extractor.clear();
-  m_extractor.str(line);
-  if (!(m_extractor >> n1 >> n2))
+  const char* p = line.c_str();
+  if (!parseUnsigned(p, n1) || !parseUnsigned(p, n2))
     throw std::runtime_error(io::Str() << "Can't parse link data from line '" << line << "'");
-  (m_extractor >> weight) || (weight = 1.0);
+  if (!parseOptionalDouble(p, weight)) {
+    weight = 1.0;
+  }
 }
 
 void Network::parseMultilayerLink(const std::string& line, unsigned int& layer1, unsigned int& n1, unsigned int& layer2, unsigned int& n2, double& weight)
 {
-  m_extractor.clear();
-  m_extractor.str(line);
-  if (!(m_extractor >> layer1 >> n1 >> layer2 >> n2))
+  const char* p = line.c_str();
+  if (!parseUnsigned(p, layer1) || !parseUnsigned(p, n1) || !parseUnsigned(p, layer2) || !parseUnsigned(p, n2))
     throw std::runtime_error(io::Str() << "Can't parse multilayer link data from line '" << line << "'");
-  (m_extractor >> weight) || (weight = 1.0);
+  if (!parseOptionalDouble(p, weight)) {
+    weight = 1.0;
+  }
 }
 
 void Network::parseMultilayerIntraLink(const std::string& line, unsigned int& layer, unsigned int& n1, unsigned int& n2, double& weight)
 {
-  m_extractor.clear();
-  m_extractor.str(line);
-  if (!(m_extractor >> layer >> n1 >> n2))
+  const char* p = line.c_str();
+  if (!parseUnsigned(p, layer) || !parseUnsigned(p, n1) || !parseUnsigned(p, n2))
     throw std::runtime_error(io::Str() << "Can't parse intra-multilayer link data from line '" << line << "'");
-  (m_extractor >> weight) || (weight = 1.0);
+  if (!parseOptionalDouble(p, weight)) {
+    weight = 1.0;
+  }
 }
 
 void Network::parseMultilayerInterLink(const std::string& line, unsigned int& layer1, unsigned int& n, unsigned int& layer2, double& weight)
 {
-  m_extractor.clear();
-  m_extractor.str(line);
-  if (!(m_extractor >> layer1 >> n >> layer2))
+  const char* p = line.c_str();
+  if (!parseUnsigned(p, layer1) || !parseUnsigned(p, n) || !parseUnsigned(p, layer2))
     throw std::runtime_error(io::Str() << "Can't parse inter-multilayer link data from line '" << line << "'");
-  (m_extractor >> weight) || (weight = 1.0);
+  if (!parseOptionalDouble(p, weight)) {
+    weight = 1.0;
+  }
   if (layer1 == layer2)
     throw std::runtime_error(io::Str() << "Inter-layer link from line '" << line << "' doesn't go between different layers.");
   // TODO: Same as intra-layer self-link?

--- a/src/utils/FlowCalculator.cpp
+++ b/src/utils/FlowCalculator.cpp
@@ -41,6 +41,7 @@ FlowCalculator::FlowCalculator(StateNetwork& network, const Config& config)
 
   // Prepare data in sequence containers for fast access of individual elements
   // Map to zero-based dense indexing
+  nodeIndexMap.reserve(numNodes);
   nodeFlow.assign(numNodes, 0.0);
   nodeTeleportWeights.assign(numNodes, 0.0); // Fraction of teleportation flow landing on node i
 

--- a/src/utils/FlowCalculator.h
+++ b/src/utils/FlowCalculator.h
@@ -10,7 +10,7 @@
 #ifndef FLOW_CALCULATOR_H_
 #define FLOW_CALCULATOR_H_
 
-#include <map>
+#include <unordered_map>
 #include <vector>
 
 namespace infomap {
@@ -53,7 +53,7 @@ private:
   double sumLinkWeight = 0;
   double sumWeightedDegree = 0;
 
-  std::map<unsigned int, unsigned int> nodeIndexMap;
+  std::unordered_map<unsigned int, unsigned int> nodeIndexMap;
   std::vector<double> nodeFlow;
   std::vector<double> nodeTeleportWeights;
   std::vector<double> nodeTeleportFlow;


### PR DESCRIPTION
## Summary

This PR speeds up large text input handling before the optimizer starts.

Changes:

- Replace hot per-line `std::istringstream` extraction in `src/io/Network.cpp` with a small pointer-based parser for unsigned IDs and optional weights.
- Use reserved `std::unordered_map` lookups for transient node-id-to-index maps in `src/utils/FlowCalculator.*` and `src/core/InfomapBase.cpp`.

The parser change targets the large edge, state, and multilayer input paths:

- `parseLink()`
- `parseStateNode()`
- `parseMultilayerLink()`
- `parseMultilayerIntraLink()`
- `parseMultilayerInterLink()`

The hash-map change only affects temporary lookup maps used while calculating flow and building the internal `InfoNode`/`InfoEdge` graph. It does not change graph ordering, optimizer behavior, public API, or CLI semantics.

## Why

Large `.net`/state/multilayer files spend measurable time before partitioning starts. The old parser reused a member `std::istringstream`, but still reset its string buffer and used formatted extraction for every link/state line. After parsing, `--no-infomap` still calculates flow and materializes the internal Infomap graph, and both paths used ordered maps for id-to-index lookups where ordering is not used.

## Benchmark

Benchmark setup:

- Baseline: `master` at `f78bb243`
- Head: `b526685b`
- Harness: `test/bench/native_benchmark.cpp`
- Inputs: large profile files in `build/benchmarks/generated-large`
- Repeats: 3 per case
- Flags: `--silent --no-file-output --num-trials 1 --seed 123 --no-infomap`

`--no-infomap` is used here to isolate input parsing, flow calculation, and internal graph construction from optimizer runtime.

| Case | Read input base (s) | Read input head (s) | Read uplift | Total base (s) | Total head (s) | Total uplift | Peak RSS base/head (MiB) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `sparse_1m` | 3.918 | 2.753 | 29.7% | 6.218 | 4.298 | 30.9% | 1776/1796 |
| `ring_of_cliques_1m` | 3.650 | 2.609 | 28.5% | 5.643 | 4.079 | 27.7% | 1664/1722 |
| `block_sparse_1m` | 2.305 | 1.457 | 36.8% | 4.033 | 2.749 | 31.8% | 1539/1607 |
| `state_ring_500k` | 2.035 | 1.293 | 36.5% | 3.297 | 2.335 | 29.2% | 1318/1279 |
| `state_block_1m_states` | 2.644 | 1.508 | 42.9% | 4.582 | 2.970 | 35.2% | 1361/1405 |
| `multilayer_100k_x10` | 3.239 | 1.950 | 39.8% | 4.800 | 3.072 | 36.0% | 1519/1440 |
| `multilayer_250k_x8` | 6.863 | 4.225 | 38.4% | 10.792 | 7.668 | 28.9% | 2141/2292 |

Aggregate over the measured cases:

- Sum of median read-input time: `24.653s -> 15.796s`, `35.9%` lower
- Sum of median total time with `--no-infomap`: `39.364s -> 27.171s`, `31.0%` lower
- Geomean total speedup with `--no-infomap`: `1.46x`
- Geomean max-RSS delta: `+1.5%`

Outputs remained stable in the benchmark harness: top-module count, level count, and codelength matched for all measured cases.

## Phase Probe

A temporary local phase probe split `--no-infomap` into read, flow calculation, internal graph initialization, and codelength calculation. Median timings over 3 runs showed that after parsing, most remaining cost is internal graph initialization, followed by flow calculation; codelength calculation is small.

| Case | Read | Flow | Init internal graph | Codelength |
| --- | ---: | ---: | ---: | ---: |
| `sparse_1m` | 2.890s | 0.633s | 1.287s | 0.132s |
| `state_ring_500k` | 1.384s | 0.306s | 0.733s | 0.050s |
| `state_block_1m_states` | 1.699s | 0.562s | 1.172s | 0.061s |
| `multilayer_100k_x10` | 1.867s | 0.373s | 1.063s | 0.056s |
| `multilayer_250k_x8` | 4.256s | 1.299s | 2.880s | 0.114s |

Replacing the transient ordered maps with reserved hash maps improved the measured flow/init phases in the same probe. For example, `multilayer_250k_x8` changed from `flow=1.299s, init=2.880s` to `flow=0.608s, init=2.232s` in the probe median.

## Memory Notes

The parser does not add a persistent data structure. The hash maps are temporary construction indexes replacing temporary ordered maps. Large benchmark max RSS is broadly neutral, with geomean max-RSS at `+1.5%`. `multilayer_250k_x8` had the largest max-RSS increase in this run (`2141 -> 2292 MiB`, about `+7.0%`), while `multilayer_100k_x10` decreased (`1519 -> 1440 MiB`). Earlier ad hoc probes showed multilayer RSS is noisy on macOS.

I also checked `multilayer_250k_x8` separately because RSS was noisy in earlier probes. `leaks --atExit` reported `0 leaks for 0 total leaked bytes`, and current RSS after `run()` did not show a stable increase. The remaining variation appears to be allocator/VM noise from large graph construction rather than leaked parser memory.

## Verification

- `make build-native`
- `make test-native`
- `make tidy-native`

`make tidy-native` still reports existing warnings in `src/core/InfoNode.cpp` and `src/core/InfoNode.h`; it does not report new warnings from the files changed here.
