### PR TITLE
feat(python): add AnnData Scanpy integration

### DIFF
--- a/interfaces/python/source/api/functions.rst
+++ b/interfaces/python/source/api/functions.rst
@@ -8,6 +8,7 @@ Graph-package entry points
 
 .. autofunction:: find_communities
 .. autofunction:: find_igraph_communities
+.. autofunction:: infomap.tl.infomap
 
 Information-theoretic primitives
 --------------------------------

--- a/interfaces/python/source/index.rst
+++ b/interfaces/python/source/index.rst
@@ -36,6 +36,8 @@ Where to go next
 - :doc:`usage` — NetworkX, igraph, state and multilayer networks, reusable
   options, and a migration guide for users of other community-detection
   packages.
+- :doc:`scanpy` — run Infomap on AnnData graphs in Scanpy-style single-cell
+  workflows.
 - :doc:`api/index` — full API reference, split into top-level functions, the
   :class:`infomap.Infomap` class, options, and tree iterators.
 
@@ -56,4 +58,5 @@ External resources
    installation
    quickstart
    usage
+   scanpy
    api/index

--- a/interfaces/python/source/installation.rst
+++ b/interfaces/python/source/installation.rst
@@ -26,6 +26,7 @@ Install optional integrations for common research workflows:
     pip install "infomap[igraph]"
     pip install "infomap[pandas]"
     pip install "infomap[scipy]"
+    pip install "infomap[anndata]"
 
 Or install all optional integrations at once:
 

--- a/interfaces/python/source/scanpy.rst
+++ b/interfaces/python/source/scanpy.rst
@@ -1,0 +1,110 @@
+Using Infomap with AnnData and Scanpy
+=====================================
+
+Use :func:`infomap.tl.infomap` to run Infomap directly on an AnnData
+observation graph. The function follows Scanpy ``tl`` conventions: it reads a
+sparse graph from ``adata.obsp``, stores categorical cluster labels in
+``adata.obs``, and records run metadata in ``adata.uns``.
+
+Infomap does not import Scanpy. It only requires an AnnData-compatible object
+with ``obs``, ``obsp``, ``uns`` and ``obs_names``.
+
+Minimal AnnData example
+-----------------------
+
+.. code-block:: python
+
+    import anndata as ad
+    import pandas as pd
+    import scipy.sparse as sp
+    import infomap
+
+    adata = ad.AnnData(obs=pd.DataFrame(index=["cell-a", "cell-b", "cell-c"]))
+    adata.obsp["connectivities"] = sp.csr_matrix([
+        [0, 1, 0],
+        [1, 0, 1],
+        [0, 1, 0],
+    ])
+
+    infomap.tl.infomap(adata)
+
+    adata.obs["infomap"]
+    adata.uns["infomap"]
+
+Scanpy workflow
+---------------
+
+In Scanpy workflows, nearest-neighbor graphs are commonly created with
+``sc.pp.neighbors``. By default, Infomap uses ``adata.obsp["connectivities"]``,
+which is the graph used by Scanpy clustering tools:
+
+.. code-block:: python
+
+    import scanpy as sc
+    import infomap
+
+    adata = sc.datasets.pbmc3k_processed()
+    sc.pp.neighbors(adata)
+
+    infomap.tl.infomap(adata, key_added="infomap")
+
+    sc.tl.leiden(adata, key_added="leiden")
+    sc.pl.umap(adata, color=["infomap", "leiden"])
+
+If the neighbor graph was stored under a custom key, pass ``neighbors_key`` and
+Infomap will resolve the graph through
+``adata.uns[neighbors_key]["connectivities_key"]``:
+
+.. code-block:: python
+
+    sc.pp.neighbors(adata, key_added="neighbors_pca")
+    infomap.tl.infomap(adata, neighbors_key="neighbors_pca")
+
+Graph selection
+---------------
+
+Use ``obsp`` to select a graph directly from ``adata.obsp``:
+
+.. code-block:: python
+
+    infomap.tl.infomap(adata, obsp="connectivities")
+
+Use ``adjacency`` when you already have a sparse matrix object:
+
+.. code-block:: python
+
+    infomap.tl.infomap(adata, adjacency=adata.obsp["connectivities"])
+
+For single-cell clustering, ``connectivities`` is usually the right default.
+``distances`` stores neighbor distances rather than graph affinities, so it is
+not used unless you explicitly pass ``obsp="distances"``.
+
+Directed and weighted graphs
+----------------------------
+
+By default, Infomap treats the graph as undirected and weighted. For a directed
+observation graph, pass ``directed=True``; then ``A[i, j]`` is interpreted as a
+link from observation ``i`` to observation ``j``. Pass ``use_weights=False`` to
+treat every nonzero sparse entry as weight ``1.0``.
+
+.. code-block:: python
+
+    infomap.tl.infomap(
+        adata,
+        directed=False,
+        use_weights=True,
+        key_added="infomap",
+    )
+
+Results and lower-level access
+------------------------------
+
+``adata.obs[key_added]`` is a pandas categorical column with string module
+labels, matching common Scanpy clustering output. ``adata.uns[key_added]``
+contains the selected graph key, Infomap options, number of modules and
+codelength.
+
+For hierarchical module assignments, flows, custom output files or repeated
+runs with the same graph, use the lower-level :class:`infomap.Infomap` API with
+:meth:`infomap.Infomap.add_scipy_sparse_matrix`. The AnnData helper keeps the
+default output compact for interactive single-cell analysis.

