### PR TITLE
fix(R): improve R igraph integration

### DIFF
--- a/interfaces/R/infomap/R/Infomap.R
+++ b/interfaces/R/infomap/R/Infomap.R
@@ -662,16 +662,20 @@ InfomapClass <- R6::R6Class(
     #' **Node id convention.** Infomap result accessors report the numeric
     #' node ids used to build the network. For links added directly with
     #' `add_link()` or `add_links()`, those user-supplied ids are preserved.
-    #' `add_igraph()` uses R igraph's 1-indexed vertex ids directly. If the
-    #' original igraph had vertex names (`V(g)$name`), the returned mapping
-    #' recovers them.
+    #' `add_igraph()` uses R igraph's 1-indexed vertex ids as state ids.
+    #' Plain graph results therefore use those ids directly. State and
+    #' multilayer graphs may use separate physical ids from `phys_id`; if
+    #' those ids are labels, they are mapped to stable internal integers and
+    #' returned as `attr(mapping, "phys_id")`. If the original igraph had
+    #' vertex names (`V(g)$name`), the returned mapping recovers them.
     #'
     #' If the graph is directed, `run()` will inject `--directed`
     #' unless the user has already chosen a flow model via `opts` or
     #' raw args.
     #'
     #' @param g An igraph graph.
-    #' @param weight Edge attribute to use as link weight.
+    #' @param weight Edge attribute to use as link weight. Use `NULL` to use
+    #'   `"weight"` when present, or `FALSE` to ignore edge weights.
     #' @param phys_id Vertex attribute holding physical node ids
     #'   (state-node case).
     #' @param layer_id Vertex attribute holding layer ids
@@ -682,8 +686,10 @@ InfomapClass <- R6::R6Class(
     #'   `add_multilayer_link()` for arbitrary (layer, node) pairs.
     #' @return Invisibly returns a named character vector mapping igraph
     #'   vertex ids to the original igraph vertex names (or stringified
-    #'   vertex ids when `V(g)$name` is absent). Useful for joining Infomap
-    #'   results back to the original graph.
+    #'   vertex ids when `V(g)$name` is absent). For state or multilayer
+    #'   networks with non-numeric `phys_id` labels, the returned vector has
+    #'   a `"phys_id"` attribute mapping internal physical ids to original
+    #'   labels. Useful for joining Infomap results back to the original graph.
     add_igraph = function(g,
                           weight = "weight",
                           phys_id = "phys_id",
@@ -701,9 +707,8 @@ InfomapClass <- R6::R6Class(
       }
 
       is_directed <- igraph::is_directed(g)
-      has_phys <- phys_id %in% igraph::vertex_attr_names(g)
-      has_layer <- layer_id %in% igraph::vertex_attr_names(g)
-      has_weight <- weight %in% igraph::edge_attr_names(g)
+      has_phys <- length(phys_id) == 1L && phys_id %in% igraph::vertex_attr_names(g)
+      has_layer <- length(layer_id) == 1L && layer_id %in% igraph::vertex_attr_names(g)
 
       vertex_names <- igraph::V(g)$name
       if (is.null(vertex_names)) {
@@ -714,7 +719,11 @@ InfomapClass <- R6::R6Class(
       mapping <- stats::setNames(vertex_names, as.character(vertex_ids))
 
       if (has_phys) {
-        phys <- as.integer(igraph::vertex_attr(g, phys_id))
+        phys_data <- .map_igraph_phys_ids(igraph::vertex_attr(g, phys_id))
+        phys <- phys_data$ids
+        if (!is.null(phys_data$mapping)) {
+          attr(mapping, "phys_id") <- phys_data$mapping
+        }
       } else {
         phys <- vertex_ids
       }
@@ -728,11 +737,7 @@ InfomapClass <- R6::R6Class(
       # Vertex names are captured in `mapping` above; edge endpoints use
       # R igraph's 1-indexed vertex ids.
       edges <- igraph::as_edgelist(g, names = FALSE)
-      weights <- if (has_weight) {
-        as.numeric(igraph::edge_attr(g, weight))
-      } else {
-        rep(1.0, nrow(edges))
-      }
+      weights <- .igraph_edge_weights(g, weight, nrow(edges))
 
       if (has_phys && has_layer) {
         # Multilayer state network.
@@ -799,6 +804,8 @@ InfomapClass <- R6::R6Class(
         # (via opts at construction/run, or via raw args).
         private$.directed_from_igraph <- TRUE
       }
+      private$.igraph_vcount <- igraph::vcount(g)
+      private$.igraph_have_memory <- has_phys
 
       invisible(mapping)
     },
@@ -818,13 +825,32 @@ InfomapClass <- R6::R6Class(
       if (!inherits(g, "igraph")) {
         stop("`g` must be an igraph graph.", call. = FALSE)
       }
-      # self$modules returns a named integer vector: node_id -> 0-indexed
-      # module. add_igraph() uses R igraph's 1-indexed vertex ids directly,
-      # so look up by vertex sequence.
-      mods <- self$modules
+      if (!is.null(private$.igraph_vcount) &&
+          igraph::vcount(g) != private$.igraph_vcount) {
+        stop(
+          "`g` must be the same igraph graph passed to add_igraph().",
+          call. = FALSE
+        )
+      }
+
+      # add_igraph() uses R igraph's 1-indexed vertex ids as state ids. For
+      # state/multilayer graphs, membership therefore has to be looked up by
+      # state id; plain graphs can keep using physical node ids.
+      mods <- if (isTRUE(private$.igraph_have_memory)) {
+        self$get_modules(states = TRUE)
+      } else {
+        self$modules
+      }
       n <- igraph::vcount(g)
       vertex_ids <- as.character(seq_len(n))
       membership <- as.integer(mods[vertex_ids])
+      if (length(membership) != n || anyNA(membership)) {
+        stop(
+          "Could not align Infomap membership with `g`; `g` must be the ",
+          "same igraph graph passed to add_igraph().",
+          call. = FALSE
+        )
+      }
       igraph::make_clusters(
         g,
         membership = membership,
@@ -1130,7 +1156,9 @@ InfomapClass <- R6::R6Class(
   private = list(
     .swig = NULL,
     .flow_model_set = FALSE,
-    .directed_from_igraph = FALSE
+    .directed_from_igraph = FALSE,
+    .igraph_vcount = NULL,
+    .igraph_have_memory = FALSE
   )
 )
 
@@ -1141,4 +1169,62 @@ InfomapClass <- R6::R6Class(
 .flow_model_in_args <- function(args) {
   if (is.null(args) || !nzchar(args)) return(FALSE)
   grepl("(^|\\s)(--directed|-d\\b|--flow-model|-f\\b)", args)
+}
+
+.igraph_edge_weights <- function(g, weight, num_edges) {
+  if (identical(weight, FALSE)) {
+    return(rep(1.0, num_edges))
+  }
+
+  attr_name <- if (is.null(weight)) {
+    "weight"
+  } else {
+    if (!is.character(weight) || length(weight) != 1L || is.na(weight)) {
+      stop(
+        "`weight` must be NULL, FALSE, or a single igraph edge attribute name.",
+        call. = FALSE
+      )
+    }
+    weight
+  }
+
+  if (!(attr_name %in% igraph::edge_attr_names(g))) {
+    return(rep(1.0, num_edges))
+  }
+
+  weights <- igraph::edge_attr(g, attr_name)
+  if (!is.numeric(weights)) {
+    stop("`weight` edge attribute must be numeric.", call. = FALSE)
+  }
+  if (anyNA(weights)) {
+    stop("`weight` edge attribute cannot contain missing values.", call. = FALSE)
+  }
+  as.numeric(weights)
+}
+
+.map_igraph_phys_ids <- function(values) {
+  if (anyNA(values)) {
+    stop("`phys_id` vertex attribute cannot contain missing values.", call. = FALSE)
+  }
+
+  if (is.numeric(values)) {
+    ids <- as.integer(values)
+    if (any(!is.finite(values)) || any(values != ids)) {
+      stop(
+        "`phys_id` vertex attribute must contain integer-like numeric values or non-missing labels.",
+        call. = FALSE
+      )
+    }
+    return(list(ids = ids, mapping = NULL))
+  }
+
+  labels <- as.character(values)
+  if (anyNA(labels)) {
+    stop("`phys_id` vertex attribute cannot contain missing values.", call. = FALSE)
+  }
+
+  unique_labels <- unique(labels)
+  ids <- match(labels, unique_labels)
+  mapping <- stats::setNames(unique_labels, as.character(seq_along(unique_labels)))
+  list(ids = as.integer(ids), mapping = mapping)
 }

--- a/interfaces/R/infomap/R/cluster_infomap.R
+++ b/interfaces/R/infomap/R/cluster_infomap.R
@@ -19,7 +19,8 @@
 #' @param weight Edge weight column. For data frames, use a column name or
 #'   numeric column index. For matrices, use a numeric column index. Set
 #'   `FALSE` to ignore weights. For igraph graphs, use the edge attribute
-#'   name, or `NULL` to use `"weight"` when present.
+#'   name, `NULL` to use `"weight"` when present, or `FALSE` to ignore
+#'   igraph edge weights.
 #' @param e.weights Alias for `weight`, provided for familiarity with
 #'   `igraph::cluster_infomap()`. For igraph inputs, this can be an edge
 #'   attribute name or a numeric vector with one value per edge. Do not

--- a/interfaces/R/infomap/README.md
+++ b/interfaces/R/infomap/README.md
@@ -99,13 +99,22 @@ comm <- im$as_communities(g)  # igraph 'communities' object
 `add_igraph()` and `as_communities()` raise an informative error if
 `igraph` is not installed.
 
+`add_igraph()` uses an igraph edge attribute named `weight` by default.
+Use `weight = NULL` to use that attribute only when present, or
+`weight = FALSE` to ignore edge weights. Non-numeric or missing weight
+values raise an error.
+
 **Node id convention.** Infomap result accessors report the numeric node
 ids used to build the network. For links added directly with
 `add_link()` or `add_links()`, those user-supplied ids are preserved.
-`add_igraph()` uses R igraph's 1-indexed vertex ids directly. The
-`mapping` returned by `add_igraph()` recovers the original igraph vertex
-names (or stringified vertex ids) keyed by those ids, so you can join
-Infomap results back to the original graph.
+`add_igraph()` uses R igraph's 1-indexed vertex ids as state ids. Plain
+graph results use those ids directly. State and multilayer graphs can use
+separate physical ids from a `phys_id` vertex attribute; non-numeric
+physical labels are mapped to stable internal integers. The `mapping`
+returned by `add_igraph()` recovers the original igraph vertex names (or
+stringified vertex ids) keyed by vertex id, and `attr(mapping, "phys_id")`
+maps internal physical ids back to original physical labels when such a
+mapping was needed.
 
 ## Related packages
 

--- a/interfaces/R/infomap/man/Infomap.Rd
+++ b/interfaces/R/infomap/man/Infomap.Rd
@@ -636,7 +636,8 @@ Import an igraph graph.
 \describe{
 \item{\code{g}}{An igraph graph.}
 
-\item{\code{weight}}{Edge attribute to use as link weight.}
+\item{\code{weight}}{Edge attribute to use as link weight. Use \code{NULL} to use
+\code{"weight"} when present, or \code{FALSE} to ignore edge weights.}
 
 \item{\code{phys_id}}{Vertex attribute holding physical node ids
 (state-node case).}
@@ -657,9 +658,12 @@ Translated from \verb{interfaces/python/src/infomap/_networkx.py}.
 \strong{Node id convention.} Infomap result accessors report the numeric
 node ids used to build the network. For links added directly with
 \code{add_link()} or \code{add_links()}, those user-supplied ids are preserved.
-\code{add_igraph()} uses R igraph's 1-indexed vertex ids directly. If the
-original igraph had vertex names (\code{V(g)$name}), the returned mapping
-recovers them.
+\code{add_igraph()} uses R igraph's 1-indexed vertex ids as state ids.
+Plain graph results therefore use those ids directly. State and
+multilayer graphs may use separate physical ids from \code{phys_id}; if
+those ids are labels, they are mapped to stable internal integers and
+returned as \code{attr(mapping, "phys_id")}. If the original igraph had
+vertex names (\code{V(g)$name}), the returned mapping recovers them.
 
 If the graph is directed, \code{run()} will inject \code{--directed}
 unless the user has already chosen a flow model via \code{opts} or
@@ -669,8 +673,10 @@ raw args.
 \subsection{Returns}{
 Invisibly returns a named character vector mapping igraph
 vertex ids to the original igraph vertex names (or stringified
-vertex ids when \code{V(g)$name} is absent). Useful for joining Infomap
-results back to the original graph.
+vertex ids when \code{V(g)$name} is absent). For state or multilayer
+networks with non-numeric \code{phys_id} labels, the returned vector has
+a \code{"phys_id"} attribute mapping internal physical ids to original
+labels. Useful for joining Infomap results back to the original graph.
 }
 }
 \if{html}{\out{<hr>}}

--- a/interfaces/R/infomap/man/cluster_infomap.Rd
+++ b/interfaces/R/infomap/man/cluster_infomap.Rd
@@ -31,7 +31,8 @@ cluster_infomap(
 \item{weight}{Edge weight column. For data frames, use a column name or
 numeric column index. For matrices, use a numeric column index. Set
 \code{FALSE} to ignore weights. For igraph graphs, use the edge attribute
-name, or \code{NULL} to use \code{"weight"} when present.}
+name, \code{NULL} to use \code{"weight"} when present, or \code{FALSE} to ignore
+igraph edge weights.}
 
 \item{e.weights}{Alias for \code{weight}, provided for familiarity with
 \code{igraph::cluster_infomap()}. For igraph inputs, this can be an edge

--- a/interfaces/R/infomap/tests/testthat/test-igraph.R
+++ b/interfaces/R/infomap/tests/testthat/test-igraph.R
@@ -15,6 +15,42 @@ test_that("add_igraph imports edges from an igraph graph", {
   expect_setequal(as.data.frame(im)$node_id, seq_len(igraph::vcount(g)))
 })
 
+test_that("add_igraph normalizes igraph weight inputs", {
+  skip_if_not_installed("igraph")
+
+  g <- igraph::make_graph(c(1, 2, 2, 3, 3, 1), directed = FALSE)
+  igraph::E(g)$weight <- c(2, 3, 4)
+
+  default_weight <- Infomap(silent = TRUE)
+  expect_silent(default_weight$add_igraph(g, weight = NULL))
+
+  ignored_weight <- Infomap(silent = TRUE)
+  expect_silent(ignored_weight$add_igraph(g, weight = FALSE))
+
+  no_weight <- igraph::delete_edge_attr(g, "weight")
+  missing_weight <- Infomap(silent = TRUE)
+  expect_silent(missing_weight$add_igraph(no_weight, weight = NULL))
+  expect_silent(missing_weight$run())
+})
+
+test_that("add_igraph rejects invalid igraph weights", {
+  skip_if_not_installed("igraph")
+
+  non_numeric <- igraph::make_graph(c(1, 2, 2, 3), directed = FALSE)
+  igraph::E(non_numeric)$weight <- c("a", "b")
+  expect_error(
+    Infomap(silent = TRUE)$add_igraph(non_numeric),
+    "weight.*numeric"
+  )
+
+  missing <- igraph::make_graph(c(1, 2, 2, 3), directed = FALSE)
+  igraph::E(missing)$weight <- c(1, NA)
+  expect_error(
+    Infomap(silent = TRUE)$add_igraph(missing),
+    "weight.*missing"
+  )
+})
+
 test_that("as_communities aligns membership with igraph vertex ids", {
   skip_if_not_installed("igraph")
 
@@ -28,4 +64,20 @@ test_that("as_communities aligns membership with igraph vertex ids", {
   expect_s3_class(communities, "communities")
   expect_length(igraph::membership(communities), igraph::vcount(g))
   expect_false(anyNA(igraph::membership(communities)))
+})
+
+test_that("as_communities rejects graphs that do not match imported igraph vertices", {
+  skip_if_not_installed("igraph")
+
+  g <- igraph::make_graph(c(1, 2, 2, 3, 3, 1), directed = FALSE)
+  other <- igraph::make_graph(c(1, 2, 2, 3, 3, 4), directed = FALSE)
+
+  im <- Infomap(silent = TRUE)
+  im$add_igraph(g)
+  im$run()
+
+  expect_error(
+    im$as_communities(other),
+    "same igraph graph"
+  )
 })

--- a/interfaces/R/infomap/tests/testthat/test-multilayer.R
+++ b/interfaces/R/infomap/tests/testthat/test-multilayer.R
@@ -230,6 +230,32 @@ test_that("add_igraph accepts intra/inter-compatible multilayer links", {
   expect_gt(im$num_links, 0L)
 })
 
+test_that("add_igraph supports non-numeric physical ids", {
+  skip_if_not_installed("igraph")
+
+  g <- igraph::make_empty_graph(4, directed = TRUE)
+  g <- igraph::set_vertex_attr(
+    g, "phys_id",
+    value = factor(c("alpha", "beta", "alpha", "beta"))
+  )
+  g <- igraph::set_vertex_attr(g, "layer_id", value = c(1, 1, 2, 2))
+  g <- igraph::add_edges(g, c(1, 2, 3, 4, 1, 3, 2, 4))
+
+  im <- Infomap(silent = TRUE, num_trials = 1L, two_level = TRUE)
+  mapping <- im$add_igraph(g)
+  im$run()
+
+  phys_mapping <- attr(mapping, "phys_id")
+  expect_named(phys_mapping)
+  expect_setequal(unname(phys_mapping), c("alpha", "beta"))
+  expect_false(anyNA(im$nodes$node_id))
+
+  communities <- im$as_communities(g)
+  expect_s3_class(communities, "communities")
+  expect_length(igraph::membership(communities), igraph::vcount(g))
+  expect_false(anyNA(igraph::membership(communities)))
+})
+
 test_that("add_igraph accepts diagonal links with multilayer_inter_intra_format = FALSE", {
   skip_if_not_installed("igraph")
   g <- igraph::make_empty_graph(4, directed = FALSE)


### PR DESCRIPTION
## Summary

- Normalize `Infomap$add_igraph()` handling of igraph edge weights, including `weight = NULL` and `weight = FALSE`.
- Reject non-numeric or missing igraph edge weights with explicit errors.
- Support non-numeric `phys_id` labels for state and multilayer igraph inputs through stable internal integer mapping.
- Harden `Infomap$as_communities()` so state/multilayer inputs use state-node memberships and mismatched graphs fail clearly.
- Update R documentation and README text for the clarified igraph behavior.

## Why

The R igraph adapter already keeps `igraph` optional, but a few edge cases were fragile: `weight = NULL` was not normalized in the low-level API, non-numeric physical node labels could be coerced to `NA`, and `as_communities()` could silently misalign membership for state or multilayer graphs. This makes the current integration safer without adding a new dependency or expanding the public API surface.

## Validation

- `Rscript -e 'roxygen2::roxygenise("interfaces/R/infomap")'`
- `make dev-r-install`
- `Rscript -e 'library(infomap); library(testthat); test_file("interfaces/R/infomap/tests/testthat/test-igraph.R"); test_file("interfaces/R/infomap/tests/testthat/test-multilayer.R")'`
- `make test-r-examples`
- `make test-r` ran package install, examples, and testthat successfully, but the command failed overall because this local environment is missing `checkbashisms` and `pandoc`, and R CMD check reported the existing CRAN incoming "New submission" note.