### PR TITLE
docs: add Infomap agent skill

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -269,6 +269,12 @@ Maintainers should use:
 - ``CONTRIBUTING.md`` for pull request and contributor guidance
 - ``SECURITY.md`` for vulnerability reporting
 
+Agent skill
+-----------
+
+This repository includes an Infomap agent skill in ``skills/infomap/`` for
+reproducible CLI, Python, R, and notebook research workflows.
+
 Feedback
 --------
 

--- a/skills/infomap/SKILL.md
+++ b/skills/infomap/SKILL.md
@@ -30,8 +30,9 @@ When the user already chose an interface, stay there unless a different interfac
 - Do not assume the user has an Infomap source checkout. Most users will only have the CLI, Python package, R package, or notebook image installed.
 - Treat installed help and published docs as the normal authority for current syntax. Use source files only when the user is working inside an Infomap checkout or explicitly provides repo files.
 - For CLI details, inspect the available binary with `infomap --help`, `Infomap --help`, advanced help, or `--print-json-parameters` when available.
-- For Python details, prefer installed package help (`import infomap`, `help(...)`, object signatures), published Python docs, and package examples available to the user.
-- For R details, prefer `?infomap::cluster_infomap`, `?infomap::Infomap`, `?infomap::infomap_options`, and installed package help.
+- For Python details, prefer installed package help (`help(...)`), `inspect.signature(...)`, package metadata, published Python docs, and package examples available to the user.
+- For R details, prefer installed help (`utils::help(..., package = "infomap")`), `args(...)`, `packageVersion("infomap")`, and package exports.
+- Do not copy version-sensitive examples from this skill as if they were authoritative. Generate runnable code only after checking the installed interface or published docs for the user's version.
 - Use the survey article as a decision guide for representation, flow modeling, higher-order networks, metadata, bipartite networks, incomplete data, and applications: `https://doi.org/10.1145/3779648`. Do not quote long passages from it.
 
 ## Default research standards

--- a/skills/infomap/SKILL.md
+++ b/skills/infomap/SKILL.md
@@ -37,7 +37,7 @@ When the user already chose an interface, stay there unless a different interfac
 ## Default research standards
 
 - Make examples reproducible by default: include `seed`, use meaningful `num_trials`, record Infomap version, input provenance, non-default options, and output artifacts.
-- Avoid starting expensive runs without consent. Use tiny smoke examples or `num_trials=1` for validation; ask first before running large networks, notebook images, parameter sweeps, many trials, or anything likely to take more than a few minutes.
+- Avoid starting expensive runs without consent. Use tiny smoke examples or `num_trials=1` for validation; read `references/reproducibility.md` for rough runtime hints before running large networks, notebook images, parameter sweeps, or many trials.
 - Distinguish top-level module assignments from hierarchical paths, and distinguish physical nodes from state nodes for higher-order or multilayer inputs.
 - Explain `two_level` versus multilevel only as much as the task needs.
 - Do not block users with broad method-validity warnings unless they ask for method comparison.

--- a/skills/infomap/SKILL.md
+++ b/skills/infomap/SKILL.md
@@ -37,6 +37,7 @@ When the user already chose an interface, stay there unless a different interfac
 ## Default research standards
 
 - Make examples reproducible by default: include `seed`, use meaningful `num_trials`, record Infomap version, input provenance, non-default options, and output artifacts.
+- Avoid starting expensive runs without consent. Use tiny smoke examples or `num_trials=1` for validation; ask first before running large networks, notebook images, parameter sweeps, many trials, or anything likely to take more than a few minutes.
 - Distinguish top-level module assignments from hierarchical paths, and distinguish physical nodes from state nodes for higher-order or multilayer inputs.
 - Explain `two_level` versus multilevel only as much as the task needs.
 - Do not block users with broad method-validity warnings unless they ask for method comparison.

--- a/skills/infomap/SKILL.md
+++ b/skills/infomap/SKILL.md
@@ -32,7 +32,7 @@ When the user already chose an interface, stay there unless a different interfac
 - For CLI details, inspect the available binary with `infomap --help`, `Infomap --help`, advanced help, or `--print-json-parameters` when available.
 - For Python details, prefer installed package help (`import infomap`, `help(...)`, object signatures), published Python docs, and package examples available to the user.
 - For R details, prefer `?infomap::cluster_infomap`, `?infomap::Infomap`, `?infomap::infomap_options`, and installed package help.
-- Use the survey article as a decision guide for representation, flow modeling, higher-order networks, metadata, bipartite networks, incomplete data, and applications. Do not quote long passages from it.
+- Use the survey article as a decision guide for representation, flow modeling, higher-order networks, metadata, bipartite networks, incomplete data, and applications: `https://doi.org/10.1145/3779648`. Do not quote long passages from it.
 
 ## Default research standards
 

--- a/skills/infomap/SKILL.md
+++ b/skills/infomap/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: infomap
+description: Use when helping researchers use Infomap, the map equation, or the Infomap CLI, Python package, or R package for community detection workflows, including reproducible analysis, method selection, notebooks, and multilayer, memory/state, metadata, bipartite, or flow-model choices.
+---
+
+# Infomap Research Workflows
+
+Use this skill to help researchers run, explain, adapt, or troubleshoot Infomap analyses with the CLI, Python package, R package, and survey companion notebooks.
+
+## First classify the task
+
+Identify the user's mode before answering:
+
+- **Analysis planning**: choose a network representation, flow model, interface, outputs, and reproducibility checklist. Read `references/method-selection.md` and usually `references/reproducibility.md`.
+- **Code or command generation**: choose the smallest practical interface, then read `references/cli.md`, `references/python.md`, or `references/r.md`.
+- **Notebook workflow**: read `references/notebooks.md`; also read `references/python.md` when converting notebook ideas into scripts.
+- **Result interpretation or method text**: read `references/reproducibility.md`; read interface-specific references only if output fields or APIs matter.
+- **Usage troubleshooting**: inspect current repo docs/source or local help first, then read the relevant interface reference.
+
+## Choose the interface
+
+- Prefer **Python** for notebooks, scripts, NetworkX, python-igraph, SciPy sparse matrices, edge-index data, AnnData/Scanpy workflows, tabular outputs, and GraphML/GEXF export.
+- Prefer **R** for R-native analysis, R igraph workflows, R Markdown-style reports, and users who want `cluster_infomap()` or the R6 `Infomap` API.
+- Prefer **CLI** for file-based workflows, batch jobs, shell pipelines, native output files, or wrapper-independent runs.
+
+When the user already chose an interface, stay there unless a different interface is clearly necessary.
+
+## Source rules
+
+- Treat repo docs and source as the authority for current syntax. For CLI details, inspect `./Infomap --help`, `./Infomap -hh`, or `./Infomap --print-json-parameters` when available.
+- For Python details, inspect `interfaces/python/source/`, `examples/python/`, or package API docs in the repo before giving version-sensitive advice.
+- For R details, inspect `interfaces/R/infomap/README.md`, `interfaces/R/infomap/R/`, and `examples/R/`.
+- Use the survey article as a decision guide for representation, flow modeling, higher-order networks, metadata, bipartite networks, incomplete data, and applications. Do not quote long passages from it.
+
+## Default research standards
+
+- Make examples reproducible by default: include `seed`, use meaningful `num_trials`, record Infomap version, input provenance, non-default options, and output artifacts.
+- Distinguish top-level module assignments from hierarchical paths, and distinguish physical nodes from state nodes for higher-order or multilayer inputs.
+- Explain `two_level` versus multilevel only as much as the task needs.
+- Do not block users with broad method-validity warnings unless they ask for method comparison.
+
+## Reference map
+
+- `references/method-selection.md`: survey-based guide from research problem to Infomap model.
+- `references/cli.md`: file-based CLI workflows and native outputs.
+- `references/python.md`: Python package workflows and integrations.
+- `references/r.md`: R package workflows and igraph interop.
+- `references/notebooks.md`: survey companion notebooks and Jupyter adaptation.
+- `references/reproducibility.md`: reporting, provenance, and method-section checklist.

--- a/skills/infomap/SKILL.md
+++ b/skills/infomap/SKILL.md
@@ -15,7 +15,7 @@ Identify the user's mode before answering:
 - **Code or command generation**: choose the smallest practical interface, then read `references/cli.md`, `references/python.md`, or `references/r.md`.
 - **Notebook workflow**: read `references/notebooks.md`; also read `references/python.md` when converting notebook ideas into scripts.
 - **Result interpretation or method text**: read `references/reproducibility.md`; read interface-specific references only if output fields or APIs matter.
-- **Usage troubleshooting**: inspect current repo docs/source or local help first, then read the relevant interface reference.
+- **Usage troubleshooting**: inspect the installed package help, CLI help, or online user docs first, then read the relevant interface reference.
 
 ## Choose the interface
 
@@ -27,9 +27,11 @@ When the user already chose an interface, stay there unless a different interfac
 
 ## Source rules
 
-- Treat repo docs and source as the authority for current syntax. For CLI details, inspect `./Infomap --help`, `./Infomap -hh`, or `./Infomap --print-json-parameters` when available.
-- For Python details, inspect `interfaces/python/source/`, `examples/python/`, or package API docs in the repo before giving version-sensitive advice.
-- For R details, inspect `interfaces/R/infomap/README.md`, `interfaces/R/infomap/R/`, and `examples/R/`.
+- Do not assume the user has an Infomap source checkout. Most users will only have the CLI, Python package, R package, or notebook image installed.
+- Treat installed help and published docs as the normal authority for current syntax. Use source files only when the user is working inside an Infomap checkout or explicitly provides repo files.
+- For CLI details, inspect the available binary with `infomap --help`, `Infomap --help`, advanced help, or `--print-json-parameters` when available.
+- For Python details, prefer installed package help (`import infomap`, `help(...)`, object signatures), published Python docs, and package examples available to the user.
+- For R details, prefer `?infomap::cluster_infomap`, `?infomap::Infomap`, `?infomap::infomap_options`, and installed package help.
 - Use the survey article as a decision guide for representation, flow modeling, higher-order networks, metadata, bipartite networks, incomplete data, and applications. Do not quote long passages from it.
 
 ## Default research standards

--- a/skills/infomap/SKILL.md
+++ b/skills/infomap/SKILL.md
@@ -14,8 +14,8 @@ Identify the user's mode before answering:
 - **Analysis planning**: choose a network representation, flow model, interface, outputs, and reproducibility checklist. Read `references/method-selection.md` and usually `references/reproducibility.md`.
 - **Code or command generation**: choose the smallest practical interface, then read `references/cli.md`, `references/python.md`, or `references/r.md`.
 - **Notebook workflow**: read `references/notebooks.md`; also read `references/python.md` when converting notebook ideas into scripts.
