### PR TITLE
feat(python): add edge index input support

### DIFF
--- a/interfaces/python/source/usage.rst
+++ b/interfaces/python/source/usage.rst
@@ -153,6 +153,81 @@ and ``A[j, i]`` exist, one undirected link is added. If the two entries have
 different weights, the larger weight is used. For large graphs, prefer CSR or
 COO input to avoid unnecessary conversion work.
 
+edge_index and graph ML workflows
+---------------------------------
+
+Use :meth:`infomap.Infomap.from_edge_index` when your graph is stored in the
+PyTorch Geometric-style ``edge_index`` format. The input has shape
+``(2, num_edges)``, with source node ids in row 0 and target node ids in row
+1. NumPy arrays, Python lists and PyTorch tensors are accepted. PyTorch is
+optional; tensor inputs are converted with ``detach().cpu().numpy()`` only
+when provided. NumPy is required for edge-index conversion; install it with
+``python -m pip install numpy`` if it is not already available.
+
+.. code-block:: python
+
+    import numpy as np
+    from infomap import Infomap
+
+    edge_index = np.array([
+        [0, 1, 1, 2],
+        [1, 0, 2, 1],
+    ])
+
+    im = Infomap.from_edge_index(edge_index, directed=False, args="--silent")
+    im.run()
+    modules = im.get_modules()
+
+Pass ``edge_weight`` for weighted graphs:
+
+.. code-block:: python
+
+    edge_weight = np.array([1.0, 1.0, 3.5, 3.5])
+    im = Infomap.from_edge_index(
+        edge_index,
+        edge_weight=edge_weight,
+        directed=False,
+        args="--silent",
+    )
+
+PyTorch tensors can be passed directly when PyTorch is installed:
+
+.. code-block:: python
+
+    import torch
+    from infomap import Infomap
+
+    edge_index = torch.tensor([
+        [0, 1, 2],
+        [1, 2, 0],
+    ])
+    im = Infomap.from_edge_index(edge_index, directed=True, args="--silent")
+
+PyTorch Geometric ``Data`` objects are not required. Pass their attributes to
+the edge-index API:
+
+.. code-block:: python
+
+    im = Infomap.from_edge_index(
+        data.edge_index,
+        edge_weight=data.edge_weight,
+        num_nodes=data.num_nodes,
+        args="--silent",
+    )
+
+Pass ``num_nodes`` to preserve isolated nodes that do not appear in
+``edge_index``. For undirected input, reverse duplicate edges are
+de-duplicated; if the two entries have different weights, the larger weight is
+used. Custom ``node_ids`` follow the same mapping pattern as
+:meth:`infomap.Infomap.add_networkx_graph`:
+
+.. code-block:: python
+
+    im = Infomap(silent=True)
+    mapping = im.add_edge_index(edge_index, node_ids=["gene_a", "gene_b", "gene_c"])
+    im.run()
+    modules = {mapping[node_id]: module_id for node_id, module_id in im.get_modules().items()}
+
 State and multilayer networks
 -----------------------------
 

