### PR TITLE
feat(python): add GraphML and GEXF export helpers

### DIFF
--- a/interfaces/python/source/api/export.rst
+++ b/interfaces/python/source/api/export.rst
@@ -1,0 +1,9 @@
+Export helpers
+==============
+
+.. currentmodule:: infomap.export
+
+.. autofunction:: annotate_networkx_graph
+.. autofunction:: annotate_igraph_graph
+.. autofunction:: write_graphml
+.. autofunction:: write_gexf

--- a/interfaces/python/source/api/index.rst
+++ b/interfaces/python/source/api/index.rst
@@ -14,6 +14,8 @@ tree iterators returned when walking the resulting partition.
    * - :doc:`functions`
      - Top-level helpers: :func:`find_communities`,
        :func:`find_igraph_communities`, and information-theoretic primitives.
+   * - :doc:`export`
+     - GraphML and GEXF export helpers for graph-package workflows.
    * - :doc:`infomap`
      - The main :class:`Infomap` class with all configuration and run methods.
    * - :doc:`options`
@@ -28,6 +30,7 @@ tree iterators returned when walking the resulting partition.
    :maxdepth: 1
 
    functions
+   export
    infomap
    options
    iterators

--- a/interfaces/python/source/export.rst
+++ b/interfaces/python/source/export.rst
@@ -1,0 +1,113 @@
+Export GraphML and GEXF
+=======================
+
+Infomap can write module assignments back to graph objects before exporting
+them to common visualization formats. This keeps the graph topology and the
+Infomap result in one file, so tools such as Gephi and Cytoscape can color or
+filter nodes by community without a separate join step.
+
+NetworkX GraphML and GEXF
+-------------------------
+
+For reusable :class:`infomap.Infomap` workflows, keep the mapping returned by
+:meth:`infomap.Infomap.add_networkx_graph`. The export helpers use it to align
+Infomap's internal integer ids with the original NetworkX node labels:
+
+.. code-block:: python
+
+    import networkx as nx
+    from infomap import Infomap
+    from infomap.export import write_gexf, write_graphml
+
+    graph = nx.karate_club_graph()
+
+    im = Infomap(silent=True, num_trials=20, seed=123)
+    mapping = im.add_networkx_graph(graph)
+    im.run()
+
+    write_graphml(graph, im, "karate_infomap.graphml", node_mapping=mapping)
+    write_gexf(graph, im, "karate_infomap.gexf", node_mapping=mapping)
+
+The helpers copy the graph by default, annotate the copy, and pass it to
+NetworkX's native writers. Use ``copy=False`` when you explicitly want the
+attributes written to the graph object you pass in.
+
+If you only need top-level modules, the NetworkX-style entry point can write
+the node attribute directly. Then call NetworkX's writer yourself:
+
+.. code-block:: python
+
+    import networkx as nx
+    import infomap
+
+    graph = nx.karate_club_graph()
+    infomap.find_communities(
+        graph,
+        module_attribute="infomap_module",
+        seed=123,
+        num_trials=20,
+    )
+
+    nx.write_graphml(graph, "karate_infomap.graphml")
+    nx.write_gexf(graph, "karate_infomap.gexf")
+
+igraph GraphML
+--------------
+
+For python-igraph, use :meth:`infomap.Infomap.add_igraph_graph` and
+:func:`infomap.export.write_graphml`. The helper annotates vertex attributes
+and uses python-igraph's native GraphML writer:
+
+.. code-block:: python
+
+    import igraph as ig
+    from infomap import Infomap
+    from infomap.export import write_graphml
+
+    graph = ig.Graph.Famous("Zachary")
+
+    im = Infomap(silent=True, num_trials=20, seed=123)
+    im.add_igraph_graph(graph)
+    im.run()
+
+    write_graphml(graph, im, "karate_infomap.graphml")
+
+GEXF export is available for NetworkX graphs only. python-igraph does not
+provide a native GEXF writer, and Infomap does not convert igraph graphs
+through NetworkX implicitly because that adds overhead and can change ids or
+attributes in surprising ways.
+
+Written attributes
+------------------
+
+By default, exported nodes receive string-valued attributes for broad
+compatibility with visualization tools:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Attribute
+     - Meaning
+   * - ``infomap_module``
+     - Top-level module assignment.
+   * - ``infomap_path``
+     - Colon-separated hierarchical module path, such as ``"3:12"``.
+   * - ``infomap_level_1``, ``infomap_level_2``, ...
+     - One attribute per hierarchy level.
+
+Set ``module_attribute`` or ``path_attribute`` to change the main attribute
+names. Set ``include_hierarchy=False`` when you only want the top-level module
+attribute.
+
+Visualization workflow
+----------------------
+
+Open the exported GraphML or GEXF file in Gephi or Cytoscape and style nodes
+by the ``infomap_module`` attribute. For hierarchical runs, use
+``infomap_path`` to identify full paths or ``infomap_level_N`` attributes to
+color one hierarchy level at a time.
+
+The native ``infomap`` CLI does not read or write GraphML/GEXF in this
+release. Use the Python workflow above when you need these interchange
+formats.