-- **Result interpretation or method text**: read `references/reproducibility.md`; read interface-specific references only if output fields or APIs matter.
-- **Usage troubleshooting**: inspect the installed package help, CLI help, or online user docs first, then read the relevant interface reference.
+- **Result interpretation or method text**: read `references/reproducibility.md`; read `references/faq.md` for common interpretation traps.
+- **Usage troubleshooting**: inspect the installed package help, CLI help, or online user docs first, then read `references/faq.md` and the relevant interface reference.
 
 ## Choose the interface
 
@@ -50,3 +50,4 @@ When the user already chose an interface, stay there unless a different interfac
 - `references/r.md`: R package workflows and igraph interop.
 - `references/notebooks.md`: survey companion notebooks and Jupyter adaptation.
 - `references/reproducibility.md`: reporting, provenance, and method-section checklist.
+- `references/faq.md`: common troubleshooting patterns distilled from Infomap Discussions.

--- a/skills/infomap/agents/openai.yaml
+++ b/skills/infomap/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Infomap"
+  short_description: "Use Infomap for reproducible research workflows"
+  default_prompt: "Use $infomap to plan or implement a reproducible Infomap analysis with CLI, Python, R, or notebooks."

--- a/skills/infomap/references/cli.md
+++ b/skills/infomap/references/cli.md
@@ -55,7 +55,11 @@ mkdir -p results/transitions
   printf 'binary=%s\n' "$INFOMAP_BIN"
   printf '%s\n' "$INFOMAP_BIN data/transitions.tsv results/transitions --directed --seed 123 --num-trials 20 --tree --clu --silent"
   "$INFOMAP_BIN" --version
-  shasum -a 256 data/transitions.tsv
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum data/transitions.tsv
+  else
+    shasum -a 256 data/transitions.tsv
+  fi
   "$INFOMAP_BIN" --print-json-parameters
 } > results/transitions/run-log.txt
 ```

--- a/skills/infomap/references/cli.md
+++ b/skills/infomap/references/cli.md
@@ -4,12 +4,11 @@ Use this reference when the user wants native Infomap commands, file-based analy
 
 ## Sources to inspect
 
-- `./Infomap --help`
-- `./Infomap -hh` for advanced options
-- `./Infomap --print-json-parameters` for current parameter names
-- `README.rst`
-- `examples/networks/`
-- `src/io/Config.cpp` and `src/io/Network.cpp` only when help text is not enough
+- `infomap --help` or `Infomap --help`, depending on the installed binary name.
+- `infomap -hh` or `Infomap -hh` for advanced options.
+- `infomap --print-json-parameters` or `Infomap --print-json-parameters` for current parameter names.
+- The published user guide at `https://www.mapequation.org/infomap/`.
+- Source checkout files only when the user is actually working inside an Infomap repository.
 
 ## Basic shape
 
@@ -19,28 +18,30 @@ The native command shape is:
 Infomap network_file out_directory [options]
 ```
 
-From a source checkout, examples may use `./Infomap`. Installed Python packages may provide an `infomap` entry point. Verify which binary is on `PATH` before giving exact commands.
+Installed Python packages usually provide an `infomap` entry point; native builds may expose `Infomap`. Verify which binary is on `PATH` before giving exact commands. In shell examples, use `INFOMAP_BIN` when the binary name is unknown.
 
 ## Reproducible command pattern
 
 ```bash
+INFOMAP_BIN="${INFOMAP_BIN:-infomap}"
 mkdir -p results/karate
-./Infomap data/karate.net results/karate \
+"$INFOMAP_BIN" data/karate.net results/karate \
   --flow-model undirected \
   --seed 123 \
   --num-trials 20 \
   --tree \
   --clu
 
-./Infomap --version > results/karate/infomap-version.txt
-./Infomap --print-json-parameters > results/karate/infomap-parameters.json
+"$INFOMAP_BIN" --version > results/karate/infomap-version.txt
+"$INFOMAP_BIN" --print-json-parameters > results/karate/infomap-parameters.json
 ```
 
 Weighted directed edge-list pattern:
 
 ```bash
+INFOMAP_BIN="${INFOMAP_BIN:-infomap}"
 mkdir -p results/transitions
-./Infomap data/transitions.tsv results/transitions \
+"$INFOMAP_BIN" data/transitions.tsv results/transitions \
   --directed \
   --seed 123 \
   --num-trials 20 \
@@ -49,14 +50,15 @@ mkdir -p results/transitions
   --silent
 
 {
-  printf '%s\n' './Infomap data/transitions.tsv results/transitions --directed --seed 123 --num-trials 20 --tree --clu --silent'
-  ./Infomap --version
+  printf 'binary=%s\n' "$INFOMAP_BIN"
+  printf '%s\n' "$INFOMAP_BIN data/transitions.tsv results/transitions --directed --seed 123 --num-trials 20 --tree --clu --silent"
+  "$INFOMAP_BIN" --version
   shasum -a 256 data/transitions.tsv
-  ./Infomap --print-json-parameters
+  "$INFOMAP_BIN" --print-json-parameters
 } > results/transitions/run-log.txt
 ```
 
-For a weighted link list, ensure the input columns and delimiter match the current supported format. The usual edge-list shape is source, target, and optional weight; inspect the user guide, examples, or parser tests before giving format-specific guarantees.
+For a weighted link list, ensure the input columns and delimiter match the current supported format. The usual edge-list shape is source, target, and optional weight; inspect the installed help or user guide before giving format-specific guarantees.
 
 Use `--silent` for scripts when console progress is not needed. Use `-v`, `-vv`, or `-vvv` when diagnosing a run.
 
@@ -78,7 +80,7 @@ Use `--silent` for scripts when console progress is not needed. Use `-v`, `-vv`,
 - Infomap assumes link-list input unless a file starts with a Pajek-style heading.
 - Use weighted input when weights carry interaction strength or observed flow frequency.
 - Use directed options when edge orientation is part of the process.
-- For state, multilayer, metadata, or bipartite formats, inspect current docs/examples before writing a full command.
+- For state, multilayer, metadata, or bipartite formats, inspect installed help, published docs, or user-provided examples before writing a full command.
 - Choose `--clu` when the user needs one top-level module id per node.
 - Choose `--tree` when the user needs hierarchy, flow, names, or downstream parsing.
 - Choose `--ftree` when Network Navigator or aggregated module links are needed.

--- a/skills/infomap/references/cli.md
+++ b/skills/infomap/references/cli.md
@@ -22,6 +22,8 @@ Installed Python packages usually provide an `infomap` entry point; native build
 
 ## Reproducible command pattern
 
+For examples in answers, `--num-trials 20` is a good research default. For local validation that the command and input format work, run a smoke test with `--num-trials 1` first. Ask before launching commands on large files, many trials, multiple seeds, parameter sweeps, or jobs likely to take more than a few minutes.
+
 ```bash
 INFOMAP_BIN="${INFOMAP_BIN:-infomap}"
 mkdir -p results/karate

--- a/skills/infomap/references/cli.md
+++ b/skills/infomap/references/cli.md
@@ -1,0 +1,84 @@
+# CLI Workflows
+
+Use this reference when the user wants native Infomap commands, file-based analysis, batch jobs, or wrapper-independent output.
+
+## Sources to inspect
+
+- `./Infomap --help`
+- `./Infomap -hh` for advanced options
+- `./Infomap --print-json-parameters` for current parameter names
+- `README.rst`
+- `examples/networks/`
+- `src/io/Config.cpp` and `src/io/Network.cpp` only when help text is not enough
+
+## Basic shape
+
+The native command shape is:
+
+```bash
+Infomap network_file out_directory [options]
+```
+
+From a source checkout, examples may use `./Infomap`. Installed Python packages may provide an `infomap` entry point. Verify which binary is on `PATH` before giving exact commands.
+
+## Reproducible command pattern
+
+```bash
+mkdir -p results/karate
+./Infomap data/karate.net results/karate \
+  --flow-model undirected \
+  --seed 123 \
+  --num-trials 20 \
+  --tree \
+  --clu
+
+./Infomap --version > results/karate/infomap-version.txt
+./Infomap --print-json-parameters > results/karate/infomap-parameters.json
+```
+
+Weighted directed edge-list pattern:
+
+```bash
+mkdir -p results/transitions
+./Infomap data/transitions.tsv results/transitions \
+  --directed \
+  --seed 123 \
+  --num-trials 20 \
+  --tree \
+  --clu \
+  --silent
+
+{
+  printf '%s\n' './Infomap data/transitions.tsv results/transitions --directed --seed 123 --num-trials 20 --tree --clu --silent'
+  ./Infomap --version
+  shasum -a 256 data/transitions.tsv
+  ./Infomap --print-json-parameters
+} > results/transitions/run-log.txt
+```
+
+For a weighted link list, ensure the input columns and delimiter match the current supported format. The usual edge-list shape is source, target, and optional weight; inspect the user guide, examples, or parser tests before giving format-specific guarantees.
+
+Use `--silent` for scripts when console progress is not needed. Use `-v`, `-vv`, or `-vvv` when diagnosing a run.
+
+## Common options
+
+- `--flow-model undirected|directed|undirdir|outdirdir|rawdir|precomputed`: choose how Infomap derives flow from links. Verify current choices from help.
+- `--directed`: shorthand for directed flow modeling.
+- `--two-level`: optimize a two-level partition instead of the default multilevel hierarchy.
+- `--seed INTEGER`: set the random number generator seed.
+- `--num-trials INTEGER`: run independent trials and keep the best result.
+- `--tree`: write hierarchy output.
+- `--ftree`: write hierarchy plus aggregated links for Network Navigator.
+- `--clu`: write top-level module ids for each node.
+- `--cluster-data PATH`: read an initial partition or hierarchy.
+- `--no-infomap`: skip optimization, useful for codelength or non-modular statistics with supplied cluster data.
+
+## Input and output guidance
+
+- Infomap assumes link-list input unless a file starts with a Pajek-style heading.
+- Use weighted input when weights carry interaction strength or observed flow frequency.
+- Use directed options when edge orientation is part of the process.
+- For state, multilayer, metadata, or bipartite formats, inspect current docs/examples before writing a full command.
+- Choose `--clu` when the user needs one top-level module id per node.
+- Choose `--tree` when the user needs hierarchy, flow, names, or downstream parsing.
+- Choose `--ftree` when Network Navigator or aggregated module links are needed.

--- a/skills/infomap/references/cli.md
+++ b/skills/infomap/references/cli.md
@@ -2,91 +2,53 @@
 
 Use this reference when the user wants native Infomap commands, file-based analysis, batch jobs, or wrapper-independent output.
 
-## Sources to inspect
+## Authority for current syntax
 
-- `infomap --help` or `Infomap --help`, depending on the installed binary name.
-- `infomap -hh` or `Infomap -hh` for advanced options.
-- `infomap --print-json-parameters` or `Infomap --print-json-parameters` for current parameter names.
-- The published user guide at `https://www.mapequation.org/infomap/`.
-- Source checkout files only when the user is actually working inside an Infomap repository.
+Do not treat this skill as the CLI manual. Before giving runnable commands, inspect the installed binary:
 