--- a/interfaces/python/src/infomap/_edge_index.py
+++ b/interfaces/python/src/infomap/_edge_index.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from numbers import Integral
+from typing import Any
+
+
+def _as_numpy_array(value: Any, *, name: str):
+    try:
+        import numpy as np
+    except ImportError as exc:
+        raise ImportError(
+            "The 'numpy' package is required for edge_index support."
+        ) from exc
+
+    if hasattr(value, "detach") and callable(value.detach):
+        try:
+            value = value.detach().cpu().numpy()
+        except AttributeError as exc:
+            raise ValueError(
+                f"`{name}` tensor inputs must support detach().cpu().numpy()."
+            ) from exc
+
+    try:
+        return np.asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"`{name}` must be array-like.") from exc
+
+
+def _validate_edge_index(edge_index: Any):
+    edge_index_array = _as_numpy_array(edge_index, name="edge_index")
+    if edge_index_array.ndim != 2 or edge_index_array.shape[0] != 2:
+        raise ValueError("`edge_index` must have shape `(2, num_edges)`.")
+    if edge_index_array.dtype.kind not in "iu":
+        raise ValueError("`edge_index` values must be integer node ids.")
+    if bool((edge_index_array < 0).any()):
+        raise ValueError("`edge_index` cannot contain negative node ids.")
+    return edge_index_array
+
+
+def _validate_num_nodes(edge_index: Any, num_nodes: int | None) -> int:
+    if num_nodes is not None and (
+        not isinstance(num_nodes, Integral) or isinstance(num_nodes, bool)
+    ):
+        raise ValueError("`num_nodes` must be an integer.")
+
+    if edge_index.shape[1] == 0:
+        if num_nodes is None:
+            return 0
+        if num_nodes < 0:
+            raise ValueError("`num_nodes` cannot be negative.")
+        return int(num_nodes)
+
+    inferred_num_nodes = int(edge_index.max()) + 1
+    if num_nodes is None:
+        return inferred_num_nodes
+    if num_nodes < inferred_num_nodes:
+        raise ValueError(
+            "`num_nodes` cannot be smaller than the largest node id plus one."
+        )
+    return int(num_nodes)
+
+
+def _validate_node_ids(node_ids: Sequence[Any] | None, n_nodes: int) -> list[Any]:
+    if node_ids is None:
+        return list(range(n_nodes))
+
+    labels = list(node_ids)
+    if len(labels) != n_nodes:
+        raise ValueError("`node_ids` length must match `num_nodes`.")
+    if len(set(labels)) != len(labels):
+        raise ValueError("`node_ids` values must be unique.")
+    return labels
+
+
+def _validate_edge_weight(edge_weight: Any, num_edges: int):
+    import numpy as np
+
+    if edge_weight is None:
+        return None
+
+    weights = _as_numpy_array(edge_weight, name="edge_weight")
+    if weights.ndim != 1 or weights.shape[0] != num_edges:
+        raise ValueError(
+            "`edge_weight` must be a one-dimensional array with one value per edge."
+        )
+    if weights.dtype.kind not in "iuf":
+        raise ValueError("`edge_weight` values must be numeric.")
+    if bool(np.isnan(weights).any()):
+        raise ValueError("`edge_weight` contains NaN weights.")
+    if bool((weights < 0).any()):
+        raise ValueError(
+            "`edge_weight` contains negative weights, which Infomap does not support."
+        )
+    return weights
+
+
+def _edge_items(edge_index: Any, weights: Any, *, directed: bool):
+    if directed:
+        if weights is None:
+            for source, target in zip(edge_index[0], edge_index[1], strict=True):
+                yield int(source), int(target), 1.0
+        else:
+            for source, target, weight in zip(
+                edge_index[0], edge_index[1], weights, strict=True
+            ):
+                yield int(source), int(target), float(weight)
+        return
+
+    edges: dict[tuple[int, int], float] = {}
+    if weights is None:
+        edge_values = zip(edge_index[0], edge_index[1], strict=True)
+    else:
+        edge_values = zip(edge_index[0], edge_index[1], weights, strict=True)
+
+    for edge_value in edge_values:
+        if weights is None:
+            source, target = edge_value
+            weight = 1.0
+        else:
+            source, target, weight = edge_value
+            weight = float(weight)
+        source_id = int(source)
+        target_id = int(target)
+        edge = (
+            (source_id, target_id) if source_id <= target_id else (target_id, source_id)
+        )
+        if edge in edges:
+            edges[edge] = max(edges[edge], weight)
+        else:
+            edges[edge] = weight
+
+    for (source, target), weight in edges.items():
+        yield source, target, weight
+
+
+def add_edge_index(
+    infomap: Any,
+    edge_index: Any,
+    *,
+    edge_weight: Any = None,
+    num_nodes: int | None = None,
+    directed: bool = True,
+    node_ids: Sequence[Any] | None = None,
+) -> dict[int, Any]:
+    edge_index_array = _validate_edge_index(edge_index)
+    n_nodes = _validate_num_nodes(edge_index_array, num_nodes)
+    labels = _validate_node_ids(node_ids, n_nodes)
+    weights = _validate_edge_weight(edge_weight, edge_index_array.shape[1])
+
+    internal_to_label = {index: label for index, label in enumerate(labels)}
+
+    if not infomap.flowModelIsSet and directed:
+        infomap.setDirected(True)
+
+    for internal_id, label in internal_to_label.items():
+        infomap.add_node(internal_id, name=label if isinstance(label, str) else None)
+
+    for source, target, weight in _edge_items(
+        edge_index_array, weights, directed=directed
+    ):
+        infomap.add_link(source, target, weight)
+
+    return internal_to_label

--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 
 from ._bindings import *  # noqa: F401,F403
 from ._bindings import __all__ as _BINDINGS_ALL
+from ._edge_index import add_edge_index as _add_edge_index
 from ._igraph import add_igraph_graph as _add_igraph_graph
 from ._igraph import find_igraph_communities
 from ._networkx import add_networkx_graph as _add_networkx_graph
@@ -197,6 +198,29 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin, InfomapWrapper):  # no
             A,
             directed=directed,
             weighted=weighted,
