### PR TITLE
docs(python): add comparison tutorial notebooks

### DIFF
--- a/examples/notebooks/README.md
+++ b/examples/notebooks/README.md
@@ -1,7 +1,9 @@
 # Infomap tutorial notebooks
 
-These notebooks accompany [Community Detection with the Map Equation and
-Infomap: Theory and Applications](https://doi.org/10.1145/3779648).
+Most numbered notebooks accompany [Community Detection with the Map Equation
+and Infomap: Theory and Applications](https://doi.org/10.1145/3779648).
+Descriptive, unnumbered notebooks cover practical Python workflows that are
+not tied to the article section numbering.
 
 They live in the main Infomap repository so API changes, dependency drift, and
 broken examples are caught by the normal maintenance workflow.

--- a/examples/notebooks/compare-infomap-louvain-leiden-igraph.ipynb
+++ b/examples/notebooks/compare-infomap-louvain-leiden-igraph.ipynb
@@ -1,0 +1,115 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Compare Infomap, Louvain, and Leiden with igraph\n\nThis tutorial shows how to use Infomap in a python-igraph workflow. It keeps the result in igraph's native `VertexClustering` shape so it fits next to `community_multilevel()` for Louvain and `community_leiden()` for Leiden.\n\nInfomap optimizes the map equation, which describes flow on the network. Louvain and Leiden optimize modularity-style objectives. The labels produced by all three methods are local community IDs, so compare partitions by membership, sizes, and downstream behavior rather than by the numeric label values themselves.\n",
+   "id": "louvain_leiden_igraph_01"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import infomap\nimport igraph as ig\nimport networkx as nx\nimport pandas as pd\n\nprint(\"infomap:\", infomap.__version__)\nprint(\"igraph:\", ig.__version__)\nprint(\"networkx:\", nx.__version__)\nprint(\"pandas:\", pd.__version__)\n",
+   "id": "louvain_leiden_igraph_02"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Build a small igraph graph\n\nNetworkX provides the karate club graph as a convenient built-in dataset. The graph is converted to igraph for this tutorial so all community methods use igraph-native graph data.\n",
+   "id": "louvain_leiden_igraph_03"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "nx_graph = nx.karate_club_graph()\ngraph = ig.Graph(edges=list(nx_graph.edges()), directed=False)\ngraph.vs[\"name\"] = [str(vertex.index) for vertex in graph.vs]\ngraph.vs[\"club\"] = [nx_graph.nodes[vertex.index][\"club\"] for vertex in graph.vs]\ngraph.es[\"weight\"] = [1.0] * graph.ecount()\n\nprint(graph.summary())\n",
+   "id": "louvain_leiden_igraph_04"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Run the community methods\n\n`infomap.find_igraph_communities()` returns an `igraph.VertexClustering` and adds a `codelength` attribute. Louvain is available as `community_multilevel()`. Leiden is used through `community_leiden()` when the installed igraph build supports it.\n",
+   "id": "louvain_leiden_igraph_05"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "infomap_clusters = infomap.find_igraph_communities(\n    graph,\n    edge_weights=\"weight\",\n    trials=20,\n    seed=123,\n)\n\nlouvain_clusters = graph.community_multilevel(weights=\"weight\")\n\nleiden_clusters = None\nleiden_note = None\nif not hasattr(graph, \"community_leiden\"):\n    leiden_note = \"igraph Leiden is not available in this igraph installation.\"\nelse:\n    try:\n        leiden_clusters = graph.community_leiden(\n            weights=\"weight\",\n            objective_function=\"modularity\",\n        )\n    except Exception as exc:\n        leiden_note = f\"igraph Leiden skipped: {exc}\"\n\nprint(\"Infomap communities:\", len(infomap_clusters), \"codelength:\", infomap_clusters.codelength)\nprint(\"Louvain communities:\", len(louvain_clusters), \"modularity:\", louvain_clusters.modularity)\nif leiden_clusters is None:\n    print(leiden_note)\nelse:\n    print(\"Leiden communities:\", len(leiden_clusters), \"modularity:\", leiden_clusters.modularity)\n",
+   "id": "louvain_leiden_igraph_06"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Compare assignments\n\nThe DataFrame uses vertex names as user-facing node labels. Community IDs are generated independently by each algorithm.\n",
+   "id": "louvain_leiden_igraph_07"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "df = pd.DataFrame(\n    {\n        \"node\": graph.vs[\"name\"],\n        \"club\": graph.vs[\"club\"],\n        \"infomap\": infomap_clusters.membership,\n        \"louvain\": louvain_clusters.membership,\n    }\n)\n\nif leiden_clusters is not None:\n    df[\"leiden\"] = leiden_clusters.membership\n\ndf.head(10)\n",
+   "id": "louvain_leiden_igraph_08"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "df.drop(columns=\"node\").nunique().rename(\"communities\").to_frame()\n",
+   "id": "louvain_leiden_igraph_09"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Simple similarity metrics\n\nARI and NMI help summarize how similar two assignments are. They are symmetric label-comparison metrics and do not depend on the actual numeric community IDs.\n",
+   "id": "louvain_leiden_igraph_10"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "try:\n    from sklearn.metrics import adjusted_rand_score, normalized_mutual_info_score\nexcept ImportError:\n    print(\"Install scikit-learn to compute ARI and NMI.\")\nelse:\n    comparisons = []\n    for method in [\"louvain\", \"leiden\"]:\n        if method not in df:\n            continue\n        comparisons.append(\n            {\n                \"method\": method,\n                \"ARI vs Infomap\": adjusted_rand_score(df[\"infomap\"], df[method]),\n                \"NMI vs Infomap\": normalized_mutual_info_score(df[\"infomap\"], df[method]),\n            }\n        )\n    pd.DataFrame(comparisons)\n",
+   "id": "louvain_leiden_igraph_11"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Annotate vertices for downstream igraph use\n\nUse `module_attribute` and `flow_attribute` when you want Infomap results stored directly on the igraph vertices for plotting, filtering, or export.\n",
+   "id": "louvain_leiden_igraph_12"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "annotated = graph.copy()\ninfomap.find_igraph_communities(\n    annotated,\n    edge_weights=\"weight\",\n    module_attribute=\"infomap\",\n    flow_attribute=\"infomap_flow\",\n    trials=20,\n    seed=123,\n)\n\npd.DataFrame(\n    {\n        \"node\": annotated.vs[\"name\"],\n        \"infomap\": annotated.vs[\"infomap\"],\n        \"infomap_flow\": annotated.vs[\"infomap_flow\"],\n    }\n).head()\n",
+   "id": "louvain_leiden_igraph_13"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Citation\n\nIf you use Infomap in published work, cite the Infomap software and the map equation literature. See the repository and Infomap user guide for the current recommended references.\n",
+   "id": "louvain_leiden_igraph_14"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/compare-infomap-louvain-leiden-networkx.ipynb
+++ b/examples/notebooks/compare-infomap-louvain-leiden-networkx.ipynb
@@ -1,0 +1,129 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Compare Infomap, Louvain, and Leiden with NetworkX\n\nThis tutorial shows how to run Infomap next to modularity-based community detection in a NetworkX workflow. It uses Zachary's karate club graph because it is small, built into NetworkX, and common in community-detection examples.\n\nInfomap optimizes the map equation: it searches for a partition that compresses the description of flow on the network. Louvain and Leiden are modularity-based methods. The goal here is not to declare a universal winner, but to make the outputs easy to run, inspect, compare, visualize, and export.\n",
+   "id": "louvain_leiden_networkx_01"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import tempfile\n\nimport infomap\nimport matplotlib.pyplot as plt\nimport networkx as nx\nimport pandas as pd\n\nprint(\"infomap:\", infomap.__version__)\nprint(\"networkx:\", nx.__version__)\nprint(\"pandas:\", pd.__version__)\n",
+   "id": "louvain_leiden_networkx_02"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Load a small graph\n\n`nx.karate_club_graph()` is undirected and unweighted. For weighted graphs, pass the edge attribute name with `weight=\"weight\"`; for unweighted graphs, pass `weight=None`. Infomap detects directed NetworkX graphs automatically when the input is a `DiGraph`.\n",
+   "id": "louvain_leiden_networkx_03"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "graph = nx.karate_club_graph()\nnodes = list(graph.nodes())\nprint(graph)\nprint(\"nodes:\", graph.number_of_nodes())\nprint(\"edges:\", graph.number_of_edges())\n",
+   "id": "louvain_leiden_networkx_04"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Run the community methods\n\n`infomap.find_communities()` follows the NetworkX convention of returning a partition as `list[set]` while preserving the original node labels. NetworkX provides Louvain directly through `nx.community.louvain_communities()`. Leiden is used when it is available in the installed NetworkX version/backend; otherwise the notebook records a clear skipped result.\n",
+   "id": "louvain_leiden_networkx_05"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "def partition_to_labels(partition, ordered_nodes):\n    labels = {}\n    for community_id, community in enumerate(partition, start=1):\n        for node in community:\n            labels[node] = community_id\n    return [labels[node] for node in ordered_nodes]\n\n\ninfomap_partition = infomap.find_communities(\n    graph,\n    weight=None,\n    seed=123,\n    num_trials=20,\n)\n\nlouvain_partition = nx.community.louvain_communities(\n    graph,\n    weight=None,\n    seed=123,\n)\n\nleiden_partition = None\nleiden_note = None\nleiden = getattr(nx.community, \"leiden_communities\", None)\nif leiden is None:\n    leiden_note = \"NetworkX Leiden is not available in this NetworkX installation.\"\nelse:\n    try:\n        leiden_partition = leiden(graph, weight=None, seed=123)\n    except Exception as exc:\n        leiden_note = f\"NetworkX Leiden skipped: {exc}\"\n\nprint(\"Infomap communities:\", len(infomap_partition))\nprint(\"Louvain communities:\", len(louvain_partition))\nif leiden_partition is None:\n    print(leiden_note)\nelse:\n    print(\"Leiden communities:\", len(leiden_partition))\n",
+   "id": "louvain_leiden_networkx_06"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Compare assignments\n\nCommunity IDs are local labels. Their numeric values only identify groups within one result; they should not be interpreted as stable or ordered labels across methods.\n",
+   "id": "louvain_leiden_networkx_07"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "df = pd.DataFrame(\n    {\n        \"node\": nodes,\n        \"club\": [graph.nodes[node][\"club\"] for node in nodes],\n        \"infomap\": partition_to_labels(infomap_partition, nodes),\n        \"louvain\": partition_to_labels(louvain_partition, nodes),\n    }\n)\n\nif leiden_partition is not None:\n    df[\"leiden\"] = partition_to_labels(leiden_partition, nodes)\n\ndf.head(10)\n",
+   "id": "louvain_leiden_networkx_08"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "summary = df.drop(columns=\"node\").nunique().rename(\"communities\").to_frame()\nsummary\n",
+   "id": "louvain_leiden_networkx_09"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Simple similarity metrics\n\nAdjusted Rand index (ARI) and normalized mutual information (NMI) compare two label assignments. They are useful checks, but they do not replace inspecting the graph and understanding the objective each method optimizes.\n",
+   "id": "louvain_leiden_networkx_10"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "try:\n    from sklearn.metrics import adjusted_rand_score, normalized_mutual_info_score\nexcept ImportError:\n    print(\"Install scikit-learn to compute ARI and NMI.\")\nelse:\n    comparisons = []\n    for method in [\"louvain\", \"leiden\"]:\n        if method not in df:\n            continue\n        comparisons.append(\n            {\n                \"method\": method,\n                \"ARI vs Infomap\": adjusted_rand_score(df[\"infomap\"], df[method]),\n                \"NMI vs Infomap\": normalized_mutual_info_score(df[\"infomap\"], df[method]),\n            }\n        )\n    pd.DataFrame(comparisons)\n",
+   "id": "louvain_leiden_networkx_11"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Visualize the partitions\n\nThe same layout is reused for each method so the visual comparison focuses on module assignments rather than node placement.\n",
+   "id": "louvain_leiden_networkx_12"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "methods = [\"infomap\", \"louvain\"] + ([\"leiden\"] if \"leiden\" in df else [])\npos = nx.spring_layout(graph, seed=123)\nfig, axes = plt.subplots(1, len(methods), figsize=(5 * len(methods), 4), squeeze=False)\n\nfor ax, method in zip(axes[0], methods):\n    colors = [df.loc[df[\"node\"] == node, method].iloc[0] for node in graph.nodes]\n    nx.draw_networkx(\n        graph,\n        pos=pos,\n        node_color=colors,\n        cmap=\"tab20\",\n        with_labels=True,\n        node_size=450,\n        edge_color=\"#999999\",\n        ax=ax,\n    )\n    ax.set_title(method.title())\n    ax.axis(\"off\")\n\nplt.tight_layout()\n",
+   "id": "louvain_leiden_networkx_13"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Export Infomap results\n\nFor downstream tools, write Infomap module IDs back to the NetworkX graph and export with NetworkX's GraphML or GEXF writers. The export helpers can also add hierarchical Infomap attributes when you need more than top-level modules.\n",
+   "id": "louvain_leiden_networkx_14"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "export_graph = graph.copy()\ninfomap.find_communities(\n    export_graph,\n    weight=None,\n    module_attribute=\"infomap\",\n    flow_attribute=\"infomap_flow\",\n    seed=123,\n    num_trials=20,\n)\n\nwith tempfile.TemporaryDirectory() as tmpdir:\n    graphml_path = f\"{tmpdir}/karate-infomap.graphml\"\n    gexf_path = f\"{tmpdir}/karate-infomap.gexf\"\n    nx.write_graphml(export_graph, graphml_path)\n    nx.write_gexf(export_graph, gexf_path)\n    print(\"wrote:\", graphml_path)\n    print(\"wrote:\", gexf_path)\n\npd.DataFrame.from_dict(dict(export_graph.nodes(data=True)), orient=\"index\").head()\n",
+   "id": "louvain_leiden_networkx_15"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Citation\n\nIf you use Infomap in published work, cite the Infomap software and the map equation literature. See the citation information in the repository and the Infomap user guide for the current recommended references.\n",
+   "id": "louvain_leiden_networkx_16"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/compare-infomap-scanpy-workflow.ipynb
+++ b/examples/notebooks/compare-infomap-scanpy-workflow.ipynb
@@ -1,0 +1,101 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Compare Infomap and Leiden in a Scanpy workflow\n\nThis tutorial shows how to run Infomap on an AnnData neighbor graph and compare the result with Scanpy's Leiden workflow. It uses a small synthetic dataset to avoid network downloads and to keep the example reproducible.\n\nInfomap reads the sparse observation graph from `adata.obsp` and writes categorical labels to `adata.obs`, matching Scanpy `tl` conventions. Leiden remains the standard Scanpy baseline shown here; if the optional Leiden dependency is unavailable, the notebook keeps running and reports that comparison as skipped.\n",
+   "id": "scanpy_workflow_01"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import importlib.util\n\nSCANPY_AVAILABLE = importlib.util.find_spec(\"scanpy\") is not None\nif not SCANPY_AVAILABLE:\n    print('Install scanpy to run the full workflow: python -m pip install \"scanpy[leiden]\"')\nelse:\n    import infomap\n    import numpy as np\n    import pandas as pd\n    import scanpy as sc\n    from sklearn.datasets import make_blobs\n\n    print(\"infomap:\", infomap.__version__)\n    print(\"scanpy:\", sc.__version__)\n    print(\"pandas:\", pd.__version__)\n",
+   "id": "scanpy_workflow_02"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Create a small AnnData object\n\nThe dataset is synthetic and local. Scanpy builds a nearest-neighbor graph in `adata.obsp[\"connectivities\"]`, which is the same graph used by Scanpy clustering tools and the default graph read by `infomap.tl.infomap()`.\n",
+   "id": "scanpy_workflow_03"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "if SCANPY_AVAILABLE:\n    X, truth = make_blobs(\n        n_samples=120,\n        centers=4,\n        n_features=12,\n        cluster_std=1.8,\n        random_state=123,\n    )\n    adata = sc.AnnData(X)\n    adata.obs[\"truth\"] = pd.Categorical([str(label) for label in truth])\n\n    sc.pp.neighbors(adata, n_neighbors=12, random_state=123)\n    sc.tl.umap(adata, random_state=123)\n\n    adata\n",
+   "id": "scanpy_workflow_04"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Run Infomap and Leiden\n\n`infomap.tl.infomap()` stores labels in `adata.obs[key_added]` and run metadata in `adata.uns[key_added]`. Scanpy's Leiden function is called with the same neighbor graph. Leiden is skipped gracefully if the optional backend is not installed.\n",
+   "id": "scanpy_workflow_05"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "if SCANPY_AVAILABLE:\n    infomap.tl.infomap(\n        adata,\n        key_added=\"infomap\",\n        seed=123,\n        num_trials=20,\n    )\n\n    leiden_note = None\n    try:\n        sc.tl.leiden(adata, key_added=\"leiden\", random_state=123)\n    except Exception as exc:\n        leiden_note = f\"Scanpy Leiden skipped: {exc}\"\n\n    print(\"Infomap communities:\", adata.obs[\"infomap\"].nunique())\n    if \"leiden\" in adata.obs:\n        print(\"Leiden communities:\", adata.obs[\"leiden\"].nunique())\n    else:\n        print(leiden_note)\n\n    adata.uns[\"infomap\"]\n",
+   "id": "scanpy_workflow_06"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Compare assignments\n\nThe labels are categorical strings because that is the common Scanpy representation for cluster assignments.\n",
+   "id": "scanpy_workflow_07"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "if SCANPY_AVAILABLE:\n    columns = [\"truth\", \"infomap\"] + ([\"leiden\"] if \"leiden\" in adata.obs else [])\n    comparison = adata.obs[columns].copy()\n    comparison.head(10)\n",
+   "id": "scanpy_workflow_08"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "if SCANPY_AVAILABLE:\n    try:\n        from sklearn.metrics import adjusted_rand_score, normalized_mutual_info_score\n    except ImportError:\n        print(\"Install scikit-learn to compute ARI and NMI.\")\n    else:\n        rows = [\n            {\n                \"method\": \"infomap\",\n                \"ARI vs truth\": adjusted_rand_score(comparison[\"truth\"], comparison[\"infomap\"]),\n                \"NMI vs truth\": normalized_mutual_info_score(comparison[\"truth\"], comparison[\"infomap\"]),\n            }\n        ]\n        if \"leiden\" in comparison:\n            rows.append(\n                {\n                    \"method\": \"leiden\",\n                    \"ARI vs truth\": adjusted_rand_score(comparison[\"truth\"], comparison[\"leiden\"]),\n                    \"NMI vs truth\": normalized_mutual_info_score(comparison[\"truth\"], comparison[\"leiden\"]),\n                }\n            )\n        pd.DataFrame(rows)\n",
+   "id": "scanpy_workflow_09"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Visualize the clusters\n\nWhen Scanpy plotting is available, color the same UMAP layout by the known synthetic labels and the detected communities.\n",
+   "id": "scanpy_workflow_10"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "if SCANPY_AVAILABLE:\n    colors = [\"truth\", \"infomap\"] + ([\"leiden\"] if \"leiden\" in adata.obs else [])\n    sc.pl.umap(adata, color=colors, wspace=0.35)\n",
+   "id": "scanpy_workflow_11"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Notes on graph choices\n\nBy default, Infomap uses `adata.obsp[\"connectivities\"]`. Pass `neighbors_key` when using a named Scanpy neighbor graph, or `obsp`/`adjacency` when selecting a graph directly. Use `directed=True` for directed observation graphs and `use_weights=False` for unweighted treatment of nonzero sparse entries.\n\nIf you use Infomap in published work, cite the Infomap software and the map equation literature. See the repository and Infomap user guide for the current recommended references.\n",
+   "id": "scanpy_workflow_12"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/notebooks.toml
+++ b/examples/notebooks/notebooks.toml
@@ -67,3 +67,18 @@ description = "Requires geospatial dependencies and external data access."
 path = "9.4 Model Selection with Correlational Data.ipynb"
 tier = "full"
 description = "Correlational-data model-selection example with local dependencies."
+
+[[notebooks]]
+path = "compare-infomap-louvain-leiden-networkx.ipynb"
+tier = "smoke"
+description = "NetworkX comparison of Infomap, Louvain, and Leiden when available."
+
+[[notebooks]]
+path = "compare-infomap-louvain-leiden-igraph.ipynb"
+tier = "full"
+description = "python-igraph comparison of Infomap, Louvain, and Leiden."
+
+[[notebooks]]
+path = "compare-infomap-scanpy-workflow.ipynb"
+tier = "manual"
+description = "Scanpy and AnnData comparison of Infomap and Leiden with optional Scanpy dependencies."

--- a/interfaces/python/source/notebooks.rst
+++ b/interfaces/python/source/notebooks.rst
@@ -30,6 +30,21 @@ The notebooks cover:
 The notebook source is available in
 `examples/notebooks <https://github.com/mapequation/infomap/tree/master/examples/notebooks>`_.
 
+Comparison tutorials
+--------------------
+
+The unnumbered workflow notebooks show how to run Infomap next to common
+community-detection tools without following the article section numbering:
+
+- `compare-infomap-louvain-leiden-networkx.ipynb <https://github.com/mapequation/infomap/blob/master/examples/notebooks/compare-infomap-louvain-leiden-networkx.ipynb>`_
+  compares :func:`infomap.find_communities` with NetworkX Louvain and Leiden
+  when Leiden is available.
+- `compare-infomap-louvain-leiden-igraph.ipynb <https://github.com/mapequation/infomap/blob/master/examples/notebooks/compare-infomap-louvain-leiden-igraph.ipynb>`_
+  compares :func:`infomap.find_igraph_communities` with python-igraph
+  Louvain and Leiden.
+- `compare-infomap-scanpy-workflow.ipynb <https://github.com/mapequation/infomap/blob/master/examples/notebooks/compare-infomap-scanpy-workflow.ipynb>`_
+  shows :func:`infomap.tl.infomap` in an AnnData and Scanpy-style workflow.
+
 Run with Docker
 ---------------
 

--- a/interfaces/python/source/scanpy.rst
+++ b/interfaces/python/source/scanpy.rst
@@ -108,3 +108,6 @@ For hierarchical module assignments, flows, custom output files or repeated
 runs with the same graph, use the lower-level :class:`infomap.Infomap` API with
 :meth:`infomap.Infomap.add_scipy_sparse_matrix`. The AnnData helper keeps the
 default output compact for interactive single-cell analysis.
+
+For a worked comparison with Scanpy's Leiden workflow, see the unnumbered
+Scanpy comparison tutorial on the :doc:`notebooks` page.

--- a/interfaces/python/source/usage.rst
+++ b/interfaces/python/source/usage.rst
@@ -355,4 +355,8 @@ Use :meth:`infomap.Infomap.add_networkx_graph` or
 you need state networks, multilayer networks, explicit result iteration,
 dataframe export, or several runs with different Infomap options.
 
+For worked comparisons against Louvain and Leiden in NetworkX and igraph
+workflows, see the unnumbered comparison tutorials on the :doc:`notebooks`
+page.
+
 See the :doc:`api/index` reference for the full surface.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ examples = [
 ]
 notebooks = [
   "coloraide",
+  "igraph",
   "ipykernel",
   "jupyterlab",
   "matplotlib",


### PR DESCRIPTION
## Summary

- add unnumbered comparison notebooks for NetworkX, python-igraph, and Scanpy-style workflows under `examples/notebooks`
- register the new notebooks in `examples/notebooks/notebooks.toml` with smoke/full/manual tiers
- add lightweight links from `interfaces/python/source/notebooks.rst`, `interfaces/python/source/usage.rst`, and `interfaces/python/source/scanpy.rst`
- include `igraph` in the notebook extra so the full notebook suite can execute the igraph comparison

Closes #539

## Verification

- `PYTHON=/Users/anton/kod/infomap/.venv/bin/python PYTEST='/Users/anton/kod/infomap/.venv/bin/python -m pytest' make test-python-notebooks-smoke`
- `PYTHON=/Users/anton/kod/infomap/.venv/bin/python PYTEST='/Users/anton/kod/infomap/.venv/bin/python -m pytest' make test-python-notebooks-full`
- `PYTHON=/Users/anton/kod/infomap/.venv/bin/python PIP='/Users/anton/kod/infomap/.venv/bin/python -m pip' SPHINX_BUILD='/Users/anton/kod/infomap/.venv/bin/python -m sphinx' make build-docs`
- `PYTHON=/Users/anton/kod/infomap/.venv/bin/python PYTEST='/Users/anton/kod/infomap/.venv/bin/python -m pytest' make test-python-unit PYTEST_ARGS='test/python/test_api.py::test_python_package_extras_are_declared'`
- `cd examples/notebooks && /Users/anton/kod/infomap/.venv/bin/python -m pytest --nbmake --nbmake-timeout=300 compare-infomap-scanpy-workflow.ipynb`

## Notes

The Scanpy notebook remains `manual` because `scanpy` is intentionally not added to the default notebook extra. It was executed locally through its graceful no-Scanpy path.
