### PR TITLE
feat(python): add scipy sparse matrix support

### DIFF
--- a/interfaces/python/source/conf.py
+++ b/interfaces/python/source/conf.py
@@ -69,6 +69,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "pandas": ("https://pandas.pydata.org/docs/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     "networkx": ("https://networkx.org/documentation/stable/", None),
     "igraph": ("https://python.igraph.org/en/main/", None),
 }

--- a/interfaces/python/source/installation.rst
+++ b/interfaces/python/source/installation.rst
@@ -25,6 +25,7 @@ Install optional integrations for common research workflows:
     pip install "infomap[networkx]"
     pip install "infomap[igraph]"
     pip install "infomap[pandas]"
+    pip install "infomap[scipy]"
 
 Or install all optional integrations at once:
 

--- a/interfaces/python/source/usage.rst
+++ b/interfaces/python/source/usage.rst
@@ -87,6 +87,72 @@ mapped to stable internal ids in first-seen order and returned as a mapping:
     mapping = im.add_networkx_graph(graph)
     im.run()
 
+SciPy sparse matrices
+---------------------
+
+Use :meth:`infomap.Infomap.from_scipy_sparse_matrix` when your graph is
+already stored as a SciPy sparse adjacency matrix. CSR, CSC and COO matrices
+and sparse arrays are accepted. The adapter imports SciPy lazily, so SciPy is
+only required when this API is used.
+
+.. code-block:: python
+
+    import scipy.sparse as sp
+    from infomap import Infomap
+
+    adjacency = sp.csr_matrix([
+        [0, 1, 0],
+        [1, 0, 2],
+        [0, 2, 0],
+    ])
+
+    im = Infomap.from_scipy_sparse_matrix(adjacency, directed=False, args="--silent")
+    im.run()
+    modules = im.get_modules()
+
+For unweighted graphs, pass ``weighted=False`` to treat every nonzero matrix
+entry as weight ``1.0``:
+
+.. code-block:: python
+
+    im = Infomap.from_scipy_sparse_matrix(adjacency, weighted=False, args="--silent")
+
+For directed graphs, pass ``directed=True``. Then ``A[i, j]`` is interpreted
+as a directed edge from row ``i`` to column ``j``:
+
+.. code-block:: python
+
+    directed_adjacency = sp.coo_matrix([
+        [0, 1],
+        [0, 0],
+    ])
+    im = Infomap.from_scipy_sparse_matrix(
+        directed_adjacency,
+        directed=True,
+        args="--silent",
+    )
+
+Custom node ids can be supplied in matrix row order. The adapter returns a
+mapping from Infomap's internal integer ids to those external ids, matching
+the pattern used by :meth:`infomap.Infomap.add_networkx_graph`:
+
+.. code-block:: python
+
+    adjacency = sp.coo_matrix([
+        [0, 3],
+        [3, 0],
+    ])
+    im = Infomap(silent=True)
+    mapping = im.add_scipy_sparse_matrix(adjacency, directed=False, node_ids=["gene_a", "gene_b"])
+    im.run()
+    modules = {mapping[node_id]: module_id for node_id, module_id in im.get_modules().items()}
+    assert set(modules) == {"gene_a", "gene_b"}
+
+For undirected input, symmetric entries are de-duplicated: if both ``A[i, j]``
+and ``A[j, i]`` exist, one undirected link is added. If the two entries have
+different weights, the larger weight is used. For large graphs, prefer CSR or
+COO input to avoid unnecessary conversion work.
+
 State and multilayer networks
 -----------------------------
 

--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -21,6 +21,7 @@ from ._options import (
 )
 from ._results import _InfomapResultsMixin
 from ._results import entropy, perplexity, plogp
+from ._scipy import add_scipy_sparse_matrix as _add_scipy_sparse_matrix
 from ._writers import _InfomapWritersMixin
 
 
