### PR TITLE
refactor: extract network input parser

### DIFF
--- a/src/io/Network.cpp
+++ b/src/io/Network.cpp
@@ -8,14 +8,13 @@
  ******************************************************************************/
 
 #include "Network.h"
-#include "../io/SafeFile.h"
+#include "NetworkInputParser.h"
 #include "../utils/FileURI.h"
 #include "../utils/Log.h"
 #include "../utils/PrettyOutput.h"
 
 #include <cmath>
 #include <algorithm>
-#include <cstdlib>
 #include <limits>
 #include <stdexcept>
 
@@ -25,70 +24,106 @@ using std::make_pair;
 
 namespace {
 
-  inline bool isInputWhitespace(char c)
+  void addParsedVertex(Network& network, const input::ParsedVertex& vertex)
   {
-    return c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '\f' || c == '\v';
-  }
-
-  inline bool isDigit(char c)
-  {
-    return c >= '0' && c <= '9';
-  }
-
-  void skipWhitespace(const char*& p)
-  {
-    while (isInputWhitespace(*p)) {
-      ++p;
+    if (vertex.hasWeight) {
+      network.addPhysicalNode(vertex.id, vertex.weight, vertex.name);
+    } else {
+      network.addPhysicalNode(vertex.id, vertex.name);
     }
-  }
-
-  bool parseUnsigned(const char*& p, unsigned int& value)
-  {
-    skipWhitespace(p);
-    if (*p == '+') {
-      ++p;
-    }
-    if (!isDigit(*p)) {
-      return false;
-    }
-
-    unsigned long long result = 0;
-    const unsigned long long maxValue = std::numeric_limits<unsigned int>::max();
-    do {
-      result = result * 10 + static_cast<unsigned long long>(*p - '0');
-      if (result > maxValue) {
-        return false;
-      }
-      ++p;
-    } while (isDigit(*p));
-
-    value = static_cast<unsigned int>(result);
-    return true;
-  }
-
-  bool parseOptionalDouble(const char*& p, double& value)
-  {
-    skipWhitespace(p);
-    if (*p == '\0' || *p == '#') {
-      return false;
-    }
-
-    char* end = nullptr;
-    const double parsed = std::strtod(p, &end);
-    if (end == p) {
-      return false;
-    }
-
-    value = parsed;
-    p = end;
-    return true;
   }
 
 } // namespace
 
+class NetworkInputSinkAdapter {
+public:
+  explicit NetworkInputSinkAdapter(Network& network) : m_network(network) {}
+
+  bool isUndirectedFlow() const { return m_network.m_config.isUndirectedFlow(); }
+  unsigned int matchableMultilayerIds() const { return m_network.m_config.matchableMultilayerIds; }
+  unsigned int numPhysicalNodes() const { return m_network.numPhysicalNodes(); }
+  unsigned int numLinks() const { return m_network.numLinks(); }
+  unsigned int numIntraLayerLinks() const { return m_network.m_numIntraLayerLinks; }
+  unsigned int numInterLayerLinks() const { return m_network.m_numInterLayerLinks; }
+  unsigned int numLayerLinks() const { return m_network.m_numIntraLayerLinks + m_network.m_numInterLayerLinks; }
+  unsigned int numLayers() const { return m_network.m_layers.size(); }
+  unsigned int numMetaDataColumns() const { return m_network.m_numMetaDataColumns; }
+  unsigned int numMetaDataRows() const { return m_network.m_metaData.size(); }
+
+  void onFileInput() { m_network.m_haveFileInput = true; }
+
+  void onNetworkParsed()
+  {
+    m_network.postProcessInputData();
+  }
+
+  void onPhysicalNode(const input::ParsedVertex& vertex)
+  {
+    if (vertex.hasWeight) {
+      m_network.m_haveNodeWeights = true;
+    }
+    addParsedVertex(m_network, vertex);
+  }
+
+  void onStateNode(const input::ParsedStateNode& parsed)
+  {
+    const auto& stateNode = parsed.node;
+    m_network.m_higherOrderInputMethodCalled = true;
+    if (parsed.hasWeight) {
+      m_network.m_haveStateNodeWeights = true;
+    }
+    m_network.addStateNode(stateNode);
+    m_network.addPhysicalNode(stateNode.physicalId);
+    ++m_network.m_numStateNodesFound;
+  }
+
+  void onLink(const input::ParsedLink& link)
+  {
+    m_network.addLink(link.source, link.target, link.weight);
+  }
+
+  void onMultilayerLink(const input::ParsedMultilayerLink& link)
+  {
+    m_network.addMultilayerLink(link.sourceLayer, link.sourceNode, link.targetLayer, link.targetNode, link.weight);
+  }
+
+  void onMultilayerIntraLink(const input::ParsedMultilayerIntraLink& link)
+  {
+    m_network.addMultilayerIntraLink(link.layer, link.sourceNode, link.targetNode, link.weight);
+  }
+
+  void onMultilayerInterLink(const input::ParsedMultilayerInterLink& link)
+  {
+    m_network.addMultilayerInterLink(link.sourceLayer, link.node, link.targetLayer, link.weight);
+  }
+
+  void onBipartiteStart(unsigned int bipartiteStartId)
+  {
+    m_network.m_bipartiteStartId = bipartiteStartId;
+    m_network.m_config.bipartite = true;
+  }
+
+  void onBipartiteLink(const std::string& line, const input::ParsedLink& link)
+  {
+    bool sourceIsFeature = link.source >= m_network.m_bipartiteStartId;
+    bool targetIsFeature = link.target >= m_network.m_bipartiteStartId;
+    if (sourceIsFeature == targetIsFeature) {
+      throw std::runtime_error(io::Str() << "Bipartite link '" << line << "' must cross bipartite start id " << m_network.m_bipartiteStartId << ".");
+    }
+    m_network.addLink(link.source, link.target, link.weight);
+  }
+
+  void onMetaData(unsigned int nodeId, const std::vector<int>& metaData)
+  {
+    m_network.addMetaData(nodeId, metaData);
+  }
+
+private:
+  Network& m_network;
+};
+
 void Network::init()
 {
-  initValidHeadings();
   updateDerivedConfig();
 }
 
@@ -97,56 +132,6 @@ void Network::updateDerivedConfig()
   m_multilayerStateIdBitShift = m_config.matchableMultilayerIds == 0
       ? 0
       : static_cast<unsigned int>(std::ceil(std::log2(m_config.matchableMultilayerIds)));
-}
-
-void Network::initValidHeadings()
-{
-  auto& headingsPajek = m_validHeadings["pajek"];
-  headingsPajek.insert("*vertices");
-  headingsPajek.insert("*edges");
-  headingsPajek.insert("*arcs");
-
-  auto& headingsLinklist = m_validHeadings["link-list"];
-  headingsLinklist.insert("*links");
-  headingsLinklist.insert("*edges");
-  headingsLinklist.insert("*arcs");
-
-  auto& headingsBipartite = m_validHeadings["bipartite"];
-  headingsBipartite.insert("*vertices");
-  headingsBipartite.insert("*bipartite");
-
-  auto& headingsStates = m_validHeadings["states"];
-  headingsStates.insert("*vertices");
-  headingsStates.insert("*states");
-  headingsStates.insert("*edges");
-  headingsStates.insert("*arcs");
-  headingsStates.insert("*links");
-  headingsStates.insert("*contexts");
-  auto& ignoreHeadingsStates = m_ignoreHeadings["states"];
-  ignoreHeadingsStates.insert("*edges");
-  ignoreHeadingsStates.insert("*contexts");
-
-  auto& headingsMultilayer = m_validHeadings["multilayer"];
-  headingsMultilayer.insert("*vertices");
-  headingsMultilayer.insert("*multiplex");
-  headingsMultilayer.insert("*multilayer");
-  headingsMultilayer.insert("*intra");
-  headingsMultilayer.insert("*inter");
-
-  auto& headingsGeneral = m_validHeadings["general"];
-  headingsGeneral.insert("*vertices");
-  headingsGeneral.insert("*states");
-  headingsGeneral.insert("*multilayer");
-  headingsGeneral.insert("*intra");
-  headingsGeneral.insert("*inter");
-  headingsGeneral.insert("*paths");
-  headingsGeneral.insert("*edges");
-  headingsGeneral.insert("*arcs");
-  headingsGeneral.insert("*links");
-  headingsGeneral.insert("*contexts");
-  headingsGeneral.insert("*bipartite");
-  auto& ignoreHeadingsGeneral = m_ignoreHeadings["general"];
-  ignoreHeadingsGeneral.insert("*contexts");
 }
 
 void Network::clear()