--- a/interfaces/python/source/usage.rst
+++ b/interfaces/python/source/usage.rst
@@ -6,6 +6,9 @@ NetworkX- and igraph-style entry points, state and multilayer networks, and a
 short migration guide for users coming from other community-detection
 packages.
 
+For single-cell analysis workflows using AnnData or Scanpy, see
+:doc:`scanpy`.
+
 Reusable options
 ----------------
 

--- a/interfaces/python/src/infomap/__init__.py
+++ b/interfaces/python/src/infomap/__init__.py
@@ -32,7 +32,11 @@ try:
     from ._facade import __all__ as _FACADE_ALL
     from ._facade import *  # noqa: F401,F403
     from ._facade import _construct_args as _construct_args
+
+    from . import tl as tl
+
     __all__.extend(_FACADE_ALL)
+    __all__.append("tl")
 except ImportError:
     # Allow setuptools to read package metadata before the extension is built.
     pass

--- a/interfaces/python/src/infomap/tl.py
+++ b/interfaces/python/src/infomap/tl.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def _import_pandas() -> Any:
+    try:
+        import pandas as pd
+    except ImportError as exc:
+        raise ImportError(
+            "The 'pandas' package is required for AnnData support. "
+            'Install it with `python -m pip install "infomap[anndata]"`.'
+        ) from exc
+    return pd
+
+
+def _validate_anndata_like(adata: Any) -> int:
+    missing = [
+        attribute
+        for attribute in ("obs", "obsp", "uns", "obs_names")
+        if not hasattr(adata, attribute)
+    ]
+    if missing:
+        raise ValueError(
+            "`adata` must be an AnnData-like object with `.obs`, `.obsp`, "
+            f"`.uns`, and `.obs_names`; missing `.{missing[0]}`."
+        )
+
+    obs_names = list(adata.obs_names)
+    n_obs = getattr(adata, "n_obs", len(obs_names))
+    if n_obs != len(obs_names):
+        raise ValueError("`adata.n_obs` must match the length of `adata.obs_names`.")
+    return n_obs
+
+
+def _require_mapping(value: Any, *, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"`{name}` must be a mapping.")
+    return value
+
+
+def _resolve_adjacency(
+    adata: Any,
+    *,
+    adjacency: Any,
+    neighbors_key: str | None,
+    obsp: str | None,
+) -> tuple[Any, str | None]:
+    if adjacency is not None and (neighbors_key is not None or obsp is not None):
+        raise ValueError("Pass only one of `adjacency`, `neighbors_key`, or `obsp`.")
+    if neighbors_key is not None and obsp is not None:
+        raise ValueError("Pass only one of `neighbors_key` and `obsp`.")
+
+    if adjacency is not None:
+        return adjacency, None
+
+    if neighbors_key is not None:
+        uns = _require_mapping(adata.uns, name="adata.uns")
+        if neighbors_key not in uns:
+            raise ValueError(f"`adata.uns[{neighbors_key!r}]` does not exist.")
+        neighbors = _require_mapping(
+            uns[neighbors_key], name=f"adata.uns[{neighbors_key!r}]"
+        )
+        connectivities_key = neighbors.get("connectivities_key")
+        if not isinstance(connectivities_key, str) or not connectivities_key:
+            raise ValueError(
+                f"`adata.uns[{neighbors_key!r}]` must contain a non-empty "
+                "`'connectivities_key'` string."
+            )
+        obsp = connectivities_key
+    elif obsp is None:
+        obsp = "connectivities"
+
+    if obsp not in adata.obsp:
+        raise ValueError(f"`adata.obsp[{obsp!r}]` does not exist.")
+    return adata.obsp[obsp], obsp
+
+
+def _validate_adjacency_shape(matrix: Any, *, n_obs: int) -> None:
+    shape = getattr(matrix, "shape", None)
+    if shape is None or len(shape) != 2:
+        raise ValueError("`adjacency` must be a two-dimensional adjacency matrix.")
+    if shape[0] != shape[1]:
+        raise ValueError("`adjacency` must be a square adjacency matrix.")
+    if shape[0] != n_obs:
+        raise ValueError("`adjacency` shape must match `adata.n_obs`.")
+
+
+def _copy_anndata_like(adata: Any) -> Any:
+    copy_method = getattr(adata, "copy", None)
+    if not callable(copy_method):
+        raise ValueError("`adata` must provide a `.copy()` method when `copy=True`.")
+    return copy_method()
+
+
+def _module_labels(im: Any, mapping: dict[int, Any], obs_names: list[Any]) -> list[str]:
+    modules = im.get_modules()
+    modules_by_obs_name = {
+        mapping[internal_id]: module_id for internal_id, module_id in modules.items()
+    }
+    try:
+        return [str(modules_by_obs_name[obs_name]) for obs_name in obs_names]
+    except KeyError as exc:
+        raise RuntimeError(
+            "Could not align Infomap modules with `adata.obs_names`."
+        ) from exc
+
+
+def infomap(
+    adata: Any,
+    *,
+    adjacency: Any = None,
+    directed: bool = False,
+    use_weights: bool = True,
+    key_added: str = "infomap",
+    neighbors_key: str | None = None,
+    obsp: str | None = None,
+    copy: bool = False,
+    args: str | None = None,
+    **infomap_options: Any,
+) -> Any:
+    """Run Infomap on an AnnData observation graph.
+
+    This function follows Scanpy ``tl`` conventions: by default it reads
+    ``adata.obsp["connectivities"]``, writes categorical module labels to
+    ``adata.obs[key_added]``, and stores run metadata in ``adata.uns[key_added]``.
+    Scanpy itself is not imported.
+    """
+    from ._facade import Infomap
+
+    pd = _import_pandas()
+    n_obs = _validate_anndata_like(adata)
+    if copy:
+        adata = _copy_anndata_like(adata)
+        n_obs = _validate_anndata_like(adata)
+    matrix, resolved_obsp = _resolve_adjacency(
+        adata,
+        adjacency=adjacency,
+        neighbors_key=neighbors_key,
+        obsp=obsp,
+    )
+    _validate_adjacency_shape(matrix, n_obs=n_obs)
+
+    options = {"silent": True, "no_file_output": True}
+    options.update(infomap_options)
+    im = Infomap(args=args, **options)
+    obs_names = list(adata.obs_names)
+    mapping = im.add_scipy_sparse_matrix(
+        matrix,
+        directed=directed,
+        weighted=use_weights,
+        node_ids=obs_names,
+    )
+    im.run()
+
+    labels = _module_labels(im, mapping, obs_names)
+    categories = sorted({int(label) for label in labels})
+    adata.obs[key_added] = pd.Categorical(
+        labels,
+        categories=[str(category) for category in categories],
+    )
+    adata.uns[key_added] = {
+        "params": {
+            "directed": directed,
+            "use_weights": use_weights,
+            "neighbors_key": neighbors_key,
+            "obsp": resolved_obsp,
+            "args": args,
+            **options,
+        },
+        "n_modules": im.num_top_modules,
+        "codelength": im.codelength,
+    }
+
+    if copy:
+        return adata
+    return None