@@ -178,6 +179,27 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin, InfomapWrapper):  # no
         if not isinstance(options, InfomapOptions):
             raise TypeError("options must be an InfomapOptions instance")
         return cls(args=args, **options.to_kwargs())
+
+    @classmethod
+    def from_scipy_sparse_matrix(
+        cls,
+        A,
+        *,
+        directed=False,
+        weighted=True,
+        node_ids=None,
+        args=None,
+        **infomap_options,
+    ):
+        """Create an :class:`Infomap` instance from a SciPy sparse adjacency matrix."""
+        im = cls(args=args, **infomap_options)
+        im.add_scipy_sparse_matrix(
+            A,
+            directed=directed,
+            weighted=weighted,
+            node_ids=node_ids,
+        )
+        return im
 
     # ----------------------------------------
     # Input
@@ -1153,6 +1175,37 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin, InfomapWrapper):  # no
             node_id=node_id,
             layer_id=layer_id,
             multilayer_inter_intra_format=multilayer_inter_intra_format,
+        )
+
+    def add_scipy_sparse_matrix(self, A, directed=False, weighted=True, node_ids=None):
+        """Add links and nodes from a SciPy sparse adjacency matrix.
+
+        Parameters
+        ----------
+        A : scipy.sparse matrix or array
+            Square sparse adjacency matrix.
+        directed : bool, optional
+            Interpret ``A[i, j]`` as a directed edge from row ``i`` to column
+            ``j``. Default ``False``.
+        weighted : bool, optional
+            Use sparse matrix values as link weights. If ``False``, every
+            nonzero entry is treated as weight ``1.0``. Default ``True``.
+        node_ids : sequence, optional
+            External node ids in matrix row order. If omitted, ``0..n-1`` is
+            used.
+
+        Returns
+        -------
+        dict
+            Dict with internal integer node ids as keys and external node ids
+            as values.
+        """
+        return _add_scipy_sparse_matrix(
+            self,
+            A,
+            directed=directed,
+            weighted=weighted,
+            node_ids=node_ids,
         )
 
     def add_igraph_graph(

--- a/interfaces/python/src/infomap/_scipy.py
+++ b/interfaces/python/src/infomap/_scipy.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+
+def _import_sparse() -> Any:
+    try:
+        import scipy.sparse as sparse
+    except ImportError as exc:
+        raise ImportError(
+            "The 'scipy' package is required for SciPy sparse matrix support. "
+            'Install it with `python -m pip install "infomap[scipy]"`.'
+        ) from exc
+    return sparse
+
+
+def _validate_sparse_matrix(sparse: Any, A: Any) -> Any:
+    if not sparse.issparse(A):
+        raise ValueError(
+            "`A` must be a scipy sparse matrix or sparse array, not a dense array."
+        )
+    if A.shape[0] != A.shape[1]:
+        raise ValueError("`A` must be a square adjacency matrix.")
+    return A
+
+
+def _validate_node_ids(node_ids: Sequence[Any] | None, n_nodes: int) -> list[Any]:
+    if node_ids is None:
+        return list(range(n_nodes))
+
+    labels = list(node_ids)
+    if len(labels) != n_nodes:
+        raise ValueError("`node_ids` length must match `A.shape[0]`.")
+    if len(set(labels)) != len(labels):
+        raise ValueError("`node_ids` values must be unique.")
+    return labels
+
+
+def _validate_weights(coo: Any) -> None:
+    import numpy as np
+
+    data = coo.data
+    if data.size == 0:
+        return
+    if bool(np.isnan(data).any()):
+        raise ValueError("`A` contains NaN weights.")
+    if bool((data < 0).any()):
+        raise ValueError(
+            "`A` contains negative weights, which Infomap does not support."
+        )
+
+
+def _edge_items(coo: Any, *, directed: bool, weighted: bool):
+    if directed:
+        for source, target, value in zip(coo.row, coo.col, coo.data, strict=True):
+            yield int(source), int(target), float(value) if weighted else 1.0
+        return
+
+    edges: dict[tuple[int, int], float] = {}
+    for source, target, value in zip(coo.row, coo.col, coo.data, strict=True):
+        source_id = int(source)
+        target_id = int(target)
+        edge = (
+            (source_id, target_id) if source_id <= target_id else (target_id, source_id)
+        )
+        weight = float(value) if weighted else 1.0
+        if edge in edges:
+            edges[edge] = max(edges[edge], weight)
+        else:
+            edges[edge] = weight
+
+    for (source, target), weight in edges.items():
+        yield source, target, weight
+
+
+def add_scipy_sparse_matrix(
+    infomap: Any,
+    A: Any,
+    *,
+    directed: bool = False,
+    weighted: bool = True,
+    node_ids: Sequence[Any] | None = None,
+) -> dict[int, Any]:
+    sparse = _import_sparse()
+    matrix = _validate_sparse_matrix(sparse, A)
+    labels = _validate_node_ids(node_ids, matrix.shape[0])
+    coo = matrix.tocoo(copy=False)
+    coo.sum_duplicates()
+    _validate_weights(coo)
+
+    internal_to_label = {index: label for index, label in enumerate(labels)}
+
+    if not infomap.flowModelIsSet and directed:
+        infomap.setDirected(True)
+
+    for internal_id, label in internal_to_label.items():
+        infomap.add_node(internal_id, name=label if isinstance(label, str) else None)
+
+    for source, target, weight in _edge_items(
+        coo, directed=directed, weighted=weighted
+    ):
+        infomap.add_link(source, target, weight)
+
+    return internal_to_label

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,16 +48,21 @@ igraph = [
 pandas = [
   "pandas",
 ]
+scipy = [
+  "scipy",
+]
 all = [
   "igraph",
   "networkx",
   "pandas",
+  "scipy",
 ]
 test = [
   "igraph",
   "pytest",
   "networkx",
   "ruff",
+  "scipy",
 ]
 docs = [
   "sphinx",
@@ -71,6 +76,7 @@ examples = [
   "numpy",
   "pandas",
   "scikit-learn",
+  "scipy",
 ]
 release = [
   "build",

--- a/test/python/test_api.py
+++ b/test/python/test_api.py
@@ -244,7 +244,13 @@ def test_python_package_extras_are_declared(test_paths):
     assert optional_dependencies["networkx"] == ["networkx"]
     assert optional_dependencies["igraph"] == ["igraph"]
     assert optional_dependencies["pandas"] == ["pandas"]
-    assert set(optional_dependencies["all"]) == {"igraph", "networkx", "pandas"}
+    assert optional_dependencies["scipy"] == ["scipy"]
+    assert set(optional_dependencies["all"]) == {
+        "igraph",
+        "networkx",
+        "pandas",
+        "scipy",
+    }
 
 
 def test_py_typed_marker_is_packaged():

--- a/test/python/test_scipy.py
+++ b/test/python/test_scipy.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import builtins
+import math
+
+import pytest
+from infomap import Infomap
+from infomap._scipy import _import_sparse
+
+scipy = pytest.importorskip("scipy")
+sp = scipy.sparse
+
+
+def test_missing_scipy_error_mentions_extra(monkeypatch):
+    def missing_scipy_import(name, *args, **kwargs):
+        if name == "scipy.sparse":
+            raise ImportError("missing scipy")
+        return original_import(name, *args, **kwargs)
+
+    original_import = builtins.__import__
+    monkeypatch.setattr(builtins, "__import__", missing_scipy_import)
+
+    with pytest.raises(ImportError, match=r"infomap\[scipy\]"):
+        _import_sparse()
+
+
+def test_add_scipy_sparse_matrix_accepts_csr_csc_and_coo(make_infomap):
+    for matrix_factory in (sp.csr_matrix, sp.csc_matrix, sp.coo_matrix):
+        im = make_infomap(no_infomap=True)
+        mapping = im.add_scipy_sparse_matrix(matrix_factory([[0, 1], [1, 0]]))
+
+        assert mapping == {0: 0, 1: 1}
+        assert im.num_links == 1
+
+
+def test_add_scipy_sparse_matrix_accepts_sparse_arrays_when_available(make_infomap):
+    csr_array = getattr(sp, "csr_array", None)
+    if csr_array is None:
+        pytest.skip("SciPy sparse arrays are not available")
+
+    im = make_infomap(no_infomap=True)
+    mapping = im.add_scipy_sparse_matrix(csr_array([[0, 1], [1, 0]]))
+
+    assert mapping == {0: 0, 1: 1}
+    assert im.num_links == 1
+
+
+def test_add_scipy_sparse_matrix_rejects_dense_arrays(make_infomap):
+    im = make_infomap(no_infomap=True)
+
+    with pytest.raises(ValueError, match="scipy sparse"):
+        im.add_scipy_sparse_matrix([[0, 1], [1, 0]])
+
+
+def test_add_scipy_sparse_matrix_rejects_non_square(make_infomap):
+    im = make_infomap(no_infomap=True)
+
+    with pytest.raises(ValueError, match="square"):
+        im.add_scipy_sparse_matrix(sp.csr_matrix((2, 3)))
+
+
+def test_add_scipy_sparse_matrix_rejects_invalid_node_ids_length(make_infomap):
+    im = make_infomap(no_infomap=True)
+
+    with pytest.raises(ValueError, match="node_ids"):
+        im.add_scipy_sparse_matrix(sp.csr_matrix((2, 2)), node_ids=["a"])
+
+
+def test_add_scipy_sparse_matrix_rejects_duplicate_node_ids(make_infomap):
+    im = make_infomap(no_infomap=True)
+
+    with pytest.raises(ValueError, match="unique"):
+        im.add_scipy_sparse_matrix(sp.csr_matrix((2, 2)), node_ids=["a", "a"])
+
+
+def test_add_scipy_sparse_matrix_rejects_nan_weights(make_infomap):
+    im = make_infomap(no_infomap=True)
+
+    with pytest.raises(ValueError, match="NaN"):
+        im.add_scipy_sparse_matrix(
+            sp.coo_matrix(([math.nan], ([0], [1])), shape=(2, 2))
+        )
+
+
+def test_add_scipy_sparse_matrix_rejects_negative_weights(make_infomap):
+    im = make_infomap(no_infomap=True)
+
+    with pytest.raises(ValueError, match="negative"):
+        im.add_scipy_sparse_matrix(sp.coo_matrix(([-1.0], ([0], [1])), shape=(2, 2)))
+
+
+def test_from_scipy_sparse_matrix_constructs_infomap_with_args():
+    im = Infomap.from_scipy_sparse_matrix(
+        sp.csr_matrix([[0, 1], [1, 0]]),
+        args="--silent --no-infomap",
+    )
+
+    assert isinstance(im, Infomap)
+    assert im.num_links == 1
+
+
+def test_add_scipy_sparse_matrix_returns_custom_node_id_mapping(make_infomap):
+    im = make_infomap(no_infomap=True)
+
+    mapping = im.add_scipy_sparse_matrix(
+        sp.coo_matrix([[0, 3], [3, 0]]),
+        directed=False,
+        node_ids=["gene_a", "gene_b"],
+    )
+
+    im.run()
+    modules = {
+        mapping[node_id]: module_id for node_id, module_id in im.get_modules().items()
+    }
+
+    assert mapping == {0: "gene_a", 1: "gene_b"}
+    assert set(modules) == {"gene_a", "gene_b"}
+
+
+def test_add_scipy_sparse_matrix_directed_adds_each_nonzero(make_infomap):
+    im = make_infomap(no_infomap=True)
+
+    im.add_scipy_sparse_matrix(sp.csr_matrix([[0, 2], [3, 0]]), directed=True)
+
+    assert im.num_links == 2
+
+
+def test_add_scipy_sparse_matrix_undirected_deduplicates_symmetric_entries(
+    make_infomap,
+):
+    im = make_infomap(no_infomap=True)
+
+    im.add_scipy_sparse_matrix(sp.csr_matrix([[0, 2], [2, 0]]), directed=False)
+
+    assert im.num_links == 1
+
+
+def test_add_scipy_sparse_matrix_undirected_accepts_upper_triangular(make_infomap):
+    im = make_infomap(no_infomap=True)
+
+    im.add_scipy_sparse_matrix(
+        sp.csr_matrix([[0, 2, 0], [0, 0, 4], [0, 0, 0]]), directed=False
+    )
+
+    assert im.num_links == 2
+
+
+def test_add_scipy_sparse_matrix_unweighted_ignores_values(make_infomap):
+    weighted = make_infomap(no_infomap=True)
+    unweighted = make_infomap(no_infomap=True)
+
+    weighted.add_scipy_sparse_matrix(
+        sp.csr_matrix([[0, 5], [0, 0]]), directed=True, weighted=True
+    )
+    unweighted.add_scipy_sparse_matrix(
+        sp.csr_matrix([[0, 5], [0, 0]]), directed=True, weighted=False
+    )
+
+    assert weighted.num_links == 1
+    assert unweighted.num_links == 1
+
+
+def test_from_scipy_sparse_matrix_runs_empty_graph_with_nodes():
+    im = Infomap.from_scipy_sparse_matrix(sp.csr_matrix((3, 3)), args="--silent")
+
+    im.run()
+
+    assert set(im.get_modules()) == {0, 1, 2}
+
+
+def test_from_scipy_sparse_matrix_runs_single_node_graph():
+    im = Infomap.from_scipy_sparse_matrix(sp.coo_matrix((1, 1)), args="--silent")
+
+    im.run()
+
+    assert im.get_modules() == {0: 1}
+
+
+def test_from_scipy_sparse_matrix_weighted_graph_returns_all_nodes():
+    matrix = sp.csr_matrix(
+        [
+            [0, 1, 0, 0],
+            [1, 0, 4, 0],
+            [0, 4, 0, 1],
+            [0, 0, 1, 0],
+        ]
+    )
+    im = Infomap.from_scipy_sparse_matrix(
+        matrix, args="--silent --num-trials 2 --seed 123"
+    )
+
+    im.run()
+
+    assert set(im.get_modules()) == {0, 1, 2, 3}


### PR DESCRIPTION
## Summary

- Add `Infomap.add_scipy_sparse_matrix(...)` and `Infomap.from_scipy_sparse_matrix(...)` for SciPy CSR, CSC, COO matrices and sparse arrays.
- Validate sparse adjacency input, weights, and `node_ids`, and de-duplicate symmetric undirected entries.
- Document the new Python API in `interfaces/python/source/usage.rst` and add the `scipy` optional extra.

Closes #535.

## Validation

- `python3 -m ruff format interfaces/python/src/infomap/_scipy.py interfaces/python/src/infomap/_facade.py interfaces/python/src/infomap/_results.py test/python/test_scipy.py test/python/test_api.py`
- `python3 -m ruff check --fix interfaces/python/src/infomap/_scipy.py interfaces/python/src/infomap/_facade.py interfaces/python/src/infomap/_results.py test/python/test_scipy.py test/python/test_api.py`
- `make test-python-unit PYTEST_ARGS='test/python/test_scipy.py test/python/test_api.py::test_python_package_extras_are_declared -q'`
- `make test-python`
- `make PYTHON=.venv/bin/python PYTHON_FOR_BUILD_CONFIG=.venv/bin/python build-docs`

Note: plain `make build-docs` used Homebrew system Python and failed before the docs build because that Python is PEP 668 externally managed. The docs build passed with the repo virtual environment explicitly selected.