+            node_ids=node_ids,
+        )
+        return im
+
+    @classmethod
+    def from_edge_index(
+        cls,
+        edge_index,
+        *,
+        edge_weight=None,
+        num_nodes=None,
+        directed=True,
+        node_ids=None,
+        args=None,
+        **infomap_options,
+    ):
+        """Create an :class:`Infomap` instance from a PyG-style edge index."""
+        im = cls(args=args, **infomap_options)
+        im.add_edge_index(
+            edge_index,
+            edge_weight=edge_weight,
+            num_nodes=num_nodes,
+            directed=directed,
             node_ids=node_ids,
         )
         return im
@@ -1205,6 +1229,47 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin, InfomapWrapper):  # no
             A,
             directed=directed,
             weighted=weighted,
+            node_ids=node_ids,
+        )
+
+    def add_edge_index(
+        self,
+        edge_index,
+        edge_weight=None,
+        num_nodes=None,
+        directed=True,
+        node_ids=None,
+    ):
+        """Add links and nodes from a PyG-style edge index.
+
+        Parameters
+        ----------
+        edge_index : array-like
+            Two-row edge index where row 0 contains source node ids and row 1
+            contains target node ids.
+        edge_weight : array-like, optional
+            One-dimensional edge weights with one value per edge. If omitted,
+            every edge is treated as weight ``1.0``.
+        num_nodes : int, optional
+            Total number of nodes. Pass this to preserve isolated nodes.
+        directed : bool, optional
+            Interpret edges as directed. Default ``True``.
+        node_ids : sequence, optional
+            External node ids in internal node order. If omitted, ``0..n-1`` is
+            used.
+
+        Returns
+        -------
+        dict
+            Dict with internal integer node ids as keys and external node ids
+            as values.
+        """
+        return _add_edge_index(
+            self,
+            edge_index,
+            edge_weight=edge_weight,
+            num_nodes=num_nodes,
+            directed=directed,
             node_ids=node_ids,
         )
 