--- a/interfaces/python/source/index.rst
+++ b/interfaces/python/source/index.rst
@@ -36,6 +36,8 @@ Where to go next
 - :doc:`usage` — NetworkX, igraph, state and multilayer networks, reusable
   options, and a migration guide for users of other community-detection
   packages.
+- :doc:`export` — write Infomap module assignments to GraphML and GEXF for
+  visualization tools.
 - :doc:`scanpy` — run Infomap on AnnData graphs in Scanpy-style single-cell
   workflows.
 - :doc:`api/index` — full API reference, split into top-level functions, the
@@ -58,5 +60,6 @@ External resources
    installation
    quickstart
    usage
+   export
    scanpy
    api/index

--- a/interfaces/python/source/usage.rst
+++ b/interfaces/python/source/usage.rst
@@ -9,6 +9,9 @@ packages.
 For single-cell analysis workflows using AnnData or Scanpy, see
 :doc:`scanpy`.
 
+For GraphML and GEXF files with module assignments attached to nodes, see
+:doc:`export`.
+
 Reusable options
 ----------------
 

--- a/interfaces/python/src/infomap/export.py
+++ b/interfaces/python/src/infomap/export.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import warnings
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+
+_DEFAULT_MODULE_ATTRIBUTE = "infomap_module"
+_DEFAULT_PATH_ATTRIBUTE = "infomap_path"
+
+
+def _import_networkx() -> Any:
+    try:
+        import networkx as nx
+    except ImportError as exc:
+        raise ImportError(
+            "The 'networkx' package is required for NetworkX export support. "
+            'Install it with `python -m pip install "infomap[networkx]"`.'
+        ) from exc
+    return nx
+
+
+def _import_igraph() -> Any:
+    try:
+        import igraph as ig
+    except ImportError as exc:
+        raise ImportError(
+            "The 'igraph' package is required for igraph export support. "
+            'Install it with `python -m pip install "infomap[igraph]"`.'
+        ) from exc
+    return ig
+
+
+def _require_modules(infomap: Any) -> None:
+    if not infomap.haveModules():
+        raise ValueError(
+            "Infomap results are not available. Run Infomap before exporting."
+        )
+
+
+def _string_attributes(
+    path: tuple[int, ...],
+    *,
+    module_attribute: str | None,
+    path_attribute: str | None,
+    include_hierarchy: bool,
+    flow: Any = None,
+    flow_attribute: str | None = None,
+) -> dict[str, str]:
+    attributes = {}
+    if module_attribute is not None:
+        attributes[module_attribute] = str(path[0])
+    if include_hierarchy:
+        if path_attribute is not None:
+            attributes[path_attribute] = ":".join(str(module_id) for module_id in path)
+        for level, module_id in enumerate(path, start=1):
+            attributes[f"infomap_level_{level}"] = str(module_id)
+    if flow_attribute is not None and flow is not None:
+        attributes[flow_attribute] = str(flow)
+    return attributes
+
+
+def _flow_by_state_id(infomap: Any) -> dict[int, float]:
+    return {node.state_id: node.flow for node in infomap.nodes}
+
+
+def _mapped_assignments(
+    infomap: Any,
+    node_mapping: Mapping[Any, Any] | None,
+) -> dict[Any, tuple[int, ...]]:
+    assignments = infomap.get_multilevel_modules(states=True)
+    if node_mapping is None:
+        return assignments
+    return {
+        node_mapping[internal_id]: path
+        for internal_id, path in assignments.items()
+        if internal_id in node_mapping
+    }
+
+
+def _mapped_flows(
+    infomap: Any,
+    node_mapping: Mapping[Any, Any] | None,
+) -> dict[Any, float]:
+    flows = _flow_by_state_id(infomap)
+    if node_mapping is None:
+        return flows
+    return {
+        node_mapping[internal_id]: flow
+        for internal_id, flow in flows.items()
+        if internal_id in node_mapping
+    }
+
+
+def _validate_node_sets(
+    graph_nodes: set[Any],
+    assignment_nodes: set[Any],
+    *,
+    strict: bool,
+    warning_stacklevel: int,
+) -> set[Any]:
+    missing_assignments = graph_nodes - assignment_nodes
+    extra_assignments = assignment_nodes - graph_nodes
+    if strict and missing_assignments:
+        raise ValueError(
+            "The graph contains nodes without Infomap assignments: "
+            f"{sorted(missing_assignments, key=repr)!r}."
+        )
+    if strict and extra_assignments:
+        raise ValueError(
+            "Infomap assignments contain nodes not present in the graph: "
+            f"{sorted(extra_assignments, key=repr)!r}."
+        )
+    if missing_assignments or extra_assignments:
+        warnings.warn(
+            "Infomap export annotated only matching graph nodes; "
+            f"{len(missing_assignments)} graph nodes had no assignment and "
+            f"{len(extra_assignments)} assignments had no graph node.",
+            UserWarning,
+            stacklevel=warning_stacklevel,
+        )
+    return graph_nodes & assignment_nodes
+
+
+def _is_igraph_graph(graph: Any) -> bool:
+    try:
+        ig = _import_igraph()
+    except ImportError:
+        return False
+    return isinstance(graph, ig.Graph)
+
+
+def _annotate_networkx_graph(
+    graph: Any,
+    im: Any,
+    *,
+    node_mapping: Mapping[Any, Any] | None = None,
+    module_attribute: str | None = _DEFAULT_MODULE_ATTRIBUTE,
+    path_attribute: str | None = _DEFAULT_PATH_ATTRIBUTE,
+    include_hierarchy: bool = True,
+    flow_attribute: str | None = None,
+    copy: bool = True,
+    strict: bool = True,
+    warning_stacklevel: int,
+) -> Any:
+    _require_modules(im)
+
+    output_graph = graph.copy() if copy else graph
+    assignments = _mapped_assignments(im, node_mapping)
+    flows = _mapped_flows(im, node_mapping) if flow_attribute is not None else {}
+    graph_nodes = set(output_graph.nodes)
+    matching_nodes = _validate_node_sets(
+        graph_nodes,
+        set(assignments),
+        strict=strict,
+        warning_stacklevel=warning_stacklevel,
+    )
+
+    for node in matching_nodes:
+        output_graph.nodes[node].update(
+            _string_attributes(
+                assignments[node],
+                module_attribute=module_attribute,
+                path_attribute=path_attribute,
+                include_hierarchy=include_hierarchy,
+                flow=flows.get(node),
+                flow_attribute=flow_attribute,
+            )
+        )
+
+    return output_graph
+
+
+def annotate_networkx_graph(
+    graph: Any,
+    im: Any,
+    *,
+    node_mapping: Mapping[Any, Any] | None = None,
+    module_attribute: str | None = _DEFAULT_MODULE_ATTRIBUTE,
+    path_attribute: str | None = _DEFAULT_PATH_ATTRIBUTE,
+    include_hierarchy: bool = True,
+    flow_attribute: str | None = None,
+    copy: bool = True,
+    strict: bool = True,
+) -> Any:
+    """Return a NetworkX graph annotated with Infomap result attributes."""
+    return _annotate_networkx_graph(
+        graph,
+        im,
+        node_mapping=node_mapping,
+        module_attribute=module_attribute,
+        path_attribute=path_attribute,
+        include_hierarchy=include_hierarchy,
+        flow_attribute=flow_attribute,
+        copy=copy,
+        strict=strict,
+        warning_stacklevel=3,
+    )
+
+
+def _annotate_igraph_graph(
+    graph: Any,
+    im: Any,
+    *,
+    module_attribute: str | None = _DEFAULT_MODULE_ATTRIBUTE,
+    path_attribute: str | None = _DEFAULT_PATH_ATTRIBUTE,
+    include_hierarchy: bool = True,
+    flow_attribute: str | None = None,
+    copy: bool = True,
+    strict: bool = True,
+    warning_stacklevel: int,
+) -> Any:
+    ig = _import_igraph()
+    if not isinstance(graph, ig.Graph):
+        raise TypeError("`graph` must be an igraph.Graph.")
+    _require_modules(im)
+
+    output_graph = graph.copy() if copy else graph
+    n_vertices = output_graph.vcount()
+    assignments = im.get_multilevel_modules(states=True)
+    flows = _flow_by_state_id(im) if flow_attribute is not None else {}
+    graph_nodes = set(range(n_vertices))
+    matching_nodes = _validate_node_sets(
+        graph_nodes,
+        set(assignments),
+        strict=strict,
+        warning_stacklevel=warning_stacklevel,
+    )
+
+    values_by_attribute: dict[str, list[str | None]] = {}
+    for vertex_id in matching_nodes:
+        attributes = _string_attributes(
+            assignments[vertex_id],
+            module_attribute=module_attribute,
+            path_attribute=path_attribute,
+            include_hierarchy=include_hierarchy,
+            flow=flows.get(vertex_id),
+            flow_attribute=flow_attribute,
+        )
+        for attribute, value in attributes.items():
+            values_by_attribute.setdefault(attribute, [None] * n_vertices)
+            values_by_attribute[attribute][vertex_id] = value
+
+    for attribute, values in values_by_attribute.items():
+        output_graph.vs[attribute] = values
+
+    return output_graph
+
+
+def annotate_igraph_graph(
+    graph: Any,
+    im: Any,
+    *,
+    module_attribute: str | None = _DEFAULT_MODULE_ATTRIBUTE,
+    path_attribute: str | None = _DEFAULT_PATH_ATTRIBUTE,
+    include_hierarchy: bool = True,
+    flow_attribute: str | None = None,
+    copy: bool = True,
+    strict: bool = True,
+) -> Any:
+    """Return a python-igraph graph annotated with Infomap result attributes."""
+    return _annotate_igraph_graph(
+        graph,
+        im,
+        module_attribute=module_attribute,
+        path_attribute=path_attribute,
+        include_hierarchy=include_hierarchy,
+        flow_attribute=flow_attribute,
+        copy=copy,
+        strict=strict,
+        warning_stacklevel=3,
+    )
+
+
+def write_graphml(graph: Any, im: Any, path: str | Path, **options: Any) -> None:
+    """Write a GraphML file with Infomap result attributes on nodes."""
+    if _is_igraph_graph(graph):
+        writer_options = {}
+        writer_options.update(options.pop("writer_options", {}))
+        annotated_graph = _annotate_igraph_graph(
+            graph,
+            im,
+            warning_stacklevel=4,
+            **options,
+        )
+        annotated_graph.write_graphml(str(path), **writer_options)
+        return
+
+    nx = _import_networkx()
+    writer_options = {}
+    writer_options.update(options.pop("writer_options", {}))
+    annotated_graph = _annotate_networkx_graph(
+        graph,
+        im,
+        warning_stacklevel=4,
+        **options,
+    )
+    nx.write_graphml(annotated_graph, path, **writer_options)
+
+
+def write_gexf(graph: Any, im: Any, path: str | Path, **options: Any) -> None:
+    """Write a GEXF file with Infomap result attributes on NetworkX nodes."""
+    if _is_igraph_graph(graph):
+        raise NotImplementedError(
+            "GEXF export for igraph graphs is not supported because "
+            "python-igraph does not provide a native GEXF writer. Use "
+            "`write_graphml()` for igraph graphs or pass a NetworkX graph."
+        )
+
+    nx = _import_networkx()
+    writer_options = {}
+    writer_options.update(options.pop("writer_options", {}))
+    annotated_graph = _annotate_networkx_graph(
+        graph,
+        im,
+        warning_stacklevel=4,
+        **options,
+    )
+    nx.write_gexf(annotated_graph, path, **writer_options)

