### PR TITLE
fix: align Python network input validation

### DIFF
--- a/interfaces/python/src/infomap/_network_input.py
+++ b/interfaces/python/src/infomap/_network_input.py
@@ -1,3 +1,6 @@
+import numbers
+
+
 def is_numpy_input(value):
     return value.__class__.__module__.startswith("numpy")
 
@@ -87,13 +90,45 @@ class RowUnpacker:
         return self._callback(row, row_length)
 
 
+def scalar_numeric(value, *, scalar_message, numeric_message):
+    if isinstance(value, bool):
+        raise ValueError(numeric_message)
+    if isinstance(value, (str, bytes)):
+        raise ValueError(numeric_message)
+    try:
+        len(value)
+    except TypeError:
+        pass
+    else:
+        raise ValueError(scalar_message)
+    if not isinstance(value, numbers.Real):
+        raise ValueError(numeric_message)
+    return value
+
+
 def first_order_unpacker():
     def unpack(row, row_length):
         if row_length == 2:
             source_id, target_id = row
-            return (source_id, target_id), 1.0
-        source_id, target_id, weight = row
-        return (source_id, target_id), weight
+            weight = 1.0
+        else:
+            source_id, target_id, weight = row
+        return (
+            scalar_numeric(
+                source_id,
+                scalar_message="Each link source value must be scalar.",
+                numeric_message="Link source and target values must be numeric.",
+            ),
+            scalar_numeric(
+                target_id,
+                scalar_message="Each link target value must be scalar.",
+                numeric_message="Link source and target values must be numeric.",
+            ),
+        ), scalar_numeric(
+            weight,
+            scalar_message="Each link weight value must be scalar.",
+            numeric_message="Link weight values must be numeric.",
+        )
 
     return RowUnpacker(2, "(source_id, target_id, [weight])", unpack)
 
@@ -101,9 +136,22 @@ def first_order_unpacker():
 def flat_multilayer_unpacker(value_names):
     def unpack(row, row_length):
         if row_length == len(value_names):
-            return tuple(row), 1.0
-        *values, weight = row
-        return tuple(values), weight
+            values = tuple(row)
+            weight = 1.0
+        else:
+            *values, weight = row
+        return tuple(
+            scalar_numeric(
+                value,
+                scalar_message=f"Each multilayer {name} value must be scalar.",
+                numeric_message="Multilayer id values must be numeric.",
+            )
+            for name, value in zip(value_names, values)
+        ), scalar_numeric(
+            weight,
+            scalar_message="Each multilayer weight value must be scalar.",
+            numeric_message="Multilayer weight values must be numeric.",
+        )
 
     return RowUnpacker(
         len(value_names),
@@ -129,10 +177,30 @@ def paired_multilayer_unpacker():
             ) from err
 
         return (
-            source_layer_id,
-            source_node_id,
-            target_layer_id,
-            target_node_id,
-        ), weight
+            scalar_numeric(
+                source_layer_id,
+                scalar_message="Each multilayer source layer value must be scalar.",
+                numeric_message="Multilayer layer and node values must be numeric.",
+            ),
+            scalar_numeric(
+                source_node_id,
+                scalar_message="Each multilayer source node value must be scalar.",
+                numeric_message="Multilayer layer and node values must be numeric.",
+            ),
+            scalar_numeric(
+                target_layer_id,
+                scalar_message="Each multilayer target layer value must be scalar.",
+                numeric_message="Multilayer layer and node values must be numeric.",
+            ),
+            scalar_numeric(
+                target_node_id,
+                scalar_message="Each multilayer target node value must be scalar.",
+                numeric_message="Multilayer layer and node values must be numeric.",
+            ),
+        ), scalar_numeric(
+            weight,
+            scalar_message="Each multilayer link weight value must be scalar.",
+            numeric_message="Multilayer link weight values must be numeric.",
+        )
 
     return RowUnpacker(4, "(source_node, target_node, [weight])", unpack)

--- a/test/python/test_add_links.py
+++ b/test/python/test_add_links.py
@@ -25,7 +25,15 @@ def test_add_links_smoke(make_infomap, load_graph_fixture, canonical_modules):
 
 
 def test_add_links_matches_repeated_add_link(make_infomap, canonical_modules):
-    links = [(1, 2, 2.0), (1, 3, 2.0), (2, 3, 2.0), (3, 4, 1.0), (4, 5, 3.0), (4, 6, 3.0), (5, 6, 3.0)]
+    links = [
+        (1, 2, 2.0),
+        (1, 3, 2.0),
+        (2, 3, 2.0),
+        (3, 4, 1.0),
+        (4, 5, 3.0),
+        (4, 6, 3.0),
+        (5, 6, 3.0),
+    ]
 
     baseline = make_infomap()
     for link in links:
