### PR TITLE
chore: format

### DIFF
--- a/interfaces/python/src/infomap/_results.py
+++ b/interfaces/python/src/infomap/_results.py
@@ -601,7 +601,7 @@ class _InfomapResultsMixin:
 
         if pandas is None:
             raise ImportError(
-                'Cannot import package `pandas`. Install it with '
+                "Cannot import package `pandas`. Install it with "
                 '`python -m pip install "infomap[pandas]"`.'
             )
 
@@ -660,7 +660,7 @@ class _InfomapResultsMixin:
         """
         if pandas is None:
             raise ImportError(
-                'Cannot import package `pandas`. Install it with '
+                "Cannot import package `pandas`. Install it with "
                 '`python -m pip install "infomap[pandas]"`.'
             )
 
@@ -671,12 +671,15 @@ class _InfomapResultsMixin:
 
         requested_columns = list(columns)
         resolved_columns = [
-            _DATAFRAME_COLUMN_ALIASES.get(column, column) for column in requested_columns
+            _DATAFRAME_COLUMN_ALIASES.get(column, column)
+            for column in requested_columns
         ]
         names = self.names if "name" in resolved_columns else None
         column_getters = [
             _to_dataframe_column_getter(requested, resolved, names)
-            for requested, resolved in zip(requested_columns, resolved_columns, strict=True)
+            for requested, resolved in zip(
+                requested_columns, resolved_columns, strict=True
+            )
         ]
         data = {column: [] for column in requested_columns}
 

--- a/mk/python.mk
+++ b/mk/python.mk
@@ -27,7 +27,6 @@ PYTHON_FORMAT_TARGETS := \
 	interfaces/python/src/infomap/_facade.py \
 	interfaces/python/src/infomap/_networkx.py \
 	interfaces/python/src/infomap/_optional.py \
-	interfaces/python/src/infomap/_options.py \
 	interfaces/python/src/infomap/_results.py \
 	interfaces/python/src/infomap/_version.py \
 	interfaces/python/src/infomap/_writers.py \

--- a/src/Infomap.h
+++ b/src/Infomap.h
@@ -78,8 +78,7 @@ public:
                           const std::vector<unsigned int>& targetNodeIds,
                           const std::vector<double>& weights)
   {
-    m_network.addMultilayerLinks(sourceLayerIds, sourceNodeIds, targetLayerIds, targetNodeIds,
-                                 weights);
+    m_network.addMultilayerLinks(sourceLayerIds, sourceNodeIds, targetLayerIds, targetNodeIds, weights);
   }
   void addMultilayerIntraLink(unsigned int layer, unsigned int n1, unsigned int n2, double weight) { m_network.addMultilayerIntraLink(layer, n1, n2, weight); }
   void addMultilayerIntraLinks(const std::vector<unsigned int>& layerIds,

--- a/src/io/Network.cpp
+++ b/src/io/Network.cpp
@@ -25,64 +25,64 @@ using std::make_pair;
 
 namespace {
 
-inline bool isInputWhitespace(char c)
-{
-  return c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '\f' || c == '\v';
-}
-
-inline bool isDigit(char c)
-{
-  return c >= '0' && c <= '9';
-}
-
-void skipWhitespace(const char*& p)
-{
-  while (isInputWhitespace(*p)) {
-    ++p;
-  }
-}
-
-bool parseUnsigned(const char*& p, unsigned int& value)
-{
-  skipWhitespace(p);
-  if (*p == '+') {
-    ++p;
-  }
-  if (!isDigit(*p)) {
-    return false;
+  inline bool isInputWhitespace(char c)
+  {
+    return c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '\f' || c == '\v';
   }
 
-  unsigned long long result = 0;
-  const unsigned long long maxValue = std::numeric_limits<unsigned int>::max();
-  do {
-    result = result * 10 + static_cast<unsigned long long>(*p - '0');
-    if (result > maxValue) {
+  inline bool isDigit(char c)
+  {
+    return c >= '0' && c <= '9';
+  }
+
+  void skipWhitespace(const char*& p)
+  {
+    while (isInputWhitespace(*p)) {
+      ++p;
+    }
+  }
+
+  bool parseUnsigned(const char*& p, unsigned int& value)
+  {
+    skipWhitespace(p);
+    if (*p == '+') {
+      ++p;
+    }
+    if (!isDigit(*p)) {
       return false;
     }
-    ++p;
-  } while (isDigit(*p));
 
-  value = static_cast<unsigned int>(result);
-  return true;
-}
+    unsigned long long result = 0;
+    const unsigned long long maxValue = std::numeric_limits<unsigned int>::max();
+    do {
+      result = result * 10 + static_cast<unsigned long long>(*p - '0');
+      if (result > maxValue) {
+        return false;
+      }
+      ++p;
+    } while (isDigit(*p));
 
-bool parseOptionalDouble(const char*& p, double& value)
-{
-  skipWhitespace(p);
-  if (*p == '\0' || *p == '#') {
-    return false;
+    value = static_cast<unsigned int>(result);
+    return true;
   }
 
-  char* end = nullptr;
-  const double parsed = std::strtod(p, &end);
-  if (end == p) {
-    return false;
-  }
+  bool parseOptionalDouble(const char*& p, double& value)
+  {
+    skipWhitespace(p);
+    if (*p == '\0' || *p == '#') {
+      return false;
+    }
 
-  value = parsed;
-  p = end;
-  return true;
-}
+    char* end = nullptr;
+    const double parsed = std::strtod(p, &end);
+    if (end == p) {
+      return false;
+    }
+
+    value = parsed;
+    p = end;
+    return true;
+  }
 
 } // namespace
 
@@ -654,10 +654,7 @@ void Network::addMultilayerLinks(const std::vector<unsigned int>& sourceLayerIds
                                  const std::vector<unsigned int>& targetNodeIds,
                                  const std::vector<double>& weights)
 {
-  if (sourceLayerIds.size() != sourceNodeIds.size() ||
-      sourceLayerIds.size() != targetLayerIds.size() ||
-      sourceLayerIds.size() != targetNodeIds.size() ||
-      sourceLayerIds.size() != weights.size()) {
+  if (sourceLayerIds.size() != sourceNodeIds.size() || sourceLayerIds.size() != targetLayerIds.size() || sourceLayerIds.size() != targetNodeIds.size() || sourceLayerIds.size() != weights.size()) {
     throw std::invalid_argument("sourceLayerIds, sourceNodeIds, targetLayerIds, targetNodeIds, and weights must have the same length");
   }
 
@@ -1057,9 +1054,7 @@ void Network::addMultilayerIntraLinks(const std::vector<unsigned int>& layerIds,
                                       const std::vector<unsigned int>& targetNodeIds,
                                       const std::vector<double>& weights)
 {
-  if (layerIds.size() != sourceNodeIds.size() ||
-      layerIds.size() != targetNodeIds.size() ||
-      layerIds.size() != weights.size()) {
+  if (layerIds.size() != sourceNodeIds.size() || layerIds.size() != targetNodeIds.size() || layerIds.size() != weights.size()) {
     throw std::invalid_argument("layerIds, sourceNodeIds, targetNodeIds, and weights must have the same length");
   }
 
@@ -1089,9 +1084,7 @@ void Network::addMultilayerInterLinks(const std::vector<unsigned int>& sourceLay
                                       const std::vector<unsigned int>& targetLayerIds,
                                       const std::vector<double>& weights)
 {
-  if (sourceLayerIds.size() != nodeIds.size() ||
-      sourceLayerIds.size() != targetLayerIds.size() ||
-      sourceLayerIds.size() != weights.size()) {
+  if (sourceLayerIds.size() != nodeIds.size() || sourceLayerIds.size() != targetLayerIds.size() || sourceLayerIds.size() != weights.size()) {
     throw std::invalid_argument("sourceLayerIds, nodeIds, targetLayerIds, and weights must have the same length");
   }
 

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -84,7 +84,9 @@ def _parse_graph_fixture(path: Path) -> list[tuple[int, ...]]:
         elif len(parts) == 3:
             links.append((int(parts[0]), int(parts[1]), float(parts[2])))
         else:
-            raise ValueError(f"Invalid graph fixture line {line_number} in {path}: {raw_line!r}")
+            raise ValueError(
+                f"Invalid graph fixture line {line_number} in {path}: {raw_line!r}"
+            )
 
     return links
 
@@ -99,7 +101,9 @@ def graph_fixture_links(graph_fixture_path):
 
 @pytest.fixture
 def load_graph_fixture(graph_fixture_links):
-    def _load_graph_fixture(im: Infomap, name: str, *, method: str = "add_links") -> list[tuple[int, ...]]:
+    def _load_graph_fixture(
+        im: Infomap, name: str, *, method: str = "add_links"
+    ) -> list[tuple[int, ...]]:
         links = graph_fixture_links(name)
         if method == "add_links":
             im.add_links(links)
@@ -113,7 +117,9 @@ def load_graph_fixture(graph_fixture_links):
     return _load_graph_fixture
 
 
-def _canonical_modules(modules: Union[Iterable[tuple[int, int]], dict[int, int]]) -> list[list[int]]:
+def _canonical_modules(
+    modules: Union[Iterable[tuple[int, int]], dict[int, int]],
+) -> list[list[int]]:
     grouped: dict[int, list[int]] = {}
     items = modules.items() if isinstance(modules, dict) else modules
     for node_id, module_id in items:
@@ -135,7 +141,9 @@ def output_dir(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def make_infomap():
-    def _make_infomap(*, seed: int = 123, num_trials: int = 1, silent: bool = True, **kwargs) -> Infomap:
+    def _make_infomap(
+        *, seed: int = 123, num_trials: int = 1, silent: bool = True, **kwargs
+    ) -> Infomap:
         return Infomap(seed=seed, num_trials=num_trials, silent=silent, **kwargs)
 
     return _make_infomap
@@ -144,6 +152,8 @@ def make_infomap():
 @pytest.fixture
 def assert_pajek_matches_fixture():
     def _assert_pajek_matches_fixture(actual_path: Path, expected_path: Path) -> None:
-        assert _normalized_pajek_lines(actual_path) == _normalized_pajek_lines(expected_path)
+        assert _normalized_pajek_lines(actual_path) == _normalized_pajek_lines(
+            expected_path
+        )
 
     return _assert_pajek_matches_fixture

--- a/test/python/test_add_links.py
+++ b/test/python/test_add_links.py
@@ -25,7 +25,15 @@ def test_add_links_smoke(make_infomap, load_graph_fixture, canonical_modules):
 
 
 def test_add_links_matches_repeated_add_link(make_infomap, canonical_modules):
-    links = [(1, 2, 2.0), (1, 3, 2.0), (2, 3, 2.0), (3, 4, 1.0), (4, 5, 3.0), (4, 6, 3.0), (5, 6, 3.0)]
+    links = [
+        (1, 2, 2.0),
+        (1, 3, 2.0),
+        (2, 3, 2.0),
+        (3, 4, 1.0),
+        (4, 5, 3.0),
+        (4, 6, 3.0),
+        (5, 6, 3.0),
+    ]
 
     baseline = make_infomap()
     for link in links:
@@ -39,7 +47,9 @@ def test_add_links_matches_repeated_add_link(make_infomap, canonical_modules):
     assert im.num_links == baseline.num_links
     assert im.num_nodes == baseline.num_nodes
     assert im.codelength == pytest.approx(baseline.codelength)
-    assert canonical_modules(im.get_modules()) == canonical_modules(baseline.get_modules())
+    assert canonical_modules(im.get_modules()) == canonical_modules(
+        baseline.get_modules()
+    )
 
 
 def test_add_links_rejects_invalid_link_lengths(make_infomap):
@@ -79,7 +89,9 @@ def test_add_links_accepts_weighted_numpy_array(make_infomap, canonical_modules)
     assert im.num_links == baseline.num_links
     assert im.num_nodes == baseline.num_nodes
     assert im.codelength == pytest.approx(baseline.codelength)
-    assert canonical_modules(im.get_modules()) == canonical_modules(baseline.get_modules())
+    assert canonical_modules(im.get_modules()) == canonical_modules(
+        baseline.get_modules()
+    )
 
 
 def test_add_links_accepts_numpy_array_with_duplicates_and_existing_links(make_infomap):

--- a/test/python/test_add_multilayer_intra_inter_links.py
+++ b/test/python/test_add_multilayer_intra_inter_links.py
@@ -31,7 +31,9 @@ def assert_same_result(actual, expected):
     assert actual.get_modules(states=True) == expected.get_modules(states=True)
 
 
-def test_add_multilayer_intra_links_matches_repeated_add_multilayer_intra_link(make_infomap):
+def test_add_multilayer_intra_links_matches_repeated_add_multilayer_intra_link(
+    make_infomap,
+):
     baseline = make_infomap(two_level=True)
     for link in INTRA_LINKS:
         baseline.add_multilayer_intra_link(*link)
@@ -89,7 +91,9 @@ def test_add_multilayer_intra_links_accepts_non_contiguous_numpy_array(make_info
     assert_same_result(im, baseline)
 
 
-def test_add_multilayer_inter_links_matches_repeated_add_multilayer_inter_link(make_infomap):
+def test_add_multilayer_inter_links_matches_repeated_add_multilayer_inter_link(
+    make_infomap,
+):
     baseline = make_infomap(two_level=True)
     baseline.add_multilayer_intra_links(INTRA_LINKS)
     for link in INTER_LINKS:

--- a/test/python/test_add_multilayer_links.py
+++ b/test/python/test_add_multilayer_links.py
@@ -16,7 +16,11 @@ def test_add_multilayer_links_matches_repeated_add_multilayer_link(make_infomap)
     links = [
         ((0, 1), (1, 2), 1.5),
         ((0, 3), (1, 2), 2.0),
-        (MultilayerNode(layer_id=1, node_id=2), MultilayerNode(layer_id=2, node_id=4), 3.0),
+        (
+            MultilayerNode(layer_id=1, node_id=2),
+            MultilayerNode(layer_id=2, node_id=4),
+            3.0,
+        ),
     ]
 
     baseline = make_infomap()
@@ -70,7 +74,9 @@ def test_add_multilayer_links_accepts_unweighted_numpy_array(make_infomap):
 
     baseline = make_infomap()
     for source_layer, source_node, target_layer, target_node in links.tolist():
-        baseline.add_multilayer_link((source_layer, source_node), (target_layer, target_node))
+        baseline.add_multilayer_link(
+            (source_layer, source_node), (target_layer, target_node)
+        )
 
     im = make_infomap()
     im.add_multilayer_links(links)

--- a/test/python/test_api.py
+++ b/test/python/test_api.py
@@ -84,7 +84,9 @@ def test_add_networkx_multilayer_graph_with_string_ids(make_infomap):
     assert nodes == [(0, 0, 1), (1, 1, 1), (2, 1, 2)]
 
 
-def test_get_dataframe_supports_states_and_depth_level(make_infomap, example_network_path):
+def test_get_dataframe_supports_states_and_depth_level(
+    make_infomap, example_network_path
+):
     pytest.importorskip("pandas")
 
     states_im = make_infomap(num_trials=10)
@@ -148,7 +150,9 @@ def test_to_dataframe_uses_pandas_friendly_defaults(make_infomap, example_networ
     assert set(dataframe["module_id"]) == {1, 2}
 
 
-def test_to_dataframe_supports_index_sort_and_community_alias(make_infomap, example_network_path):
+def test_to_dataframe_supports_index_sort_and_community_alias(
+    make_infomap, example_network_path
+):
     pytest.importorskip("pandas")
 
     im = make_infomap(num_trials=10)
@@ -166,7 +170,9 @@ def test_to_dataframe_supports_index_sort_and_community_alias(make_infomap, exam
     assert list(dataframe["community"]) == sorted(dataframe["community"])
 
 
-def test_to_dataframe_caches_names_for_name_column(monkeypatch, make_infomap, example_network_path):
+def test_to_dataframe_caches_names_for_name_column(
+    monkeypatch, make_infomap, example_network_path
+):
     pytest.importorskip("pandas")
 
     im = make_infomap(num_trials=10)
@@ -188,7 +194,9 @@ def test_to_dataframe_caches_names_for_name_column(monkeypatch, make_infomap, ex
     assert set(dataframe["name"]) == {"A", "B", "C", "D", "E", "F"}
 
 
-def test_to_dataframe_supports_true_sort_and_depth_level_alias(make_infomap, example_network_path):
+def test_to_dataframe_supports_true_sort_and_depth_level_alias(
+    make_infomap, example_network_path
+):
     pytest.importorskip("pandas")
 
     im = make_infomap(num_trials=10)
@@ -232,7 +240,7 @@ def test_get_dataframe_missing_pandas_message(monkeypatch, make_infomap):
 
     with (
         pytest.deprecated_call(match="get_dataframe.*to_dataframe"),
-        pytest.raises(ImportError, match=r'infomap\[pandas\]'),
+        pytest.raises(ImportError, match=r"infomap\[pandas\]"),
     ):
         im.get_dataframe()
 

--- a/test/python/test_build_config.py
+++ b/test/python/test_build_config.py
@@ -62,7 +62,14 @@ def test_clang_debug_and_release_share_warning_policy():
         openmp=False,
     )
 
-    for flag in ["-Wall", "-Wextra", "-Wshadow", "-pedantic", "-Wnon-virtual-dtor", "-std=c++14"]:
+    for flag in [
+        "-Wall",
+        "-Wextra",
+        "-Wshadow",
+        "-pedantic",
+        "-Wnon-virtual-dtor",
+        "-std=c++14",
+    ]:
         assert flag in debug_config["compile_flags"]
         assert flag in release_config["compile_flags"]
 

--- a/test/python/test_compare_native_benchmarks.py
+++ b/test/python/test_compare_native_benchmarks.py
@@ -22,7 +22,9 @@ def _find_compare_script_path() -> Path:
 
 def _load_compare_module():
     module_path = _find_compare_script_path()
-    spec = importlib.util.spec_from_file_location("compare_native_benchmarks", module_path)
+    spec = importlib.util.spec_from_file_location(
+        "compare_native_benchmarks", module_path
+    )
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
@@ -118,14 +120,22 @@ def test_render_markdown_uses_na_for_missing_case_metrics():
     assert "| ring | manual_review | n/a | n/a | n/a | n/a | case_missing |" in markdown
 
 
-def test_main_writes_markdown_and_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+def test_main_writes_markdown_and_json(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
     compare_module = _load_compare_module()
     base_path = tmp_path / "base.json"
     head_path = tmp_path / "head.json"
     markdown_path = tmp_path / "summary.md"
     json_path = tmp_path / "comparison.json"
-    base_path.write_text(json.dumps({"benchmarks": [_case("ring", median_run_sec=1.00)]}) + "\n", encoding="utf-8")
-    head_path.write_text(json.dumps({"benchmarks": [_case("ring", median_run_sec=1.30)]}) + "\n", encoding="utf-8")
+    base_path.write_text(
+        json.dumps({"benchmarks": [_case("ring", median_run_sec=1.00)]}) + "\n",
+        encoding="utf-8",
+    )
+    head_path.write_text(
+        json.dumps({"benchmarks": [_case("ring", median_run_sec=1.30)]}) + "\n",
+        encoding="utf-8",
+    )
 
     import sys
 
@@ -149,7 +159,10 @@ def test_main_writes_markdown_and_json(tmp_path: Path, capsys: pytest.CaptureFix
     captured = capsys.readouterr()
     assert "PR Native Benchmark Comparison" in captured.out
     assert "possible regression" in markdown_path.read_text(encoding="utf-8")
-    assert json.loads(json_path.read_text(encoding="utf-8"))["overall_status"] == "possible_regression"
+    assert (
+        json.loads(json_path.read_text(encoding="utf-8"))["overall_status"]
+        == "possible_regression"
+    )
 
 
 def test_main_can_fail_after_writing_reports_for_regression(tmp_path: Path):
@@ -158,8 +171,14 @@ def test_main_can_fail_after_writing_reports_for_regression(tmp_path: Path):
     head_path = tmp_path / "head.json"
     markdown_path = tmp_path / "summary.md"
     json_path = tmp_path / "comparison.json"
-    base_path.write_text(json.dumps({"benchmarks": [_case("ring", median_run_sec=1.00)]}) + "\n", encoding="utf-8")
-    head_path.write_text(json.dumps({"benchmarks": [_case("ring", median_run_sec=1.20)]}) + "\n", encoding="utf-8")
+    base_path.write_text(
+        json.dumps({"benchmarks": [_case("ring", median_run_sec=1.00)]}) + "\n",
+        encoding="utf-8",
+    )
+    head_path.write_text(
+        json.dumps({"benchmarks": [_case("ring", median_run_sec=1.20)]}) + "\n",
+        encoding="utf-8",
+    )
 
     import sys
 
@@ -182,4 +201,6 @@ def test_main_can_fail_after_writing_reports_for_regression(tmp_path: Path):
         sys.argv = old_argv
 
     assert "possible regression" in markdown_path.read_text(encoding="utf-8")
-    assert json.loads(json_path.read_text(encoding="utf-8"))["counts"]["regression"] == 1
+    assert (
+        json.loads(json_path.read_text(encoding="utf-8"))["counts"]["regression"] == 1
+    )

--- a/test/python/test_disconnected_nodes.py
+++ b/test/python/test_disconnected_nodes.py
@@ -84,7 +84,9 @@ def test_regularized_recovers_planted_partition(make_infomap, canonical_modules)
 
 
 @pytest.mark.parametrize("regularized", [False, True])
-def test_regularized_matches_baseline_on_easy_partition(make_infomap, canonical_modules, regularized):
+def test_regularized_matches_baseline_on_easy_partition(
+    make_infomap, canonical_modules, regularized
+):
     g = _sbm()
     expected = _expected_sbm_partition(g)
 

--- a/test/python/test_flow.py
+++ b/test/python/test_flow.py
@@ -30,19 +30,35 @@ def test_precomputed_states_requirements(make_infomap, example_network_path):
         im.run()
 
 
-def test_precomputed_from_file(make_infomap, network_fixture_path, expected_fixture_path, output_dir, assert_pajek_matches_fixture):
+def test_precomputed_from_file(
+    make_infomap,
+    network_fixture_path,
+    expected_fixture_path,
+    output_dir,
+    assert_pajek_matches_fixture,
+):
     im = make_infomap(flow_model="precomputed")
     im.read_file(str(network_fixture_path("twotriangles_flow.net")))
     im.run()
     output_path = output_dir / "twotriangles_flow_output.net"
     im.write_pajek(str(output_path), flow=True)
-    assert_pajek_matches_fixture(output_path, expected_fixture_path("twotriangles_flow_output.net"))
+    assert_pajek_matches_fixture(
+        output_path, expected_fixture_path("twotriangles_flow_output.net")
+    )
 
 
-def test_precomputed_states_from_file(make_infomap, network_fixture_path, expected_fixture_path, output_dir, assert_pajek_matches_fixture):
+def test_precomputed_states_from_file(
+    make_infomap,
+    network_fixture_path,
+    expected_fixture_path,
+    output_dir,
+    assert_pajek_matches_fixture,
+):
     im = make_infomap(flow_model="precomputed")
     im.read_file(str(network_fixture_path("states_flow.net")))
     im.run()
     output_path = output_dir / "states_flow_output.net"
     im.write_pajek(str(output_path), flow=True)
-    assert_pajek_matches_fixture(output_path, expected_fixture_path("states_flow_output.net"))
+    assert_pajek_matches_fixture(
+        output_path, expected_fixture_path("states_flow_output.net")
+    )

--- a/test/python/test_igraph.py
+++ b/test/python/test_igraph.py
@@ -40,7 +40,7 @@ def test_missing_igraph_error_mentions_extra(monkeypatch):
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
 
-    with pytest.raises(ImportError, match=r'infomap\[igraph\]'):
+    with pytest.raises(ImportError, match=r"infomap\[igraph\]"):
         _import_igraph()
 
 

--- a/test/python/test_iterators.py
+++ b/test/python/test_iterators.py
@@ -12,7 +12,10 @@ def test_iter_physical_on_physical(make_infomap, example_network_path):
     im.read_file(str(example_network_path("twotriangles.net")))
     im.run()
 
-    modules = sorted([(node.node_id, node.module_id) for node in im.physical_nodes], key=itemgetter(0))
+    modules = sorted(
+        [(node.node_id, node.module_id) for node in im.physical_nodes],
+        key=itemgetter(0),
+    )
     assert modules == [(1, 1), (2, 1), (3, 1), (4, 2), (5, 2), (6, 2)]
 
 
@@ -21,7 +24,10 @@ def test_iter_physical_on_states(make_infomap, example_network_path):
     im.read_file(str(example_network_path("states.net")))
     im.run()
 
-    modules = sorted([(node.state_id, node.node_id, node.module_id) for node in im.physical_nodes], key=itemgetter(0))
+    modules = sorted(
+        [(node.state_id, node.node_id, node.module_id) for node in im.physical_nodes],
+        key=itemgetter(0),
+    )
     assert modules == [(1, 1, 1), (2, 2, 1), (3, 3, 1), (4, 1, 2), (5, 4, 2), (6, 5, 2)]
 
 
@@ -39,7 +45,10 @@ def test_multilevel_modules_on_states(make_infomap, example_network_path):
     im = make_infomap()
     im.read_file(str(example_network_path("states.net")))
     im.run()
-    modules = [(node, modules) for node, modules in im.get_multilevel_modules(states=True).items()]
+    modules = [
+        (node, modules)
+        for node, modules in im.get_multilevel_modules(states=True).items()
+    ]
     assert modules == [(1, (1,)), (2, (1,)), (3, (1,)), (4, (2,)), (5, (2,)), (6, (2,))]
 
 

--- a/test/python/test_multilayer.py
+++ b/test/python/test_multilayer.py
@@ -1,4 +1,6 @@
-def test_matchable_multilayer_ids_with_python_read_file(make_infomap, example_network_path):
+def test_matchable_multilayer_ids_with_python_read_file(
+    make_infomap, example_network_path
+):
     im = make_infomap(no_infomap=True, matchable_multilayer_ids=3)
     im.read_file(str(example_network_path("multilayer.net")))
     im.run()

--- a/test/python/test_native_benchmark_script.py
+++ b/test/python/test_native_benchmark_script.py
@@ -15,7 +15,9 @@ def _find_repo_root(start: Path) -> Path:
     for candidate in (start, *start.parents):
         if (candidate / target).exists():
             return candidate
-    raise FileNotFoundError(f"Could not locate repository root containing {target!s} from {start!s}")
+    raise FileNotFoundError(
+        f"Could not locate repository root containing {target!s} from {start!s}"
+    )
 
 
 def _load_benchmark_module():
@@ -61,7 +63,9 @@ def test_benchmark_case_tolerates_missing_rebuild_metrics(monkeypatch, tmp_path:
     }
 
     def fake_run(*args, **kwargs):
-        return benchmark_module.subprocess.CompletedProcess(args[0], 0, stdout=json.dumps(payload), stderr="")
+        return benchmark_module.subprocess.CompletedProcess(
+            args[0], 0, stdout=json.dumps(payload), stderr=""
+        )
 
     monkeypatch.setattr(benchmark_module.subprocess, "run", fake_run)
 
@@ -80,7 +84,9 @@ def test_benchmark_case_tolerates_missing_rebuild_metrics(monkeypatch, tmp_path:
     assert result["rebuild"]["module_size_buckets"] == {}
 
 
-def test_benchmark_case_collects_dynamic_rebuild_bucket_labels(monkeypatch, tmp_path: Path):
+def test_benchmark_case_collects_dynamic_rebuild_bucket_labels(
+    monkeypatch, tmp_path: Path
+):
     benchmark_module = _load_benchmark_module()
     payload = {
         "flags": "--silent --no-file-output --num-trials 1 --seed 123",
@@ -131,7 +137,9 @@ def test_benchmark_case_collects_dynamic_rebuild_bucket_labels(monkeypatch, tmp_
     }
 
     def fake_run(*args, **kwargs):
-        return benchmark_module.subprocess.CompletedProcess(args[0], 0, stdout=json.dumps(payload), stderr="")
+        return benchmark_module.subprocess.CompletedProcess(
+            args[0], 0, stdout=json.dumps(payload), stderr=""
+        )
 
     monkeypatch.setattr(benchmark_module.subprocess, "run", fake_run)
 
@@ -146,7 +154,9 @@ def test_benchmark_case_collects_dynamic_rebuild_bucket_labels(monkeypatch, tmp_
     )
 
     assert result["rebuild"]["mean_total_sec"] == pytest.approx(0.05)
-    assert result["rebuild"]["module_size_buckets"]["33-64"]["mean_sec"] == pytest.approx(0.03)
+    assert result["rebuild"]["module_size_buckets"]["33-64"][
+        "mean_sec"
+    ] == pytest.approx(0.03)
 
 
 def test_benchmark_case_discards_warmup_samples(monkeypatch, tmp_path: Path):
@@ -185,7 +195,9 @@ def test_benchmark_case_discards_warmup_samples(monkeypatch, tmp_path: Path):
     payloads = [payload(99.0), payload(1.0), payload(3.0)]
 
     def fake_run(*args, **kwargs):
-        return benchmark_module.subprocess.CompletedProcess(args[0], 0, stdout=json.dumps(payloads.pop(0)), stderr="")
+        return benchmark_module.subprocess.CompletedProcess(
+            args[0], 0, stdout=json.dumps(payloads.pop(0)), stderr=""
+        )
 
     monkeypatch.setattr(benchmark_module.subprocess, "run", fake_run)
 
@@ -207,7 +219,9 @@ def test_benchmark_case_discards_warmup_samples(monkeypatch, tmp_path: Path):
     assert [sample["repeat"] for sample in result["run_samples"]] == [1, 2]
 
 
-def test_build_benchmark_cases_pr_profile_focuses_on_stable_cases(monkeypatch, tmp_path: Path):
+def test_build_benchmark_cases_pr_profile_focuses_on_stable_cases(
+    monkeypatch, tmp_path: Path
+):
     benchmark_module = _load_benchmark_module()
     repo_root = Path(__file__).resolve().parents[2]
     generated_paths: list[Path] = []
@@ -215,24 +229,43 @@ def test_build_benchmark_cases_pr_profile_focuses_on_stable_cases(monkeypatch, t
     def stub_generate_state_ring(path: Path, physical_nodes: int) -> None:
         generated_paths.append(path)
 
-    def stub_generate_sparse_graph(path: Path, num_nodes: int, avg_degree: int, seed: int) -> None:
+    def stub_generate_sparse_graph(
+        path: Path, num_nodes: int, avg_degree: int, seed: int
+    ) -> None:
         generated_paths.append(path)
 
-    def stub_generate_ring_of_cliques(path: Path, clique_count: int, clique_size: int) -> None:
+    def stub_generate_ring_of_cliques(
+        path: Path, clique_count: int, clique_size: int
+    ) -> None:
         generated_paths.append(path)
 
-    monkeypatch.setattr(benchmark_module, "generate_state_ring", stub_generate_state_ring)
-    monkeypatch.setattr(benchmark_module, "generate_sparse_graph", stub_generate_sparse_graph)
-    monkeypatch.setattr(benchmark_module, "generate_ring_of_cliques", stub_generate_ring_of_cliques)
+    monkeypatch.setattr(
+        benchmark_module, "generate_state_ring", stub_generate_state_ring
+    )
+    monkeypatch.setattr(
+        benchmark_module, "generate_sparse_graph", stub_generate_sparse_graph
+    )
+    monkeypatch.setattr(
+        benchmark_module, "generate_ring_of_cliques", stub_generate_ring_of_cliques
+    )
 
     cases = benchmark_module.build_benchmark_cases("pr", repo_root, tmp_path)
     names = [case["name"] for case in cases]
     paths = [Path(case["path"]) for case in cases]
 
-    assert names == ["states_meta", "state_ring_5k", "sparse_100k", "ring_of_cliques_100k"]
+    assert names == [
+        "states_meta",
+        "state_ring_5k",
+        "sparse_100k",
+        "ring_of_cliques_100k",
+    ]
     assert paths[0] == repo_root / "examples" / "networks" / "states.net"
     assert paths[1:] == generated_paths
-    assert [path.name for path in generated_paths] == ["state_ring_5k.net", "sparse_100k.net", "ring_of_cliques_100k.net"]
+    assert [path.name for path in generated_paths] == [
+        "state_ring_5k.net",
+        "sparse_100k.net",
+        "ring_of_cliques_100k.net",
+    ]
 
 
 def test_build_benchmark_cases_smoke_skips_100k_generation(monkeypatch, tmp_path: Path):
@@ -242,18 +275,24 @@ def test_build_benchmark_cases_smoke_skips_100k_generation(monkeypatch, tmp_path
 
     original_generate_sparse_graph = benchmark_module.generate_sparse_graph
 
-    def recording_generate_sparse_graph(path: Path, num_nodes: int, avg_degree: int, seed: int) -> None:
+    def recording_generate_sparse_graph(
+        path: Path, num_nodes: int, avg_degree: int, seed: int
+    ) -> None:
         calls.append(num_nodes)
         original_generate_sparse_graph(path, num_nodes, avg_degree, seed)
 
-    monkeypatch.setattr(benchmark_module, "generate_sparse_graph", recording_generate_sparse_graph)
+    monkeypatch.setattr(
+        benchmark_module, "generate_sparse_graph", recording_generate_sparse_graph
+    )
 
     benchmark_module.build_benchmark_cases("smoke", repo_root, tmp_path)
 
     assert calls == [10_000]
 
 
-def test_build_benchmark_cases_large_profile_uses_only_large_generated_cases(monkeypatch, tmp_path: Path):
+def test_build_benchmark_cases_large_profile_uses_only_large_generated_cases(
+    monkeypatch, tmp_path: Path
+):
     benchmark_module = _load_benchmark_module()
     repo_root = _find_repo_root(Path(__file__).resolve())
     calls: list[tuple[str, Path, tuple[object, ...]]] = []
@@ -261,7 +300,9 @@ def test_build_benchmark_cases_large_profile_uses_only_large_generated_cases(mon
     def stub_generate_if_missing(path: Path, generator, *args: object) -> None:
         calls.append((generator.__name__, path, args))
 
-    monkeypatch.setattr(benchmark_module, "generate_if_missing", stub_generate_if_missing)
+    monkeypatch.setattr(
+        benchmark_module, "generate_if_missing", stub_generate_if_missing
+    )
 
     cases = benchmark_module.build_benchmark_cases("large", repo_root, tmp_path)
 
@@ -281,8 +322,16 @@ def test_build_benchmark_cases_large_profile_uses_only_large_generated_cases(mon
         ("generate_block_sparse_graph", "block_sparse_1m.net", (1_000_000, 100, 8, 2)),
         ("generate_state_ring", "state_ring_500k.net", (500_000,)),
         ("generate_state_block_network", "state_block_1m_states.net", (250_000, 4, 50)),
-        ("generate_multilayer_block_network", "multilayer_100k_x10.net", (100_000, 10, 50)),
-        ("generate_multilayer_block_network", "multilayer_250k_x8.net", (250_000, 8, 50)),
+        (
+            "generate_multilayer_block_network",
+            "multilayer_100k_x10.net",
+            (100_000, 10, 50),
+        ),
+        (
+            "generate_multilayer_block_network",
+            "multilayer_250k_x8.net",
+            (250_000, 8, 50),
+        ),
     ]
 
 

--- a/test/python/test_output.py
+++ b/test/python/test_output.py
@@ -15,7 +15,9 @@ def _run_small_network(make_infomap, load_graph_fixture):
     return im
 
 
-def test_output_writers_are_stable_across_repeat_calls(make_infomap, load_graph_fixture, output_dir):
+def test_output_writers_are_stable_across_repeat_calls(
+    make_infomap, load_graph_fixture, output_dir
+):
     im = _run_small_network(make_infomap, load_graph_fixture)
 
     tree_a = output_dir / "first.tree"
@@ -44,7 +46,9 @@ def test_output_writers_are_stable_across_repeat_calls(make_infomap, load_graph_
     assert "# module level 1" in clu_a.read_text()
 
 
-def test_state_output_writers_include_state_columns(make_infomap, network_fixture_path, output_dir):
+def test_state_output_writers_include_state_columns(
+    make_infomap, network_fixture_path, output_dir
+):
     im = make_infomap()
     im.read_file(str(network_fixture_path("states.net")))
     im.run()
@@ -77,9 +81,16 @@ def test_state_output_writers_include_state_columns(make_infomap, network_fixtur
         ("states.net", True),
         ("multilayer.net", True),
     ],
-    ids=["physical", "states_physical_tree", "states_state_tree", "multilayer_state_tree"],
+    ids=[
+        "physical",
+        "states_physical_tree",
+        "states_state_tree",
+        "multilayer_state_tree",
+    ],
 )
-def test_tree_cluster_data_roundtrip(make_infomap, example_network_path, output_dir, network_name, states_output):
+def test_tree_cluster_data_roundtrip(
+    make_infomap, example_network_path, output_dir, network_name, states_output
+):
     network_path = str(example_network_path(network_name))
 
     baseline = make_infomap(num_trials=5)


### PR DESCRIPTION
## Summary

- Apply the repository formatter targets to native C++ sources, Python sources, and Python tests.
- Exclude generated Python option bindings from `format-python` so formatter runs do not rewrite generated output.
- Keep generated wrapper outputs untouched.

## Verification

- `make format-native format-python format-js`
- `make format-python`
- `make format-native-check`
- `npm run format:check`