--- a/test/python/test_export.py
+++ b/test/python/test_export.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import networkx as nx
+import pytest
+
+from infomap import Infomap
+from infomap.export import (
+    annotate_igraph_graph,
+    annotate_networkx_graph,
+    write_gexf,
+    write_graphml,
+)
+
+
+pytestmark = pytest.mark.fast
+
+
+def _networkx_result(graph):
+    im = Infomap(silent=True, num_trials=1, seed=123)
+    mapping = im.add_networkx_graph(graph)
+    im.run()
+    return im, mapping
+
+
+def test_write_networkx_graphml_can_be_read_back(tmp_path):
+    graph = nx.karate_club_graph()
+    im, mapping = _networkx_result(graph)
+    path = tmp_path / "karate.graphml"
+
+    write_graphml(graph, im, path, node_mapping=mapping)
+
+    exported = nx.read_graphml(path)
+    assert exported.number_of_nodes() == graph.number_of_nodes()
+    assert all("infomap_module" in data for _, data in exported.nodes(data=True))
+
+
+def test_write_networkx_gexf_can_be_read_back(tmp_path):
+    graph = nx.Graph([(1, 2), (2, 3), (10, 11), (11, 12)])
+    im, mapping = _networkx_result(graph)
+    path = tmp_path / "communities.gexf"
+
+    write_gexf(graph, im, path, node_mapping=mapping)
+
+    exported = nx.read_gexf(path)
+    assert exported.number_of_nodes() == graph.number_of_nodes()
+    assert all("infomap_module" in data for _, data in exported.nodes(data=True))
+
+
+def test_networkx_export_supports_custom_module_attribute():
+    graph = nx.Graph([(1, 2)])
+    im, mapping = _networkx_result(graph)
+
+    annotated = annotate_networkx_graph(
+        graph,
+        im,
+        node_mapping=mapping,
+        module_attribute="community",
+    )
+
+    assert set(nx.get_node_attributes(annotated, "community")) == set(graph.nodes)
+    assert all(
+        isinstance(value, str)
+        for value in nx.get_node_attributes(annotated, "community").values()
+    )
+
+
+def test_networkx_export_can_disable_hierarchy_attributes():
+    graph = nx.Graph([(1, 2)])
+    im, mapping = _networkx_result(graph)
+
+    annotated = annotate_networkx_graph(
+        graph,
+        im,
+        node_mapping=mapping,
+        include_hierarchy=False,
+    )
+
+    assert all("infomap_module" in data for _, data in annotated.nodes(data=True))
+    assert all("infomap_path" not in data for _, data in annotated.nodes(data=True))
+    assert all("infomap_level_1" not in data for _, data in annotated.nodes(data=True))
+
+
+def test_networkx_export_copy_true_leaves_original_graph_unchanged():
+    graph = nx.Graph([(1, 2)])
+    im, mapping = _networkx_result(graph)
+
+    annotated = annotate_networkx_graph(graph, im, node_mapping=mapping)
+
+    assert annotated is not graph
+    assert all("infomap_module" not in data for _, data in graph.nodes(data=True))
+    assert all("infomap_module" in data for _, data in annotated.nodes(data=True))
+
+
+def test_networkx_export_copy_false_mutates_original_graph():
+    graph = nx.Graph([(1, 2)])
+    im, mapping = _networkx_result(graph)
+
+    annotated = annotate_networkx_graph(graph, im, node_mapping=mapping, copy=False)
+
+    assert annotated is graph
+    assert all("infomap_module" in data for _, data in graph.nodes(data=True))
+
+
+def test_networkx_export_rejects_unrun_infomap():
+    graph = nx.Graph([(1, 2)])
+    im = Infomap(silent=True)
+    im.add_networkx_graph(graph)
+
+    with pytest.raises(ValueError, match="Run Infomap"):
+        annotate_networkx_graph(graph, im)
+
+
+def test_networkx_export_rejects_node_mismatch_when_strict():
+    graph = nx.Graph([(1, 2)])
+    im, mapping = _networkx_result(graph)
+    graph.add_node(3)
+
+    with pytest.raises(ValueError, match="without Infomap assignments"):
+        annotate_networkx_graph(graph, im, node_mapping=mapping)
+
+
+def test_networkx_export_warns_and_partially_annotates_when_not_strict():
+    graph = nx.Graph([(1, 2)])
+    im, mapping = _networkx_result(graph)
+    graph.add_node(3)
+
+    with pytest.warns(UserWarning, match="annotated only matching"):
+        annotated = annotate_networkx_graph(
+            graph, im, node_mapping=mapping, strict=False
+        )
+
+    assert "infomap_module" in annotated.nodes[1]
+    assert "infomap_module" not in annotated.nodes[3]
+
+
+def test_networkx_writer_warning_points_to_user_call(tmp_path):
+    graph = nx.Graph([(1, 2)])
+    im, mapping = _networkx_result(graph)
+    graph.add_node(3)
+
+    with pytest.warns(UserWarning, match="annotated only matching") as warnings:
+        write_gexf(
+            graph,
+            im,
+            tmp_path / "partial.gexf",
+            node_mapping=mapping,
+            strict=False,
+        )
+
+    assert Path(warnings[0].filename) == Path(__file__)
+
+
+def test_networkx_export_requires_mapping_for_string_labels():
+    graph = nx.Graph([("a", "b")])
+    im, mapping = _networkx_result(graph)
+
+    with pytest.raises(ValueError, match="without Infomap assignments"):
+        annotate_networkx_graph(graph, im)
+
+    annotated = annotate_networkx_graph(graph, im, node_mapping=mapping)
+    assert set(nx.get_node_attributes(annotated, "infomap_module")) == {"a", "b"}
+
+
+def _igraph_result(graph):
+    im = Infomap(silent=True, num_trials=1, seed=123)
+    im.add_igraph_graph(graph)
+    im.run()
+    return im
+
+
+def test_igraph_graphml_export_writes_vertex_attributes(tmp_path):
+    ig = pytest.importorskip("igraph")
+    graph = ig.Graph(edges=[(0, 1), (2, 3)], directed=False)
+    im = _igraph_result(graph)
+    path = tmp_path / "communities.graphml"
+
+    write_graphml(graph, im, path)
+
+    exported = ig.Graph.Read_GraphML(str(path))
+    assert "infomap_module" in exported.vs.attributes()
+    assert all(value is not None for value in exported.vs["infomap_module"])
+
+
+def test_igraph_export_copy_true_leaves_original_graph_unchanged():
+    ig = pytest.importorskip("igraph")
+    graph = ig.Graph(edges=[(0, 1)], directed=False)
+    im = _igraph_result(graph)
+
+    annotated = annotate_igraph_graph(graph, im)
+
+    assert annotated is not graph
+    assert "infomap_module" not in graph.vs.attributes()
+    assert "infomap_module" in annotated.vs.attributes()
+
+
+def test_igraph_export_copy_false_mutates_original_graph():
+    ig = pytest.importorskip("igraph")
+    graph = ig.Graph(edges=[(0, 1)], directed=False)
+    im = _igraph_result(graph)
+
+    annotated = annotate_igraph_graph(graph, im, copy=False)
+
+    assert annotated is graph
+    assert "infomap_module" in graph.vs.attributes()
+
+
+def test_igraph_export_supports_custom_attribute_and_hierarchy_toggle():
+    ig = pytest.importorskip("igraph")
+    graph = ig.Graph(edges=[(0, 1)], directed=False)
+    im = _igraph_result(graph)
+
+    annotated = annotate_igraph_graph(
+        graph,
+        im,
+        module_attribute="community",
+        include_hierarchy=False,
+    )
+
+    assert "community" in annotated.vs.attributes()
+    assert "infomap_path" not in annotated.vs.attributes()
+    assert "infomap_level_1" not in annotated.vs.attributes()
+
+
+def test_write_gexf_rejects_igraph_graph(tmp_path):
+    ig = pytest.importorskip("igraph")
+    graph = ig.Graph(edges=[(0, 1)], directed=False)
+    im = _igraph_result(graph)
+
+    with pytest.raises(NotImplementedError, match="python-igraph does not provide"):
+        write_gexf(graph, im, tmp_path / "communities.gexf")


### PR DESCRIPTION
## Summary
- add `infomap.export` helpers to annotate NetworkX and python-igraph graphs with Infomap module metadata
- write NetworkX GraphML/GEXF exports and python-igraph GraphML exports using native graph-library writers
- document visualization workflows and add API reference coverage

Closes #538

## Validation
- `.venv/bin/python -m ruff format interfaces/python/src/infomap/export.py test/python/test_export.py`
- `.venv/bin/python -m ruff check --fix interfaces/python/src/infomap/export.py test/python/test_export.py`
- `.venv/bin/python -m pytest test/python/test_export.py test/python/test_networkx.py test/python/test_igraph.py`
- `PATH="/opt/homebrew/bin:$PATH" make PYTHON=.venv/bin/python build-docs`