-## Basic shape
+```bash
+INFOMAP_BIN="${INFOMAP_BIN:-infomap}"
+command -v "$INFOMAP_BIN" || command -v Infomap
+"$INFOMAP_BIN" --version
+"$INFOMAP_BIN" --help
+"$INFOMAP_BIN" -hh
+"$INFOMAP_BIN" --print-json-parameters
+```
 
-The native command shape is:
+If `infomap` is not found, try `Infomap`. Installed Python packages often provide `infomap`; native builds may expose `Infomap`.
+
+Use the published user guide at `https://www.mapequation.org/infomap/` for file formats and examples. Use source checkout files only when the user is actually working inside an Infomap repository.
+
+## Stable command shape
+
+The stable CLI pattern is:
 
 ```bash
 Infomap network_file out_directory [options]
 ```
 
-Installed Python packages usually provide an `infomap` entry point; native builds may expose `Infomap`. Verify which binary is on `PATH` before giving exact commands. In shell examples, use `INFOMAP_BIN` when the binary name is unknown.
+When the binary name is uncertain, write examples with `INFOMAP_BIN` and tell the agent to verify current option names from help before running.
 
-## Reproducible command pattern
+## Generating commands
 
-For examples in answers, `--num-trials 20` is a good research default. For local validation that the command and input format work, run a smoke test with `--num-trials 1` first. Ask before launching commands on large files, many trials, multiple seeds, parameter sweeps, or jobs likely to take more than a few minutes.
+- Prefer CLI for existing network files, batch jobs, shell pipelines, native output files, or wrapper-independent reproducibility.
+- For validation, use tiny inputs or one trial first. Ask before launching large files, many trials, multiple seeds, parameter sweeps, notebooks, or runs likely to take more than a few minutes.
+- Make research commands record the binary version, exact command, input checksum, non-default options, and output directory.
+- Use `--print-json-parameters` when available to log the installed version's actual parameter names and defaults.
+- For edge lists, state/multilayer input, metadata, bipartite data, and output formats, verify the installed help or published guide before making format-specific claims.
 
-```bash
-INFOMAP_BIN="${INFOMAP_BIN:-infomap}"
-mkdir -p results/karate
-"$INFOMAP_BIN" data/karate.net results/karate \
-  --flow-model undirected \
-  --seed 123 \
-  --num-trials 20 \
-  --tree \
-  --clu
-
-"$INFOMAP_BIN" --version > results/karate/infomap-version.txt
-"$INFOMAP_BIN" --print-json-parameters > results/karate/infomap-parameters.json
-```
-
-Weighted directed edge-list pattern:
+Portable checksum snippet for run logs:
 
 ```bash
-INFOMAP_BIN="${INFOMAP_BIN:-infomap}"
-mkdir -p results/transitions
-"$INFOMAP_BIN" data/transitions.tsv results/transitions \
-  --directed \
-  --seed 123 \
-  --num-trials 20 \
-  --tree \
-  --clu \
-  --silent
-
-{
-  printf 'binary=%s\n' "$INFOMAP_BIN"
-  printf '%s\n' "$INFOMAP_BIN data/transitions.tsv results/transitions --directed --seed 123 --num-trials 20 --tree --clu --silent"
-  "$INFOMAP_BIN" --version
-  if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum data/transitions.tsv
-  else
-    shasum -a 256 data/transitions.tsv
-  fi
-  "$INFOMAP_BIN" --print-json-parameters
-} > results/transitions/run-log.txt
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256sum data/input.tsv
+else
+  shasum -a 256 data/input.tsv
+fi
 ```
 
-For a weighted link list, ensure the input columns and delimiter match the current supported format. The usual edge-list shape is source, target, and optional weight; inspect the installed help or user guide before giving format-specific guarantees.
+## Output choice prompts
 
-Use `--silent` for scripts when console progress is not needed. Use `-v`, `-vv`, or `-vvv` when diagnosing a run.
-
-## Common options
-
-- `--flow-model undirected|directed|undirdir|outdirdir|rawdir|precomputed`: choose how Infomap derives flow from links. Verify current choices from help.
-- `--directed`: shorthand for directed flow modeling.
-- `--two-level`: optimize a two-level partition instead of the default multilevel hierarchy.
-- `--seed INTEGER`: set the random number generator seed.
-- `--num-trials INTEGER`: run independent trials and keep the best result.
-- `--tree`: write hierarchy output.
-- `--ftree`: write hierarchy plus aggregated links for Network Navigator.
-- `--clu`: write top-level module ids for each node.
-- `--cluster-data PATH`: read an initial partition or hierarchy.
-- `--no-infomap`: skip optimization, useful for codelength or non-modular statistics with supplied cluster data.
-
-## Input and output guidance
-
-- Infomap assumes link-list input unless a file starts with a Pajek-style heading.
-- Use weighted input when weights carry interaction strength or observed flow frequency.
-- Use directed options when edge orientation is part of the process.
-- For state, multilayer, metadata, or bipartite formats, inspect installed help, published docs, or user-provided examples before writing a full command.
-- Choose `--clu` when the user needs one top-level module id per node.
-- Choose `--tree` when the user needs hierarchy, flow, names, or downstream parsing.
-- Choose `--ftree` when Network Navigator or aggregated module links are needed.
+- Ask whether the user needs one module id per node, a hierarchy, state-level output, physical-node output, Network Navigator input, or machine-readable tables.
+- Choose native output formats only after checking current help, because option names and writer behavior are version-sensitive.
+- When a user cites an old command from a discussion or paper, translate it through current `--help`, `-hh`, and `--print-json-parameters` rather than copying it verbatim.