@@ -180,60 +165,9 @@ void Network::readInputData(std::string filename, bool accumulate)
   }
   FileURI networkFilename(filename, false);
 
-  parseNetwork(filename);
+  NetworkInputSinkAdapter sink(*this);
+  input::parseNetworkInput(filename, sink);
   printSummary();
-}
-
-void Network::parseNetwork(const std::string& filename)
-{
-  Log() << "Parsing " << (m_config.isUndirectedFlow() ? "undirected" : "directed") << " network from file '" << filename << "'...\n";
-
-  parseNetwork(filename, m_validHeadings["general"], m_ignoreHeadings["general"]);
-}
-
-void Network::parseNetwork(const std::string& filename, const InsensitiveStringSet& validHeadings, const InsensitiveStringSet& ignoreHeadings, const std::string& startHeading)
-{
-  m_haveFileInput = true;
-  SafeInFile input(filename);
-
-  // Parse standard links by default until possible heading is reached
-  std::string heading = !startHeading.empty() ? startHeading : parseLinks(input);
-
-  while (!heading.empty() && heading[0] == '*') {
-    std::string headingLowerCase = io::tolower(io::firstWord(heading));
-    if (validHeadings.count(headingLowerCase) == 0) {
-      throw std::runtime_error(io::Str() << "Unrecognized heading in network file: '" << headingLowerCase << "'.");
-    }
-    bool shouldIgnoreHeading = ignoreHeadings.count(headingLowerCase) > 0;
-    if (!shouldIgnoreHeading && headingLowerCase == "*vertices") {
-      heading = parseVertices(input, heading);
-    } else if (!shouldIgnoreHeading && headingLowerCase == "*states") {
-      heading = parseStateNodes(input, heading);
-    } else if (!shouldIgnoreHeading && headingLowerCase == "*edges") {
-      if (!m_config.isUndirectedFlow())
-        Log() << "\n --> Notice: Links marked as undirected but parsed as directed.\n";
-      heading = parseLinks(input);
-    } else if (!shouldIgnoreHeading && headingLowerCase == "*arcs") {
-      if (m_config.isUndirectedFlow())
-        Log() << "\n --> Notice: Links marked as directed but parsed as undirected.\n";
-      heading = parseLinks(input);
-    } else if (!shouldIgnoreHeading && headingLowerCase == "*links") {
-      heading = parseLinks(input);
-    } else if (!shouldIgnoreHeading && (headingLowerCase == "*multilayer" || headingLowerCase == "*multiplex")) {
-      heading = parseMultilayerLinks(input);
-    } else if (!shouldIgnoreHeading && headingLowerCase == "*intra") {
-      heading = parseMultilayerIntraLinks(input);
-    } else if (!shouldIgnoreHeading && headingLowerCase == "*inter") {
-      heading = parseMultilayerInterLinks(input);
-    } else if (!shouldIgnoreHeading && headingLowerCase == "*bipartite") {
-      heading = parseBipartiteLinks(input, heading);
-    } else {
-      heading = ignoreSection(input, headingLowerCase);
-    }
-  }
-
-  postProcessInputData();
-  Log() << "Done!\n";
 }
 
 void Network::postProcessInputData()
