### PR TITLE
perf(js): build worker as single-file wasm

### DIFF
--- a/interfaces/js/pre-worker-module.js
+++ b/interfaces/js/pre-worker-module.js
@@ -22,11 +22,34 @@ function readResultFile(file) {
 }
 
 let outName = "Untitled";
+let pendingMessage = undefined;
+let readyForFiles = false;
+
+function prepareFiles(message) {
+  const data = message.data;
+  outName = data.outName;
+  Module.arguments.push(...[data.filename, ".", ...data.arguments]);
+  FS.writeFile(data.filename, data.network);
+  for (let filename of Object.keys(data.files)) {
+    FS.writeFile(filename, data.files[filename]);
+  }
+  removeRunDependency("filesReady");
+}
+
+function processPendingMessage() {
+  if (readyForFiles && pendingMessage) {
+    const message = pendingMessage;
+    pendingMessage = undefined;
+    prepareFiles(message);
+  }
+}
 
 var Module = {
   arguments: [],
   preRun: function () {
     addRunDependency("filesReady");
+    readyForFiles = true;
+    processPendingMessage();
   },
   print: function (content) {
     postMessage({ type: "data", content });
@@ -44,12 +67,6 @@ var Module = {
 };
 
 onmessage = function onmessage(message) {
-  const data = message.data;
-  outName = data.outName;
-  Module.arguments.push(...[data.filename, ".", ...data.arguments]);
-  FS.writeFile(data.filename, data.network);
-  for (let filename of Object.keys(data.files)) {
-    FS.writeFile(filename, data.files[filename]);
-  }
-  removeRunDependency("filesReady");
+  pendingMessage = message;
+  processPendingMessage();
 };

--- a/mk/js.mk
+++ b/mk/js.mk
@@ -38,7 +38,7 @@ $(JS_WORKER_OUTPUT_FORMATS): $(JS_OUTPUT_FORMATS_JSON) interfaces/js/scripts/wri
 $(JS_WORKER_TARGET): $(SOURCES) $(HEADERS) $(PRE_WORKER_MODULES) $(MK_FILES) Makefile
 	@echo "Compiling Infomap to run in a worker in the browser..."
 	@mkdir -p $(dir $@)
-	$(EMXX) -std=c++14 -O3 -s WASM=0 -s ALLOW_MEMORY_GROWTH=1 -s DISABLE_EXCEPTION_CATCHING=0 -s ENVIRONMENT=worker $(foreach file,$(PRE_WORKER_MODULES),--pre-js $(file)) -o $@ $(SOURCES)
+	$(EMXX) -std=c++14 -O3 -s SINGLE_FILE=1 -s ALLOW_MEMORY_GROWTH=1 -s DISABLE_EXCEPTION_CATCHING=0 -s ENVIRONMENT=worker $(foreach file,$(PRE_WORKER_MODULES),--pre-js $(file)) -o $@ $(SOURCES)
 
 test-js: build-js
 	$(RM) -r $(NPM_UNPACK_DIR) $(NPM_STAGE_DIR)/*.tgz $(NPM_PACK_JSON)


### PR DESCRIPTION
## Summary
- switch the browser worker build from wasm2js to single-file WebAssembly
- queue worker input until Emscripten preRun so FS/heap views are initialized before files are written

## Verification
- npm run format
- make test-js