@@ -39,7 +47,9 @@ def test_add_links_matches_repeated_add_link(make_infomap, canonical_modules):
     assert im.num_links == baseline.num_links
     assert im.num_nodes == baseline.num_nodes
     assert im.codelength == pytest.approx(baseline.codelength)
-    assert canonical_modules(im.get_modules()) == canonical_modules(baseline.get_modules())
+    assert canonical_modules(im.get_modules()) == canonical_modules(
+        baseline.get_modules()
+    )
 
 
 def test_add_links_rejects_invalid_link_lengths(make_infomap):
@@ -50,6 +60,22 @@ def test_add_links_rejects_invalid_link_lengths(make_infomap):
 
     with pytest.raises(ValueError, match="2 or 3 values"):
         im.add_links([(1, 2, 3, 4)])
+
+
+def test_add_links_rejects_non_numeric_iterable_values(make_infomap):
+    im = make_infomap()
+
+    with pytest.raises(ValueError, match="source.*scalar"):
+        im.add_links([([1], 2)])
+
+    with pytest.raises(ValueError, match="source and target values must be numeric"):
+        im.add_links([("1", 2)])
+
+    with pytest.raises(ValueError, match="weight value must be scalar"):
+        im.add_links([(1, 2, [3])])
+
+    with pytest.raises(ValueError, match="weight values must be numeric"):
+        im.add_links([(1, 2, "3")])
 
 
 def test_add_links_accepts_weighted_numpy_array(make_infomap, canonical_modules):
@@ -79,7 +105,9 @@ def test_add_links_accepts_weighted_numpy_array(make_infomap, canonical_modules)
     assert im.num_links == baseline.num_links
     assert im.num_nodes == baseline.num_nodes
     assert im.codelength == pytest.approx(baseline.codelength)
-    assert canonical_modules(im.get_modules()) == canonical_modules(baseline.get_modules())
+    assert canonical_modules(im.get_modules()) == canonical_modules(
+        baseline.get_modules()
+    )
 
 
 def test_add_links_accepts_numpy_array_with_duplicates_and_existing_links(make_infomap):

--- a/test/python/test_add_multilayer_intra_inter_links.py
+++ b/test/python/test_add_multilayer_intra_inter_links.py
@@ -31,7 +31,9 @@ def assert_same_result(actual, expected):
     assert actual.get_modules(states=True) == expected.get_modules(states=True)
 
 
-def test_add_multilayer_intra_links_matches_repeated_add_multilayer_intra_link(make_infomap):
+def test_add_multilayer_intra_links_matches_repeated_add_multilayer_intra_link(
+    make_infomap,
+):
     baseline = make_infomap(two_level=True)
     for link in INTRA_LINKS:
         baseline.add_multilayer_intra_link(*link)