@@ -252,324 +186,8 @@ void Network::postProcessInputData()
 
 void Network::readMetaData(const std::string& filename)
 {
-  Log() << "Parsing meta data from '" << filename << "'...\n";
-  SafeInFile input(filename);
-  std::string line;
-  while (!std::getline(input, line).fail()) {
-    if (line.empty() || line[0] == '#')
-      continue;
-
-    if (line[0] == '*')
-      break;
-
-    m_extractor.clear();
-    m_extractor.str(line);
-
-    unsigned int nodeId;
-    if (!(m_extractor >> nodeId))
-      throw std::runtime_error(io::Str() << "Can't parse node id from line '" << line << "'");
-
-    std::vector<int> metaData;
-    unsigned int metaId;
-    while (m_extractor >> metaId) {
-      metaData.push_back(metaId);
-    }
-    if (metaData.empty())
-      throw std::runtime_error(io::Str() << "Can't parse any meta data from line '" << line << "'");
-
-    addMetaData(nodeId, metaData);
-  }
-  Log() << " -> Parsed " << m_numMetaDataColumns << " columns of meta data for " << m_metaData.size() << " nodes.\n";
-}
-//////////////////////////////////////////////////////////////////////////////////////////
-//
-//  HELPER METHODS
-//
-//////////////////////////////////////////////////////////////////////////////////////////
-
-std::string Network::parseVertices(std::ifstream& file, const std::string& /*heading*/)
-{
-  Log() << "  Parsing vertices...\n"
-        << std::flush;
-  std::string line;
-  while (!std::getline(file, line).fail()) {
-    if (line.empty() || line[0] == '#')
-      continue;
-
-    if (line[0] == '*')
-      break;
-
-    m_extractor.clear();
-    m_extractor.str(line);
-
-    unsigned int id = 0;
-    if (!(m_extractor >> id))
-      throw std::runtime_error(io::Str() << "Can't parse node id from line '" << line << "'");
-
-    auto nameStart = line.find_first_of('\"');
-    auto nameEnd = line.find_last_of('\"');
-    std::string name;
-    if (nameStart < nameEnd) {
-      name = std::string(line.begin() + nameStart + 1, line.begin() + nameEnd);
-      line = line.substr(nameEnd + 1);
-      m_extractor.clear();
-      m_extractor.str(line);
-    } else {
-      if (!(m_extractor >> name))
-        throw std::runtime_error(io::Str() << "Can't parse node name from line '" << line << "'");
-    }
-    double weight = 1.0;
-    if ((m_extractor >> weight)) {
-      m_haveNodeWeights = true;
-      if (weight < 0)
-        throw std::runtime_error(io::Str() << "Negative node weight (" << weight << ") from line '" << line << "'");
-    }
-
-    addPhysicalNode(id, weight, name);
-  }
-  Log() << "  -> " << m_physNodes.size() << " physical nodes added\n";
-  return line;
-}
-
-std::string Network::parseStateNodes(std::ifstream& file, const std::string& /*heading*/)
-{
-  m_higherOrderInputMethodCalled = true;
-  Log() << "  Parsing state nodes...\n"
-        << std::flush;
-  std::string line;
-  while (!std::getline(file, line).fail()) {
-    if (line.empty() || line[0] == '#')
-      continue;
-
-    if (line[0] == '*')
-      break;
-
-    StateNode stateNode;
-    parseStateNode(line, stateNode);
-
-    addStateNode(stateNode);
-    addPhysicalNode(stateNode.physicalId);
-
-    ++m_numStateNodesFound;
-  }
-  Log() << "  -> " << m_numStateNodesFound << " state nodes added\n";
-  return line;
-}
-
-std::string Network::parseLinks(std::ifstream& file)
-{
-  // This is the default action, so check for links before printing
-  bool parsingLinks = false;
-  std::string line;
-  while (!std::getline(file, line).fail()) {
-    if (line.empty() || line[0] == '#')
-      continue;
-
-    if (line[0] == '*')
-      break;
-
-    if (!parsingLinks) {
-      parsingLinks = true;
-      Log() << "  Parsing links...\n"
-            << std::flush;
-    }
-
-    unsigned int n1, n2;
-    double weight;
-    parseLink(line, n1, n2, weight);
-
-    addLink(n1, n2, weight);
-  }
-  if (parsingLinks)
-    Log() << "  -> " << m_numLinks << " links\n";
-  return line;
-}
-
-std::string Network::parseMultilayerLinks(std::ifstream& file)
-{
-  Log() << "  Parsing multilayer links...\n"
-        << std::flush;
-
-  if (m_config.matchableMultilayerIds > 0) {
-    Log() << "  Creating matchable state ids using: nodeId << (log2(" << m_config.matchableMultilayerIds << ") + 1) | layerId\n";
-  }
-
-  std::string line;
-  while (!std::getline(file, line).fail()) {
-    if (line.empty() || line[0] == '#')
-      continue;
-
-    if (line[0] == '*')
-      break;
-
-    unsigned int layer1, n1, layer2, n2;
-    double weight;
-    parseMultilayerLink(line, layer1, n1, layer2, n2, weight);
-
-    // TODO: This explicit multilayer format can allow undirected but not the inter/intra format, clear?
-    addMultilayerLink(layer1, n1, layer2, n2, weight);
-  }
-  Log() << "  -> " << (m_numIntraLayerLinks + m_numInterLayerLinks) << " links in " << m_layers.size() << " layers\n";
-  Log() << "    -> " << m_numIntraLayerLinks << " intra-layer links\n";
-  Log() << "    -> " << m_numInterLayerLinks << " inter-layer links\n";
-  return line;
-}
-
-std::string Network::parseMultilayerIntraLinks(std::ifstream& file)
-{
-  Log() << "  Parsing intra-layer links...\n"
-        << std::flush;
-
-  if (m_config.matchableMultilayerIds > 0) {
-    Log() << "  Creating matchable state ids using: nodeId << (log2(" << m_config.matchableMultilayerIds << ") + 1) | layerId\n";
-  }
-
-  std::string line;
-  while (!std::getline(file, line).fail()) {
-    if (line.empty() || line[0] == '#')
-      continue;
-
-    if (line[0] == '*')
-      break;
-
-    unsigned int layer, n1, n2;
-    double weight;
-    parseMultilayerIntraLink(line, layer, n1, n2, weight);
-
-    addMultilayerIntraLink(layer, n1, n2, weight);
-  }
-  Log() << "  -> " << m_numIntraLayerLinks << " intra-layer links\n";
-  return line;
-}
-
-std::string Network::parseMultilayerInterLinks(std::ifstream& file)
-{
-  Log() << "  Parsing inter-layer links...\n"
-        << std::flush;
-  std::string line;
-  while (!std::getline(file, line).fail()) {
-    if (line.empty() || line[0] == '#')
-      continue;
-
-    if (line[0] == '*')
-      break;
-
-    unsigned int layer1, n, layer2;
-    double weight;
-    parseMultilayerInterLink(line, layer1, n, layer2, weight);
-
-    addMultilayerInterLink(layer1, n, layer2, weight);
-  }
-  Log() << "  -> " << m_numInterLayerLinks << " inter-layer links\n";
-  return line;
-}
-
-std::string Network::parseBipartiteLinks(std::ifstream& file, const std::string& heading)
-{
-  Log() << "  Parsing bipartite links...\n";
-  // Extract break point for bipartite links
-  m_extractor.clear();
-  m_extractor.str(heading);
-  std::string tmp;
-  if (!(m_extractor >> tmp >> m_bipartiteStartId))
-    throw std::runtime_error(io::Str() << "Can't parse bipartite start id from line '" << heading << "'");
-
-  Log() << "  -> Using bipartite start id " << m_bipartiteStartId << "\n";
-  m_config.bipartite = true;
-  std::string line;
-  while (!std::getline(file, line).fail()) {
-    if (line.empty() || line[0] == '#')
-      continue;
-
-    if (line[0] == '*')
-      break;
-
-    unsigned int n1, n2;
-    double weight;
-    parseLink(line, n1, n2, weight);
-    bool sourceIsFeature = n1 >= m_bipartiteStartId;
-    bool targetIsFeature = n2 >= m_bipartiteStartId;
-    if (sourceIsFeature == targetIsFeature) {
-      throw std::runtime_error(io::Str() << "Bipartite link '" << line << "' must cross bipartite start id " << m_bipartiteStartId << ".");
-    }
-    addLink(n1, n2, weight);
-  }
-  return line;
-}
-
-std::string Network::ignoreSection(std::ifstream& file, const std::string& heading)
-{
-  Log() << "(Ignoring section " << heading << ") ";
-  std::string line;
-  while (!std::getline(file, line).fail()) {
-    if (line[0] == '*')
-      break;
-  }
-  return line;
-}
-
-void Network::parseStateNode(const std::string& line, StateNetwork::StateNode& stateNode)
-{
-  const char* p = line.c_str();
-  if (!parseUnsigned(p, stateNode.id) || !parseUnsigned(p, stateNode.physicalId))
-    throw std::runtime_error(io::Str() << "Can't parse any state node from line '" << line << "'");
-
-  // Optional name enclosed in double quotes
-  auto nameStart = line.find_first_of('\"', static_cast<std::size_t>(p - line.c_str()));
-  auto nameEnd = line.find_last_of('\"');
-  if (nameStart < nameEnd) {
-    stateNode.name = std::string(line.begin() + nameStart + 1, line.begin() + nameEnd);
-    p = line.c_str() + nameEnd + 1;
-  }
-  // Optional weight, default to 1.0
-  if (parseOptionalDouble(p, stateNode.weight)) {
-    m_haveStateNodeWeights = true;
-    if (stateNode.weight < 0)
-      throw std::runtime_error(io::Str() << "Negative state node weight (" << stateNode.weight << ") from line '" << line << "'");
-  }
-}
-
-void Network::parseLink(const std::string& line, unsigned int& n1, unsigned int& n2, double& weight)
-{
-  const char* p = line.c_str();
-  if (!parseUnsigned(p, n1) || !parseUnsigned(p, n2))
-    throw std::runtime_error(io::Str() << "Can't parse link data from line '" << line << "'");
-  if (!parseOptionalDouble(p, weight)) {
-    weight = 1.0;
-  }
-}
-
-void Network::parseMultilayerLink(const std::string& line, unsigned int& layer1, unsigned int& n1, unsigned int& layer2, unsigned int& n2, double& weight)
-{
-  const char* p = line.c_str();
-  if (!parseUnsigned(p, layer1) || !parseUnsigned(p, n1) || !parseUnsigned(p, layer2) || !parseUnsigned(p, n2))
-    throw std::runtime_error(io::Str() << "Can't parse multilayer link data from line '" << line << "'");
-  if (!parseOptionalDouble(p, weight)) {
-    weight = 1.0;
-  }
-}
-
-void Network::parseMultilayerIntraLink(const std::string& line, unsigned int& layer, unsigned int& n1, unsigned int& n2, double& weight)
-{
-  const char* p = line.c_str();
-  if (!parseUnsigned(p, layer) || !parseUnsigned(p, n1) || !parseUnsigned(p, n2))
-    throw std::runtime_error(io::Str() << "Can't parse intra-multilayer link data from line '" << line << "'");
-  if (!parseOptionalDouble(p, weight)) {
-    weight = 1.0;
-  }
-}
-
-void Network::parseMultilayerInterLink(const std::string& line, unsigned int& layer1, unsigned int& n, unsigned int& layer2, double& weight)
-{
-  const char* p = line.c_str();
-  if (!parseUnsigned(p, layer1) || !parseUnsigned(p, n) || !parseUnsigned(p, layer2))
-    throw std::runtime_error(io::Str() << "Can't parse inter-multilayer link data from line '" << line << "'");
-  if (!parseOptionalDouble(p, weight)) {
-    weight = 1.0;
-  }
-  if (layer1 == layer2)
-    throw std::runtime_error(io::Str() << "Inter-layer link from line '" << line << "' doesn't go between different layers.");
-  // TODO: Same as intra-layer self-link?
+  NetworkInputSinkAdapter sink(*this);
+  input::parseMetaDataInput(filename, sink);
 }
 
 void Network::printSummary()