--- a/mk/python.mk
+++ b/mk/python.mk
@@ -15,6 +15,7 @@ PYTHON_LINT_TARGETS := \
 	interfaces/python/src/infomap/_results.py \
 	interfaces/python/src/infomap/_version.py \
 	interfaces/python/src/infomap/_writers.py \
+	interfaces/python/src/infomap/tl.py \
 	examples/python
 PYTHON_FORMAT_TARGETS := \
 	interfaces/python/src/infomap/__init__.py \
@@ -27,6 +28,7 @@ PYTHON_FORMAT_TARGETS := \
 	interfaces/python/src/infomap/_results.py \
 	interfaces/python/src/infomap/_version.py \
 	interfaces/python/src/infomap/_writers.py \
+	interfaces/python/src/infomap/tl.py \
 	examples/python \
 	test/python
 PYTEST_ARGS ?=

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,13 +51,20 @@ pandas = [
 scipy = [
   "scipy",
 ]
+anndata = [
+  "anndata",
+  "pandas",
+  "scipy",
+]
 all = [
+  "anndata",
   "igraph",
   "networkx",
   "pandas",
   "scipy",
 ]
 test = [
+  "anndata",
   "igraph",
   "pytest",
   "networkx",

--- a/test/python/test_anndata.py
+++ b/test/python/test_anndata.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import infomap
+
+ad = pytest.importorskip("anndata")
+pd = pytest.importorskip("pandas")
+scipy = pytest.importorskip("scipy")
+sp = scipy.sparse
+
+pytestmark = pytest.mark.fast
+
+
+def _adata(*, key: str = "connectivities", matrix=None):
+    if matrix is None:
+        matrix = sp.csr_matrix(
+            [
+                [0, 1, 0, 0],
+                [1, 0, 0, 0],
+                [0, 0, 0, 1],
+                [0, 0, 1, 0],
+            ]
+        )
+    data = ad.AnnData(obs=pd.DataFrame(index=["cell-a", "cell-b", "cell-c", "cell-d"]))
+    data.obsp[key] = matrix
+    data.uns["neighbors"] = {"connectivities_key": key}
+    return data
+
+
+def test_tl_infomap_mutates_anndata_in_place():
+    data = _adata()
+
+    result = infomap.tl.infomap(data, seed=123, num_trials=1)
+
+    assert result is None
+    assert "infomap" in data.obs
+    assert str(data.obs["infomap"].dtype) == "category"
+    assert set(data.obs["infomap"].astype(str)) == {"1", "2"}
+
+
+def test_tl_infomap_copy_returns_modified_copy_only():
+    data = _adata()
+
+    copied = infomap.tl.infomap(data, copy=True, seed=123, num_trials=1)
+
+    assert copied is not data
+    assert "infomap" not in data.obs
+    assert "infomap" in copied.obs
+
+
+def test_tl_infomap_uses_custom_key_added():
+    data = _adata()
+
+    infomap.tl.infomap(data, key_added="infomap_clusters", seed=123, num_trials=1)
+
+    assert "infomap_clusters" in data.obs
+    assert "infomap_clusters" in data.uns
+    assert "infomap" not in data.obs
+
+
+def test_tl_infomap_uses_custom_obsp_key():
+    data = _adata(key="custom_connectivities")
+
+    infomap.tl.infomap(data, obsp="custom_connectivities", seed=123, num_trials=1)
+
+    assert data.uns["infomap"]["params"]["obsp"] == "custom_connectivities"
+
+
+def test_tl_infomap_resolves_neighbors_key():
+    data = _adata(key="custom_connectivities")
+
+    infomap.tl.infomap(data, neighbors_key="neighbors", seed=123, num_trials=1)
+
+    assert data.uns["infomap"]["params"]["neighbors_key"] == "neighbors"
+    assert data.uns["infomap"]["params"]["obsp"] == "custom_connectivities"
+
+
+def test_tl_infomap_accepts_explicit_adjacency_matrix():
+    data = _adata()
+
+    infomap.tl.infomap(
+        data,
+        adjacency=data.obsp["connectivities"],
+        key_added="from_matrix",
+        seed=123,
+        num_trials=1,
+    )
+
+    assert "from_matrix" in data.obs
+    assert data.uns["from_matrix"]["params"]["obsp"] is None
+
+
+def test_tl_infomap_rejects_ambiguous_graph_inputs():
+    data = _adata()
+
+    with pytest.raises(ValueError, match="only one"):
+        infomap.tl.infomap(
+            data, adjacency=data.obsp["connectivities"], obsp="connectivities"
+        )
+
+    with pytest.raises(ValueError, match="only one"):
+        infomap.tl.infomap(data, neighbors_key="neighbors", obsp="connectivities")
+
+
+def test_tl_infomap_rejects_missing_obsp_key():
+    data = _adata()
+
+    with pytest.raises(ValueError, match=r"adata\.obsp\['missing'\]"):
+        infomap.tl.infomap(data, obsp="missing")
+
+
+def test_tl_infomap_rejects_missing_neighbors_key():
+    data = _adata()
+
+    with pytest.raises(ValueError, match=r"adata\.uns\['missing'\]"):
+        infomap.tl.infomap(data, neighbors_key="missing")
+
+
+def test_tl_infomap_rejects_neighbors_without_connectivities_key():
+    data = _adata()
+    data.uns["neighbors"] = {}
+
+    with pytest.raises(ValueError, match="connectivities_key"):
+        infomap.tl.infomap(data, neighbors_key="neighbors")
+
+
+def test_tl_infomap_rejects_malformed_anndata_like_object():
+    data = SimpleNamespace(obs={}, obsp={}, obs_names=[])
+
+    with pytest.raises(ValueError, match=r"missing `\.uns`"):
+        infomap.tl.infomap(data)
+
+
+def test_tl_infomap_rejects_copy_without_copy_method():
+    data = SimpleNamespace(
+        obs=pd.DataFrame(index=["cell-a"]),
+        obsp={"connectivities": sp.csr_matrix((1, 1))},
+        uns={},
+        obs_names=["cell-a"],
+        n_obs=1,
+    )
+
+    with pytest.raises(ValueError, match=r"\.copy\(\)"):
+        infomap.tl.infomap(data, copy=True)
+
+
+def test_tl_infomap_rejects_non_square_adjacency():
+    data = _adata(matrix=sp.csr_matrix((4, 4)))
+
+    with pytest.raises(ValueError, match="square"):
+        infomap.tl.infomap(data, adjacency=sp.csr_matrix((2, 3)))
+
+
+def test_tl_infomap_rejects_shape_mismatch():
+    data = _adata()
+
+    with pytest.raises(ValueError, match="adata.n_obs"):
+        infomap.tl.infomap(data, adjacency=sp.csr_matrix((3, 3)))
+
+
+def test_tl_infomap_writes_metadata():
+    data = _adata()
+
+    infomap.tl.infomap(
+        data,
+        directed=True,
+        use_weights=False,
+        args="--silent",
+        seed=123,
+        num_trials=1,
+    )
+
+    metadata = data.uns["infomap"]
+    assert metadata["params"] == {
+        "directed": True,
+        "use_weights": False,
+        "neighbors_key": None,
+        "obsp": "connectivities",
+        "args": "--silent",
+        "silent": True,
+        "no_file_output": True,
+        "seed": 123,
+        "num_trials": 1,
+    }
+    assert metadata["n_modules"] == 2
+    assert isinstance(metadata["codelength"], float)
+
+
+def test_tl_infomap_preserves_obs_name_order_for_string_node_ids(monkeypatch):
+    data = _adata()
+    seen_node_ids = []
+
+    original_add_scipy_sparse_matrix = infomap.Infomap.add_scipy_sparse_matrix
+
+    def recording_add_scipy_sparse_matrix(self, matrix, **kwargs):
+        seen_node_ids.extend(kwargs["node_ids"])
+        return original_add_scipy_sparse_matrix(self, matrix, **kwargs)
+
+    monkeypatch.setattr(
+        infomap.Infomap,
+        "add_scipy_sparse_matrix",
+        recording_add_scipy_sparse_matrix,
+    )
+
+    infomap.tl.infomap(data, seed=123, num_trials=1)
+
+    assert seen_node_ids == ["cell-a", "cell-b", "cell-c", "cell-d"]
+    assert list(data.obs.index) == ["cell-a", "cell-b", "cell-c", "cell-d"]

--- a/test/python/test_api.py
+++ b/test/python/test_api.py
@@ -245,7 +245,9 @@ def test_python_package_extras_are_declared(test_paths):
     assert optional_dependencies["igraph"] == ["igraph"]
     assert optional_dependencies["pandas"] == ["pandas"]
     assert optional_dependencies["scipy"] == ["scipy"]
+    assert optional_dependencies["anndata"] == ["anndata", "pandas", "scipy"]
     assert set(optional_dependencies["all"]) == {
+        "anndata",
         "igraph",
         "networkx",
         "pandas",


### PR DESCRIPTION
## Summary

- add `infomap.tl.infomap()` for AnnData-compatible observation graphs
- write Scanpy-style categorical labels to `adata.obs[key_added]` and run metadata to `adata.uns[key_added]`
- document AnnData/Scanpy usage in `interfaces/python/source/scanpy.rst`
- add AnnData to the `test` extra so CI installs it before Python unit tests

Closes #537

## Validation

- `python3 -m ruff format interfaces/python/src/infomap/__init__.py interfaces/python/src/infomap/tl.py test/python/test_anndata.py test/python/test_api.py`
- `python3 -m ruff check --fix interfaces/python/src/infomap/__init__.py interfaces/python/src/infomap/tl.py test/python/test_anndata.py test/python/test_api.py`
- `make test-python-unit PYTHON=.venv/bin/python PYTEST='.venv/bin/python -m pytest' PYTEST_ARGS='test/python/test_anndata.py test/python/test_scipy.py test/python/test_api.py'`
- `make build-docs PYTHON=.venv/bin/python`