@@ -89,7 +91,9 @@ def test_add_multilayer_intra_links_accepts_non_contiguous_numpy_array(make_info
     assert_same_result(im, baseline)
 
 
-def test_add_multilayer_inter_links_matches_repeated_add_multilayer_inter_link(make_infomap):
+def test_add_multilayer_inter_links_matches_repeated_add_multilayer_inter_link(
+    make_infomap,
+):
     baseline = make_infomap(two_level=True)
     baseline.add_multilayer_intra_links(INTRA_LINKS)
     for link in INTER_LINKS:
@@ -175,6 +179,22 @@ def test_add_multilayer_intra_links_rejects_invalid_input(make_infomap):
         im.add_multilayer_intra_links(np.array([["1", "2", "3"]]))
 
 
+def test_add_multilayer_intra_links_rejects_non_numeric_iterable_values(make_infomap):
+    im = make_infomap()
+
+    with pytest.raises(ValueError, match="layer_id value must be scalar"):
+        im.add_multilayer_intra_links([([1], 2, 3)])
+
+    with pytest.raises(ValueError, match="id values must be numeric"):
+        im.add_multilayer_intra_links([("1", 2, 3)])
+
+    with pytest.raises(ValueError, match="weight value must be scalar"):
+        im.add_multilayer_intra_links([(1, 2, 3, [1.0])])
+
+    with pytest.raises(ValueError, match="weight values must be numeric"):
+        im.add_multilayer_intra_links([(1, 2, 3, "1.0")])
+
+
 def test_add_multilayer_inter_links_rejects_invalid_input(make_infomap):
     np = pytest.importorskip("numpy")
     im = make_infomap()
@@ -193,6 +213,22 @@ def test_add_multilayer_inter_links_rejects_invalid_input(make_infomap):
 
     with pytest.raises(ValueError, match="numeric dtype"):
         im.add_multilayer_inter_links(np.array([["1", "2", "3"]]))
+
+
+def test_add_multilayer_inter_links_rejects_non_numeric_iterable_values(make_infomap):
+    im = make_infomap()
+
+    with pytest.raises(ValueError, match="source_layer_id value must be scalar"):
+        im.add_multilayer_inter_links([([1], 2, 3)])
+
+    with pytest.raises(ValueError, match="id values must be numeric"):
+        im.add_multilayer_inter_links([("1", 2, 3)])
+
+    with pytest.raises(ValueError, match="weight value must be scalar"):
+        im.add_multilayer_inter_links([(1, 2, 3, [1.0])])
+
+    with pytest.raises(ValueError, match="weight values must be numeric"):
+        im.add_multilayer_inter_links([(1, 2, 3, "1.0")])
 
 
 def test_add_multilayer_inter_links_preserves_native_layer_validation(make_infomap):

--- a/test/python/test_add_multilayer_links.py
+++ b/test/python/test_add_multilayer_links.py
@@ -16,7 +16,11 @@ def test_add_multilayer_links_matches_repeated_add_multilayer_link(make_infomap)
     links = [
         ((0, 1), (1, 2), 1.5),
         ((0, 3), (1, 2), 2.0),
-        (MultilayerNode(layer_id=1, node_id=2), MultilayerNode(layer_id=2, node_id=4), 3.0),
+        (
+            MultilayerNode(layer_id=1, node_id=2),
+            MultilayerNode(layer_id=2, node_id=4),
+            3.0,
+        ),
     ]
 
     baseline = make_infomap()
@@ -70,7 +74,9 @@ def test_add_multilayer_links_accepts_unweighted_numpy_array(make_infomap):
 
     baseline = make_infomap()
     for source_layer, source_node, target_layer, target_node in links.tolist():
-        baseline.add_multilayer_link((source_layer, source_node), (target_layer, target_node))
+        baseline.add_multilayer_link(
+            (source_layer, source_node), (target_layer, target_node)
+        )
 
     im = make_infomap()
     im.add_multilayer_links(links)
@@ -118,6 +124,22 @@ def test_add_multilayer_links_rejects_invalid_node_lengths(make_infomap):
 
     with pytest.raises(ValueError, match="multilayer node.*2 values"):
         im.add_multilayer_links([((0, 1), (1, 2, 3))])
+
+
+def test_add_multilayer_links_rejects_non_numeric_iterable_values(make_infomap):
+    im = make_infomap()
+
+    with pytest.raises(ValueError, match="source layer value must be scalar"):
+        im.add_multilayer_links([(([0], 1), (1, 2))])
+
+    with pytest.raises(ValueError, match="layer and node values must be numeric"):
+        im.add_multilayer_links([(("0", 1), (1, 2))])
+
+    with pytest.raises(ValueError, match="weight value must be scalar"):
+        im.add_multilayer_links([((0, 1), (1, 2), [1.0])])
+
+    with pytest.raises(ValueError, match="weight values must be numeric"):
+        im.add_multilayer_links([((0, 1), (1, 2), "1.0")])
 
 
 def test_add_multilayer_links_rejects_invalid_numpy_shapes(make_infomap):


### PR DESCRIPTION
## Summary

- align Python iterable network input validation with the shared contract from #565
- reject non-scalar and non-numeric source/target/layer/node/weight values before calling SWIG
- add first-order, full multilayer, intra-layer, and inter-layer invalid-input coverage

Stacked on #565. Completes phase 3 alignment for the safe malformed-input differences identified after phases 1 and 2.

## Verification

- /opt/homebrew/bin/python3 -m ruff format interfaces/python/src/infomap/_network_input.py test/python/test_add_links.py test/python/test_add_multilayer_links.py test/python/test_add_multilayer_intra_inter_links.py
- /opt/homebrew/bin/python3 -m ruff check interfaces/python/src/infomap/_network_input.py test/python/test_add_links.py test/python/test_add_multilayer_links.py test/python/test_add_multilayer_intra_inter_links.py
- make test-python-unit PYTEST_ARGS='test/python/test_add_links.py test/python/test_add_multilayer_links.py test/python/test_add_multilayer_intra_inter_links.py'
- git diff --check