--- a/src/io/Network.h
+++ b/src/io/Network.h
@@ -20,18 +20,16 @@
 #include <set>
 #include <utility>
 #include <limits>
-#include <sstream>
-#include <locale>
 
 namespace infomap {
 
 struct LayerNode;
+class NetworkInputSinkAdapter;
 
 class Network : public StateNetwork {
-private:
-  // Helpers
-  std::istringstream m_extractor;
+  friend class NetworkInputSinkAdapter;
 
+private:
   // Multilayer
   std::map<unsigned int, Network> m_networks; // intra-layer links
   std::map<LayerNode, std::map<unsigned int, double>> m_interLinks;
@@ -48,16 +46,6 @@ private:
   // Meta data
   std::map<unsigned int, std::vector<int>> m_metaData;
   unsigned int m_numMetaDataColumns = 0;
-
-  using InsensitiveStringSet = std::set<std::string, io::InsensitiveCompare>;
-
-  std::map<std::string, InsensitiveStringSet> m_ignoreHeadings;
-  std::map<std::string, InsensitiveStringSet> m_validHeadings; // {
-  // 	{ "pajek", {"*Vertices", "*Edges", "*Arcs"} },
-  // 	{ "link-list", {"*Links"} },
-  // 	{ "bipartite", {"*Vertices", "*Bipartite"} },
-  // 	{ "general", {"*Vertices", "*States", "*Edges", "*Arcs", "*Links", "*Context"} }
-  // };
 
 public:
   Network() { init(); }
@@ -152,70 +140,6 @@ public:
 private:
   void init();
   void updateDerivedConfig();
-  void initValidHeadings();
-
-  void parseNetwork(const std::string& filename);
-  void parseNetwork(const std::string& filename, const InsensitiveStringSet& validHeadings, const InsensitiveStringSet& ignoreHeadings, const std::string& startHeading = "");
-
-  // Helper methods
-
-  /**
-   * Parse vertices under the heading
-   * @return The line after the vertices
-   */
-  std::string parseVertices(std::ifstream& file, const std::string& heading);
-  std::string parseStateNodes(std::ifstream& file, const std::string& heading);
-
-  std::string parseLinks(std::ifstream& file);
-
-  /**
-   * Parse multilayer links from a *multilayer section
-   */
-  std::string parseMultilayerLinks(std::ifstream& file);
-
-  /**
-   * Parse multilayer links from an *intra section
-   */
-  std::string parseMultilayerIntraLinks(std::ifstream& file);
-
-  /**
-   * Parse multilayer links from an *inter section
-   */
-  std::string parseMultilayerInterLinks(std::ifstream& file);
-
-  std::string parseBipartiteLinks(std::ifstream& file, const std::string& heading);
-
-  static std::string ignoreSection(std::ifstream& file, const std::string& heading);
-
-  void parseStateNode(const std::string& line, StateNetwork::StateNode& stateNode);
-
-  /**
-   * Parse a string of link data.
-   * If no weight data can be extracted, the default value 1.0 will be used.
-   * @throws an error if not both node ids can be extracted.
-   */
-  void parseLink(const std::string& line, unsigned int& n1, unsigned int& n2, double& weight);
-
-  /**
-   * Parse a string of multilayer link data.
-   * If no weight data can be extracted, the default value 1.0 will be used.
-   * @throws an error if not both node and layer ids can be extracted.
-   */
-  void parseMultilayerLink(const std::string& line, unsigned int& layer1, unsigned int& n1, unsigned int& layer2, unsigned int& n2, double& weight);
-
-  /**
-   * Parse a string of intra-multilayer link data.
-   * If no weight data can be extracted, the default value 1.0 will be used.
-   * @throws an error if not both node and layer ids can be extracted.
-   */
-  void parseMultilayerIntraLink(const std::string& line, unsigned int& layer, unsigned int& n1, unsigned int& n2, double& weight);
-
-  /**
-   * Parse a string of inter-multilayer link data.
-   * If no weight data can be extracted, the default value 1.0 will be used.
-   * @throws an error if not both node and layer ids can be extracted.
-   */
-  void parseMultilayerInterLink(const std::string& line, unsigned int& layer1, unsigned int& n, unsigned int& layer2, double& weight);
 
   static double calculateJensenShannonDivergence(bool& intersect, const OutLinkMap& layer1OutLinks, double sumOutLinkWeightLayer1, const OutLinkMap& layer2OutLinks, double sumOutLinkWeightLayer2);
 

--- a/src/io/NetworkInputParser.h
+++ b/src/io/NetworkInputParser.h
@@ -1,0 +1,496 @@
+/*******************************************************************************
+ Infomap software package for multi-level network clustering
+ Copyright (c) 2013, 2014 Daniel Edler, Anton Holmgren, Martin Rosvall
+
+ This file is part of the Infomap software package.
+ See file LICENSE_GPLv3.txt for full license details.
+ For more information, see <http://www.mapequation.org>
+ ******************************************************************************/
+
+#ifndef NETWORK_INPUT_PARSER_H_
+#define NETWORK_INPUT_PARSER_H_
+
+#include "SafeFile.h"
+#include "../core/StateNetwork.h"
+#include "../utils/Log.h"
+#include "../utils/convert.h"
+
+#include <cstdlib>
+#include <fstream>
+#include <limits>
+#include <map>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace infomap {
+namespace input {
+
+  struct ParsedVertex {
+    unsigned int id = 0;
+    std::string name;
+    bool hasWeight = false;
+    double weight = 1.0;
+  };
+
+  struct ParsedLink {
+    unsigned int source = 0;
+    unsigned int target = 0;
+    double weight = 1.0;
+  };
+
+  struct ParsedStateNode {
+    StateNetwork::StateNode node;
+    bool hasWeight = false;
+  };
+
+  struct ParsedMultilayerLink {
+    unsigned int sourceLayer = 0;
+    unsigned int sourceNode = 0;
+    unsigned int targetLayer = 0;
+    unsigned int targetNode = 0;
+    double weight = 1.0;
+  };
+
+  struct ParsedMultilayerIntraLink {
+    unsigned int layer = 0;
+    unsigned int sourceNode = 0;
+    unsigned int targetNode = 0;
+    double weight = 1.0;
+  };
+
+  struct ParsedMultilayerInterLink {
+    unsigned int sourceLayer = 0;
+    unsigned int node = 0;
+    unsigned int targetLayer = 0;
+    double weight = 1.0;
+  };
+
+  namespace detail {
+
+    using InsensitiveStringSet = std::set<std::string, io::InsensitiveCompare>;
+
+    inline bool isInputWhitespace(char c)
+    {
+      return c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '\f' || c == '\v';
+    }
+
+    inline bool isDigit(char c)
+    {
+      return c >= '0' && c <= '9';
+    }
+
+    inline void skipWhitespace(const char*& p)
+    {
+      while (isInputWhitespace(*p)) {
+        ++p;
+      }
+    }
+
+    inline bool parseUnsigned(const char*& p, unsigned int& value)
+    {
+      skipWhitespace(p);
+      if (*p == '+') {
+        ++p;
+      }
+      if (!isDigit(*p)) {
+        return false;
+      }
+
+      unsigned long long result = 0;
+      const unsigned long long maxValue = std::numeric_limits<unsigned int>::max();
+      do {
+        result = result * 10 + static_cast<unsigned long long>(*p - '0');
+        if (result > maxValue) {
+          return false;
+        }
+        ++p;
+      } while (isDigit(*p));
+
+      value = static_cast<unsigned int>(result);
+      return true;
+    }
+
+    inline bool parseOptionalDouble(const char*& p, double& value)
+    {
+      skipWhitespace(p);
+      if (*p == '\0' || *p == '#') {
+        return false;
+      }
+
+      char* end = nullptr;
+      const double parsed = std::strtod(p, &end);
+      if (end == p) {
+        return false;
+      }
+
+      value = parsed;
+      p = end;
+      return true;
+    }
+
+    inline ParsedLink parseLink(const std::string& line)
+    {
+      const char* p = line.c_str();
+      ParsedLink link;
+      if (!parseUnsigned(p, link.source) || !parseUnsigned(p, link.target))
+        throw std::runtime_error(io::Str() << "Can't parse link data from line '" << line << "'");
+      if (!parseOptionalDouble(p, link.weight)) {
+        link.weight = 1.0;
+      }
+      return link;
+    }
+
+    inline ParsedStateNode parseStateNode(const std::string& line)
+    {
+      const char* p = line.c_str();
+      ParsedStateNode parsed;
+      if (!parseUnsigned(p, parsed.node.id) || !parseUnsigned(p, parsed.node.physicalId))
+        throw std::runtime_error(io::Str() << "Can't parse any state node from line '" << line << "'");
+
+      auto nameStart = line.find_first_of('\"', static_cast<std::size_t>(p - line.c_str()));
+      auto nameEnd = line.find_last_of('\"');
+      if (nameStart < nameEnd) {
+        parsed.node.name = std::string(line.begin() + nameStart + 1, line.begin() + nameEnd);
+        p = line.c_str() + nameEnd + 1;
+      }
+      if (parseOptionalDouble(p, parsed.node.weight)) {
+        parsed.hasWeight = true;
+        if (parsed.node.weight < 0)
+          throw std::runtime_error(io::Str() << "Negative state node weight (" << parsed.node.weight << ") from line '" << line << "'");
+      }
+      return parsed;
+    }
+
+    inline ParsedMultilayerLink parseMultilayerLink(const std::string& line)
+    {
+      const char* p = line.c_str();
+      ParsedMultilayerLink link;
+      if (!parseUnsigned(p, link.sourceLayer) || !parseUnsigned(p, link.sourceNode) || !parseUnsigned(p, link.targetLayer) || !parseUnsigned(p, link.targetNode))
+        throw std::runtime_error(io::Str() << "Can't parse multilayer link data from line '" << line << "'");
+      if (!parseOptionalDouble(p, link.weight)) {
+        link.weight = 1.0;
+      }
+      return link;
+    }
+
+    inline ParsedMultilayerIntraLink parseMultilayerIntraLink(const std::string& line)
+    {
+      const char* p = line.c_str();
+      ParsedMultilayerIntraLink link;
+      if (!parseUnsigned(p, link.layer) || !parseUnsigned(p, link.sourceNode) || !parseUnsigned(p, link.targetNode))
+        throw std::runtime_error(io::Str() << "Can't parse intra-multilayer link data from line '" << line << "'");
+      if (!parseOptionalDouble(p, link.weight)) {
+        link.weight = 1.0;
+      }
+      return link;
+    }
+
+    inline ParsedMultilayerInterLink parseMultilayerInterLink(const std::string& line)
+    {
+      const char* p = line.c_str();
+      ParsedMultilayerInterLink link;
+      if (!parseUnsigned(p, link.sourceLayer) || !parseUnsigned(p, link.node) || !parseUnsigned(p, link.targetLayer))
+        throw std::runtime_error(io::Str() << "Can't parse inter-multilayer link data from line '" << line << "'");
+      if (!parseOptionalDouble(p, link.weight)) {
+        link.weight = 1.0;
+      }
+      if (link.sourceLayer == link.targetLayer)
+        throw std::runtime_error(io::Str() << "Inter-layer link from line '" << line << "' doesn't go between different layers.");
+      return link;
+    }
+
+    inline InsensitiveStringSet generalValidHeadings()
+    {
+      return { "*vertices", "*states", "*multilayer", "*multiplex", "*intra", "*inter", "*paths", "*edges", "*arcs", "*links", "*contexts", "*bipartite" };
+    }
+
+    inline InsensitiveStringSet generalIgnoredHeadings()
+    {
+      return { "*contexts" };
+    }
+
+    template <typename Sink>
+    std::string parseVertices(std::ifstream& file, const std::string&, Sink& sink)
+    {
+      Log() << "  Parsing vertices...\n"
+            << std::flush;
+      std::string line;
+      while (!std::getline(file, line).fail()) {
+        if (line.empty() || line[0] == '#')
+          continue;
+
+        if (line[0] == '*')
+          break;
+
+        std::istringstream extractor(line);
+        ParsedVertex vertex;
+        if (!(extractor >> vertex.id))
+          throw std::runtime_error(io::Str() << "Can't parse node id from line '" << line << "'");
+
+        auto nameStart = line.find_first_of('\"');
+        auto nameEnd = line.find_last_of('\"');
+        if (nameStart < nameEnd) {
+          vertex.name = std::string(line.begin() + nameStart + 1, line.begin() + nameEnd);
+          line = line.substr(nameEnd + 1);
+          extractor.clear();
+          extractor.str(line);
+        } else {
+          if (!(extractor >> vertex.name))
+            throw std::runtime_error(io::Str() << "Can't parse node name from line '" << line << "'");
+        }
+        if ((extractor >> vertex.weight)) {
+          vertex.hasWeight = true;
+          if (vertex.weight < 0)
+            throw std::runtime_error(io::Str() << "Negative node weight (" << vertex.weight << ") from line '" << line << "'");
+        }
+
+        sink.onPhysicalNode(vertex);
+      }
+      Log() << "  -> " << sink.numPhysicalNodes() << " physical nodes added\n";
+      return line;
+    }
+
+    template <typename Sink>
+    std::string parseStateNodes(std::ifstream& file, const std::string&, Sink& sink)
+    {
+      Log() << "  Parsing state nodes...\n"
+            << std::flush;
+      unsigned int numStateNodesFound = 0;
+      std::string line;
+      while (!std::getline(file, line).fail()) {
+        if (line.empty() || line[0] == '#')
+          continue;
+
+        if (line[0] == '*')
+          break;
+
+        auto stateNode = parseStateNode(line);
+        sink.onStateNode(stateNode);
+        ++numStateNodesFound;
+      }
+      Log() << "  -> " << numStateNodesFound << " state nodes added\n";
+      return line;
+    }
+
+    template <typename Sink>
+    std::string parseLinks(std::ifstream& file, Sink& sink)
+    {
+      bool parsingLinks = false;
+      std::string line;
+      while (!std::getline(file, line).fail()) {
+        if (line.empty() || line[0] == '#')
+          continue;
+
+        if (line[0] == '*')
+          break;
+
+        if (!parsingLinks) {
+          parsingLinks = true;
+          Log() << "  Parsing links...\n"
+                << std::flush;
+        }
+
+        sink.onLink(parseLink(line));
+      }
+      if (parsingLinks)
+        Log() << "  -> " << sink.numLinks() << " links\n";
+      return line;
+    }
+
+    template <typename Sink>
+    std::string parseMultilayerLinks(std::ifstream& file, Sink& sink)
+    {
+      Log() << "  Parsing multilayer links...\n"
+            << std::flush;
+
+      if (sink.matchableMultilayerIds() > 0) {
+        Log() << "  Creating matchable state ids using: nodeId << (log2(" << sink.matchableMultilayerIds() << ") + 1) | layerId\n";
+      }
+
+      std::string line;
+      while (!std::getline(file, line).fail()) {
+        if (line.empty() || line[0] == '#')
+          continue;
+
+        if (line[0] == '*')
+          break;
+
+        sink.onMultilayerLink(parseMultilayerLink(line));
+      }
+      Log() << "  -> " << sink.numLayerLinks() << " links in " << sink.numLayers() << " layers\n";
+      Log() << "    -> " << sink.numIntraLayerLinks() << " intra-layer links\n";
+      Log() << "    -> " << sink.numInterLayerLinks() << " inter-layer links\n";
+      return line;
+    }
+
+    template <typename Sink>
+    std::string parseMultilayerIntraLinks(std::ifstream& file, Sink& sink)
+    {
+      Log() << "  Parsing intra-layer links...\n"
+            << std::flush;
+
+      if (sink.matchableMultilayerIds() > 0) {
+        Log() << "  Creating matchable state ids using: nodeId << (log2(" << sink.matchableMultilayerIds() << ") + 1) | layerId\n";
+      }
+
+      std::string line;
+      while (!std::getline(file, line).fail()) {
+        if (line.empty() || line[0] == '#')
+          continue;
+
+        if (line[0] == '*')
+          break;
+
+        sink.onMultilayerIntraLink(parseMultilayerIntraLink(line));
+      }
+      Log() << "  -> " << sink.numIntraLayerLinks() << " intra-layer links\n";
+      return line;
+    }
+
+    template <typename Sink>
+    std::string parseMultilayerInterLinks(std::ifstream& file, Sink& sink)
+    {
+      Log() << "  Parsing inter-layer links...\n"
+            << std::flush;
+      std::string line;
+      while (!std::getline(file, line).fail()) {
+        if (line.empty() || line[0] == '#')
+          continue;
+
+        if (line[0] == '*')
+          break;
+
+        sink.onMultilayerInterLink(parseMultilayerInterLink(line));
+      }
+      Log() << "  -> " << sink.numInterLayerLinks() << " inter-layer links\n";
+      return line;
+    }
+
+    template <typename Sink>
+    std::string parseBipartiteLinks(std::ifstream& file, const std::string& heading, Sink& sink)
+    {
+      Log() << "  Parsing bipartite links...\n";
+      std::istringstream extractor(heading);
+      std::string tmp;
+      unsigned int bipartiteStartId = 0;
+      if (!(extractor >> tmp >> bipartiteStartId))
+        throw std::runtime_error(io::Str() << "Can't parse bipartite start id from line '" << heading << "'");
+
+      Log() << "  -> Using bipartite start id " << bipartiteStartId << "\n";
+      sink.onBipartiteStart(bipartiteStartId);
+      std::string line;
+      while (!std::getline(file, line).fail()) {
+        if (line.empty() || line[0] == '#')
+          continue;
+
+        if (line[0] == '*')
+          break;
+
+        sink.onBipartiteLink(line, parseLink(line));
+      }
+      return line;
+    }
+
+    inline std::string ignoreSection(std::ifstream& file, const std::string& heading)
+    {
+      Log() << "(Ignoring section " << heading << ") ";
+      std::string line;
+      while (!std::getline(file, line).fail()) {
+        if (line[0] == '*')
+          break;
+      }
+      return line;
+    }
+
+    template <typename Sink>
+    void parseNetwork(const std::string& filename, const InsensitiveStringSet& validHeadings, const InsensitiveStringSet& ignoreHeadings, Sink& sink, const std::string& startHeading = "")
+    {
+      sink.onFileInput();
+      SafeInFile input(filename);
+
+      std::string heading = !startHeading.empty() ? startHeading : parseLinks(input, sink);
+
+      while (!heading.empty() && heading[0] == '*') {
+        std::string headingLowerCase = io::tolower(io::firstWord(heading));
+        if (validHeadings.count(headingLowerCase) == 0) {
+          throw std::runtime_error(io::Str() << "Unrecognized heading in network file: '" << headingLowerCase << "'.");
+        }
+        bool shouldIgnoreHeading = ignoreHeadings.count(headingLowerCase) > 0;
+        if (!shouldIgnoreHeading && headingLowerCase == "*vertices") {
+          heading = parseVertices(input, heading, sink);
+        } else if (!shouldIgnoreHeading && headingLowerCase == "*states") {
+          heading = parseStateNodes(input, heading, sink);
+        } else if (!shouldIgnoreHeading && headingLowerCase == "*edges") {
+          if (!sink.isUndirectedFlow())
+            Log() << "\n --> Notice: Links marked as undirected but parsed as directed.\n";
+          heading = parseLinks(input, sink);
+        } else if (!shouldIgnoreHeading && headingLowerCase == "*arcs") {
+          if (sink.isUndirectedFlow())
+            Log() << "\n --> Notice: Links marked as directed but parsed as undirected.\n";
+          heading = parseLinks(input, sink);
+        } else if (!shouldIgnoreHeading && headingLowerCase == "*links") {
+          heading = parseLinks(input, sink);
+        } else if (!shouldIgnoreHeading && (headingLowerCase == "*multilayer" || headingLowerCase == "*multiplex")) {
+          heading = parseMultilayerLinks(input, sink);
+        } else if (!shouldIgnoreHeading && headingLowerCase == "*intra") {
+          heading = parseMultilayerIntraLinks(input, sink);
+        } else if (!shouldIgnoreHeading && headingLowerCase == "*inter") {
+          heading = parseMultilayerInterLinks(input, sink);
+        } else if (!shouldIgnoreHeading && headingLowerCase == "*bipartite") {
+          heading = parseBipartiteLinks(input, heading, sink);
+        } else {
+          heading = ignoreSection(input, headingLowerCase);
+        }
+      }
+
+      sink.onNetworkParsed();
+      Log() << "Done!\n";
+    }
+
+  } // namespace detail
+
+  template <typename Sink>
+  void parseNetworkInput(const std::string& filename, Sink& sink)
+  {
+    Log() << "Parsing " << (sink.isUndirectedFlow() ? "undirected" : "directed") << " network from file '" << filename << "'...\n";
+    detail::parseNetwork(filename, detail::generalValidHeadings(), detail::generalIgnoredHeadings(), sink);
+  }
+
+  template <typename Sink>
+  void parseMetaDataInput(const std::string& filename, Sink& sink)
+  {
+    Log() << "Parsing meta data from '" << filename << "'...\n";
+    SafeInFile input(filename);
+    std::string line;
+    while (!std::getline(input, line).fail()) {
+      if (line.empty() || line[0] == '#')
+        continue;
+
+      if (line[0] == '*')
+        break;
+
+      std::istringstream extractor(line);
+      unsigned int nodeId = 0;
+      if (!(extractor >> nodeId))
+        throw std::runtime_error(io::Str() << "Can't parse node id from line '" << line << "'");
+
+      std::vector<int> metaData;
+      unsigned int metaId = 0;
+      while (extractor >> metaId) {
+        metaData.push_back(metaId);
+      }
+      if (metaData.empty())
+        throw std::runtime_error(io::Str() << "Can't parse any meta data from line '" << line << "'");
+
+      sink.onMetaData(nodeId, metaData);
+    }
+    Log() << " -> Parsed " << sink.numMetaDataColumns() << " columns of meta data for " << sink.numMetaDataRows() << " nodes.\n";
+  }
+
+} // namespace input
+} // namespace infomap
+
+#endif // NETWORK_INPUT_PARSER_H_

--- a/test/cpp/test_network.cpp
+++ b/test/cpp/test_network.cpp
@@ -2,13 +2,74 @@
 
 #include "io/Config.h"
 #include "io/Network.h"
+#include "io/NetworkInputParser.h"
 
 #include "TestUtils.h"
+
+#include <string>
+#include <vector>
 
 namespace {
 
 using infomap::Config;
 using infomap::Network;
+
+struct FakeInputSink {
+  bool undirectedFlow = true;
+  unsigned int matchableIds = 0;
+  unsigned int bipartiteStartId = 0;
+  bool fileInput = false;
+  bool parsed = false;
+
+  std::vector<infomap::input::ParsedVertex> vertices;
+  std::vector<infomap::input::ParsedStateNode> stateNodes;
+  std::vector<infomap::input::ParsedLink> links;
+  std::vector<infomap::input::ParsedMultilayerLink> multilayerLinks;
+  std::vector<infomap::input::ParsedMultilayerIntraLink> intraLinks;
+  std::vector<infomap::input::ParsedMultilayerInterLink> interLinks;
+  std::vector<infomap::input::ParsedLink> bipartiteLinks;
+  std::vector<std::vector<int>> metaDataRows;
+
+  bool isUndirectedFlow() const { return undirectedFlow; }
+  unsigned int matchableMultilayerIds() const { return matchableIds; }
+  unsigned int numPhysicalNodes() const { return vertices.size(); }
+  unsigned int numLinks() const { return links.size(); }
+  unsigned int numIntraLayerLinks() const { return intraLinks.size() + countExplicitIntraLinks(); }
+  unsigned int numInterLayerLinks() const { return interLinks.size() + countExplicitInterLinks(); }
+  unsigned int numLayerLinks() const { return numIntraLayerLinks() + numInterLayerLinks(); }
+  unsigned int numLayers() const { return 0; }
+  unsigned int numMetaDataColumns() const { return metaDataRows.empty() ? 0 : metaDataRows.front().size(); }
+  unsigned int numMetaDataRows() const { return metaDataRows.size(); }
+
+  void onFileInput() { fileInput = true; }
+  void onNetworkParsed() { parsed = true; }
+  void onPhysicalNode(const infomap::input::ParsedVertex& vertex) { vertices.push_back(vertex); }
+  void onStateNode(const infomap::input::ParsedStateNode& stateNode) { stateNodes.push_back(stateNode); }
+  void onLink(const infomap::input::ParsedLink& link) { links.push_back(link); }
+  void onMultilayerLink(const infomap::input::ParsedMultilayerLink& link) { multilayerLinks.push_back(link); }
+  void onMultilayerIntraLink(const infomap::input::ParsedMultilayerIntraLink& link) { intraLinks.push_back(link); }
+  void onMultilayerInterLink(const infomap::input::ParsedMultilayerInterLink& link) { interLinks.push_back(link); }
+  void onBipartiteStart(unsigned int startId) { bipartiteStartId = startId; }
+  void onBipartiteLink(const std::string&, const infomap::input::ParsedLink& link) { bipartiteLinks.push_back(link); }
+  void onMetaData(unsigned int, const std::vector<int>& metaData) { metaDataRows.push_back(metaData); }
+
+private:
+  unsigned int countExplicitIntraLinks() const
+  {
+    unsigned int count = 0;
+    for (const auto& link : multilayerLinks) {
+      if (link.sourceLayer == link.targetLayer) {
+        ++count;
+      }
+    }
+    return count;
+  }
+
+  unsigned int countExplicitInterLinks() const
+  {
+    return multilayerLinks.size() - countExplicitIntraLinks();
+  }
+};
 
 TEST_CASE("Network aggregates duplicate links [fast][core]")
 {
@@ -62,6 +123,91 @@ TEST_CASE("Network rejects malformed multilayer fixture lines [fast][core][parse
 
   CHECK_THROWS_WITH_AS(
       network.readInputData(infomap::test::repoPath("test/fixtures/networks/invalid_multilayer.net")),
+      "Can't parse multilayer link data from line '1 1 broken'",
+      std::runtime_error);
+}
+
+TEST_CASE("NetworkInputParser emits events for link-list input [fast][core][parser]")
+{
+  FakeInputSink sink;
+
+  infomap::input::parseNetworkInput(infomap::test::repoPath("test/fixtures/graphs/twotriangles_unweighted.edges"), sink);
+
+  CHECK(sink.fileInput);
+  CHECK(sink.parsed);
+  CHECK(sink.links.size() == 7);
+  CHECK(sink.links.front().source == 1);
+  CHECK(sink.links.front().target == 2);
+  CHECK(sink.links.front().weight == doctest::Approx(1.0));
+}
+
+TEST_CASE("NetworkInputParser emits vertex and bipartite events [fast][core][parser]")
+{
+  FakeInputSink sink;
+
+  infomap::input::parseNetworkInput(infomap::test::repoPath("examples/networks/bipartite.net"), sink);
+
+  CHECK(sink.vertices.size() == 5);
+  CHECK(sink.vertices.front().id == 1);
+  CHECK(sink.vertices.front().name == "Node 1");
+  CHECK(sink.bipartiteStartId == 4);
+  CHECK(sink.bipartiteLinks.size() == 4);
+}
+
+TEST_CASE("NetworkInputParser emits state-network events [fast][core][parser]")
+{
+  FakeInputSink sink;
+
+  infomap::input::parseNetworkInput(infomap::test::repoPath("examples/networks/states.net"), sink);
+
+  CHECK(sink.vertices.size() == 5);
+  CHECK(sink.stateNodes.size() == 6);
+  CHECK(sink.stateNodes.front().node.id == 1);
+  CHECK(sink.stateNodes.front().node.physicalId == 1);
+  CHECK(sink.links.size() == 16);
+}
+
+TEST_CASE("NetworkInputParser emits explicit multilayer events [fast][core][parser]")
+{
+  FakeInputSink sink;
+
+  infomap::input::parseNetworkInput(infomap::test::repoPath("examples/networks/multilayer.net"), sink);
+
+  CHECK(sink.vertices.size() == 5);
+  CHECK(sink.multilayerLinks.size() == 16);
+  CHECK(sink.numIntraLayerLinks() == 12);
+  CHECK(sink.numInterLayerLinks() == 4);
+}
+
+TEST_CASE("NetworkInputParser emits intra and inter events [fast][core][parser]")
+{
+  FakeInputSink sink;
+
+  infomap::input::parseNetworkInput(infomap::test::repoPath("test/fixtures/networks/intra_inter.net"), sink);
+
+  CHECK(sink.intraLinks.size() == 2);
+  CHECK(sink.interLinks.size() == 2);
+  CHECK(sink.intraLinks.front().layer == 1);
+  CHECK(sink.interLinks.front().sourceLayer == 1);
+  CHECK(sink.interLinks.front().targetLayer == 2);
+}
+
+TEST_CASE("NetworkInputParser emits metadata events [fast][core][parser]")
+{
+  FakeInputSink sink;
+
+  infomap::input::parseMetaDataInput(infomap::test::repoPath("test/fixtures/meta/states.meta"), sink);
+
+  CHECK(sink.metaDataRows.size() == 6);
+  CHECK(sink.metaDataRows.front().size() == 1);
+}
+
+TEST_CASE("NetworkInputParser preserves malformed multilayer errors [fast][core][parser]")
+{
+  FakeInputSink sink;
+
+  CHECK_THROWS_WITH_AS(
+      infomap::input::parseNetworkInput(infomap::test::repoPath("test/fixtures/networks/invalid_multilayer.net"), sink),
       "Can't parse multilayer link data from line '1 1 broken'",
       std::runtime_error);
 }

--- a/test/fixtures/networks/intra_inter.net
+++ b/test/fixtures/networks/intra_inter.net
@@ -1,0 +1,9 @@
+# A multilayer network using separate intra/inter sections
+*Intra
+# layer node node weight
+1 1 2 3
+2 1 2 4
+*Inter
+# layer node layer weight
+1 1 2 0.5
+2 2 1 0.6


### PR DESCRIPTION
## Summary
- add an internal template-based network input parser under `src/io`
- route `Network::readInputData` and metadata parsing through a sink adapter that preserves existing `Network` invariants and binding-facing behavior
- add parser event coverage for link lists, vertices, states, multilayer, intra/inter, bipartite, metadata, and malformed multilayer input

## Verification
- `rtk make test-native`
- `rtk make test-python-unit PYTEST_ARGS='test/python/test_wrapper_args.py test/python/test_api.py -q'`