--- a/test/python/test_edge_index.py
+++ b/test/python/test_edge_index.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+from infomap import Infomap
+from infomap._edge_index import add_edge_index
+
+
+class FakeTensor:
+    def __init__(self, value):
+        self.value = np.asarray(value)
+
+    def detach(self):
+        return self
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return self.value
+
+
+class IncompleteTensor:
+    def detach(self):
+        return self
+
+
+class Recorder:
+    flowModelIsSet = False
+
+    def __init__(self):
+        self.directed = False
+        self.nodes = []
+        self.links = []
+
+    def setDirected(self, value):
+        self.directed = value
+
+    def add_node(self, node_id, name=None):
+        self.nodes.append((node_id, name))
+
+    def add_link(self, source_id, target_id, weight=1.0):
+        self.links.append((source_id, target_id, weight))
+
+
+def test_from_edge_index_accepts_numpy_array():
+    edge_index = np.array([[0, 1, 1, 2], [1, 0, 2, 1]], dtype=np.int64)
+
+    im = Infomap.from_edge_index(edge_index, directed=False, args="--silent")
+    im.run()
+
+    assert im.num_links == 2
+    assert set(im.get_modules()) == {0, 1, 2}
+
+
+def test_add_edge_index_accepts_list_input(make_infomap):
+    im = make_infomap(no_infomap=True)
+
+    mapping = im.add_edge_index([[0, 1], [1, 2]], directed=True)
+
+    assert mapping == {0: 0, 1: 1, 2: 2}
+    assert im.num_links == 2
+
+
+def test_add_edge_index_accepts_torch_like_tensors():
+    recorder = Recorder()
+
+    mapping = add_edge_index(
+        recorder,
+        FakeTensor([[0, 1], [1, 2]]),
+        edge_weight=FakeTensor([2.5, 3.5]),
+    )
+
+    assert mapping == {0: 0, 1: 1, 2: 2}
+    assert recorder.links == [(0, 1, 2.5), (1, 2, 3.5)]
+
+
+def test_add_edge_index_rejects_incomplete_tensor_interface(make_infomap):
+    im = make_infomap(no_infomap=True)
+
+    with pytest.raises(ValueError, match=r"detach\(\)\.cpu\(\)\.numpy\(\)"):
+        im.add_edge_index(IncompleteTensor())
+
+
+def test_add_edge_index_defaults_to_unweighted_edges():
+    recorder = Recorder()
+
+    add_edge_index(recorder, np.array([[0, 1], [1, 2]], dtype=np.int64))
+
+    assert recorder.links == [(0, 1, 1.0), (1, 2, 1.0)]
+
+
+def test_add_edge_index_rejects_invalid_edge_weight_length(make_infomap):
+    im = make_infomap(no_infomap=True)
+
+    with pytest.raises(ValueError, match="one value per edge"):
+        im.add_edge_index([[0, 1], [1, 2]], edge_weight=[1.0])
+
+
+def test_add_edge_index_rejects_nan_edge_weight(make_infomap):
+    im = make_infomap(no_infomap=True)
+
+    with pytest.raises(ValueError, match="NaN"):
+        im.add_edge_index([[0], [1]], edge_weight=[math.nan])
+
+
+def test_add_edge_index_rejects_negative_edge_weight(make_infomap):
+    im = make_infomap(no_infomap=True)
+
+    with pytest.raises(ValueError, match="negative"):
+        im.add_edge_index([[0], [1]], edge_weight=[-1.0])
+
+
+def test_add_edge_index_sets_directed_by_default():
+    recorder = Recorder()
+
+    add_edge_index(recorder, np.array([[0], [1]], dtype=np.int64))
+
+    assert recorder.directed is True
+
+
+def test_add_edge_index_undirected_deduplicates_reverse_edges():
+    recorder = Recorder()
+
+    add_edge_index(
+        recorder,
+        np.array([[0, 1, 1, 2], [1, 0, 2, 1]], dtype=np.int64),
+        edge_weight=[1.0, 2.0, 3.0, 4.0],
+        directed=False,
+    )
+
+    assert recorder.directed is False
+    assert recorder.links == [(0, 1, 2.0), (1, 2, 4.0)]
+
+
+def test_from_edge_index_preserves_isolated_nodes_with_num_nodes():
+    im = Infomap.from_edge_index([[0], [1]], num_nodes=4, args="--silent")
+
+    im.run()
+
+    assert set(im.get_modules()) == {0, 1, 2, 3}
+
+
+def test_add_edge_index_returns_custom_node_id_mapping(make_infomap):
+    im = make_infomap(no_infomap=True)
+
+    mapping = im.add_edge_index(
+        [[0, 1], [1, 2]],
+        node_ids=["gene_a", "gene_b", "gene_c"],
+    )
+    im.run()
+    modules = {
+        mapping[node_id]: module_id for node_id, module_id in im.get_modules().items()
+    }
+
+    assert mapping == {0: "gene_a", 1: "gene_b", 2: "gene_c"}
+    assert dict(im.names) == {0: "gene_a", 1: "gene_b", 2: "gene_c"}
+    assert set(modules) == {"gene_a", "gene_b", "gene_c"}
+
+
+def test_add_edge_index_rejects_invalid_shape(make_infomap):
+    im = make_infomap(no_infomap=True)
+
+    with pytest.raises(ValueError, match=r"shape `\(2, num_edges\)`"):
+        im.add_edge_index([[0, 1], [1, 2], [2, 3]])
+
+
+def test_add_edge_index_rejects_negative_node_id(make_infomap):
+    im = make_infomap(no_infomap=True)
+
+    with pytest.raises(ValueError, match="negative node ids"):
+        im.add_edge_index([[0, -1], [1, 2]])
+
+
+def test_add_edge_index_rejects_non_integer_node_id(make_infomap):
+    im = make_infomap(no_infomap=True)
+
+    with pytest.raises(ValueError, match="integer node ids"):
+        im.add_edge_index(np.array([[0.0], [1.0]]))
+
+
+def test_add_edge_index_rejects_num_nodes_too_small(make_infomap):
+    im = make_infomap(no_infomap=True)
+
+    with pytest.raises(ValueError, match="num_nodes"):
+        im.add_edge_index([[0, 2], [1, 3]], num_nodes=3)
+
+
+def test_add_edge_index_rejects_invalid_node_ids(make_infomap):
+    im = make_infomap(no_infomap=True)
+
+    with pytest.raises(ValueError, match="node_ids"):
+        im.add_edge_index([[0], [1]], node_ids=["a"])
+
+    with pytest.raises(ValueError, match="unique"):
+        im.add_edge_index([[0], [1]], node_ids=["a", "a"])


### PR DESCRIPTION
## Summary

- Add `Infomap.add_edge_index(...)` and `Infomap.from_edge_index(...)` for PyTorch Geometric-style edge-index graph input.
- Support NumPy/list inputs and duck-typed tensor conversion via `detach().cpu().numpy()` without adding PyTorch as a dependency.
- Preserve isolated nodes with `num_nodes`, return custom `node_ids` mappings, validate invalid inputs, and document graph ML usage patterns.

Closes #536.

## Validation

- `python3 -m ruff format interfaces/python/src/infomap/_edge_index.py interfaces/python/src/infomap/_facade.py test/python/test_edge_index.py`
- `python3 -m ruff check --fix interfaces/python/src/infomap/_edge_index.py interfaces/python/src/infomap/_facade.py test/python/test_edge_index.py`
- `make test-python-unit PYTEST_ARGS='test/python/test_edge_index.py -q'`
- `make test-python`
- `make PYTHON=.venv/bin/python PYTHON_FOR_BUILD_CONFIG=.venv/bin/python build-docs`