### PR TITLE
docs: clarify Infomap option help text

### DIFF
--- a/interfaces/R/infomap/R/options.R
+++ b/interfaces/R/infomap/R/options.R
@@ -171,74 +171,74 @@ OPTION_DEFAULTS <- list(
 #' Input
 #' \describe{
 #'   \item{`include_self_links`}{Deprecated. Self-links are included by default; use `no_self_links = TRUE` to exclude them.}
-#'   \item{`skip_adjust_bipartite_flow`}{Skip distributing all flow from the bipartite nodes to the primary nodes.}
-#'   \item{`bipartite_teleportation`}{Teleport like the bipartite flow instead of two-step (unipartite) teleportation.}
-#'   \item{`weight_threshold`}{Limit the number of links to read from the network. Ignore links with less weight than the threshold.}
-#'   \item{`no_self_links`}{Exclude self links in the input network.}
-#'   \item{`node_limit`}{Limit the number of nodes to read from the network. Ignore links connected to ignored nodes.}
-#'   \item{`matchable_multilayer_ids`}{Construct state ids from node and layer ids that are consistent across networks for the same max number of layers. Set to at least the largest layer id among networks to match.}
-#'   \item{`cluster_data`}{Provide an initial partition as cluster ids (clu) or a hierarchical tree (tree, ftree). Tree input may be physical or state-level for higher-order networks.}
-#'   \item{`assign_to_neighbouring_module`}{Assign nodes without module assignments (from --cluster-data) to the module assignment of a neighbouring node if possible.}
-#'   \item{`meta_data`}{Provide meta data (clu format) that should be encoded.}
-#'   \item{`meta_data_rate`}{Metadata encoding rate. Default is to encode each step.}
-#'   \item{`meta_data_unweighted`}{Don't weight meta data by node flow.}
-#'   \item{`no_infomap`}{Don't run the optimizer. Useful to calculate codelength of provided cluster data or to print non-modular statistics.}
+#'   \item{`skip_adjust_bipartite_flow`}{Keep flow on bipartite nodes instead of distributing it to primary nodes.}
+#'   \item{`bipartite_teleportation`}{Use bipartite teleportation instead of the default two-step unipartite teleportation.}
+#'   \item{`weight_threshold`}{Ignore input links with weight below this threshold.}
+#'   \item{`no_self_links`}{Exclude self-links from the input network.}
+#'   \item{`node_limit`}{Read only nodes up to this node id and ignore links connected to higher node ids.}
+#'   \item{`matchable_multilayer_ids`}{Construct state ids from node ids and layer ids that stay comparable across networks. Set at least to the largest layer id among networks to match.}
+#'   \item{`cluster_data`}{Read an initial partition from a clu file or a hierarchy from a tree/ftree file. Tree input may use physical or state nodes for higher-order networks.}
+#'   \item{`assign_to_neighbouring_module`}{With --cluster-data, assign nodes missing module ids to a neighboring node's module when possible.}
+#'   \item{`meta_data`}{Read metadata to encode from a clu-format file.}
+#'   \item{`meta_data_rate`}{With --meta-data, set the metadata encoding rate. The default encodes metadata at each step.}
+#'   \item{`meta_data_unweighted`}{With --meta-data, encode metadata without weighting by node flow.}
+#'   \item{`no_infomap`}{Skip optimization. Use this to calculate codelength for --cluster-data or to print non-modular statistics.}
 #' }
 #'
 #' Output
 #' \describe{
-#'   \item{`out_name`}{Name for the output files, e.g. \[output_directory\]/\[out-name\].tree}
-#'   \item{`no_file_output`}{Don't write output to file.}
-#'   \item{`tree`}{Write a tree file with the modular hierarchy. Automatically enabled if no other output is specified.}
-#'   \item{`ftree`}{Write a ftree file with the modular hierarchy including aggregated links between (nested) modules. (Used by Network Navigator)}
-#'   \item{`clu`}{Write a clu file with the top cluster ids for each node.}
-#'   \item{`clu_level`}{For clu output, print modules at specified depth from root. Use -1 for bottom level modules.}
-#'   \item{`output`}{Comma-separated output formats without spaces, e.g. -o clu,tree,ftree. Options: clu, tree, ftree, newick, json, csv, network, states, flow.}
-#'   \item{`hide_bipartite_nodes`}{Project bipartite solution to unipartite.}
-#'   \item{`print_all_trials`}{Print all trials to separate files.}
-#'   \item{`verbosity_level`}{Verbose output on the console. Add additional 'v' flags to increase verbosity up to -vvv.}
-#'   \item{`silent`}{No output on the console.}
+#'   \item{`out_name`}{Base name for output files, for example \[out_directory\]/\[out-name\].tree.}
+#'   \item{`no_file_output`}{Do not write output files.}
+#'   \item{`tree`}{Write the modular hierarchy to a tree file. Enabled by default when no other output format is selected.}
+#'   \item{`ftree`}{Write the modular hierarchy and aggregated links between nested modules to an ftree file. Used by Network Navigator.}
+#'   \item{`clu`}{Write top-level module ids for each node to a clu file.}
+#'   \item{`clu_level`}{With --clu or --output clu, write module ids at this depth from the root. Use -1 for bottom-level modules.}
+#'   \item{`output`}{Write selected output formats as a comma-separated list without spaces, e.g. -o clu,tree,ftree. Options: clu, tree, ftree, newick, json, csv, network, states, flow.}
+#'   \item{`hide_bipartite_nodes`}{Hide bipartite nodes in output by projecting the solution to primary nodes.}
+#'   \item{`print_all_trials`}{Write each trial to separate output files. Has effect only when --num-trials is greater than 1.}
+#'   \item{`verbosity_level`}{Increase console verbosity. Add more v flags to increase verbosity up to -vvv.}
+#'   \item{`silent`}{Suppress console output.}
 #' }
 #'
 #' Algorithm
 #' \describe{
-#'   \item{`two_level`}{Optimize a two-level partition of the network. Default is multi-level.}
-#'   \item{`flow_model`}{Specify flow model. Options: undirected, directed, undirdir, outdirdir, rawdir, precomputed.}
-#'   \item{`directed`}{Assume directed links. Shorthand for '--flow-model directed'.}
-#'   \item{`recorded_teleportation`}{If teleportation is used to calculate the flow, also record it when minimizing codelength.}
-#'   \item{`use_node_weights_as_flow`}{Use node weights (from api or after names in Pajek format) as flow, normalized to sum to 1}
-#'   \item{`to_nodes`}{Teleport to nodes instead of to links, assuming uniform node weights if no such input data.}
-#'   \item{`teleportation_probability`}{Probability of teleporting to a random node or link.}
-#'   \item{`regularized`}{Effectively add a fully connected Bayesian prior network to not overfit due to missing links. Implies recorded teleportation}
-#'   \item{`regularization_strength`}{Adjust relative strength of Bayesian prior network with this multiplier.}
-#'   \item{`entropy_corrected`}{Correct for negative entropy bias in small samples (many modules).}
-#'   \item{`entropy_correction_strength`}{Increase or decrease the default entropy correction with this factor.}
-#'   \item{`markov_time`}{Scale link flow to change the cost of moving between modules. Higher values results in fewer modules.}
-#'   \item{`variable_markov_time`}{Increase Markov time locally to level out link flow. Reduces risk of overpartitioning sparse areas while keeping high resolution in dense areas.}
-#'   \item{`variable_markov_damping`}{Damping parameter for variable Markov time, to scale with local effective degree (0) or local entropy (1).}
-#'   \item{`variable_markov_min_scale`}{Minimum local scale for nodes with zero entropy to avoid division by zero. Local Markov time is max scale divided by local scale.}
-#'   \item{`preferred_number_of_modules`}{Penalize solutions the more they differ from this number.}
-#'   \item{`multilayer_relax_rate`}{Probability to relax the constraint to move only in the current layer.}
-#'   \item{`multilayer_relax_limit`}{Number of neighboring layers in each direction to relax to. If negative, relax to any layer.}
-#'   \item{`multilayer_relax_limit_up`}{Number of neighboring layers with higher id to relax to. If negative, relax to any layer.}
-#'   \item{`multilayer_relax_limit_down`}{Number of neighboring layers with lower id to relax to. If negative, relax to any layer.}
-#'   \item{`multilayer_relax_by_jsd`}{Relax proportional to the out-link similarity measured by the Jensen-Shannon divergence.}
+#'   \item{`two_level`}{Optimize a two-level partition instead of the default multi-level hierarchy.}
+#'   \item{`flow_model`}{Choose how Infomap derives flow from the input links. Options: undirected, directed, undirdir, outdirdir, rawdir, precomputed.}
+#'   \item{`directed`}{Treat input links as directed. Shorthand for --flow-model directed.}
+#'   \item{`recorded_teleportation`}{When teleportation is used to calculate flow, also record teleportation steps in the codelength.}
+#'   \item{`use_node_weights_as_flow`}{Use node weights from the API or Pajek node records as normalized node flow.}
+#'   \item{`to_nodes`}{Teleport to nodes instead of links. Uses uniform node weights unless node weights are provided.}
+#'   \item{`teleportation_probability`}{Set the probability of teleporting to a random node or link when calculating flow.}
+#'   \item{`regularized`}{Add a fully connected Bayesian prior network to reduce overfitting to missing links. Activates --recorded-teleportation.}
+#'   \item{`regularization_strength`}{Scale the relative strength of the Bayesian prior network used by --regularized.}
+#'   \item{`entropy_corrected`}{Correct for negative entropy bias in small samples, especially solutions with many modules.}
+#'   \item{`entropy_correction_strength`}{Scale the default correction used by --entropy-corrected.}
+#'   \item{`markov_time`}{Scale link flow to change the cost of moving between modules. Higher values result in fewer modules.}
+#'   \item{`variable_markov_time`}{Vary Markov time locally to reduce overpartitioning in sparse areas while keeping higher resolution in dense areas.}
+#'   \item{`variable_markov_damping`}{With --variable-markov-time, set damping between local effective degree (0) and local entropy (1).}
+#'   \item{`variable_markov_min_scale`}{With --variable-markov-time, set the minimum local scale for zero-entropy nodes. Local Markov time is max scale divided by local scale.}
+#'   \item{`preferred_number_of_modules`}{Penalize solutions by how far their number of modules differs from this value.}
+#'   \item{`multilayer_relax_rate`}{Set the probability of relaxing from a state node to neighboring layers instead of staying in the current layer.}
+#'   \item{`multilayer_relax_limit`}{Limit relaxation to this many neighboring layer ids in each direction. Use a negative value to allow relaxation to any layer.}
+#'   \item{`multilayer_relax_limit_up`}{Limit relaxation upward to this many higher neighboring layer ids. Use a negative value to allow relaxation to any higher layer.}
+#'   \item{`multilayer_relax_limit_down`}{Limit relaxation downward to this many lower neighboring layer ids. Use a negative value to allow relaxation to any lower layer.}
+#'   \item{`multilayer_relax_by_jsd`}{Weight multilayer relaxation by out-link similarity measured with Jensen-Shannon divergence.}
 #' }
 #'
 #' Accuracy
 #' \describe{
-#'   \item{`seed`}{A seed (integer) to the random number generator for reproducible results.}
-#'   \item{`num_trials`}{Number of outer-most loops to run before picking the best solution.}
-#'   \item{`core_loop_limit`}{Limit the number of loops that tries to move each node into the best possible module.}
-#'   \item{`core_level_limit`}{Limit the number of times the core loops are reapplied on existing modular network to search bigger structures.}
-#'   \item{`tune_iteration_limit`}{Limit the number of main iterations in the two-level partition algorithm. 0 means no limit.}
-#'   \item{`core_loop_codelength_threshold`}{Minimum codelength threshold for accepting a new solution in core loop.}
-#'   \item{`tune_iteration_relative_threshold`}{Set codelength improvement threshold of each new tune iteration to 'f' times the initial two-level codelength.}
-#'   \item{`fast_hierarchical_solution`}{Find top modules fast. Use -FF to keep all fast levels. Use -FFF to skip recursive part.}
-#'   \item{`inner_parallelization`}{Parallelize the inner-most loop for greater speed. This may give some accuracy tradeoff.}
-#'   \item{`prefer_modular_solution`}{Prefer modular solutions even if they are worse than putting all nodes in one module.}
-#'   \item{`num_random_moves`}{Number of random moves to try in core loop to try merge weakly connected nodes.}
-#'   \item{`max_degree_for_random_moves`}{Maximum degree of nodes for which to try random moves.}
+#'   \item{`seed`}{Set the random number generator seed for reproducible results.}
+#'   \item{`num_trials`}{Run this many independent trials and keep the best solution.}
+#'   \item{`core_loop_limit`}{Limit how many core loops try to move each node to the best module.}
+#'   \item{`core_level_limit`}{Limit how many times core loops are reapplied to the aggregated modular network to find larger structures.}
+#'   \item{`tune_iteration_limit`}{Limit the main iterations in the two-level partition algorithm. 0 means no limit.}
+#'   \item{`core_loop_codelength_threshold`}{Require at least this codelength improvement to accept a new solution in a core loop.}
+#'   \item{`tune_iteration_relative_threshold`}{Require each tune iteration to improve codelength by this fraction of the initial two-level codelength.}
+#'   \item{`fast_hierarchical_solution`}{Find top modules quickly. Use -FF to keep all fast levels. Use -FFF to skip recursive refinement.}
+#'   \item{`inner_parallelization`}{Parallelize the innermost loop for speed, with a possible accuracy tradeoff.}
+#'   \item{`prefer_modular_solution`}{Prefer a modular solution even when one module gives a lower codelength.}
+#'   \item{`num_random_moves`}{Try this many random moves in each core loop to merge weakly connected nodes.}
+#'   \item{`max_degree_for_random_moves`}{Try random moves only for nodes with degree at most this value.}
 #' }
 #'
 #' @return A named list of options.

--- a/interfaces/R/infomap/man/infomap_options.Rd
+++ b/interfaces/R/infomap/man/infomap_options.Rd
@@ -27,72 +27,74 @@ underscores) and the keyword arguments accepted by the Python interface.
 Input
 \describe{
 \item{\code{include_self_links}}{Deprecated. Self-links are included by default; use \code{no_self_links = TRUE} to exclude them.}
-\item{\code{skip_adjust_bipartite_flow}}{Skip distributing all flow from the bipartite nodes to the primary nodes.}
-\item{\code{bipartite_teleportation}}{Teleport like the bipartite flow instead of two-step (unipartite) teleportation.}
-\item{\code{weight_threshold}}{Limit the number of links to read from the network. Ignore links with less weight than the threshold.}
-\item{\code{no_self_links}}{Exclude self links in the input network.}
-\item{\code{node_limit}}{Limit the number of nodes to read from the network. Ignore links connected to ignored nodes.}
-\item{\code{matchable_multilayer_ids}}{Construct state ids from node and layer ids that are consistent across networks for the same max number of layers. Set to at least the largest layer id among networks to match.}
-\item{\code{cluster_data}}{Provide an initial two-level (clu format) or multi-layer (tree format) solution.}
-\item{\code{assign_to_neighbouring_module}}{Assign nodes without module assignments (from --cluster-data) to the module assignment of a neighbouring node if possible.}
-\item{\code{meta_data}}{Provide meta data (clu format) that should be encoded.}
-\item{\code{meta_data_rate}}{Metadata encoding rate. Default is to encode each step.}
-\item{\code{meta_data_unweighted}}{Don't weight meta data by node flow.}
-\item{\code{no_infomap}}{Don't run the optimizer. Useful to calculate codelength of provided cluster data or to print non-modular statistics.}
+\item{\code{skip_adjust_bipartite_flow}}{Keep flow on bipartite nodes instead of distributing it to primary nodes.}
+\item{\code{bipartite_teleportation}}{Use bipartite teleportation instead of the default two-step unipartite teleportation.}
+\item{\code{weight_threshold}}{Ignore input links with weight below this threshold.}
+\item{\code{no_self_links}}{Exclude self-links from the input network.}
+\item{\code{node_limit}}{Read only nodes up to this node id and ignore links connected to higher node ids.}
+\item{\code{matchable_multilayer_ids}}{Construct state ids from node ids and layer ids that stay comparable across networks. Set at least to the largest layer id among networks to match.}
+\item{\code{cluster_data}}{Read an initial partition from a clu file or a hierarchy from a tree/ftree file. Tree input may use physical or state nodes for higher-order networks.}
+\item{\code{assign_to_neighbouring_module}}{With --cluster-data, assign nodes missing module ids to a neighboring node's module when possible.}
+\item{\code{meta_data}}{Read metadata to encode from a clu-format file.}
+\item{\code{meta_data_rate}}{With --meta-data, set the metadata encoding rate. The default encodes metadata at each step.}
+\item{\code{meta_data_unweighted}}{With --meta-data, encode metadata without weighting by node flow.}
+\item{\code{no_infomap}}{Skip optimization. Use this to calculate codelength for --cluster-data or to print non-modular statistics.}
 }
 
 Output
 \describe{
-\item{\code{out_name}}{Name for the output files, e.g. [output_directory]/[out-name].tree}
-\item{\code{no_file_output}}{Don't write output to file.}
-\item{\code{tree}}{Write a tree file with the modular hierarchy. Automatically enabled if no other output is specified.}
-\item{\code{ftree}}{Write a ftree file with the modular hierarchy including aggregated links between (nested) modules. (Used by Network Navigator)}
-\item{\code{clu}}{Write a clu file with the top cluster ids for each node.}
-\item{\code{clu_level}}{For clu output, print modules at specified depth from root. Use -1 for bottom level modules.}
-\item{\code{output}}{Comma-separated output formats without spaces, e.g. -o clu,tree,ftree. Options: clu, tree, ftree, newick, json, csv, network, states, flow.}
-\item{\code{hide_bipartite_nodes}}{Project bipartite solution to unipartite.}
-\item{\code{print_all_trials}}{Print all trials to separate files.}
-\item{\code{verbosity_level}}{Verbose output on the console. Add additional 'v' flags to increase verbosity up to -vvv.}
-\item{\code{silent}}{No output on the console.}
+\item{\code{out_name}}{Base name for output files, for example [out_directory]/[out-name].tree.}
+\item{\code{no_file_output}}{Do not write output files.}
+\item{\code{tree}}{Write the modular hierarchy to a tree file. Enabled by default when no other output format is selected.}
+\item{\code{ftree}}{Write the modular hierarchy and aggregated links between nested modules to an ftree file. Used by Network Navigator.}
+\item{\code{clu}}{Write top-level module ids for each node to a clu file.}
+\item{\code{clu_level}}{With --clu or --output clu, write module ids at this depth from the root. Use -1 for bottom-level modules.}
+\item{\code{output}}{Write selected output formats as a comma-separated list without spaces, e.g. -o clu,tree,ftree. Options: clu, tree, ftree, newick, json, csv, network, states, flow.}
+\item{\code{hide_bipartite_nodes}}{Hide bipartite nodes in output by projecting the solution to primary nodes.}
+\item{\code{print_all_trials}}{Write each trial to separate output files. Has effect only when --num-trials is greater than 1.}
+\item{\code{verbosity_level}}{Increase console verbosity. Add more v flags to increase verbosity up to -vvv.}
+\item{\code{silent}}{Suppress console output.}
 }
 
 Algorithm
 \describe{
-\item{\code{two_level}}{Optimize a two-level partition of the network. Default is multi-level.}
-\item{\code{flow_model}}{Specify flow model. Options: undirected, directed, undirdir, outdirdir, rawdir, precomputed.}
-\item{\code{directed}}{Assume directed links. Shorthand for '--flow-model directed'.}
-\item{\code{recorded_teleportation}}{If teleportation is used to calculate the flow, also record it when minimizing codelength.}
-\item{\code{use_node_weights_as_flow}}{Use node weights (from api or after names in Pajek format) as flow, normalized to sum to 1}
-\item{\code{to_nodes}}{Teleport to nodes instead of to links, assuming uniform node weights if no such input data.}
-\item{\code{teleportation_probability}}{Probability of teleporting to a random node or link.}
-\item{\code{regularized}}{Effectively add a fully connected Bayesian prior network to not overfit due to missing links. Implies recorded teleportation}
-\item{\code{regularization_strength}}{Adjust relative strength of Bayesian prior network with this multiplier.}
-\item{\code{entropy_corrected}}{Correct for negative entropy bias in small samples (many modules).}
-\item{\code{entropy_correction_strength}}{Increase or decrease the default entropy correction with this factor.}
-\item{\code{markov_time}}{Scale link flow to change the cost of moving between modules. Higher values results in fewer modules.}
-\item{\code{variable_markov_time}}{Increase Markov time locally to level out link flow. Reduces risk of overpartitioning sparse areas while keeping high resolution in dense areas.}
-\item{\code{variable_markov_damping}}{Damping parameter for variable Markov time, to scale with local effective degree (0) or local entropy (1).}
-\item{\code{variable_markov_min_scale}}{Minimum local scale for nodes with zero entropy to avoid division by zero. Local Markov time is max scale divided by local scale.}
-\item{\code{preferred_number_of_modules}}{Penalize solutions the more they differ from this number.}
-\item{\code{multilayer_relax_rate}}{Probability to relax the constraint to move only in the current layer.}
-\item{\code{multilayer_relax_limit}}{Number of neighboring layers in each direction to relax to. If negative, relax to any layer.}
-\item{\code{multilayer_relax_limit_up}}{Number of neighboring layers with higher id to relax to. If negative, relax to any layer.}
-\item{\code{multilayer_relax_limit_down}}{Number of neighboring layers with lower id to relax to. If negative, relax to any layer.}
-\item{\code{multilayer_relax_by_jsd}}{Relax proportional to the out-link similarity measured by the Jensen-Shannon divergence.}
+\item{\code{two_level}}{Optimize a two-level partition instead of the default multi-level hierarchy.}
+\item{\code{flow_model}}{Choose how Infomap derives flow from the input links. Options: undirected, directed, undirdir, outdirdir, rawdir, precomputed.}
+\item{\code{directed}}{Treat input links as directed. Shorthand for --flow-model directed.}
+\item{\code{recorded_teleportation}}{When teleportation is used to calculate flow, also record teleportation steps in the codelength.}
+\item{\code{use_node_weights_as_flow}}{Use node weights from the API or Pajek node records as normalized node flow.}
+\item{\code{to_nodes}}{Teleport to nodes instead of links. Uses uniform node weights unless node weights are provided.}
+\item{\code{teleportation_probability}}{Set the probability of teleporting to a random node or link when calculating flow.}
+\item{\code{regularized}}{Add a fully connected Bayesian prior network to reduce overfitting to missing links. Activates --recorded-teleportation.}
+\item{\code{regularization_strength}}{Scale the relative strength of the Bayesian prior network used by --regularized.}
+\item{\code{entropy_corrected}}{Correct for negative entropy bias in small samples, especially solutions with many modules.}
+\item{\code{entropy_correction_strength}}{Scale the default correction used by --entropy-corrected.}
+\item{\code{markov_time}}{Scale link flow to change the cost of moving between modules. Higher values result in fewer modules.}
+\item{\code{variable_markov_time}}{Vary Markov time locally to reduce overpartitioning in sparse areas while keeping higher resolution in dense areas.}
+\item{\code{variable_markov_damping}}{With --variable-markov-time, set damping between local effective degree (0) and local entropy (1).}
+\item{\code{variable_markov_min_scale}}{With --variable-markov-time, set the minimum local scale for zero-entropy nodes. Local Markov time is max scale divided by local scale.}
+\item{\code{preferred_number_of_modules}}{Penalize solutions by how far their number of modules differs from this value.}
+\item{\code{multilayer_relax_rate}}{Set the probability of relaxing from a state node to neighboring layers instead of staying in the current layer.}
+\item{\code{multilayer_relax_limit}}{Limit relaxation to this many neighboring layer ids in each direction. Use a negative value to allow relaxation to any layer.}
+\item{\code{multilayer_relax_limit_up}}{Limit relaxation upward to this many higher neighboring layer ids. Use a negative value to allow relaxation to any higher layer.}
+\item{\code{multilayer_relax_limit_down}}{Limit relaxation downward to this many lower neighboring layer ids. Use a negative value to allow relaxation to any lower layer.}
+\item{\code{multilayer_relax_by_jsd}}{Weight multilayer relaxation by out-link similarity measured with Jensen-Shannon divergence.}
 }
 
 Accuracy
 \describe{
-\item{\code{seed}}{A seed (integer) to the random number generator for reproducible results.}
-\item{\code{num_trials}}{Number of outer-most loops to run before picking the best solution.}
-\item{\code{core_loop_limit}}{Limit the number of loops that tries to move each node into the best possible module.}
-\item{\code{core_level_limit}}{Limit the number of times the core loops are reapplied on existing modular network to search bigger structures.}
-\item{\code{tune_iteration_limit}}{Limit the number of main iterations in the two-level partition algorithm. 0 means no limit.}
-\item{\code{core_loop_codelength_threshold}}{Minimum codelength threshold for accepting a new solution in core loop.}
-\item{\code{tune_iteration_relative_threshold}}{Set codelength improvement threshold of each new tune iteration to 'f' times the initial two-level codelength.}
-\item{\code{fast_hierarchical_solution}}{Find top modules fast. Use -FF to keep all fast levels. Use -FFF to skip recursive part.}
-\item{\code{prefer_modular_solution}}{Prefer modular solutions even if they are worse than putting all nodes in one module.}
-\item{\code{inner_parallelization}}{Parallelize the inner-most loop for greater speed. This may give some accuracy tradeoff.}
+\item{\code{seed}}{Set the random number generator seed for reproducible results.}
+\item{\code{num_trials}}{Run this many independent trials and keep the best solution.}
+\item{\code{core_loop_limit}}{Limit how many core loops try to move each node to the best module.}
+\item{\code{core_level_limit}}{Limit how many times core loops are reapplied to the aggregated modular network to find larger structures.}
+\item{\code{tune_iteration_limit}}{Limit the main iterations in the two-level partition algorithm. 0 means no limit.}
+\item{\code{core_loop_codelength_threshold}}{Require at least this codelength improvement to accept a new solution in a core loop.}
+\item{\code{tune_iteration_relative_threshold}}{Require each tune iteration to improve codelength by this fraction of the initial two-level codelength.}
+\item{\code{fast_hierarchical_solution}}{Find top modules quickly. Use -FF to keep all fast levels. Use -FFF to skip recursive refinement.}
+\item{\code{inner_parallelization}}{Parallelize the innermost loop for speed, with a possible accuracy tradeoff.}
+\item{\code{prefer_modular_solution}}{Prefer a modular solution even when one module gives a lower codelength.}
+\item{\code{num_random_moves}}{Try this many random moves in each core loop to merge weakly connected nodes.}
+\item{\code{max_degree_for_random_moves}}{Try random moves only for nodes with degree at most this value.}
 }
 }
 

--- a/interfaces/js/generated/parameters.json
+++ b/interfaces/js/generated/parameters.json
@@ -20,9 +20,25 @@
     "default": false
   },
   {
+    "long": "--completion",
+    "short": "",
+    "description": "Print shell completion script for bash or zsh.",
+    "group": "About",
+    "required": true,
+    "advanced": false,
+    "incremental": false,
+    "longType": "option",
+    "shortType": "o",
+    "default": "",
+    "choices": [
+      "bash",
+      "zsh"
+    ]
+  },
+  {
     "long": "--skip-adjust-bipartite-flow",
     "short": "",
-    "description": "Skip distributing all flow from the bipartite nodes to the primary nodes.",
+    "description": "Keep flow on bipartite nodes instead of distributing it to primary nodes.",
     "group": "Input",
     "required": false,
     "advanced": true,
@@ -32,7 +48,7 @@
   {
     "long": "--bipartite-teleportation",
     "short": "",
-    "description": "Teleport like the bipartite flow instead of two-step (unipartite) teleportation.",
+    "description": "Use bipartite teleportation instead of the default two-step unipartite teleportation.",
     "group": "Input",
     "required": false,
     "advanced": true,
@@ -42,7 +58,7 @@
   {
     "long": "--weight-threshold",
     "short": "",
-    "description": "Limit the number of links to read from the network. Ignore links with less weight than the threshold.",
+    "description": "Ignore input links with weight below this threshold.",
     "group": "Input",
     "required": true,
     "advanced": true,
@@ -54,7 +70,7 @@
   {
     "long": "--no-self-links",
     "short": "",
-    "description": "Exclude self links in the input network.",
+    "description": "Exclude self-links from the input network.",
     "group": "Input",
     "required": false,
     "advanced": true,
@@ -64,7 +80,7 @@
   {
     "long": "--node-limit",
     "short": "",
-    "description": "Limit the number of nodes to read from the network. Ignore links connected to ignored nodes.",
+    "description": "Read only nodes up to this node id and ignore links connected to higher node ids.",
     "group": "Input",
     "required": true,
     "advanced": true,
@@ -76,7 +92,7 @@
   {
     "long": "--matchable-multilayer-ids",
     "short": "",
-    "description": "Construct state ids from node and layer ids that are consistent across networks for the same max number of layers. Set to at least the largest layer id among networks to match.",
+    "description": "Construct state ids from node ids and layer ids that stay comparable across networks. Set at least to the largest layer id among networks to match.",
     "group": "Input",
     "required": true,
     "advanced": true,
@@ -88,7 +104,7 @@
   {
     "long": "--cluster-data",
     "short": "-c",
-    "description": "Provide an initial partition as cluster ids (clu) or a hierarchical tree (tree, ftree). Tree input may be physical or state-level for higher-order networks.",
+    "description": "Read an initial partition from a clu file or a hierarchy from a tree/ftree file. Tree input may use physical or state nodes for higher-order networks.",
     "group": "Input",
     "required": true,
     "advanced": false,
@@ -100,7 +116,7 @@
   {
     "long": "--assign-to-neighbouring-module",
     "short": "",
-    "description": "Assign nodes without module assignments (from --cluster-data) to the module assignment of a neighbouring node if possible.",
+    "description": "With --cluster-data, assign nodes missing module ids to a neighboring node's module when possible.",
     "group": "Input",
     "required": false,
     "advanced": true,
@@ -110,7 +126,7 @@
   {
     "long": "--meta-data",
     "short": "",
-    "description": "Provide meta data (clu format) that should be encoded.",
+    "description": "Read metadata to encode from a clu-format file.",
     "group": "Input",
     "required": true,
     "advanced": true,
@@ -122,7 +138,7 @@
   {
     "long": "--meta-data-rate",
     "short": "",
-    "description": "Metadata encoding rate. Default is to encode each step.",
+    "description": "With --meta-data, set the metadata encoding rate. The default encodes metadata at each step.",
     "group": "Input",
     "required": true,
     "advanced": true,
@@ -134,7 +150,7 @@
   {
     "long": "--meta-data-unweighted",
     "short": "",
-    "description": "Don't weight meta data by node flow.",
+    "description": "With --meta-data, encode metadata without weighting by node flow.",
     "group": "Input",
     "required": false,
     "advanced": true,
@@ -144,7 +160,7 @@
   {
     "long": "--no-infomap",
     "short": "",
-    "description": "Don't run the optimizer. Useful to calculate codelength of provided cluster data or to print non-modular statistics.",
+    "description": "Skip optimization. Use this to calculate codelength for --cluster-data or to print non-modular statistics.",
     "group": "Input",
     "required": false,
     "advanced": false,
@@ -154,7 +170,7 @@
   {
     "long": "--out-name",
     "short": "",
-    "description": "Name for the output files, e.g. [output_directory]/[out-name].tree",
+    "description": "Base name for output files, for example [out_directory]/[out-name].tree.",
     "group": "Output",
     "required": true,
     "advanced": true,
@@ -166,7 +182,7 @@
   {
     "long": "--no-file-output",
     "short": "-0",
-    "description": "Don't write output to file.",
+    "description": "Do not write output files.",
     "group": "Output",
     "required": false,
     "advanced": true,
@@ -176,7 +192,7 @@
   {
     "long": "--tree",
     "short": "",
-    "description": "Write a tree file with the modular hierarchy. Automatically enabled if no other output is specified.",
+    "description": "Write the modular hierarchy to a tree file. Enabled by default when no other output format is selected.",
     "group": "Output",
     "required": false,
     "advanced": false,
@@ -186,7 +202,7 @@
   {
     "long": "--ftree",
     "short": "",
-    "description": "Write a ftree file with the modular hierarchy including aggregated links between (nested) modules. (Used by Network Navigator)",
+    "description": "Write the modular hierarchy and aggregated links between nested modules to an ftree file. Used by Network Navigator.",
     "group": "Output",
     "required": false,
     "advanced": false,
@@ -196,7 +212,7 @@
   {
     "long": "--clu",
     "short": "",
-    "description": "Write a clu file with the top cluster ids for each node.",
+    "description": "Write top-level module ids for each node to a clu file.",
     "group": "Output",
     "required": false,
     "advanced": false,
@@ -206,7 +222,7 @@
   {
     "long": "--clu-level",
     "short": "",
-    "description": "For clu output, print modules at specified depth from root. Use -1 for bottom level modules.",
+    "description": "With --clu or --output clu, write module ids at this depth from the root. Use -1 for bottom-level modules.",
     "group": "Output",
     "required": true,
     "advanced": true,
@@ -218,19 +234,30 @@
   {
     "long": "--output",
     "short": "-o",
-    "description": "Comma-separated output formats without spaces, e.g. -o clu,tree,ftree. Options: clu, tree, ftree, newick, json, csv, network, states, flow.",
+    "description": "Write selected output formats as a comma-separated list without spaces, e.g. -o clu,tree,ftree. Options: clu, tree, ftree, newick, json, csv, network, states, flow.",
     "group": "Output",
     "required": true,
     "advanced": true,
     "incremental": false,
     "longType": "list",
     "shortType": "l",
-    "default": ""
+    "default": "",
+    "choices": [
+      "clu",
+      "tree",
+      "ftree",
+      "newick",
+      "json",
+      "csv",
+      "network",
+      "states",
+      "flow"
+    ]
   },
   {
     "long": "--hide-bipartite-nodes",
     "short": "",
-    "description": "Project bipartite solution to unipartite.",
+    "description": "Hide bipartite nodes in output by projecting the solution to primary nodes.",
     "group": "Output",
     "required": false,
     "advanced": true,
@@ -240,7 +267,7 @@
   {
     "long": "--print-all-trials",
     "short": "",
-    "description": "Print all trials to separate files.",
+    "description": "Write each trial to separate output files. Has effect only when --num-trials is greater than 1.",
     "group": "Output",
     "required": false,
     "advanced": true,
@@ -250,7 +277,7 @@
   {
     "long": "--two-level",
     "short": "-2",
-    "description": "Optimize a two-level partition of the network. Default is multi-level.",
+    "description": "Optimize a two-level partition instead of the default multi-level hierarchy.",
     "group": "Algorithm",
     "required": false,
     "advanced": false,
@@ -260,19 +287,27 @@
   {
     "long": "--flow-model",
     "short": "-f",
-    "description": "Specify flow model. Options: undirected, directed, undirdir, outdirdir, rawdir, precomputed.",
+    "description": "Choose how Infomap derives flow from the input links. Options: undirected, directed, undirdir, outdirdir, rawdir, precomputed.",
     "group": "Algorithm",
     "required": true,
     "advanced": false,
     "incremental": false,
     "longType": "option",
     "shortType": "o",
-    "default": ""
+    "default": "",
+    "choices": [
+      "undirected",
+      "directed",
+      "undirdir",
+      "outdirdir",
+      "rawdir",
+      "precomputed"
+    ]
   },
   {
     "long": "--directed",
     "short": "-d",
-    "description": "Assume directed links. Shorthand for '--flow-model directed'.",
+    "description": "Treat input links as directed. Shorthand for --flow-model directed.",
     "group": "Algorithm",
     "required": false,
     "advanced": false,
@@ -282,7 +317,7 @@
   {
     "long": "--recorded-teleportation",
     "short": "-e",
-    "description": "If teleportation is used to calculate the flow, also record it when minimizing codelength.",
+    "description": "When teleportation is used to calculate flow, also record teleportation steps in the codelength.",
     "group": "Algorithm",
     "required": false,
     "advanced": true,
@@ -292,7 +327,7 @@
   {
     "long": "--use-node-weights-as-flow",
     "short": "",
-    "description": "Use node weights (from api or after names in Pajek format) as flow, normalized to sum to 1",
+    "description": "Use node weights from the API or Pajek node records as normalized node flow.",
     "group": "Algorithm",
     "required": false,
     "advanced": true,
@@ -302,7 +337,7 @@
   {
     "long": "--to-nodes",
     "short": "",
-    "description": "Teleport to nodes instead of to links, assuming uniform node weights if no such input data.",
+    "description": "Teleport to nodes instead of links. Uses uniform node weights unless node weights are provided.",
     "group": "Algorithm",
     "required": false,
     "advanced": true,
@@ -312,7 +347,7 @@
   {
     "long": "--teleportation-probability",
     "short": "-p",
-    "description": "Probability of teleporting to a random node or link.",
+    "description": "Set the probability of teleporting to a random node or link when calculating flow.",
     "group": "Algorithm",
     "required": true,
     "advanced": true,
@@ -324,7 +359,7 @@
   {
     "long": "--regularized",
     "short": "",
-    "description": "Effectively add a fully connected Bayesian prior network to not overfit due to missing links. Implies recorded teleportation",
+    "description": "Add a fully connected Bayesian prior network to reduce overfitting to missing links. Activates --recorded-teleportation.",
     "group": "Algorithm",
     "required": false,
     "advanced": true,
@@ -334,7 +369,7 @@
   {
     "long": "--regularization-strength",
     "short": "",
-    "description": "Adjust relative strength of Bayesian prior network with this multiplier.",
+    "description": "Scale the relative strength of the Bayesian prior network used by --regularized.",
     "group": "Algorithm",
     "required": true,
     "advanced": true,
@@ -346,7 +381,7 @@
   {
     "long": "--entropy-corrected",
     "short": "",
-    "description": "Correct for negative entropy bias in small samples (many modules).",
+    "description": "Correct for negative entropy bias in small samples, especially solutions with many modules.",
     "group": "Algorithm",
     "required": false,
     "advanced": true,
@@ -356,7 +391,7 @@
   {
     "long": "--entropy-correction-strength",
     "short": "",
-    "description": "Increase or decrease the default entropy correction with this factor.",
+    "description": "Scale the default correction used by --entropy-corrected.",
     "group": "Algorithm",
     "required": true,
     "advanced": true,
@@ -368,7 +403,7 @@
   {
     "long": "--markov-time",
     "short": "",
-    "description": "Scale link flow to change the cost of moving between modules. Higher values results in fewer modules.",
+    "description": "Scale link flow to change the cost of moving between modules. Higher values result in fewer modules.",
     "group": "Algorithm",
     "required": true,
     "advanced": true,
@@ -380,7 +415,7 @@
   {
     "long": "--variable-markov-time",
     "short": "",
-    "description": "Increase Markov time locally to level out link flow. Reduces risk of overpartitioning sparse areas while keeping high resolution in dense areas.",
+    "description": "Vary Markov time locally to reduce overpartitioning in sparse areas while keeping higher resolution in dense areas.",
     "group": "Algorithm",
     "required": false,
     "advanced": true,
@@ -390,7 +425,7 @@
   {
     "long": "--variable-markov-damping",
     "short": "",
-    "description": "Damping parameter for variable Markov time, to scale with local effective degree (0) or local entropy (1).",
+    "description": "With --variable-markov-time, set damping between local effective degree (0) and local entropy (1).",
     "group": "Algorithm",
     "required": true,
     "advanced": true,
@@ -402,7 +437,7 @@
   {
     "long": "--variable-markov-min-scale",
     "short": "",
-    "description": "Minimum local scale for nodes with zero entropy to avoid division by zero. Local Markov time is max scale divided by local scale.",
+    "description": "With --variable-markov-time, set the minimum local scale for zero-entropy nodes. Local Markov time is max scale divided by local scale.",
     "group": "Algorithm",
     "required": true,
     "advanced": true,
@@ -414,7 +449,7 @@
   {
     "long": "--preferred-number-of-modules",
     "short": "",
-    "description": "Penalize solutions the more they differ from this number.",
+    "description": "Penalize solutions by how far their number of modules differs from this value.",
     "group": "Algorithm",
     "required": true,
     "advanced": true,
@@ -426,7 +461,7 @@
   {
     "long": "--multilayer-relax-rate",
     "short": "",
-    "description": "Probability to relax the constraint to move only in the current layer.",
+    "description": "Set the probability of relaxing from a state node to neighboring layers instead of staying in the current layer.",
     "group": "Algorithm",
     "required": true,
     "advanced": true,
@@ -438,7 +473,7 @@
   {
     "long": "--multilayer-relax-limit",
     "short": "",
-    "description": "Number of neighboring layers in each direction to relax to. If negative, relax to any layer.",
+    "description": "Limit relaxation to this many neighboring layer ids in each direction. Use a negative value to allow relaxation to any layer.",
     "group": "Algorithm",
     "required": true,
     "advanced": true,
@@ -450,7 +485,7 @@
   {
     "long": "--multilayer-relax-limit-up",
     "short": "",
-    "description": "Number of neighboring layers with higher id to relax to. If negative, relax to any layer.",
+    "description": "Limit relaxation upward to this many higher neighboring layer ids. Use a negative value to allow relaxation to any higher layer.",
     "group": "Algorithm",
     "required": true,
     "advanced": true,
@@ -462,7 +497,7 @@
   {
     "long": "--multilayer-relax-limit-down",
     "short": "",
-    "description": "Number of neighboring layers with lower id to relax to. If negative, relax to any layer.",
+    "description": "Limit relaxation downward to this many lower neighboring layer ids. Use a negative value to allow relaxation to any lower layer.",
     "group": "Algorithm",
     "required": true,
     "advanced": true,
@@ -474,7 +509,7 @@
   {
     "long": "--multilayer-relax-by-jsd",
     "short": "",
-    "description": "Relax proportional to the out-link similarity measured by the Jensen-Shannon divergence.",
+    "description": "Weight multilayer relaxation by out-link similarity measured with Jensen-Shannon divergence.",
     "group": "Algorithm",
     "required": false,
     "advanced": true,
@@ -484,7 +519,7 @@
   {
     "long": "--seed",
     "short": "-s",
-    "description": "A seed (integer) to the random number generator for reproducible results.",
+    "description": "Set the random number generator seed for reproducible results.",
     "group": "Accuracy",
     "required": true,
     "advanced": false,
@@ -496,7 +531,7 @@
   {
     "long": "--num-trials",
     "short": "-N",
-    "description": "Number of outer-most loops to run before picking the best solution.",
+    "description": "Run this many independent trials and keep the best solution.",
     "group": "Accuracy",
     "required": true,
     "advanced": false,
@@ -508,7 +543,7 @@
   {
     "long": "--core-loop-limit",
     "short": "-M",
-    "description": "Limit the number of loops that tries to move each node into the best possible module.",
+    "description": "Limit how many core loops try to move each node to the best module.",
     "group": "Accuracy",
     "required": true,
     "advanced": true,
@@ -520,7 +555,7 @@
   {
     "long": "--core-level-limit",
     "short": "-L",
-    "description": "Limit the number of times the core loops are reapplied on existing modular network to search bigger structures.",
+    "description": "Limit how many times core loops are reapplied to the aggregated modular network to find larger structures.",
     "group": "Accuracy",
     "required": true,
     "advanced": true,
@@ -532,7 +567,7 @@
   {
     "long": "--tune-iteration-limit",
     "short": "-T",
-    "description": "Limit the number of main iterations in the two-level partition algorithm. 0 means no limit.",
+    "description": "Limit the main iterations in the two-level partition algorithm. 0 means no limit.",
     "group": "Accuracy",
     "required": true,
     "advanced": true,
@@ -544,7 +579,7 @@
   {
     "long": "--core-loop-codelength-threshold",
     "short": "",
-    "description": "Minimum codelength threshold for accepting a new solution in core loop.",
+    "description": "Require at least this codelength improvement to accept a new solution in a core loop.",
     "group": "Accuracy",
     "required": true,
     "advanced": true,
@@ -556,7 +591,7 @@
   {
     "long": "--tune-iteration-relative-threshold",
     "short": "",
-    "description": "Set codelength improvement threshold of each new tune iteration to 'f' times the initial two-level codelength.",
+    "description": "Require each tune iteration to improve codelength by this fraction of the initial two-level codelength.",
     "group": "Accuracy",
     "required": true,
     "advanced": true,
@@ -568,7 +603,7 @@
   {
     "long": "--fast-hierarchical-solution",
     "short": "-F",
-    "description": "Find top modules fast. Use -FF to keep all fast levels. Use -FFF to skip recursive part.",
+    "description": "Find top modules quickly. Use -FF to keep all fast levels. Use -FFF to skip recursive refinement.",
     "group": "Accuracy",
     "required": false,
     "advanced": true,
@@ -576,9 +611,9 @@
     "default": false
   },
   {
-    "long": "--prefer-modular-solution",
+    "long": "--inner-parallelization",
     "short": "",
-    "description": "Prefer modular solutions even if they are worse than putting all nodes in one module.",
+    "description": "Parallelize the innermost loop for speed, with a possible accuracy tradeoff.",
     "group": "Accuracy",
     "required": false,
     "advanced": true,
@@ -586,19 +621,43 @@
     "default": false
   },
   {
-    "long": "--inner-parallelization",
+    "long": "--prefer-modular-solution",
     "short": "",
-    "description": "Parallelize the inner-most loop for greater speed. This may give some accuracy tradeoff.",
+    "description": "Prefer a modular solution even when one module gives a lower codelength.",
     "group": "Accuracy",
     "required": false,
     "advanced": true,
     "incremental": false,
     "default": false
+  },
+  {
+    "long": "--num-random-moves",
+    "short": "",
+    "description": "Try this many random moves in each core loop to merge weakly connected nodes.",
+    "group": "Accuracy",
+    "required": true,
+    "advanced": true,
+    "incremental": false,
+    "longType": "integer",
+    "shortType": "n",
+    "default": "5"
+  },
+  {
+    "long": "--max-degree-for-random-moves",
+    "short": "",
+    "description": "Try random moves only for nodes with degree at most this value.",
+    "group": "Accuracy",
+    "required": true,
+    "advanced": true,
+    "incremental": false,
+    "longType": "integer",
+    "shortType": "n",
+    "default": "2"
   },
   {
     "long": "--verbose",
     "short": "-v",
-    "description": "Verbose output on the console. Add additional 'v' flags to increase verbosity up to -vvv.",
+    "description": "Increase console verbosity. Add more v flags to increase verbosity up to -vvv.",
     "group": "Output",
     "required": false,
     "advanced": false,
@@ -608,7 +667,7 @@
   {
     "long": "--silent",
     "short": "",
-    "description": "No output on the console.",
+    "description": "Suppress console output.",
     "group": "Output",
     "required": false,
     "advanced": false,

--- a/interfaces/python/src/infomap/_options.py
+++ b/interfaces/python/src/infomap/_options.py
@@ -113,149 +113,151 @@ class InfomapOptions:
     Parameters
     ----------
     skip_adjust_bipartite_flow : bool, optional
-        Skip distributing all flow from the bipartite nodes to the primary nodes.
+        Keep flow on bipartite nodes instead of distributing it to primary nodes.
     bipartite_teleportation : bool, optional
-        Teleport like the bipartite flow instead of two-step (unipartite) teleportation.
+        Use bipartite teleportation instead of the default two-step unipartite
+        teleportation.
     weight_threshold : float, optional
-        Limit the number of links to read from the network. Ignore links with less
-        weight than the threshold.
+        Ignore input links with weight below this threshold.
     no_self_links : bool, optional
-        Exclude self links in the input network.
+        Exclude self-links from the input network.
     node_limit : int, optional
-        Limit the number of nodes to read from the network. Ignore links connected to
-        ignored nodes.
+        Read only nodes up to this node id and ignore links connected to higher node
+        ids.
     matchable_multilayer_ids : int, optional
-        Construct state ids from node and layer ids that are consistent across networks
-        for the same max number of layers. Set to at least the largest layer id among
-        networks to match.
+        Construct state ids from node ids and layer ids that stay comparable across
+        networks. Set at least to the largest layer id among networks to match.
     cluster_data : str, optional
-        Provide an initial partition as cluster ids (clu) or a hierarchical tree (tree,
-        ftree). Tree input may be physical or state-level for higher-order networks.
+        Read an initial partition from a clu file or a hierarchy from a tree/ftree file.
+        Tree input may use physical or state nodes for higher-order networks.
     assign_to_neighbouring_module : bool, optional
-        Assign nodes without module assignments (from --cluster-data) to the module
-        assignment of a neighbouring node if possible.
+        With --cluster-data, assign nodes missing module ids to a neighboring node's
+        module when possible.
     meta_data : str, optional
-        Provide meta data (clu format) that should be encoded.
+        Read metadata to encode from a clu-format file.
     meta_data_rate : float, optional
-        Metadata encoding rate. Default is to encode each step.
+        With --meta-data, set the metadata encoding rate. The default encodes metadata
+        at each step.
     meta_data_unweighted : bool, optional
-        Don't weight meta data by node flow.
+        With --meta-data, encode metadata without weighting by node flow.
     no_infomap : bool, optional
-        Don't run the optimizer. Useful to calculate codelength of provided cluster data
-        or to print non-modular statistics.
+        Skip optimization. Use this to calculate codelength for --cluster-data or to
+        print non-modular statistics.
     out_name : str, optional
-        Name for the output files, e.g. [output_directory]/[out-name].tree
+        Base name for output files, for example [out_directory]/[out-name].tree.
     no_file_output : bool, optional
-        Don't write output to file.
+        Do not write output files.
     tree : bool, optional
-        Write a tree file with the modular hierarchy. Automatically enabled if no other
-        output is specified.
+        Write the modular hierarchy to a tree file. Enabled by default when no other
+        output format is selected.
     ftree : bool, optional
-        Write a ftree file with the modular hierarchy including aggregated links between
-        (nested) modules. (Used by Network Navigator)
+        Write the modular hierarchy and aggregated links between nested modules to an
+        ftree file. Used by Network Navigator.
     clu : bool, optional
-        Write a clu file with the top cluster ids for each node.
+        Write top-level module ids for each node to a clu file.
     clu_level : int, optional
-        For clu output, print modules at specified depth from root. Use -1 for bottom
-        level modules.
+        With --clu or --output clu, write module ids at this depth from the root. Use -1
+        for bottom-level modules.
     output : sequence of str, optional
-        Comma-separated output formats without spaces, e.g. -o clu,tree,ftree. Options:
-        clu, tree, ftree, newick, json, csv, network, states, flow.
+        Write selected output formats as a comma-separated list without spaces, e.g. -o
+        clu,tree,ftree. Options: clu, tree, ftree, newick, json, csv, network, states,
+        flow.
     hide_bipartite_nodes : bool, optional
-        Project bipartite solution to unipartite.
+        Hide bipartite nodes in output by projecting the solution to primary nodes.
     print_all_trials : bool, optional
-        Print all trials to separate files.
+        Write each trial to separate output files. Has effect only when --num-trials is
+        greater than 1.
     verbosity_level : int, optional
         Verbosity level on the console. 1 keeps the default output level, 2 renders -vv
         and so on.
     silent : bool, optional
-        No output on the console.
+        Suppress console output.
     two_level : bool, optional
-        Optimize a two-level partition of the network. Default is multi-level.
+        Optimize a two-level partition instead of the default multi-level hierarchy.
     flow_model : str, optional
-        Specify flow model. Options: undirected, directed, undirdir, outdirdir, rawdir,
-        precomputed.
+        Choose how Infomap derives flow from the input links. Options: undirected,
+        directed, undirdir, outdirdir, rawdir, precomputed.
     directed : bool, optional
-        Assume directed links. Shorthand for '--flow-model directed'.
+        Treat input links as directed. Shorthand for --flow-model directed.
     recorded_teleportation : bool, optional
-        If teleportation is used to calculate the flow, also record it when minimizing
-        codelength.
+        When teleportation is used to calculate flow, also record teleportation steps in
+        the codelength.
     use_node_weights_as_flow : bool, optional
-        Use node weights (from api or after names in Pajek format) as flow, normalized
-        to sum to 1
+        Use node weights from the API or Pajek node records as normalized node flow.
     to_nodes : bool, optional
-        Teleport to nodes instead of to links, assuming uniform node weights if no such
-        input data.
+        Teleport to nodes instead of links. Uses uniform node weights unless node
+        weights are provided.
     teleportation_probability : float, optional
-        Probability of teleporting to a random node or link.
+        Set the probability of teleporting to a random node or link when calculating
+        flow.
     regularized : bool, optional
-        Effectively add a fully connected Bayesian prior network to not overfit due to
-        missing links. Implies recorded teleportation
+        Add a fully connected Bayesian prior network to reduce overfitting to missing
+        links. Activates --recorded-teleportation.
     regularization_strength : float, optional
-        Adjust relative strength of Bayesian prior network with this multiplier.
+        Scale the relative strength of the Bayesian prior network used by --regularized.
     entropy_corrected : bool, optional
-        Correct for negative entropy bias in small samples (many modules).
+        Correct for negative entropy bias in small samples, especially solutions with
+        many modules.
     entropy_correction_strength : float, optional
-        Increase or decrease the default entropy correction with this factor.
+        Scale the default correction used by --entropy-corrected.
     markov_time : float, optional
         Scale link flow to change the cost of moving between modules. Higher values
-        results in fewer modules.
+        result in fewer modules.
     variable_markov_time : bool, optional
-        Increase Markov time locally to level out link flow. Reduces risk of
-        overpartitioning sparse areas while keeping high resolution in dense areas.
+        Vary Markov time locally to reduce overpartitioning in sparse areas while
+        keeping higher resolution in dense areas.
     variable_markov_damping : float, optional
-        Damping parameter for variable Markov time, to scale with local effective degree
-        (0) or local entropy (1).
+        With --variable-markov-time, set damping between local effective degree (0) and
+        local entropy (1).
     variable_markov_min_scale : float, optional
-        Minimum local scale for nodes with zero entropy to avoid division by zero. Local
-        Markov time is max scale divided by local scale.
+        With --variable-markov-time, set the minimum local scale for zero-entropy nodes.
+        Local Markov time is max scale divided by local scale.
     preferred_number_of_modules : int, optional
-        Penalize solutions the more they differ from this number.
+        Penalize solutions by how far their number of modules differs from this value.
     multilayer_relax_rate : float, optional
-        Probability to relax the constraint to move only in the current layer.
+        Set the probability of relaxing from a state node to neighboring layers instead
+        of staying in the current layer.
     multilayer_relax_limit : int, optional
-        Number of neighboring layers in each direction to relax to. If negative, relax
-        to any layer.
+        Limit relaxation to this many neighboring layer ids in each direction. Use a
+        negative value to allow relaxation to any layer.
     multilayer_relax_limit_up : int, optional
-        Number of neighboring layers with higher id to relax to. If negative, relax to
-        any layer.
+        Limit relaxation upward to this many higher neighboring layer ids. Use a
+        negative value to allow relaxation to any higher layer.
     multilayer_relax_limit_down : int, optional
-        Number of neighboring layers with lower id to relax to. If negative, relax to
-        any layer.
+        Limit relaxation downward to this many lower neighboring layer ids. Use a
+        negative value to allow relaxation to any lower layer.
     multilayer_relax_by_jsd : bool, optional
-        Relax proportional to the out-link similarity measured by the Jensen-Shannon
+        Weight multilayer relaxation by out-link similarity measured with Jensen-Shannon
         divergence.
     seed : int, optional
-        A seed (integer) to the random number generator for reproducible results.
+        Set the random number generator seed for reproducible results.
     num_trials : int, optional
-        Number of outer-most loops to run before picking the best solution.
+        Run this many independent trials and keep the best solution.
     core_loop_limit : int, optional
-        Limit the number of loops that tries to move each node into the best possible
-        module.
+        Limit how many core loops try to move each node to the best module.
     core_level_limit : int, optional
-        Limit the number of times the core loops are reapplied on existing modular
-        network to search bigger structures.
+        Limit how many times core loops are reapplied to the aggregated modular network
+        to find larger structures.
     tune_iteration_limit : int, optional
-        Limit the number of main iterations in the two-level partition algorithm. 0
-        means no limit.
+        Limit the main iterations in the two-level partition algorithm. 0 means no
+        limit.
     core_loop_codelength_threshold : float, optional
-        Minimum codelength threshold for accepting a new solution in core loop.
+        Require at least this codelength improvement to accept a new solution in a core
+        loop.
     tune_iteration_relative_threshold : float, optional
-        Set codelength improvement threshold of each new tune iteration to 'f' times the
+        Require each tune iteration to improve codelength by this fraction of the
         initial two-level codelength.
     fast_hierarchical_solution : int, optional
         Find top modules fast. Use 2 to keep all fast levels and 3 to skip the recursive
         part.
     inner_parallelization : bool, optional
-        Parallelize the inner-most loop for greater speed. This may give some accuracy
-        tradeoff.
+        Parallelize the innermost loop for speed, with a possible accuracy tradeoff.
     prefer_modular_solution : bool, optional
-        Prefer modular solutions even if they are worse than putting all nodes in one
-        module.
+        Prefer a modular solution even when one module gives a lower codelength.
     num_random_moves : int, optional
-        Number of random moves to try in core loop to try merge weakly connected nodes.
+        Try this many random moves in each core loop to merge weakly connected nodes.
     max_degree_for_random_moves : int, optional
-        Maximum degree of nodes for which to try random moves.
+        Try random moves only for nodes with degree at most this value.
     include_self_links : bool, optional
         Deprecated. Self-links are included by default; use no_self_links=True to
         exclude them.

--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -73,137 +73,137 @@ Config::Config(const std::string& flags, bool isCLI) : isCLI(isCLI)
   std::vector<std::string> optionalOutputDir; // Used if !isCLI
   // --------------------- Input options ---------------------
   if (isCLI) {
-    api.addNonOptionArgument(networkFile, "network_file", "File containing the network data. Assumes a link list format if no Pajek formatted heading.", "Input");
+    api.addNonOptionArgument(networkFile, "network_file", "Network file to read. Infomap assumes link-list format unless the file starts with a Pajek heading.", "Input");
   } else {
-    api.addOptionArgument(networkFile, "input", "File containing the network data. Assumes a link list format if no Pajek formatted heading.", ArgType::path, "Input");
+    api.addOptionArgument(networkFile, "input", "Network file to read. Infomap assumes link-list format unless the file starts with a Pajek heading.", ArgType::path, "Input");
   }
 
-  api.addOptionArgument(skipAdjustBipartiteFlow, "skip-adjust-bipartite-flow", "Skip distributing all flow from the bipartite nodes to the primary nodes.", "Input", true);
+  api.addOptionArgument(skipAdjustBipartiteFlow, "skip-adjust-bipartite-flow", "Keep flow on bipartite nodes instead of distributing it to primary nodes.", "Input", true);
 
-  api.addOptionArgument(bipartiteTeleportation, "bipartite-teleportation", "Teleport like the bipartite flow instead of two-step (unipartite) teleportation.", "Input", true);
+  api.addOptionArgument(bipartiteTeleportation, "bipartite-teleportation", "Use bipartite teleportation instead of the default two-step unipartite teleportation.", "Input", true);
 
-  api.addOptionArgument(weightThreshold, "weight-threshold", "Limit the number of links to read from the network. Ignore links with less weight than the threshold.", ArgType::number, "Input", 0.0, true);
+  api.addOptionArgument(weightThreshold, "weight-threshold", "Ignore input links with weight below this threshold.", ArgType::number, "Input", 0.0, true);
 
   bool deprecated_includeSelfLinks = false;
-  api.addOptionArgument(deprecated_includeSelfLinks, 'k', "include-self-links", "DEPRECATED. Include self links by default now, exclude with --no-self-links.", "Input", true).setHidden(true);
+  api.addOptionArgument(deprecated_includeSelfLinks, 'k', "include-self-links", "DEPRECATED. Self-links are included by default; use --no-self-links to exclude them.", "Input", true).setHidden(true);
 
-  api.addOptionArgument(noSelfLinks, "no-self-links", "Exclude self links in the input network.", "Input", true);
+  api.addOptionArgument(noSelfLinks, "no-self-links", "Exclude self-links from the input network.", "Input", true);
 
-  api.addOptionArgument(nodeLimit, "node-limit", "Limit the number of nodes to read from the network. Ignore links connected to ignored nodes.", ArgType::integer, "Input", 1u, true);
+  api.addOptionArgument(nodeLimit, "node-limit", "Read only nodes up to this node id and ignore links connected to higher node ids.", ArgType::integer, "Input", 1u, true);
 
-  api.addOptionArgument(matchableMultilayerIds, "matchable-multilayer-ids", "Construct state ids from node and layer ids that are consistent across networks for the same max number of layers. Set to at least the largest layer id among networks to match.", ArgType::integer, "Input", 1u, true);
+  api.addOptionArgument(matchableMultilayerIds, "matchable-multilayer-ids", "Construct state ids from node ids and layer ids that stay comparable across networks. Set at least to the largest layer id among networks to match.", ArgType::integer, "Input", 1u, true);
 
-  api.addOptionArgument(clusterDataFile, 'c', "cluster-data", "Provide an initial partition as cluster ids (clu) or a hierarchical tree (tree, ftree). Tree input may be physical or state-level for higher-order networks.", ArgType::path, "Input");
+  api.addOptionArgument(clusterDataFile, 'c', "cluster-data", "Read an initial partition from a clu file or a hierarchy from a tree/ftree file. Tree input may use physical or state nodes for higher-order networks.", ArgType::path, "Input");
 
-  api.addOptionArgument(assignToNeighbouringModule, "assign-to-neighbouring-module", "Assign nodes without module assignments (from --cluster-data) to the module assignment of a neighbouring node if possible.", "Input", true);
+  api.addOptionArgument(assignToNeighbouringModule, "assign-to-neighbouring-module", "With --cluster-data, assign nodes missing module ids to a neighboring node's module when possible.", "Input", true);
 
-  api.addOptionArgument(metaDataFile, "meta-data", "Provide meta data (clu format) that should be encoded.", ArgType::path, "Input", true);
+  api.addOptionArgument(metaDataFile, "meta-data", "Read metadata to encode from a clu-format file.", ArgType::path, "Input", true);
 
-  api.addOptionArgument(metaDataRate, "meta-data-rate", "Metadata encoding rate. Default is to encode each step.", ArgType::number, "Input", 0.0, true);
+  api.addOptionArgument(metaDataRate, "meta-data-rate", "With --meta-data, set the metadata encoding rate. The default encodes metadata at each step.", ArgType::number, "Input", 0.0, true);
 
-  api.addOptionArgument(unweightedMetaData, "meta-data-unweighted", "Don't weight meta data by node flow.", "Input", true);
+  api.addOptionArgument(unweightedMetaData, "meta-data-unweighted", "With --meta-data, encode metadata without weighting by node flow.", "Input", true);
 
-  api.addOptionArgument(noInfomap, "no-infomap", "Don't run the optimizer. Useful to calculate codelength of provided cluster data or to print non-modular statistics.", "Input");
+  api.addOptionArgument(noInfomap, "no-infomap", "Skip optimization. Use this to calculate codelength for --cluster-data or to print non-modular statistics.", "Input");
 
   // --------------------- Output options ---------------------
 
-  api.addOptionArgument(outName, "out-name", "Name for the output files, e.g. [output_directory]/[out-name].tree", ArgType::string, "Output", true);
+  api.addOptionArgument(outName, "out-name", "Base name for output files, for example [out_directory]/[out-name].tree.", ArgType::string, "Output", true);
 
-  api.addOptionArgument(noFileOutput, '0', "no-file-output", "Don't write output to file.", "Output", true);
+  api.addOptionArgument(noFileOutput, '0', "no-file-output", "Do not write output files.", "Output", true);
 
-  api.addOptionArgument(printTree, "tree", "Write a tree file with the modular hierarchy. Automatically enabled if no other output is specified.", "Output");
+  api.addOptionArgument(printTree, "tree", "Write the modular hierarchy to a tree file. Enabled by default when no other output format is selected.", "Output");
 
-  api.addOptionArgument(printFlowTree, "ftree", "Write a ftree file with the modular hierarchy including aggregated links between (nested) modules. (Used by Network Navigator)", "Output");
+  api.addOptionArgument(printFlowTree, "ftree", "Write the modular hierarchy and aggregated links between nested modules to an ftree file. Used by Network Navigator.", "Output");
 
-  api.addOptionArgument(printClu, "clu", "Write a clu file with the top cluster ids for each node.", "Output");
+  api.addOptionArgument(printClu, "clu", "Write top-level module ids for each node to a clu file.", "Output");
 
-  api.addOptionArgument(cluLevel, "clu-level", "For clu output, print modules at specified depth from root. Use -1 for bottom level modules.", ArgType::integer, "Output", -1, true);
+  api.addOptionArgument(cluLevel, "clu-level", "With --clu or --output clu, write module ids at this depth from the root. Use -1 for bottom-level modules.", ArgType::integer, "Output", -1, true);
 
-  api.addOptionArgument(outputFormats, 'o', "output", "Comma-separated output formats without spaces, e.g. -o clu,tree,ftree. Options: clu, tree, ftree, newick, json, csv, network, states, flow.", ArgType::list, "Output", true)
+  api.addOptionArgument(outputFormats, 'o', "output", "Write selected output formats as a comma-separated list without spaces, e.g. -o clu,tree,ftree. Options: clu, tree, ftree, newick, json, csv, network, states, flow.", ArgType::list, "Output", true)
       .setChoices({ "clu", "tree", "ftree", "newick", "json", "csv", "network", "states", "flow" });
 
-  api.addOptionArgument(hideBipartiteNodes, "hide-bipartite-nodes", "Project bipartite solution to unipartite.", "Output", true);
+  api.addOptionArgument(hideBipartiteNodes, "hide-bipartite-nodes", "Hide bipartite nodes in output by projecting the solution to primary nodes.", "Output", true);
 
-  api.addOptionArgument(printAllTrials, "print-all-trials", "Print all trials to separate files.", "Output", true);
+  api.addOptionArgument(printAllTrials, "print-all-trials", "Write each trial to separate output files. Has effect only when --num-trials is greater than 1.", "Output", true);
 
   // --------------------- Core algorithm options ---------------------
-  api.addOptionArgument(twoLevel, '2', "two-level", "Optimize a two-level partition of the network. Default is multi-level.", "Algorithm");
+  api.addOptionArgument(twoLevel, '2', "two-level", "Optimize a two-level partition instead of the default multi-level hierarchy.", "Algorithm");
 
   std::string flowModelArg;
 
-  api.addOptionArgument(flowModelArg, 'f', "flow-model", "Specify flow model. Options: undirected, directed, undirdir, outdirdir, rawdir, precomputed.", ArgType::option, "Algorithm")
+  api.addOptionArgument(flowModelArg, 'f', "flow-model", "Choose how Infomap derives flow from the input links. Options: undirected, directed, undirdir, outdirdir, rawdir, precomputed.", ArgType::option, "Algorithm")
       .setChoices({ "undirected", "directed", "undirdir", "outdirdir", "rawdir", "precomputed" });
 
-  api.addOptionArgument(directed, 'd', "directed", "Assume directed links. Shorthand for '--flow-model directed'.", "Algorithm");
+  api.addOptionArgument(directed, 'd', "directed", "Treat input links as directed. Shorthand for --flow-model directed.", "Algorithm");
 
-  api.addOptionArgument(recordedTeleportation, 'e', "recorded-teleportation", "If teleportation is used to calculate the flow, also record it when minimizing codelength.", "Algorithm", true);
+  api.addOptionArgument(recordedTeleportation, 'e', "recorded-teleportation", "When teleportation is used to calculate flow, also record teleportation steps in the codelength.", "Algorithm", true);
 
-  api.addOptionArgument(useNodeWeightsAsFlow, "use-node-weights-as-flow", "Use node weights (from api or after names in Pajek format) as flow, normalized to sum to 1", "Algorithm", true);
+  api.addOptionArgument(useNodeWeightsAsFlow, "use-node-weights-as-flow", "Use node weights from the API or Pajek node records as normalized node flow.", "Algorithm", true);
 
-  api.addOptionArgument(teleportToNodes, "to-nodes", "Teleport to nodes instead of to links, assuming uniform node weights if no such input data.", "Algorithm", true);
+  api.addOptionArgument(teleportToNodes, "to-nodes", "Teleport to nodes instead of links. Uses uniform node weights unless node weights are provided.", "Algorithm", true);
 
-  api.addOptionArgument(teleportationProbability, 'p', "teleportation-probability", "Probability of teleporting to a random node or link.", ArgType::probability, "Algorithm", 0.0, 1.0, true);
+  api.addOptionArgument(teleportationProbability, 'p', "teleportation-probability", "Set the probability of teleporting to a random node or link when calculating flow.", ArgType::probability, "Algorithm", 0.0, 1.0, true);
 
-  api.addOptionArgument(regularized, "regularized", "Effectively add a fully connected Bayesian prior network to not overfit due to missing links. Implies recorded teleportation", "Algorithm", true);
+  api.addOptionArgument(regularized, "regularized", "Add a fully connected Bayesian prior network to reduce overfitting to missing links. Activates --recorded-teleportation.", "Algorithm", true);
 
-  api.addOptionArgument(regularizationStrength, "regularization-strength", "Adjust relative strength of Bayesian prior network with this multiplier.", ArgType::number, "Algorithm", 0.0, true);
+  api.addOptionArgument(regularizationStrength, "regularization-strength", "Scale the relative strength of the Bayesian prior network used by --regularized.", ArgType::number, "Algorithm", 0.0, true);
 
-  api.addOptionArgument(entropyBiasCorrection, "entropy-corrected", "Correct for negative entropy bias in small samples (many modules).", "Algorithm", true);
+  api.addOptionArgument(entropyBiasCorrection, "entropy-corrected", "Correct for negative entropy bias in small samples, especially solutions with many modules.", "Algorithm", true);
 
-  api.addOptionArgument(entropyBiasCorrectionMultiplier, "entropy-correction-strength", "Increase or decrease the default entropy correction with this factor.", ArgType::number, "Algorithm", true);
+  api.addOptionArgument(entropyBiasCorrectionMultiplier, "entropy-correction-strength", "Scale the default correction used by --entropy-corrected.", ArgType::number, "Algorithm", true);
 
-  api.addOptionArgument(markovTime, "markov-time", "Scale link flow to change the cost of moving between modules. Higher values results in fewer modules.", ArgType::number, "Algorithm", 0.0, true);
+  api.addOptionArgument(markovTime, "markov-time", "Scale link flow to change the cost of moving between modules. Higher values result in fewer modules.", ArgType::number, "Algorithm", 0.0, true);
 
-  api.addOptionArgument(variableMarkovTime, "variable-markov-time", "Increase Markov time locally to level out link flow. Reduces risk of overpartitioning sparse areas while keeping high resolution in dense areas.", "Algorithm", true);
+  api.addOptionArgument(variableMarkovTime, "variable-markov-time", "Vary Markov time locally to reduce overpartitioning in sparse areas while keeping higher resolution in dense areas.", "Algorithm", true);
 
-  api.addOptionArgument(variableMarkovTimeDamping, "variable-markov-damping", "Damping parameter for variable Markov time, to scale with local effective degree (0) or local entropy (1).", ArgType::number, "Algorithm", true);
+  api.addOptionArgument(variableMarkovTimeDamping, "variable-markov-damping", "With --variable-markov-time, set damping between local effective degree (0) and local entropy (1).", ArgType::number, "Algorithm", true);
 
-  api.addOptionArgument(variableMarkovTimeMinLocalScale, "variable-markov-min-scale", "Minimum local scale for nodes with zero entropy to avoid division by zero. Local Markov time is max scale divided by local scale.", ArgType::number, "Algorithm", true);
+  api.addOptionArgument(variableMarkovTimeMinLocalScale, "variable-markov-min-scale", "With --variable-markov-time, set the minimum local scale for zero-entropy nodes. Local Markov time is max scale divided by local scale.", ArgType::number, "Algorithm", true);
 
   // api.addOptionArgument(markovTimeNoSelfLinks, "markov-time-no-self-links", "For testing.", "Algorithm", true);
 
-  api.addOptionArgument(preferredNumberOfModules, "preferred-number-of-modules", "Penalize solutions the more they differ from this number.", ArgType::integer, "Algorithm", 1u, true);
+  api.addOptionArgument(preferredNumberOfModules, "preferred-number-of-modules", "Penalize solutions by how far their number of modules differs from this value.", ArgType::integer, "Algorithm", 1u, true);
 
-  api.addOptionArgument(multilayerRelaxRate, "multilayer-relax-rate", "Probability to relax the constraint to move only in the current layer.", ArgType::probability, "Algorithm", 0.0, 1.0, true);
+  api.addOptionArgument(multilayerRelaxRate, "multilayer-relax-rate", "Set the probability of relaxing from a state node to neighboring layers instead of staying in the current layer.", ArgType::probability, "Algorithm", 0.0, 1.0, true);
 
-  api.addOptionArgument(multilayerRelaxLimit, "multilayer-relax-limit", "Number of neighboring layers in each direction to relax to. If negative, relax to any layer.", ArgType::integer, "Algorithm", -1, true);
+  api.addOptionArgument(multilayerRelaxLimit, "multilayer-relax-limit", "Limit relaxation to this many neighboring layer ids in each direction. Use a negative value to allow relaxation to any layer.", ArgType::integer, "Algorithm", -1, true);
 
-  api.addOptionArgument(multilayerRelaxLimitUp, "multilayer-relax-limit-up", "Number of neighboring layers with higher id to relax to. If negative, relax to any layer.", ArgType::integer, "Algorithm", -1, true);
+  api.addOptionArgument(multilayerRelaxLimitUp, "multilayer-relax-limit-up", "Limit relaxation upward to this many higher neighboring layer ids. Use a negative value to allow relaxation to any higher layer.", ArgType::integer, "Algorithm", -1, true);
 
-  api.addOptionArgument(multilayerRelaxLimitDown, "multilayer-relax-limit-down", "Number of neighboring layers with lower id to relax to. If negative, relax to any layer.", ArgType::integer, "Algorithm", -1, true);
+  api.addOptionArgument(multilayerRelaxLimitDown, "multilayer-relax-limit-down", "Limit relaxation downward to this many lower neighboring layer ids. Use a negative value to allow relaxation to any lower layer.", ArgType::integer, "Algorithm", -1, true);
 
-  api.addOptionArgument(multilayerRelaxByJensenShannonDivergence, "multilayer-relax-by-jsd", "Relax proportional to the out-link similarity measured by the Jensen-Shannon divergence.", "Algorithm", true);
+  api.addOptionArgument(multilayerRelaxByJensenShannonDivergence, "multilayer-relax-by-jsd", "Weight multilayer relaxation by out-link similarity measured with Jensen-Shannon divergence.", "Algorithm", true);
 
   // --------------------- Performance and accuracy options ---------------------
-  api.addOptionArgument(seedToRandomNumberGenerator, 's', "seed", "A seed (integer) to the random number generator for reproducible results.", ArgType::integer, "Accuracy", 1ul);
+  api.addOptionArgument(seedToRandomNumberGenerator, 's', "seed", "Set the random number generator seed for reproducible results.", ArgType::integer, "Accuracy", 1ul);
 
-  api.addOptionArgument(numTrials, 'N', "num-trials", "Number of outer-most loops to run before picking the best solution.", ArgType::integer, "Accuracy", 1u);
+  api.addOptionArgument(numTrials, 'N', "num-trials", "Run this many independent trials and keep the best solution.", ArgType::integer, "Accuracy", 1u);
 
-  api.addOptionArgument(coreLoopLimit, 'M', "core-loop-limit", "Limit the number of loops that tries to move each node into the best possible module.", ArgType::integer, "Accuracy", 1u, true);
+  api.addOptionArgument(coreLoopLimit, 'M', "core-loop-limit", "Limit how many core loops try to move each node to the best module.", ArgType::integer, "Accuracy", 1u, true);
 
-  api.addOptionArgument(levelAggregationLimit, 'L', "core-level-limit", "Limit the number of times the core loops are reapplied on existing modular network to search bigger structures.", ArgType::integer, "Accuracy", 1u, true);
+  api.addOptionArgument(levelAggregationLimit, 'L', "core-level-limit", "Limit how many times core loops are reapplied to the aggregated modular network to find larger structures.", ArgType::integer, "Accuracy", 1u, true);
 
-  api.addOptionArgument(tuneIterationLimit, 'T', "tune-iteration-limit", "Limit the number of main iterations in the two-level partition algorithm. 0 means no limit.", ArgType::integer, "Accuracy", 1u, true);
+  api.addOptionArgument(tuneIterationLimit, 'T', "tune-iteration-limit", "Limit the main iterations in the two-level partition algorithm. 0 means no limit.", ArgType::integer, "Accuracy", 1u, true);
 
-  api.addOptionArgument(minimumCodelengthImprovement, "core-loop-codelength-threshold", "Minimum codelength threshold for accepting a new solution in core loop.", ArgType::number, "Accuracy", 0.0, true);
+  api.addOptionArgument(minimumCodelengthImprovement, "core-loop-codelength-threshold", "Require at least this codelength improvement to accept a new solution in a core loop.", ArgType::number, "Accuracy", 0.0, true);
 
-  api.addOptionArgument(minimumRelativeTuneIterationImprovement, "tune-iteration-relative-threshold", "Set codelength improvement threshold of each new tune iteration to 'f' times the initial two-level codelength.", ArgType::number, "Accuracy", 0.0, true);
+  api.addOptionArgument(minimumRelativeTuneIterationImprovement, "tune-iteration-relative-threshold", "Require each tune iteration to improve codelength by this fraction of the initial two-level codelength.", ArgType::number, "Accuracy", 0.0, true);
 
-  api.addIncrementalOptionArgument(fastHierarchicalSolution, 'F', "fast-hierarchical-solution", "Find top modules fast. Use -FF to keep all fast levels. Use -FFF to skip recursive part.", "Accuracy", true);
+  api.addIncrementalOptionArgument(fastHierarchicalSolution, 'F', "fast-hierarchical-solution", "Find top modules quickly. Use -FF to keep all fast levels. Use -FFF to skip recursive refinement.", "Accuracy", true);
 
-  api.addOptionArgument(innerParallelization, "inner-parallelization", "Parallelize the inner-most loop for greater speed. This may give some accuracy tradeoff.", "Accuracy", true);
+  api.addOptionArgument(innerParallelization, "inner-parallelization", "Parallelize the innermost loop for speed, with a possible accuracy tradeoff.", "Accuracy", true);
 
-  api.addOptionArgument(preferModularSolution, "prefer-modular-solution", "Prefer modular solutions even if they are worse than putting all nodes in one module.", "Accuracy", true);
+  api.addOptionArgument(preferModularSolution, "prefer-modular-solution", "Prefer a modular solution even when one module gives a lower codelength.", "Accuracy", true);
 
-  api.addOptionArgument(numRandomMoves, "num-random-moves", "Number of random moves to try in core loop to try merge weakly connected nodes.", ArgType::integer, "Accuracy", 0u, true);
+  api.addOptionArgument(numRandomMoves, "num-random-moves", "Try this many random moves in each core loop to merge weakly connected nodes.", ArgType::integer, "Accuracy", 0u, true);
 
-  api.addOptionArgument(maxDegreeForRandomMoves, "max-degree-for-random-moves", "Maximum degree of nodes for which to try random moves.", ArgType::integer, "Accuracy", 0u, true);
+  api.addOptionArgument(maxDegreeForRandomMoves, "max-degree-for-random-moves", "Try random moves only for nodes with degree at most this value.", ArgType::integer, "Accuracy", 0u, true);
 
-  api.addOptionalNonOptionArguments(optionalOutputDir, "out_directory", "Directory to write the results to.", "Output");
+  api.addOptionalNonOptionArguments(optionalOutputDir, "out_directory", "Directory where output files are written.", "Output");
 
-  api.addIncrementalOptionArgument(verbosity, 'v', "verbose", "Verbose output on the console. Add additional 'v' flags to increase verbosity up to -vvv.", "Output");
+  api.addIncrementalOptionArgument(verbosity, 'v', "verbose", "Increase console verbosity. Add more v flags to increase verbosity up to -vvv.", "Output");
 
-  api.addOptionArgument(silent, "silent", "No output on the console.", "Output");
+  api.addOptionArgument(silent, "silent", "Suppress console output.", "Output");
 
   api.parseArgs(flags);
 


### PR DESCRIPTION
## Summary
- Clarify Infomap CLI option descriptions in `src/io/Config.cpp` without changing parameter names, defaults, choices, groups, or behavior.
- Regenerate reflected Python, R, TypeScript, and JS metadata outputs from the canonical C++ parameter metadata.
- Refresh `interfaces/R/infomap/man/infomap_options.Rd` after regenerated R option documentation changed.

## Verification
- `make build-native`
- `make build-binding-options`
- `Rscript -e 'roxygen2::roxygenise("interfaces/R/infomap")'`\n- Runtime JSON comparison confirmed only `description` fields changed for 56 parameters.\n- `make test-binding-options-freshness`\n- `make test-js-metadata`\n- `clang-format -i src/io/Config.cpp`\n\n## Notes\n- `interfaces/js/generated/changelog.json` was refreshed by `make build-js-metadata`, which regenerates JS metadata together with `interfaces/js/generated/parameters.json`.\n