### PR TITLE
docs: sync docs and Make targets with new CI flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ interfaces/R/infomap/R/swig_bindings.R
 /npm-pack.json
 /mapequation-infomap-*.tgz
 
-docs/.buildinfo
+docs/
 examples/R/.Rhistory
 examples/R/infomap/
 examples/js/index.js

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,7 @@ Do not bundle unrelated cleanup into the same change.
 - `test/`: Python-facing regression tests and fixtures
 - `examples/python/`: executable Python examples used by `make test-python`
 - `examples/R/`: executable R examples used by `make test-r-examples`
-- `docs/`: committed generated Python docs output
-- `.github/workflows/`: CI, docs verification, release, and packaging workflows
+- `.github/workflows/`: CI, release, and packaging workflows
 
 ## Source Of Truth
 
@@ -35,7 +34,6 @@ Do not bundle unrelated cleanup into the same change.
 - `interfaces/python/generated/` and `interfaces/python/src/infomap/_swig.py` are tracked Python wrapper outputs
 - `interfaces/R/infomap/` owns the R package skeleton (`R/`, `DESCRIPTION`, `tests/`, `man/`)
 - `interfaces/R/generated/` are tracked SWIG-generated R outputs; refresh with `make build-r-swig`
-- `docs/` generated HTML, JS, and `_sources` files are build output; do not hand-edit them
 
 When two documents disagree, fix the source document and regenerate derived
 output instead of patching the generated copy by hand.
@@ -100,7 +98,7 @@ Run the smallest sufficient verification for the changed surface:
   `Rscript -e 'roxygen2::roxygenise("interfaces/R/infomap")'`
   after installing with `R CMD INSTALL --with-keep.source`.
 - JavaScript worker or package changes: `npm ci` plus `make build-js` or `make test-js`
-- docs-only text changes: no code build unless docs output freshness is affected; then run `make test-docs`
+- docs-only text changes: no code build needed; run `make build-docs` to verify the site still builds
 - workflow or release changes: run the smallest relevant local smoke check and say what remains unverified
 
 Approximate local runtimes vary by machine and cache state:
@@ -111,7 +109,7 @@ Approximate local runtimes vary by machine and cache state:
 - `make test-r`: about 1-3 minutes after R dependencies are installed
 - `make build-js`: about 2-4 minutes with `em++` already on `PATH`
 - `make test-js`: about 3-6 minutes after JavaScript dependencies and browsers are installed
-- `make test-docs`: about 1-3 minutes after Python docs dependencies are installed
+- `make build-docs`: about 1-3 minutes after Python docs dependencies are installed
 
 Targeted checks:
 
@@ -130,7 +128,6 @@ Targeted checks:
 
 - Do not improvise around SWIG generation, Python packaging, or R packaging
 - Do not improvise around JS worker generation or Emscripten
-- Do not hand-edit generated docs output in `docs/`
 - Do not hand-edit `interfaces/R/generated/` or `interfaces/R/infomap/man/`;
   regenerate with `make build-r-swig` and `roxygen2::roxygenise(...)`
   respectively

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -63,8 +63,6 @@ it is not a primary public contract for release planning.
 - `ARCHITECTURE.md`, `BUILD.md`, `RELEASING.md`, `AGENTS.md`,
   `CONTRIBUTING.md`, `SECURITY.md`, and `CODE_OF_CONDUCT.md`
   - hand-maintained maintainer, contribution, and governance documentation
-- `docs/`
-  - generated Python docs output for GitHub Pages
 - `test/fixtures/`
   - shared regression inputs and expected outputs for tests
 
@@ -73,11 +71,10 @@ They are not hand-maintained source files.
 
 For the Python docs site:
 