--- a/skills/infomap/references/faq.md
+++ b/skills/infomap/references/faq.md
@@ -1,0 +1,88 @@
+# FAQ and Troubleshooting
+
+Use this reference when the user asks why a result looks surprising, why a run is slow, how to get an output field, or how to translate advice from old Infomap discussions to current versions. The entries below are distilled from high-signal GitHub Discussions and checked against current CLI/Python/R option names where possible.
+
+## One module or fewer modules than expected
+
+Start from `references/reproducibility.md` for codelength interpretation. A one-module result usually means the current representation and flow model did not find a modular description shorter than the one-level baseline.
+
+Practical checks:
+
+- Confirm weights mean stronger interaction/flow, not distance or dissimilarity.
+- Confirm directionality and `--flow-model` / `--directed`.
+- Run more trials or compare seeds if the network is stochastic or hard to optimize.
+- For dense or aggregated networks, test whether filtering weak links with `--weight-threshold` changes the signal.
+- For scale sensitivity, lower `--markov-time` / `markov_time` to explore smaller modules, but treat this as a modeling choice.
+- To bias the search toward a target granularity, consider `--preferred-number-of-modules` / `preferred_number_of_modules`, but treat it as a modeling choice and report it.
+- If the data can be stratified by context, model layers/state nodes instead of flattening.
+- To evaluate an expected partition, use `--cluster-data PARTITION --no-infomap`, or Python `initial_partition` with `run(no_infomap=True)`.
+
+Source discussions: [#241](https://github.com/mapequation/infomap/discussions/241), [#340](https://github.com/mapequation/infomap/discussions/340).
+
+## Reproducibility differs across binaries or machines
+
+Use `seed` and `num_trials`, and record the Infomap version, interface, build, options, and input. A seed is still the right starting point, but do not promise bit-identical results across all binaries, platforms, standard libraries, and OpenMP/build configurations. If exact reproduction matters, use the same Infomap version and build environment, and compare codelengths and partitions rather than assuming labels or node order are stable.
+
+Current code still exposes a standard-library based random mapping path, so keep this caveat unless the installed version explicitly documents portable cross-platform seeded permutations.
+
+Source discussion: [#524](https://github.com/mapequation/infomap/discussions/524).
+
+## Slow runs or low CPU usage
+
+Check `infomap --version` / `Infomap --version` for OpenMP support. Some phases can be single-threaded even when the binary supports OpenMP. For Python, reading a network file with `im.read_file(...)` is usually much faster than adding many links in Python loops. Also check memory pressure: swapping can make runs look CPU-light and extremely slow.
+
+For very large graphs, use runtime planning in `references/reproducibility.md`, start with one trial, and ask before launching many trials or parameter sweeps.
+
+Source discussion: [#333](https://github.com/mapequation/infomap/discussions/333).
+
+## Overlapping modules
+
+Do not suggest the old `--overlapping` workflow for current Infomap. For ordinary first-order networks, Infomap returns hard assignments. To model overlap, represent the data as multilayer, memory, or raw state networks so one physical node can have multiple state nodes in different modules.
+
+Source discussions: [#61](https://github.com/mapequation/infomap/discussions/61), [#228](https://github.com/mapequation/infomap/discussions/228).
+
+## Multilayer output looks duplicated or confusing
+
+In multilayer/state networks, one physical node may appear as multiple state nodes. A physical node can therefore appear in multiple modules across layers or contexts. For Python, iterate `im.nodes` and inspect `node.node_id`, `node.layer_id`, `node.state_id`, and `node.module_id`. For R, use `as.data.frame(im, states = TRUE)` or result node tables when available.
+
+If output should distinguish layers, request state-level output. If output should merge physical nodes, say so explicitly and explain how merging affects interpretation.
+
+Source discussions: [#267](https://github.com/mapequation/infomap/discussions/267), [#272](https://github.com/mapequation/infomap/discussions/272).
+
+## Multilayer `--cluster-data` or initial partitions
+
+For multilayer/state networks, initial partitions usually need state-level identifiers, not only physical node ids. When possible, write a state-level `.clu` from a known run and use that as the shape/template. Current CLI help says `--cluster-data` accepts a `.clu`, `.tree`, or `.ftree`, and `--no-infomap` can calculate codelength without optimization.
+
+For Python, `im.initial_partition = {...}` or `im.run(initial_partition=..., no_infomap=True)` can evaluate a supplied partition. For CLI/R, use the current `cluster_data` and `no_infomap` option names.
+
+Source discussions: [#329](https://github.com/mapequation/infomap/discussions/329), [#340](https://github.com/mapequation/infomap/discussions/340).
+
+## CLI flags changed from old versions
+
+When reproducing old commands, check `infomap -hh` or `Infomap -hh`. In current help, self-links are included by default and `-k` / `--include-self-links` is deprecated; use `--no-self-links` to exclude them. Current Infomap does not require zero-based indexing flags for ordinary non-consecutive ids.
+
+Source discussions: [#138](https://github.com/mapequation/infomap/discussions/138), [#350](https://github.com/mapequation/infomap/discussions/350).
+
+## What does flow mean, and where are Huffman codes?
+
+Flow means random-walk visit rates used by the map equation to describe system-wide interdependencies. Infomap does not need to materialize actual Huffman codewords for each node in normal use; it uses flows to calculate the lower bound on expected codelength. In tree output, the flow is included as a column; use it for interpretation rather than trying to recover literal codewords.
+
+Source discussions: [#177](https://github.com/mapequation/infomap/discussions/177), [#337](https://github.com/mapequation/infomap/discussions/337).
+
+## Output formats and Network Navigator
+
+Use `--ftree` or `--output ftree` when Network Navigator or aggregated links between modules are needed. In Python/R APIs, prefer the current writer/helper names from installed help. Do not assume `write_pajek` is a general export of the original user-facing multilayer input; check whether the desired output should be `.tree`, `.ftree`, `.clu`, `.csv`, `.json`, `states`, or graph-package export.
+
+Source discussions: [#330](https://github.com/mapequation/infomap/discussions/330), [#283](https://github.com/mapequation/infomap/discussions/283).
+
+## Install and wrapper confusion
+
+Prefer the official `infomap` Python/R packages and current docs when users hit wrapper-specific issues from CDlib, old Conda packages, or old Python APIs. For Python API errors from old examples, inspect the installed package version and current object signatures. For source installs, modern Infomap requires a C++ toolchain with the language standard supported by the package version.
+
+Source discussions: [#105](https://github.com/mapequation/infomap/discussions/105), [#171](https://github.com/mapequation/infomap/discussions/171), [#180](https://github.com/mapequation/infomap/discussions/180).
+
+## Metadata beyond simple categories
+
+For categorical metadata in current Infomap, use the installed metadata options or programmatic metadata APIs. For non-discrete or more elaborate metadata-dependent encoding, treat it as an advanced modeling problem rather than a simple option toggle; look for current research code and paper context before giving implementation advice.
+
+Source discussion: [#343](https://github.com/mapequation/infomap/discussions/343).

--- a/skills/infomap/references/faq.md
+++ b/skills/infomap/references/faq.md
@@ -1,6 +1,6 @@
 # FAQ and Troubleshooting
 
-Use this reference when the user asks why a result looks surprising, why a run is slow, how to get an output field, or how to translate advice from old Infomap discussions to current versions. The entries below are distilled from high-signal GitHub Discussions and checked against current CLI/Python/R option names where possible.
+Use this reference when the user asks why a result looks surprising, why a run is slow, how to get an output field, or how to translate advice from old Infomap discussions to current versions. The entries below are distilled from high-signal GitHub Discussions, but option names and API calls must still be verified against the user's installed CLI/Python/R package before giving runnable code.
 
 ## One module or fewer modules than expected
 
@@ -9,13 +9,13 @@ Start from `references/reproducibility.md` for codelength interpretation. A one-
 Practical checks:
 
 - Confirm weights mean stronger interaction/flow, not distance or dissimilarity.
-- Confirm directionality and `--flow-model` / `--directed`.
+- Confirm directionality and the installed flow-model or directedness options.
 - Run more trials or compare seeds if the network is stochastic or hard to optimize.
-- For dense or aggregated networks, test whether filtering weak links with `--weight-threshold` changes the signal.
-- For scale sensitivity, lower `--markov-time` / `markov_time` to explore smaller modules, but treat this as a modeling choice.
-- To bias the search toward a target granularity, consider `--preferred-number-of-modules` / `preferred_number_of_modules`, but treat it as a modeling choice and report it.
+- For dense or aggregated networks, test whether filtering weak links changes the signal, using the installed option name.
+- For scale sensitivity, explore lower Markov-time settings to look for smaller modules, but treat this as a modeling choice.
+- To bias the search toward a target granularity, consider the installed preferred-module-count option if available, but treat it as a modeling choice and report it.
 - If the data can be stratified by context, model layers/state nodes instead of flattening.
-- To evaluate an expected partition, use `--cluster-data PARTITION --no-infomap`, or Python `initial_partition` with `run(no_infomap=True)`.
+- To evaluate an expected partition, look for the installed cluster-data / no-optimization options or initial-partition API. Use them to calculate codelength without optimizing when supported.
 
 Source discussions: [#241](https://github.com/mapequation/infomap/discussions/241), [#340](https://github.com/mapequation/infomap/discussions/340).
 
@@ -29,7 +29,7 @@ Source discussion: [#524](https://github.com/mapequation/infomap/discussions/524
 
 ## Slow runs or low CPU usage
 
-Check `infomap --version` / `Infomap --version` for OpenMP support. Some phases can be single-threaded even when the binary supports OpenMP. For Python, reading a network file with `im.read_file(...)` is usually much faster than adding many links in Python loops. Also check memory pressure: swapping can make runs look CPU-light and extremely slow.
+Check `infomap --version` / `Infomap --version` for OpenMP support. Some phases can be single-threaded even when the binary supports OpenMP. For Python, reading a network file through the installed file-reading API is usually much faster than adding many links in Python loops; verify the method name from package help. Also check memory pressure: swapping can make runs look CPU-light and extremely slow.
 
 For very large graphs, use runtime planning in `references/reproducibility.md`, start with one trial, and ask before launching many trials or parameter sweeps.
 
@@ -51,15 +51,15 @@ Source discussions: [#267](https://github.com/mapequation/infomap/discussions/26
 
 ## Multilayer `--cluster-data` or initial partitions
 
-For multilayer/state networks, initial partitions usually need state-level identifiers, not only physical node ids. When possible, write a state-level `.clu` from a known run and use that as the shape/template. Current CLI help says `--cluster-data` accepts a `.clu`, `.tree`, or `.ftree`, and `--no-infomap` can calculate codelength without optimization.
+For multilayer/state networks, initial partitions usually need state-level identifiers, not only physical node ids. When possible, write a state-level partition from a known run and use that as the shape/template. Verify the installed CLI or API support for cluster-data input and no-optimization codelength calculation.
 
-For Python, `im.initial_partition = {...}` or `im.run(initial_partition=..., no_infomap=True)` can evaluate a supplied partition. For CLI/R, use the current `cluster_data` and `no_infomap` option names.
+For Python/R/CLI, inspect installed help before naming exact parameters. Older discussion examples may use names that have since changed.
 
 Source discussions: [#329](https://github.com/mapequation/infomap/discussions/329), [#340](https://github.com/mapequation/infomap/discussions/340).
 
 ## CLI flags changed from old versions
 
-When reproducing old commands, check `infomap -hh` or `Infomap -hh`. In current help, self-links are included by default and `-k` / `--include-self-links` is deprecated; use `--no-self-links` to exclude them. Current Infomap does not require zero-based indexing flags for ordinary non-consecutive ids.
+When reproducing old commands, check advanced CLI help and installed parameter metadata. Old discussions may mention flags that were removed, renamed, or made defaults. In recent/current versions, self-links are included by default and the old include-self-links flag is deprecated; verify the installed exclusion flag before using it. Current versions do not require zero-based indexing flags for ordinary non-consecutive ids.
 
 Source discussions: [#138](https://github.com/mapequation/infomap/discussions/138), [#350](https://github.com/mapequation/infomap/discussions/350).
 
@@ -71,7 +71,7 @@ Source discussions: [#177](https://github.com/mapequation/infomap/discussions/17
 
 ## Output formats and Network Navigator
 
-Use `--ftree` or `--output ftree` when Network Navigator or aggregated links between modules are needed. In Python/R APIs, prefer the current writer/helper names from installed help. Do not assume `write_pajek` is a general export of the original user-facing multilayer input; check whether the desired output should be `.tree`, `.ftree`, `.clu`, `.csv`, `.json`, `states`, or graph-package export.
+When Network Navigator or aggregated links between modules are needed, inspect current CLI help for the flow-tree or equivalent output format. In Python/R APIs, prefer the current writer/helper names from installed help. Do not assume a Pajek writer is a general export of the original user-facing multilayer input; check whether the desired output should be hierarchy, flow-tree, cluster assignment, table, JSON, state-level output, or graph-package export.
 
 Source discussions: [#330](https://github.com/mapequation/infomap/discussions/330), [#283](https://github.com/mapequation/infomap/discussions/283).
 

--- a/skills/infomap/references/faq.md
+++ b/skills/infomap/references/faq.md
@@ -23,7 +23,7 @@ Source discussions: [#241](https://github.com/mapequation/infomap/discussions/24
 
 Use `seed` and `num_trials`, and record the Infomap version, interface, build, options, and input. A seed is still the right starting point, but do not promise bit-identical results across all binaries, platforms, standard libraries, and OpenMP/build configurations. If exact reproduction matters, use the same Infomap version and build environment, and compare codelengths and partitions rather than assuming labels or node order are stable.
 
-Current code still exposes a standard-library based random mapping path, so keep this caveat unless the installed version explicitly documents portable cross-platform seeded permutations.
+Recent/current Infomap builds are known to expose a standard-library based random mapping path. Keep the cross-platform caveat unless the installed version's docs or source explicitly document portable seeded permutations.
 
 Source discussion: [#524](https://github.com/mapequation/infomap/discussions/524).
 

--- a/skills/infomap/references/method-selection.md
+++ b/skills/infomap/references/method-selection.md
@@ -4,7 +4,7 @@ Use this reference when the user needs help turning a research problem into an I
 
 ## Survey frame
 
-The survey organizes map equation workflows as:
+The survey article (`https://doi.org/10.1145/3779648`) organizes map equation workflows as:
 
 1. **Network representation**: decide what nodes and links mean.
 2. **Flow modeling**: decide how flows move on that representation.

--- a/skills/infomap/references/method-selection.md
+++ b/skills/infomap/references/method-selection.md
@@ -1,0 +1,65 @@
+# Method Selection
+
+Use this reference when the user needs help turning a research problem into an Infomap analysis design.
+
+## Survey frame
+
+The survey organizes map equation workflows as:
+
+1. **Network representation**: decide what nodes and links mean.
+2. **Flow modeling**: decide how flows move on that representation.
+3. **Flow mapping**: run Infomap to identify modules that compress those flows.
+
+Ask only the questions needed for the task. If the user wants code immediately, infer reasonable defaults and state them briefly.
+
+## Representation choices
+
+- **Simple pairwise network**: use when interactions are ordinary node-node links. Preserve weights and direction when they are meaningful and available.
+- **Directed network**: use when link orientation represents the process, such as citations, transitions, web links, pathways, or asymmetric movement.
+- **Weighted network**: use when link strength represents frequency, affinity, capacity, similarity, or confidence. Check whether larger weights mean stronger flow.
+- **State or memory network**: use when the next step depends on previous context, sequence history, or when one physical node can participate in different flow contexts.
+- **Multilayer network**: use when the same physical entities appear in layers such as time, modality, context, data source, transport mode, or interaction type.
+- **Metadata network**: use when node attributes should influence the module description, such as known categories, labels, environments, or annotations.
+- **Bipartite network**: use when links only connect two node types, such as documents-terms, plants-pollinators, users-items, or features-samples.
+- **Incomplete-data workflow**: use when observed links are sparse samples of an underlying flow process and regularization or Bayesian prior assumptions matter.
+
+## Metadata and bipartite prompts
+
+For metadata workflows, clarify:
+
+- what the metadata categories represent;
+- whether metadata should influence the compression objective or only be used for post hoc annotation;
+- whether metadata is categorical and available for every relevant node;
+- which interface supports the needed input path: Python can set metadata programmatically with `set_meta_data()`, while CLI/R workflows may use metadata option files or R6 methods depending on the current API.
+
+For bipartite workflows, clarify:
+
+- the two node types and whether links only cross between types;
+- whether the reported modules should include both node types or hide/project the second type;
+- how the second node type is identified, such as `bipartite_start_id` in programmatic APIs or a bipartite input heading in files;
+- whether bipartite flow adjustment, bipartite teleportation, or hidden bipartite-node output is part of the research question.
+
+## Flow-model choices
+
+- For undirected pairwise structure, the default unbiased random-walk model is usually enough.
+- For directed links, use directed flow modeling instead of symmetrizing unless the research question explicitly ignores direction.
+- For observed flows or transition counts, consider whether precomputed or raw directed flow better matches the data; verify current option names from CLI help or API docs.
+- For higher-order, temporal, or multi-context data, model state nodes or layers explicitly instead of flattening if flattening would mix distinct flows.
+- For metadata or bipartite workflows, verify the current interface support before generating code because details differ across CLI, Python, and R.
+
+## Output choices
+
+- Use top-level modules when the downstream analysis expects one label per node.
+- Use hierarchical paths when the research question needs multiscale modules.
+- Use state-level outputs when the same physical node can belong to different modules across contexts.
+- Use physical-level outputs when the final report needs one merged assignment per physical entity.
+- Use codelength and number of modules for run summaries; avoid treating codelength differences as a universal statistical test unless the user asks for model comparison.
+
+## Questions to ask when planning
+
+- What do nodes and links represent?
+- Are links directed, weighted, or observed flows?
+- Does a node appear in multiple contexts, layers, or histories?
+- Is the desired result one module per physical node, per state node, or per layer-node state?
+- Which environment should produce the result: CLI, Python, R, or notebook?
+- What artifacts are needed for the paper or workflow: tables, tree/clu files, graph export, plots, or method text?

--- a/skills/infomap/references/notebooks.md
+++ b/skills/infomap/references/notebooks.md
@@ -4,11 +4,10 @@ Use this reference when the user mentions Jupyter, tutorial notebooks, survey co
 
 ## Sources to inspect
 
-- `interfaces/python/source/notebooks.rst`
-- `examples/notebooks/notebooks.toml`
-- `examples/notebooks/`
-- `interfaces/python/source/quickstart.rst`
-- `interfaces/python/source/usage.rst`
+- Published Python docs and notebook page.
+- The installed or published notebook image `ghcr.io/mapequation/infomap:notebook`.
+- The public notebook source on GitHub when internet access is available.
+- Source checkout files only when the user is actually working inside an Infomap repository.
 
 ## When notebooks are the right path
 
@@ -21,7 +20,7 @@ Use notebooks when the user wants to:
 
 Use scripts instead when the user wants batch runs, CI, parameter sweeps, or stable pipeline execution.
 
-## Notebook topics in this repo
+## Notebook topics
 
 The survey companion notebooks cover:
 
@@ -53,7 +52,7 @@ docker run --rm -p 8888:8888 \
   start.sh jupyter lab
 ```
 
-From a source checkout:
+From a source checkout, only when the user has the repository locally:
 
 ```bash
 python -m pip install -e '.[notebooks]'

--- a/skills/infomap/references/notebooks.md
+++ b/skills/infomap/references/notebooks.md
@@ -1,0 +1,64 @@
+# Notebook Workflows
+
+Use this reference when the user mentions Jupyter, tutorial notebooks, survey companion notebooks, exploratory analysis, teaching material, or adapting notebook examples.
+
+## Sources to inspect
+
+- `interfaces/python/source/notebooks.rst`
+- `examples/notebooks/notebooks.toml`
+- `examples/notebooks/`
+- `interfaces/python/source/quickstart.rst`
+- `interfaces/python/source/usage.rst`
+
+## When notebooks are the right path
+
+Use notebooks when the user wants to:
+
+- connect the map equation concepts to executable examples;
+- inspect small networks, partitions, flows, and codelengths step by step;
+- adapt survey examples for a paper, teaching material, or exploratory analysis;
+- compare Infomap with Louvain, Leiden, Scanpy, or other workflow tools.
+
+Use scripts instead when the user wants batch runs, CI, parameter sweeps, or stable pipeline execution.
+
+## Notebook topics in this repo
+
+The survey companion notebooks cover:
+
+- two-level map equation and two-level search;
+- solution landscapes;
+- memory, multilayer, temporal, and multi-body network models;
+- metadata, bipartite, and incomplete-data networks;
+- map equation centrality, similarity, bioregions, and model selection with correlational data.
+
+Comparison notebooks cover NetworkX, python-igraph, and Scanpy-style workflows.
+
+## Adaptation workflow
+
+When helping adapt a notebook:
+
+1. Identify the notebook section that matches the research data or question.
+2. Preserve the conceptual structure, but replace toy data with the user's data loading cell.
+3. Add a reproducibility cell with package versions, input path or data checksum, seed, `num_trials`, and non-default options.
+4. Store outputs outside the notebook when they are needed later: CSV tables, GraphML/GEXF, `.tree`, `.clu`, or figures.
+5. Convert repeated analysis into functions or scripts once the exploratory workflow stabilizes.
+
+## Running notebooks
+
+Published notebook image:
+
+```bash
+docker run --rm -p 8888:8888 \
+  ghcr.io/mapequation/infomap:notebook \
+  start.sh jupyter lab
+```
+
+From a source checkout:
+
+```bash
+python -m pip install -e '.[notebooks]'
+cd examples/notebooks
+jupyter lab
+```
+
+Do not start a dev server or Jupyter session unless the user asks.

--- a/skills/infomap/references/notebooks.md
+++ b/skills/infomap/references/notebooks.md
@@ -1,6 +1,6 @@
 # Notebook Workflows
 
-Use this reference when the user mentions Jupyter, tutorial notebooks, survey companion notebooks, exploratory analysis, teaching material, or adapting notebook examples.
+Use this reference when the user mentions Jupyter, tutorial notebooks, survey companion notebooks, exploratory analysis, teaching material, or adapting notebook examples related to the survey article (`https://doi.org/10.1145/3779648`).
 
 ## Sources to inspect
 

--- a/skills/infomap/references/notebooks.md
+++ b/skills/infomap/references/notebooks.md
@@ -46,20 +46,4 @@ When helping adapt a notebook:
 
 ## Running notebooks
 
-Published notebook image:
-
-```bash
-docker run --rm -p 8888:8888 \
-  ghcr.io/mapequation/infomap:notebook \
-  start.sh jupyter lab
-```
-
-From a source checkout, only when the user has the repository locally:
-
-```bash
-python -m pip install -e '.[notebooks]'
-cd examples/notebooks
-jupyter lab
-```
-
-Do not start a dev server or Jupyter session unless the user asks.
+Do not start Docker, Jupyter, or full notebook execution unless the user asks. Before giving launch commands, verify the current notebook image, installation extras, or source-checkout path from the published docs, package metadata, or the user's local repository. For validation, prefer extracting one small cell into a temporary script or reduced notebook and record the package version, inputs, seed, options, and outputs.

--- a/skills/infomap/references/notebooks.md
+++ b/skills/infomap/references/notebooks.md
@@ -20,6 +20,8 @@ Use notebooks when the user wants to:
 
 Use scripts instead when the user wants batch runs, CI, parameter sweeps, or stable pipeline execution.
 
+Notebook runtimes can grow quickly when examples download data, build layouts, compare methods, or run many trials. Do not start Docker, Jupyter, full notebook execution, parameter sweeps, or long comparison notebooks unless the user asks. For validation, prefer running one small extracted cell or a reduced toy example first.
+
 ## Notebook topics
 
 The survey companion notebooks cover:

--- a/skills/infomap/references/python.md
+++ b/skills/infomap/references/python.md
@@ -4,12 +4,10 @@ Use this reference when the user works in Python, notebooks, NetworkX, python-ig
 
 ## Sources to inspect
 
-- `interfaces/python/source/quickstart.rst`
-- `interfaces/python/source/usage.rst`
-- `interfaces/python/source/scanpy.rst`
-- `interfaces/python/source/export.rst`
-- `examples/python/`
-- `test/python/` for exact behavior when docs are not enough
+- Installed package help and signatures, for example `import infomap`, `help(infomap.Infomap)`, `help(infomap.find_communities)`, and `help(infomap.tl.infomap)`.
+- Installed package metadata, such as `import importlib.metadata; importlib.metadata.version("infomap")`.
+- Published Python docs at `https://mapequation.github.io/infomap-python-docs/`.
+- Source checkout files only when the user is actually working inside an Infomap repository.
 
 ## Choose the Python entry point
 

--- a/skills/infomap/references/python.md
+++ b/skills/infomap/references/python.md
@@ -2,110 +2,49 @@
 
 Use this reference when the user works in Python, notebooks, NetworkX, python-igraph, SciPy, edge-index, AnnData, Scanpy, pandas, or graph export workflows.
 
-## Sources to inspect
+## Authority for current syntax
 
-- Installed package help and signatures, for example `import infomap`, `help(infomap.Infomap)`, `help(infomap.find_communities)`, and `help(infomap.tl.infomap)`.
-- Installed package metadata, such as `import importlib.metadata; importlib.metadata.version("infomap")`.
-- When inspecting an installed package from an Infomap source checkout, verify `infomap.__file__` so Python has not imported repo-local sources by accident. If needed, run inspection from another working directory or a clean environment.
-- Published Python docs at `https://mapequation.github.io/infomap-python-docs/`.
-- Source checkout files only when the user is actually working inside an Infomap repository.
+Do not treat this skill as the Python API manual. Before giving runnable code, inspect the installed package:
+
+```python
+import inspect
+import importlib.metadata as md
+import infomap
+
+print(md.version("infomap"))
+print(infomap.__file__)
+print(inspect.signature(infomap.Infomap))
+print(inspect.getdoc(infomap.Infomap))
+print(inspect.signature(infomap.find_communities))
+print(inspect.getdoc(infomap.find_communities))
+```
+
+For optional helpers, check availability before using them:
+
+```python
+hasattr(infomap, "InfomapOptions")
+hasattr(infomap, "tl") and hasattr(infomap.tl, "infomap")
+```
+
+If inspection is run from an Infomap source checkout, verify `infomap.__file__` so Python has not imported repo-local sources by accident. If needed, run from another working directory or a clean environment. Use the published Python docs at `https://mapequation.github.io/infomap-python-docs/` when internet access is available.
 
 ## Choose the Python entry point
 
-- Use `infomap.find_communities(...)` for NetworkX-style workflows where the user wants a partition and original node labels.
-- Use `Infomap(...)` when the user needs codelength, flow, hierarchical paths, output files, state/multilayer handling, repeated runs, or tabular results.
-- Use `InfomapOptions` when the same options should be reused across runs or documented as a structured configuration.
-- Use `infomap.tl.infomap(adata, ...)` for AnnData/Scanpy-style observation graphs.
+- Prefer a high-level community helper when the user has a NetworkX-style graph and only needs a partition with original labels. Verify the helper signature from the installed package.
+- Prefer the `Infomap` class when the user needs codelength, flow, hierarchy paths, output files, state/multilayer handling, repeated runs, or tabular results.
+- Prefer reusable option objects only if the installed package exposes them and the workflow benefits from a structured configuration.
+- Prefer the AnnData/Scanpy helper only if the installed package exposes it and the user is working with observation graphs.
 
-## Common patterns
+## Generating code
 
-For examples in answers, `num_trials=20` is a reasonable research default. For actual validation runs, use a tiny graph or `num_trials=1` first. Ask before running large graphs, many trials, repeated seeds, Scanpy workflows on large AnnData objects, or parameter sweeps.
+- Generate code after inspecting signatures or docs for the installed version.
+- Keep examples small. Use one trial for smoke tests; use a meaningful `num_trials` value for research runs only after runtime is acceptable.
+- Record package version, `infomap.__file__`, graph source, directed/weighted choice, seed, trials, non-default options, and output artifacts.
+- Preserve mappings when labels are converted to internal integer ids.
+- For state or multilayer output, state whether results are state-level or physical-node-level.
 
-NetworkX quick path:
+## Minimal patterns
 
-```python
-import networkx as nx
-import infomap
+For simple graph partitioning, use the installed high-level helper if available. For richer results, instantiate `Infomap`, add/read the network with installed methods, run, then extract modules, codelength, and node/state tables using methods confirmed by `help(...)` or `inspect`.
 
-graph = nx.karate_club_graph()
-communities = infomap.find_communities(
-    graph,
-    weight="weight",
-    seed=123,
-    num_trials=20,
-    module_attribute="infomap_module",
-)
-```
-
-Explicit run with tabular output:
-
-```python
-from infomap import Infomap
-
-im = Infomap(silent=True, seed=123, num_trials=20)
-mapping = im.add_networkx_graph(graph)
-im.run()
-
-nodes = im.to_dataframe(
-    columns=["node_id", "module_id", "flow"],
-    index="node_id",
-    sort=["module_id", "flow"],
-)
-```
-
-SciPy sparse matrix:
-
-```python
-from infomap import Infomap
-
-im = Infomap.from_scipy_sparse_matrix(
-    adjacency,
-    directed=False,
-    args="--silent --seed 123 --num-trials 20",
-)
-im.run()
-modules = im.get_modules()
-```
-
-Edge-index data:
-
-```python
-from infomap import Infomap
-
-im = Infomap.from_edge_index(
-    edge_index,
-    edge_weight=edge_weight,
-    directed=False,
-    args="--silent --seed 123 --num-trials 20",
-)
-im.run()
-```
-
-Scanpy-style AnnData:
-
-```python
-import infomap
-
-infomap.tl.infomap(
-    adata,
-    key_added="infomap",
-    directed=False,
-    use_weights=True,
-    seed=123,
-    num_trials=20,
-)
-```
-
-## State and multilayer reminders
-
-- NetworkX state networks use a `node_id` node attribute to map states to physical nodes.
-- Multilayer NetworkX graphs additionally use `layer_id`.
-- For state or multilayer output, be explicit whether results should be state-level or physical-node-level.
-- Preserve and report mappings when non-integer labels are converted to internal ids.
-
-## Export and reporting
-
-- Use `to_dataframe()` when a paper or pipeline needs node-level tables.
-- Use `get_modules()` for simple module mappings.
-- Use `infomap.export.write_graphml` or `write_gexf` for NetworkX visualization workflows.
-- Record package version, graph source, directed/weighted choice, seed, `num_trials`, and non-default options.
+Avoid copying long API examples from this skill. The exact method names, signatures, and helper coverage should come from the installed package and published docs.

--- a/skills/infomap/references/python.md
+++ b/skills/infomap/references/python.md
@@ -1,0 +1,110 @@
+# Python Workflows
+
+Use this reference when the user works in Python, notebooks, NetworkX, python-igraph, SciPy, edge-index, AnnData, Scanpy, pandas, or graph export workflows.
+
+## Sources to inspect
+
+- `interfaces/python/source/quickstart.rst`
+- `interfaces/python/source/usage.rst`
+- `interfaces/python/source/scanpy.rst`
+- `interfaces/python/source/export.rst`
+- `examples/python/`
+- `test/python/` for exact behavior when docs are not enough
+
+## Choose the Python entry point
+
+- Use `infomap.find_communities(...)` for NetworkX-style workflows where the user wants a partition and original node labels.
+- Use `Infomap(...)` when the user needs codelength, flow, hierarchical paths, output files, state/multilayer handling, repeated runs, or tabular results.
+- Use `InfomapOptions` when the same options should be reused across runs or documented as a structured configuration.
+- Use `infomap.tl.infomap(adata, ...)` for AnnData/Scanpy-style observation graphs.
+
+## Common patterns
+
+NetworkX quick path:
+
+```python
+import networkx as nx
+import infomap
+
+graph = nx.karate_club_graph()
+communities = infomap.find_communities(
+    graph,
+    weight="weight",
+    seed=123,
+    num_trials=20,
+    module_attribute="infomap_module",
+)
+```
+
+Explicit run with tabular output:
+
+```python
+from infomap import Infomap
+
+im = Infomap(silent=True, seed=123, num_trials=20)
+mapping = im.add_networkx_graph(graph)
+im.run()
+
+nodes = im.to_dataframe(
+    columns=["node_id", "module_id", "flow"],
+    index="node_id",
+    sort=["module_id", "flow"],
+)
+```
+
+SciPy sparse matrix:
+
+```python
+from infomap import Infomap
+
+im = Infomap.from_scipy_sparse_matrix(
+    adjacency,
+    directed=False,
+    args="--silent --seed 123 --num-trials 20",
+)
+im.run()
+modules = im.get_modules()
+```
+
+Edge-index data:
+
+```python
+from infomap import Infomap
+
+im = Infomap.from_edge_index(
+    edge_index,
+    edge_weight=edge_weight,
+    directed=False,
+    args="--silent --seed 123 --num-trials 20",
+)
+im.run()
+```
+
+Scanpy-style AnnData:
+
+```python
+import infomap
+
+infomap.tl.infomap(
+    adata,
+    key_added="infomap",
+    directed=False,
+    use_weights=True,
+    seed=123,
+    num_trials=20,
+)
+```
+
+## State and multilayer reminders
+
+- NetworkX state networks use a `node_id` node attribute to map states to physical nodes.
+- Multilayer NetworkX graphs additionally use `layer_id`.
+- For state or multilayer output, be explicit whether results should be state-level or physical-node-level.
+- Preserve and report mappings when non-integer labels are converted to internal ids.
+
+## Export and reporting
+
+- Use `to_dataframe()` when a paper or pipeline needs node-level tables.
+- Use `get_modules()` for simple module mappings.
+- Use `infomap.export.write_graphml` or `write_gexf` for NetworkX visualization workflows.
+- Record package version, graph source, directed/weighted choice, seed, `num_trials`, and non-default options.

--- a/skills/infomap/references/python.md
+++ b/skills/infomap/references/python.md
@@ -18,6 +18,8 @@ Use this reference when the user works in Python, notebooks, NetworkX, python-ig
 
 ## Common patterns
 
+For examples in answers, `num_trials=20` is a reasonable research default. For actual validation runs, use a tiny graph or `num_trials=1` first. Ask before running large graphs, many trials, repeated seeds, Scanpy workflows on large AnnData objects, or parameter sweeps.
+
 NetworkX quick path:
 
 ```python

--- a/skills/infomap/references/python.md
+++ b/skills/infomap/references/python.md
@@ -6,6 +6,7 @@ Use this reference when the user works in Python, notebooks, NetworkX, python-ig
 
 - Installed package help and signatures, for example `import infomap`, `help(infomap.Infomap)`, `help(infomap.find_communities)`, and `help(infomap.tl.infomap)`.
 - Installed package metadata, such as `import importlib.metadata; importlib.metadata.version("infomap")`.
+- When inspecting an installed package from an Infomap source checkout, verify `infomap.__file__` so Python has not imported repo-local sources by accident. If needed, run inspection from another working directory or a clean environment.
 - Published Python docs at `https://mapequation.github.io/infomap-python-docs/`.
 - Source checkout files only when the user is actually working inside an Infomap repository.
 

--- a/skills/infomap/references/r.md
+++ b/skills/infomap/references/r.md
@@ -4,11 +4,10 @@ Use this reference when the user works in R, R igraph, R Markdown, data frames, 
 
 ## Sources to inspect
 
-- `interfaces/R/infomap/README.md`
-- `interfaces/R/infomap/R/cluster_infomap.R`
-- `interfaces/R/infomap/R/Infomap.R`
-- `interfaces/R/infomap/R/options.R`
-- `examples/R/`
+- Installed R help: `?infomap::cluster_infomap`, `?infomap::Infomap`, and `?infomap::infomap_options`.
+- Installed package metadata, such as `packageVersion("infomap")`.
+- The r-universe package page and published repository docs when internet access is available.
+- Source checkout files only when the user is actually working inside an Infomap repository.
 
 ## Choose the R entry point
 

--- a/skills/infomap/references/r.md
+++ b/skills/infomap/references/r.md
@@ -2,95 +2,48 @@
 
 Use this reference when the user works in R, R igraph, R Markdown, data frames, or the R6 Infomap API.
 
-## Sources to inspect
+## Authority for current syntax
 
-- Installed R help: `?infomap::cluster_infomap`, `?infomap::Infomap`, and `?infomap::infomap_options`.
-- Installed package metadata, such as `packageVersion("infomap")`.
-- The r-universe package page and published repository docs when internet access is available.
-- Source checkout files only when the user is actually working inside an Infomap repository.
+Do not treat this skill as the R API manual. Before giving runnable code, inspect the installed package:
+
+```r
+packageVersion("infomap")
+system.file(package = "infomap")
+utils::help("cluster_infomap", package = "infomap")
+utils::help("cluster_infomap_multilayer", package = "infomap")
+utils::help("Infomap", package = "infomap")
+utils::help("infomap_options", package = "infomap")
+getNamespaceExports("infomap")
+args(get("cluster_infomap", asNamespace("infomap")))
+args(get("infomap_options", asNamespace("infomap")))
+```
+
+For R6 details, use installed help for `Infomap` and inspect the created object when needed:
+
+```r
+im <- infomap::Infomap(silent = TRUE)
+names(im)
+```
+
+Use the r-universe package page and published repository docs when internet access is available. Use source checkout files only when the user is actually working inside an Infomap repository.
 
 ## Choose the R entry point
 
-- Use `cluster_infomap()` for a one-call data-frame workflow that returns an `infomap_result`.
-- Use `cluster_infomap_multilayer()` for multilayer edge-list data frames.
-- Use the R6 `Infomap(...)` API when the user needs low-level control, custom link addition, codelength, active bindings, or state/multilayer methods.
-- If `igraph` is attached, qualify calls as `infomap::cluster_infomap()` or `igraph::cluster_infomap()` to avoid ambiguity.
+- Prefer the high-level `infomap` package helper for data-frame or igraph workflows when installed help confirms the call shape.
+- Prefer the multilayer helper when installed help confirms the user's edge-list format.
+- Prefer the R6 `Infomap` API when the user needs low-level control, custom link addition, codelength, active bindings, writers, or state/multilayer methods.
+- If `igraph` is attached, qualify calls as `infomap::...` or `igraph::...` to avoid ambiguity. The two packages expose different result objects and argument names.
 
-## Common patterns
+## Generating code
 
-For examples in answers, `num_trials = 20` is a reasonable research default. For actual validation runs, use a tiny graph or `num_trials = 1` first. Ask before running large graphs, many trials, repeated seeds, multilayer sweeps, or expensive R Markdown/notebook-style workflows.
+- Generate code after checking installed help, `args(...)`, or exported objects.
+- Keep examples small. Use one trial for smoke tests; use a meaningful trial count for research runs only after runtime is acceptable.
+- Record R package version, package path, graph source, directed/weighted choice, seed, trials, non-default options, and output artifacts.
+- Preserve mappings when igraph names, physical ids, layer ids, or other labels are converted.
+- For state or multilayer output, state whether results are state-level or physical-node-level.
 
-Data-frame workflow:
+## Minimal patterns
 
-```r
-library(infomap)
+For a quick partition, use the installed high-level helper and inspect its returned object fields. For richer results, create an `Infomap` R6 object, add/read the network with installed methods, run it, then extract codelength, modules, and node/state tables using installed help.
 
-edges <- data.frame(
-  source = c(1, 1, 2, 3, 4, 4, 5),
-  target = c(2, 3, 3, 4, 5, 6, 6)
-)
-
-result <- cluster_infomap(
-  edges,
-  silent = TRUE,
-  num_trials = 20,
-  seed = 123
-)
-
-result$codelength
-result$num_top_modules
-result$modules
-result$nodes
-```
-
-Low-level R6 workflow:
-
-```r
-library(infomap)
-
-im <- Infomap(silent = TRUE, num_trials = 20, seed = 123)
-im$add_links(list(c(1, 2), c(1, 3), c(2, 3), c(3, 4)))
-im$run()
-
-im$codelength
-im$num_top_modules
-as.data.frame(im)
-```
-
-igraph workflow:
-
-```r
-library(igraph)
-library(infomap)
-
-g <- make_graph("Zachary")
-
-im <- Infomap(silent = TRUE, two_level = TRUE, num_trials = 20, seed = 123)
-mapping <- im$add_igraph(g)
-im$run()
-
-communities <- im$as_communities(g)
-```
-
-Namespace choice when both packages are attached:
-
-```r
-# Infomap R package helper: returns an infomap_result with nodes/modules tables.
-result <- infomap::cluster_infomap(g, silent = TRUE, num_trials = 20, seed = 123)
-
-# igraph helper: returns an igraph communities object.
-communities <- igraph::cluster_infomap(g, nb.trials = 20)
-```
-
-## Multilayer reminders
-
-- Use `cluster_infomap_multilayer()` when multilayer links are already in a data frame.
-- Intra-layer-only edge lists can rely on multilayer coupling parameters when appropriate.
-- Use R6 methods such as `add_multilayer_intra_link()` and `add_multilayer_inter_link()` when intra- and inter-layer links come from different sources or carry different meanings.
-
-## Result and reporting reminders
-
-- `result$modules` is a named integer vector from node id to module id.
-- `result$nodes` or `as.data.frame(im)` gives one row per node/state with fields such as flow, name, module id, and layer/state ids when available.
-- State and multilayer graphs can use internal integer ids; preserve the returned mapping when labels matter.
-- Record R package version, graph source, directed/weighted choice, seed, `num_trials`, and non-default options.
+Avoid copying long R examples from this skill. The exact method names, argument aliases, and result fields should come from the installed package and published docs.

--- a/skills/infomap/references/r.md
+++ b/skills/infomap/references/r.md
@@ -18,6 +18,8 @@ Use this reference when the user works in R, R igraph, R Markdown, data frames, 
 
 ## Common patterns
 
+For examples in answers, `num_trials = 20` is a reasonable research default. For actual validation runs, use a tiny graph or `num_trials = 1` first. Ask before running large graphs, many trials, repeated seeds, multilayer sweeps, or expensive R Markdown/notebook-style workflows.
+
 Data-frame workflow:
 
 ```r

--- a/skills/infomap/references/r.md
+++ b/skills/infomap/references/r.md
@@ -1,0 +1,95 @@
+# R Workflows
+
+Use this reference when the user works in R, R igraph, R Markdown, data frames, or the R6 Infomap API.
+
+## Sources to inspect
+
+- `interfaces/R/infomap/README.md`
+- `interfaces/R/infomap/R/cluster_infomap.R`
+- `interfaces/R/infomap/R/Infomap.R`
+- `interfaces/R/infomap/R/options.R`
+- `examples/R/`
+
+## Choose the R entry point
+
+- Use `cluster_infomap()` for a one-call data-frame workflow that returns an `infomap_result`.
+- Use `cluster_infomap_multilayer()` for multilayer edge-list data frames.
+- Use the R6 `Infomap(...)` API when the user needs low-level control, custom link addition, codelength, active bindings, or state/multilayer methods.
+- If `igraph` is attached, qualify calls as `infomap::cluster_infomap()` or `igraph::cluster_infomap()` to avoid ambiguity.
+
+## Common patterns
+
+Data-frame workflow:
+
+```r
+library(infomap)
+
+edges <- data.frame(
+  source = c(1, 1, 2, 3, 4, 4, 5),
+  target = c(2, 3, 3, 4, 5, 6, 6)
+)
+
+result <- cluster_infomap(
+  edges,
+  silent = TRUE,
+  num_trials = 20,
+  seed = 123
+)
+
+result$codelength
+result$num_top_modules
+result$modules
+result$nodes
+```
+
+Low-level R6 workflow:
+
+```r
+library(infomap)
+
+im <- Infomap(silent = TRUE, num_trials = 20, seed = 123)
+im$add_links(list(c(1, 2), c(1, 3), c(2, 3), c(3, 4)))
+im$run()
+
+im$codelength
+im$num_top_modules
+as.data.frame(im)
+```
+
+igraph workflow:
+
+```r
+library(igraph)
+library(infomap)
+
+g <- make_graph("Zachary")
+
+im <- Infomap(silent = TRUE, two_level = TRUE, num_trials = 20, seed = 123)
+mapping <- im$add_igraph(g)
+im$run()
+
+communities <- im$as_communities(g)
+```
+
+Namespace choice when both packages are attached:
+
+```r
+# Infomap R package helper: returns an infomap_result with nodes/modules tables.
+result <- infomap::cluster_infomap(g, silent = TRUE, num_trials = 20, seed = 123)
+
+# igraph helper: returns an igraph communities object.
+communities <- igraph::cluster_infomap(g, nb.trials = 20)
+```
+
+## Multilayer reminders
+
+- Use `cluster_infomap_multilayer()` when multilayer links are already in a data frame.
+- Intra-layer-only edge lists can rely on multilayer coupling parameters when appropriate.
+- Use R6 methods such as `add_multilayer_intra_link()` and `add_multilayer_inter_link()` when intra- and inter-layer links come from different sources or carry different meanings.
+
+## Result and reporting reminders
+
+- `result$modules` is a named integer vector from node id to module id.
+- `result$nodes` or `as.data.frame(im)` gives one row per node/state with fields such as flow, name, module id, and layer/state ids when available.
+- State and multilayer graphs can use internal integer ids; preserve the returned mapping when labels matter.
+- Record R package version, graph source, directed/weighted choice, seed, `num_trials`, and non-default options.

--- a/skills/infomap/references/reproducibility.md
+++ b/skills/infomap/references/reproducibility.md
@@ -23,6 +23,26 @@ Record:
 - Preserve mappings from internal ids to original node labels.
 - Keep state-level and physical-node-level outputs separate when higher-order or multilayer data are involved.
 
+## Runtime planning
+
+Use these local benchmark results only as order-of-magnitude guidance. They were measured on macOS arm64 with Infomap 2.10.1, `seed=123`, no file output, and wall-clock time around `read_file + run`. Python used the package API from a virtual environment; R includes one-shot `Rscript` startup overhead.
+
+| Network | Size | States | Links | Trials | CLI | Python | R |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| state ring | 0.47 MB | 10k | 20k | 1 | 0.25s | 1.06s | 0.60s |
+| state ring | 0.47 MB | 10k | 20k | 20 | 2.07s | 2.32s | 5.87s |
+| sparse graph | 0.61 MB | 0 | 50k | 1 | 0.24s | 0.60s | 0.44s |
+| sparse graph | 0.61 MB | 0 | 50k | 20 | 3.17s | 3.64s | 4.15s |
+| first-order edge list | 16.9 MB | 0 | 1M | 1 | 3.80s | 4.11s | 8.22s |
+| first-order edge list | 16.9 MB | 0 | 1M | 5 | 16.68s | 17.55s | 41.40s |
+| state network | 19.2 MB | 400k | 800k | 1 | 10.62s | 11.51s | 26.49s |
+
+Practical gating:
+
+- Run without asking for tiny examples, smoke checks, and single-trial runs on networks around 1M links or less when the user asked for execution.
+- Ask before running `num_trials=20` on million-link or state-heavy networks unless the user explicitly requested a research run.
+- Ask before parameter sweeps, repeated seeds, full notebooks, Docker/Jupyter startup, multilayer/state networks beyond these sizes, or inputs where size is unknown.
+
 ## Method-section checklist
 
 An English method paragraph should usually state:

--- a/skills/infomap/references/reproducibility.md
+++ b/skills/infomap/references/reproducibility.md
@@ -1,0 +1,50 @@
+# Reproducibility and Reporting
+
+Use this reference when the user asks for a method section, provenance checklist, run logging, result interpretation, or publication-ready workflow.
+
+## Minimum run record
+
+Record:
+
+- Infomap version and interface: CLI, Python package, or R package.
+- Input source, preprocessing steps, node/link definitions, and whether links are weighted or directed.
+- Flow model or directedness choice.
+- Non-default options, especially `two_level`, state/multilayer/metadata/bipartite settings, and output options.
+- `seed` and `num_trials`.
+- Output files or objects used for downstream analysis.
+- Number of top modules and codelength for the reported run.
+
+## Recommended defaults
+
+- Set `seed` for repeatability.
+- Use more than one trial for serious analyses; `num_trials=20` is a practical default in examples, but large or time-sensitive runs may need adjustment.
+- Save both machine-readable results and human-readable notes.
+- Preserve mappings from internal ids to original node labels.
+- Keep state-level and physical-node-level outputs separate when higher-order or multilayer data are involved.
+
+## Method-section checklist
+
+An English method paragraph should usually state:
+
+- what the network represents;
+- whether links are directed and/or weighted;
+- which Infomap interface and version were used;
+- the key options, including flow model when relevant;
+- `seed` and `num_trials`;
+- whether a two-level or multilevel solution was used;
+- which output was analyzed: top-level modules, hierarchy paths, state nodes, physical nodes, or exported graph attributes.
+
+## Template method text
+
+Use this as a starting point and adapt it to the actual run:
+
+```text
+We detected flow-based communities with Infomap using the map equation framework. The network nodes represented [entities], and links represented [interaction or flow definition]. Links were treated as [directed/undirected] and [weighted/unweighted]. We ran Infomap [version/interface] with seed 123 and 20 trials, keeping the solution with the shortest codelength. We analyzed [top-level modules / the multilevel hierarchy / state-level assignments] and recorded the input data, non-default options, codelength, and module assignments for reproducibility.
+```
+
+## Result interpretation
+
+- `codelength` summarizes compression quality for the chosen model and run.
+- `num_top_modules` is the number of top-level modules.
+- Hierarchical output paths encode nested modules; do not collapse them unless the user wants top-level labels.
+- State nodes can allow the same physical node to appear in different modules; report whether assignments are state-level or merged to physical nodes.

--- a/skills/infomap/references/reproducibility.md
+++ b/skills/infomap/references/reproducibility.md
@@ -39,8 +39,8 @@ Use these local benchmark results only as order-of-magnitude guidance. They were
 
 Practical gating:
 
-- Run without asking for tiny examples, smoke checks, and single-trial runs on networks around 1M links or less when the user asked for execution.
-- Ask before running `num_trials=20` on million-link or state-heavy networks unless the user explicitly requested a research run.
+- Run without asking only for tiny examples, known-small smoke checks, and single-trial runs where the user requested execution and the resource context is clear.
+- Ask before million-link runs, `num_trials=20` on large or state-heavy networks, or any run that could be intrusive in a notebook, shared server, CI job, or memory-limited environment.
 - Ask before parameter sweeps, repeated seeds, full notebooks, Docker/Jupyter startup, multilayer/state networks beyond these sizes, or inputs where size is unknown.
 
 ## Method-section checklist

--- a/skills/infomap/references/reproducibility.md
+++ b/skills/infomap/references/reproducibility.md
@@ -18,6 +18,7 @@ Record:
 
 - Set `seed` for repeatability.
 - Use more than one trial for serious analyses; `num_trials=20` is a practical default in examples, but large or time-sensitive runs may need adjustment.
+- Separate smoke checks from research runs: use small inputs or one trial to validate setup, then ask before launching long runs, sweeps, repeated seeds, or notebook executions.
 - Save both machine-readable results and human-readable notes.
 - Preserve mappings from internal ids to original node labels.
 - Keep state-level and physical-node-level outputs separate when higher-order or multilayer data are involved.

--- a/skills/infomap/references/reproducibility.md
+++ b/skills/infomap/references/reproducibility.md
@@ -69,3 +69,26 @@ We detected flow-based communities with Infomap using the map equation framework
 - `num_top_modules` is the number of top-level modules.
 - Hierarchical output paths encode nested modules; do not collapse them unless the user wants top-level labels.
 - State nodes can allow the same physical node to appear in different modules; report whether assignments are state-level or merged to physical nodes.
+
+## Codelength and one-module results
+
+When Infomap returns one top module, first compare the total modular `codelength` with `one_level_codelength`.
+
+- `one_level_codelength` is the non-modular baseline: one codebook for the whole network flow.
+- `codelength` is the total description length of the selected partition.
+- For modular results, `codelength = index_codelength + module_codelength`.
+- `module_codelength` alone is not the value to compare against `one_level_codelength`; the index codebook also costs bits.
+
+If the best modular partition has a total `codelength` that is not lower than `one_level_codelength`, Infomap may collapse the solution to one module. This usually means that, under the current network representation and flow model, modules do not compress the flow better than a one-level description. It is not automatically an error.
+
+If the user expected multiple modules, check:
+
+- **Input semantics**: weights should mean stronger flow or interaction, not distances or dissimilarities unless transformed.
+- **Direction and flow model**: verify directedness, observed-flow assumptions, and `flow_model`/`--directed` choices.
+- **Network construction**: check that ids, delimiters, isolated nodes, duplicate links, self-links, and component structure match the intended graph.
+- **Search stability**: rerun with a fixed `seed`, then increase `num_trials` or compare several seeds to rule out a poor local optimum.
+- **Resolution scale**: for exploratory sensitivity analysis, try lower `markov_time` values to look for smaller-scale modules; report this as a non-default modeling choice.
+- **Representation**: if the data have layers, sequence memory, metadata, or bipartite structure, model those explicitly instead of flattening away the signal.
+- **Expectation check**: if no tested representation improves on the one-level codelength, report the one-module result rather than forcing a partition.
+
+Avoid presenting forced module counts as evidence of community structure. Options such as preferred module counts or non-default Markov time can be useful for sensitivity analysis, but they change the model and must be reported.

--- a/skills/infomap/references/reproducibility.md
+++ b/skills/infomap/references/reproducibility.md
@@ -72,14 +72,14 @@ We detected flow-based communities with Infomap using the map equation framework
 
 ## Codelength and one-module results
 
-When Infomap returns one top module, first compare the total modular `codelength` with `one_level_codelength`.
+When Infomap returns one top module, the reported `codelength` is normally equal to `one_level_codelength`. That equality does not diagnose the cause by itself; it says the selected result is the non-modular baseline.
 
 - `one_level_codelength` is the non-modular baseline: one codebook for the whole network flow.
 - `codelength` is the total description length of the selected partition.
 - For modular results, `codelength = index_codelength + module_codelength`.
 - `module_codelength` alone is not the value to compare against `one_level_codelength`; the index codebook also costs bits.
 
-If the best modular partition has a total `codelength` that is not lower than `one_level_codelength`, Infomap may collapse the solution to one module. This usually means that, under the current network representation and flow model, modules do not compress the flow better than a one-level description. It is not automatically an error.
+Infomap may collapse to one module when candidate modular partitions do not improve the total codelength over the one-level solution. This usually means that, under the current network representation and flow model, modules do not compress the flow better than a one-level description. It is not automatically an error.
 
 If the user expected multiple modules, check:
 
@@ -87,8 +87,10 @@ If the user expected multiple modules, check:
 - **Direction and flow model**: verify directedness, observed-flow assumptions, and `flow_model`/`--directed` choices.
 - **Network construction**: check that ids, delimiters, isolated nodes, duplicate links, self-links, and component structure match the intended graph.
 - **Search stability**: rerun with a fixed `seed`, then increase `num_trials` or compare several seeds to rule out a poor local optimum.
-- **Resolution scale**: for exploratory sensitivity analysis, try lower `markov_time` values to look for smaller-scale modules; report this as a non-default modeling choice.
+- **Supplied partition diagnostic**: initialize from a candidate partition with `--cluster-data` and run `--no-infomap` to calculate its codelength without optimization. This helps test whether the expected partition compresses flow better than the one-level baseline.
+- **Resolution scale**: for exploratory sensitivity analysis, try lower `markov_time` values to look for smaller-scale modules; this is a modeling choice and needs extra thought before being used in a reported result.
+- **Preferred module count**: `preferred_number_of_modules` / `--preferred-number-of-modules` can explore what partitions near a target count look like; this is also a modeling choice, not neutral evidence that the data contain that many modules.
 - **Representation**: if the data have layers, sequence memory, metadata, or bipartite structure, model those explicitly instead of flattening away the signal.
 - **Expectation check**: if no tested representation improves on the one-level codelength, report the one-module result rather than forcing a partition.
 
-Avoid presenting forced module counts as evidence of community structure. Options such as preferred module counts or non-default Markov time can be useful for sensitivity analysis, but they change the model and must be reported.
+Avoid presenting forced module counts as evidence of community structure. Non-default Markov time and preferred module counts can be useful for sensitivity analysis, but they change the model and must be reported.

--- a/skills/infomap/references/reproducibility.md
+++ b/skills/infomap/references/reproducibility.md
@@ -84,12 +84,12 @@ Infomap may collapse to one module when candidate modular partitions do not impr
 If the user expected multiple modules, check:
 
 - **Input semantics**: weights should mean stronger flow or interaction, not distances or dissimilarities unless transformed.
-- **Direction and flow model**: verify directedness, observed-flow assumptions, and `flow_model`/`--directed` choices.
+- **Direction and flow model**: verify directedness, observed-flow assumptions, and the installed flow-model or directedness options.
 - **Network construction**: check that ids, delimiters, isolated nodes, duplicate links, self-links, and component structure match the intended graph.
 - **Search stability**: rerun with a fixed `seed`, then increase `num_trials` or compare several seeds to rule out a poor local optimum.
-- **Supplied partition diagnostic**: initialize from a candidate partition with `--cluster-data` and run `--no-infomap` to calculate its codelength without optimization. This helps test whether the expected partition compresses flow better than the one-level baseline.
-- **Resolution scale**: for exploratory sensitivity analysis, try lower `markov_time` values to look for smaller-scale modules; this is a modeling choice and needs extra thought before being used in a reported result.
-- **Preferred module count**: `preferred_number_of_modules` / `--preferred-number-of-modules` can explore what partitions near a target count look like; this is also a modeling choice, not neutral evidence that the data contain that many modules.
+- **Supplied partition diagnostic**: if the installed interface supports cluster-data input and no-optimization codelength calculation, use it to test whether an expected partition compresses flow better than the one-level baseline.
+- **Resolution scale**: for exploratory sensitivity analysis, try lower Markov-time settings to look for smaller-scale modules; this is a modeling choice and needs extra thought before being used in a reported result.
+- **Preferred module count**: if the installed interface supports a preferred module count, it can explore what partitions near a target count look like; this is also a modeling choice, not neutral evidence that the data contain that many modules.
 - **Representation**: if the data have layers, sequence memory, metadata, or bipartite structure, model those explicitly instead of flattening away the signal.
 - **Expectation check**: if no tested representation improves on the one-level codelength, report the one-module result rather than forcing a partition.
 


### PR DESCRIPTION
## Summary
- add a repo-local Infomap agent skill for CLI, Python, R, and notebook research workflows
- include focused references for method selection, reproducibility, and interface-specific usage
- document the skill location from the repository README

## Verification
- ran a structural check for the skill frontmatter, UI metadata, and reference files
- checked README and skill files for placeholders
- validated weak skill scenarios with a subagent review