-- `make build-docs` refreshes the committed generated output in `docs/`
-- `make test-docs` rebuilds in a temp directory and compares that output with
-  the committed generated subset of `docs/`
-
-Do not hand-edit generated HTML, JavaScript, or `_sources` files under `docs/`.
+- `make build-docs` builds the Sphinx site into `docs/`. The output is not
+  tracked in the repo; PRs verify the build via the `docs` job in
+  `.github/workflows/ci.yml`, and the release workflow deploys the site to
+  GitHub Pages.
 
 ## Build ownership
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -303,21 +303,17 @@ Build source and wheel distributions locally when needed:
 make release-python-dist
 ```
 
-After the normal Python setup from the section above, refresh the committed
-Sphinx output in `docs/` with:
+After the normal Python setup from the section above, build the Sphinx
+site with:
 
 ```bash
 make build-docs
 ```
 
-Verify that the committed generated output is fresh without rewriting `docs/`
-with:
-
-```bash
-make test-docs
-```
-
-Do not hand-edit generated HTML, JavaScript, or `_sources` files under `docs/`.
+The output is written to `docs/` as untracked build artefacts; do not
+commit them. CI runs `make build-docs` on PRs that touch docs-relevant
+files (see the `docs` job in `.github/workflows/ci.yml`), and the release
+workflow builds and deploys the site to GitHub Pages.
 
 ## Docker
 

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|ci| |docs| |docker|
+|ci|
 
 Infomap
 =======
@@ -18,14 +18,6 @@ For contributing, security reporting, and maintainer workflows, see
 .. |ci| image:: https://github.com/mapequation/infomap/actions/workflows/ci.yml/badge.svg
    :target: https://github.com/mapequation/infomap/actions/workflows/ci.yml
    :alt: CI
-
-.. |docs| image:: https://github.com/mapequation/infomap/actions/workflows/docs.yml/badge.svg
-   :target: https://github.com/mapequation/infomap/actions/workflows/docs.yml
-   :alt: Docs
-
-.. |docker| image:: https://github.com/mapequation/infomap/actions/workflows/docker-smoke.yml/badge.svg
-   :target: https://github.com/mapequation/infomap/actions/workflows/docker-smoke.yml
-   :alt: Docker smoke
 
 .. _Map equation: https://www.mapequation.org/publications.html#Rosvall-Axelsson-Bergstrom-2009-Map-equation
 .. _`mapequation.org/infomap/`: https://www.mapequation.org/infomap/

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,7 +16,8 @@ Public release deliverables are:
 - the `@mapequation/infomap` npm package
 - multi-arch Docker images published to GHCR for `linux/amd64` and
   `linux/arm64`
-- the committed Python docs output in `docs/`
+- the Python documentation site, built from `interfaces/python/source/`
+  and `README.rst` and deployed to GitHub Pages
 
 Internal-supported packages and secondary Docker images are outside the default
 public release flow unless a maintainer explicitly widens the release scope.
@@ -176,10 +177,15 @@ If the proposed bump does not match the commit log
 
 ## Documentation publishing
 
-The published Python docs are served from the committed `docs/` tree on
-`master`. `.github/workflows/docs.yml` is verify-only: it runs `make test-docs`
-to confirm that the committed generated output derived from
-`interfaces/python/source/` and `README.rst` is fresh.
+The published Python docs are built and deployed to GitHub Pages by the
+`deploy-docs` job in `.github/workflows/release.yml` after each tagged
+release. The job runs `make build-docs`, creates `.nojekyll`, and uploads
+the result via `actions/upload-pages-artifact` and `actions/deploy-pages`.
+
+On pull requests, the `docs` job in `.github/workflows/ci.yml` runs
+`make build-docs` to verify the site still builds. Nothing is deployed
+from CI. The `docs/` directory is build output and is not tracked in the
+repo.
 
 ## Recovery
 

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -90,7 +90,7 @@ help:
 		"  build-binding-options Regenerate Python, R, and TypeScript option APIs from C++ metadata." \
 		"  build-js-metadata     Refresh the tracked JS parameters/changelog metadata." \
 		"  build-js              Build the JS worker bundle and npm package assets from tracked metadata." \
-		"  build-docs            Refresh the committed Python docs site in docs/." \
+		"  build-docs            Build the Python docs site into docs/ (untracked output)." \
 		"" \
 		"Test" \
 		"  test-cpp-stream-policy  Verify runtime C++ does not use direct global std streams outside approved files." \
@@ -104,7 +104,6 @@ help:
 		"  test-r-examples       Run the R example smoke tests." \
 		"  test-r-swig-freshness Verify tracked R SWIG outputs are up to date." \
 		"  test-binding-options-freshness Verify tracked binding option APIs are current." \
-		"  test-docs             Rebuild docs in a temp dir and verify committed docs/ is fresh." \
 		"  test-js-metadata      Regenerate JS metadata in a temp dir and verify tracked files are current." \
 		"  test-js               Run JS lint/typecheck/unit/browser/package verification for the built npm package." \
 		"  test-fast             Run the fast native + Python feedback suite." \
@@ -129,8 +128,7 @@ help:
 		"  clean-js              Remove JS build and pack outputs." \
 		"" \
 		"Docs / Release" \
-		"  build-docs            Refresh the committed Python docs site after installing the local package." \
-		"  test-docs             Verify committed docs/ matches a fresh Sphinx build." \
+		"  build-docs            Build the Python docs site into docs/ after installing the local package." \
 		"  release-python-dist   Build local sdist and wheel artifacts from the repo root." \
 		"  release-python-testpypi  Publish the built distributions to TestPyPI." \
 		"  release-python-pypi      Publish the built distributions to PyPI." \
@@ -147,8 +145,7 @@ help:
 		"  make build-binding-options test-binding-options-freshness" \
 		"  make build-js-metadata test-js-metadata" \
 		"  make build-js test-js" \
-		"  make build-docs" \
-		"  make test-docs"
+		"  make build-docs"
 
 build-binding-options: build-native
 	@$(PYTHON_FOR_BUILD_CONFIG) $(BINDING_OPTIONS_SCRIPT) --infomap-bin ./Infomap --output-root .

--- a/mk/python.mk
+++ b/mk/python.mk
@@ -2,9 +2,7 @@ PYTHON_SWIG_PY := interfaces/python/src/infomap/_swig.py
 PYTHON_SWIG_CPP := interfaces/python/generated/infomap_wrap.cpp
 SPHINX_SOURCE_DIR := interfaces/python/source
 SPHINX_TARGET_DIR ?= docs
-DOCS_FRESHNESS_EXCLUDES := maintainers .nojekyll .buildinfo
-DOCS_FRESHNESS_DIFF_ARGS := $(foreach excluded,$(DOCS_FRESHNESS_EXCLUDES),--exclude=$(excluded))
-DOCS_SYNC_ARGS := -a --delete $(foreach excluded,$(DOCS_FRESHNESS_EXCLUDES),--exclude=/$(excluded))
+DOCS_SYNC_ARGS := -a --delete
 PYTHON_TEST_DIR := test/python
 PYTHON_LINT_TARGETS := \
 	interfaces/python/src/infomap/__init__.py \
@@ -53,7 +51,6 @@ PYTHON_BUILD_ENV = \
 	test-python-doctest \
 	test-python-examples \
 	build-docs \
-	test-docs \
 	_build-docs-site \
 	clean-python \
 	format-python \
@@ -114,12 +111,6 @@ build-docs: dev-python-install
 	$(MAKE) --no-print-directory SPHINX_TARGET_DIR="$$tmp_dir/docs" _build-docs-site; \
 	mkdir -p docs; \
 	rsync $(DOCS_SYNC_ARGS) "$$tmp_dir/docs/" docs/
-
-test-docs: dev-python-install
-	@tmp_dir="$$(mktemp -d 2>/dev/null || mktemp -d -t infomap-docs)"; \
-	trap 'rm -rf "$$tmp_dir"' EXIT; \
-	$(MAKE) --no-print-directory SPHINX_TARGET_DIR="$$tmp_dir/docs" _build-docs-site; \
-	diff -ru $(DOCS_FRESHNESS_DIFF_ARGS) "$$tmp_dir/docs" docs
 
 clean-python:
 	$(RM) -r dist/python *.egg-info interfaces/python/src/infomap/_infomap*.so interfaces/python/src/infomap/*.pyd


### PR DESCRIPTION
## Summary

- Remove stale references to the old `docs/` tracking + `docs.yml` + `docker-smoke.yml` flow across README.rst, RELEASING.md, ARCHITECTURE.md, AGENTS.md, BUILD.md, and `make help`.
- Update `.gitignore` to ignore the full `docs/` build directory (previously only `docs/.buildinfo` was ignored).
- Remove the now-broken `make test-docs` target (it diffed against the committed `docs/` tree, which no longer exists) and the `DOCS_FRESHNESS_*` variables that only existed to support it.
- Drop the `|docs|` and `|docker|` README badges that pointed at deleted workflows.

## Test plan

- [x] `grep -rn -E "docs\.yml|docker-smoke|test-docs|committed.*docs" --include='*.md' --include='*.rst' --include='*.yml' --include='*.mk' --include='Makefile' --include='.gitignore' .` returns no hits.
- [x] `make help` no longer mentions `test-docs` and describes `build-docs` as untracked output.
- [x] `git check-ignore docs/anything.html` reports `docs/` is ignored.
- [ ] `make build-docs` still produces a `docs/` tree (verified by CI's `docs` job).