### PR TITLE
refactor: output artifact planning

### DIFF
--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -16,7 +16,7 @@
 #include "MetaMapEquation.h"
 #include "InfomapOptimizer.h"
 #include "../io/SafeFile.h"
-#include "../io/OutputFormats.h"
+#include "../io/OutputPlan.h"
 #include "../utils/FileURI.h"
 #include "../utils/FlowCalculator.h"
 #include "../utils/PrettyOutput.h"
@@ -33,7 +33,6 @@
 #include <cstdlib>
 #include <algorithm>
 #include <cmath>
-#include <functional>
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -108,49 +107,6 @@ namespace {
     }
   }
 
-  std::pair<std::string, std::string> splitExtension(const std::string& filename)
-  {
-    const auto slashPos = filename.find_last_of("/\\");
-    const auto dotPos = filename.find_last_of('.');
-    if (dotPos == std::string::npos || (slashPos != std::string::npos && dotPos < slashPos)) {
-      return { filename, "" };
-    }
-    return { filename.substr(0, dotPos), filename.substr(dotPos + 1) };
-  }
-
-  std::vector<std::string> summarizeOutputFiles(const std::vector<std::pair<std::string, std::string>>& outputFiles)
-  {
-    std::vector<std::pair<std::string, std::vector<std::string>>> groups;
-    for (const auto& outputFile : outputFiles) {
-      const auto parts = splitExtension(outputFile.second);
-      auto it = std::find_if(groups.begin(), groups.end(), [&parts](const std::pair<std::string, std::vector<std::string>>& group) {
-        return group.first == parts.first;
-      });
-      if (it == groups.end()) {
-        groups.push_back({ parts.first, { parts.second } });
-      } else {
-        it->second.push_back(parts.second);
-      }
-    }
-
-    std::vector<std::string> summaries;
-    summaries.reserve(groups.size());
-    for (const auto& group : groups) {
-      if (group.second.size() == 1) {
-        summaries.push_back(group.second.front().empty() ? group.first : io::Str() << group.first << "." << group.second.front());
-        continue;
-      }
-      io::Str suffixes;
-      for (unsigned int i = 0; i < group.second.size(); ++i) {
-        if (i > 0)
-          suffixes << ",";
-        suffixes << group.second[i];
-      }
-      summaries.push_back(io::Str() << group.first << ".{" << std::string(suffixes) << "}");
-    }
-    return summaries;
-  }
-
 } // namespace
 
 class InfomapBase::RunSession {
@@ -168,11 +124,10 @@ public:
   Result run()
   {
     validateNetwork();
-    writeStateNetworkIfRequested();
-    writePajekNetworkIfRequested();
+    writeOutputArtifacts(m_infomap, m_network, OutputPhase::BeforeFlow);
     configureNetworkMode();
     calculateFlowAndInitNetwork();
-    writeFlowNetworkIfRequested();
+    writeOutputArtifacts(m_infomap, m_network, OutputPhase::AfterFlow);
     releaseInputLinksIfCli();
     logRunPartitionStart();
     return runTrials();
@@ -298,46 +253,6 @@ private:
     }
   }
 
-  std::string resultFilename(const std::string& resultKey) const
-  {
-    return outputFilenameForResultKey(m_infomap.outDirectory + m_infomap.outName, resultKey);
-  }
-
-  void writeStateNetworkIfRequested()
-  {
-    if (!m_infomap.printStateNetwork) {
-      return;
-    }
-
-    std::string filename = resultFilename("states");
-    Log() << "Writing state network to '" << filename << "'... ";
-    m_network.writeStateNetwork(filename);
-    Log() << "done!\n";
-    if (m_infomap.prettyOutput)
-      PrettyOutput(true).status("Output", io::Str() << "state network -> " << filename);
-  }
-
-  void writePajekNetworkIfRequested()
-  {
-    if (!m_infomap.printPajekNetwork) {
-      return;
-    }
-
-    std::string filename;
-    if (m_infomap.printStates()) {
-      filename = resultFilename("states_as_physical");
-      Log() << "Writing state network as first order Pajek network to '" << filename << "'... ";
-    } else {
-      // Non-memory input
-      filename = resultFilename("net");
-      Log() << "Writing Pajek network to '" << filename << "'... ";
-    }
-    m_network.writePajekNetwork(filename);
-    Log() << "done!\n";
-    if (m_infomap.prettyOutput)
-      PrettyOutput(true).status("Output", io::Str() << (m_infomap.printStates() ? "state network as Pajek" : "Pajek network") << " -> " << filename);
-  }
-
   void configureNetworkMode()
   {
     if (m_network.haveMemoryInput()) {
@@ -376,27 +291,6 @@ private:
 
     if (m_infomap.numLeafNodes() == 0)
       throw std::domain_error("No nodes to partition");
-  }
-
-  void writeFlowNetworkIfRequested()
-  {
-    if (!m_infomap.printFlowNetwork) {
-      return;
-    }
-
-    std::string filename;
-    if (m_infomap.printStates()) {
-      filename = resultFilename("flow_as_physical");
-      Log() << "Writing flow state network as first order Pajek network to '" << filename << "'... ";
-    } else {
-      // Non-memory input
-      filename = resultFilename("flow");
-      Log() << "Writing flow network to '" << filename << "'... ";
-    }
-    m_network.writePajekNetwork(filename, true);
-    Log() << "done!\n";
-    if (m_infomap.prettyOutput)
-      PrettyOutput(true).status("Output", io::Str() << (m_infomap.printStates() ? "flow state network as Pajek" : "flow network") << " -> " << filename);
   }
 
   void releaseInputLinksIfCli()
@@ -2406,145 +2300,7 @@ bool InfomapBase::processPartitionQueue(PartitionQueue& queue, PartitionQueue& n
 
 void InfomapBase::writeResult(int trial)
 {
-  if (noFileOutput)
-    return;
-
-  io::Str s;
-  s << outDirectory + outName;
-
-  if (printAllTrials && trial != -1 && numTrials > 1) {
-    s << "_trial_" << trial;
-  }
-
-  std::string basename = s;
-
-  const auto filenameFor = [&basename](const std::string& resultKey) {
-    return outputFilenameForResultKey(basename, resultKey);
-  };
-
-  std::vector<std::pair<std::string, std::string>> prettyOutputFiles;
-  const auto writeOutput = [this](const std::string& label, const std::string& filename, const std::function<void()>& write) {
-    if (prettyOutput) {
-      write();
-      return;
-    }
-
-    Log() << "Write " << label << " to " << filename << "... ";
-    write();
-    Log() << "done!\n";
-  };
-  const auto trackPrettyOutput = [&prettyOutputFiles, this](const std::string& label, const std::string& filename) {
-    if (prettyOutput)
-      prettyOutputFiles.emplace_back(label, filename);
-  };
-
-  if (printTree) {
-    std::string filename = filenameFor("tree");
-
-    if (!printStates()) {
-      writeOutput("tree", filename, [&]() { writeTree(filename); });
-      trackPrettyOutput("tree", filename);
-    } else {
-      // Write both physical and state level
-      writeOutput("physical tree", filename, [&]() { writeTree(filename); });
-      trackPrettyOutput("physical tree", filename);
-      std::string filenameStates = filenameFor("tree_states");
-      writeOutput("state tree", filenameStates, [&]() { writeTree(filenameStates, true); });
-      trackPrettyOutput("state tree", filenameStates);
-    }
-  }
-
-  if (printFlowTree) {
-    std::string filename = filenameFor("ftree");
-
-    if (!printStates()) {
-      writeOutput("flow tree", filename, [&]() { writeFlowTree(filename); });
-      trackPrettyOutput("flow tree", filename);
-    } else {
-      // Write both physical and state level
-      writeOutput("physical flow tree", filename, [&]() { writeFlowTree(filename, false); });
-      trackPrettyOutput("physical flow tree", filename);
-      std::string filenameStates = filenameFor("ftree_states");
-      writeOutput("state flow tree", filenameStates, [&]() { writeFlowTree(filenameStates, true); });
-      trackPrettyOutput("state flow tree", filenameStates);
-    }
-  }
-
-  if (printNewick) {
-    std::string filename = filenameFor("newick");
-
-    if (!printStates()) {
-      writeOutput("Newick tree", filename, [&]() { writeNewickTree(filename); });
-      trackPrettyOutput("Newick tree", filename);
-    } else {
-      // Write both physical and state level
-      writeOutput("physical Newick tree", filename, [&]() { writeNewickTree(filename, false); });
-      trackPrettyOutput("physical Newick tree", filename);
-      std::string filenameStates = filenameFor("newick_states");
-      writeOutput("state Newick tree", filenameStates, [&]() { writeNewickTree(filenameStates, true); });
-      trackPrettyOutput("state Newick tree", filenameStates);
-    }
-  }
-
-  if (printJson) {
-    std::string filename = filenameFor("json");
-    const bool writeLinks = false;
-
-    if (!printStates()) {
-      writeOutput("JSON tree", filename, [&]() { writeJsonTree(filename, false, writeLinks); });
-      trackPrettyOutput("JSON tree", filename);
-    } else {
-      // Write both physical and state level
-      writeOutput("physical JSON tree", filename, [&]() { writeJsonTree(filename, false, writeLinks); });
-      trackPrettyOutput("physical JSON tree", filename);
-      std::string filenameStates = filenameFor("json_states");
-      writeOutput("state JSON tree", filenameStates, [&]() { writeJsonTree(filenameStates, true, writeLinks); });
-      trackPrettyOutput("state JSON tree", filenameStates);
-    }
-  }
-
-  if (printCsv) {
-    std::string filename = filenameFor("csv");
-
-    if (!printStates()) {
-      writeOutput("CSV tree", filename, [&]() { writeCsvTree(filename); });
-      trackPrettyOutput("CSV tree", filename);
-    } else {
-      // Write both physical and state level
-      writeOutput("physical CSV tree", filename, [&]() { writeCsvTree(filename, false); });
-      trackPrettyOutput("physical CSV tree", filename);
-      std::string filenameStates = filenameFor("csv_states");
-      writeOutput("state CSV tree", filenameStates, [&]() { writeCsvTree(filenameStates, true); });
-      trackPrettyOutput("state CSV tree", filenameStates);
-    }
-  }
-
-  if (printClu) {
-    std::string filename = filenameFor("clu");
-    if (!printStates()) {
-      writeOutput("node modules", filename, [&]() { writeClu(filename, false, cluLevel); });
-      trackPrettyOutput("node modules", filename);
-    } else {
-      // Write both physical and state level
-      writeOutput("physical node modules", filename, [&]() { writeClu(filename, false, cluLevel); });
-      trackPrettyOutput("physical node modules", filename);
-      std::string filenameStates = filenameFor("clu_states");
-      writeOutput("state node modules", filenameStates, [&]() { writeClu(filenameStates, true, cluLevel); });
-      trackPrettyOutput("state node modules", filenameStates);
-    }
-  }
-
-  if (prettyOutput && !prettyOutputFiles.empty()) {
-    if (prettyOutputFiles.size() == 1) {
-      PrettyOutput(true).status("Output", io::Str() << prettyOutputFiles.front().first << " -> " << prettyOutputFiles.front().second);
-    } else {
-      const auto summaries = summarizeOutputFiles(prettyOutputFiles);
-      for (unsigned int i = 0; i < summaries.size(); ++i) {
-        const std::string prefix = i == 0 ? std::string(io::Str() << prettyOutputFiles.size() << " files -> ") : "         ";
-        PrettyOutput(true).status("Output", io::Str() << prefix << summaries[i]);
-      }
-    }
-  }
+  writeOutputArtifacts(*this, m_network, OutputPhase::AfterPartition, trial);
 }
 
 unsigned int printPerLevelCodelength(const InfoNode& parent, std::ostream& out, bool prettyOutput)

--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -27,32 +27,32 @@ namespace {
 
   void enableOutputFormat(Config& config, const OutputFormat& format)
   {
-    switch (format.flag) {
-    case OutputFormatFlag::Clu:
+    switch (format.kind) {
+    case OutputKind::Clu:
       config.printClu = true;
       break;
-    case OutputFormatFlag::Tree:
+    case OutputKind::Tree:
       config.printTree = true;
       break;
-    case OutputFormatFlag::FlowTree:
+    case OutputKind::FlowTree:
       config.printFlowTree = true;
       break;
-    case OutputFormatFlag::Newick:
+    case OutputKind::Newick:
       config.printNewick = true;
       break;
-    case OutputFormatFlag::Json:
+    case OutputKind::Json:
       config.printJson = true;
       break;
-    case OutputFormatFlag::Csv:
+    case OutputKind::Csv:
       config.printCsv = true;
       break;
-    case OutputFormatFlag::PajekNetwork:
+    case OutputKind::PajekNetwork:
       config.printPajekNetwork = true;
       break;
-    case OutputFormatFlag::StateNetwork:
+    case OutputKind::StateNetwork:
       config.printStateNetwork = true;
       break;
-    case OutputFormatFlag::FlowNetwork:
+    case OutputKind::FlowNetwork:
       config.printFlowNetwork = true;
       break;
     }

--- a/src/io/Output.cpp
+++ b/src/io/Output.cpp
@@ -66,7 +66,7 @@ std::string writeClu(InfomapBase& im, const StateNetwork& network, const std::st
     outFile << "# node_id module flow\n";
   }
 
-  view.forEachLeaf(moduleIndexLevel, OutputLeafFilter::Regular, [&](const OutputLeafRow& row) {
+  view.forEachLeaf(moduleIndexLevel, OutputLeafPolicy::HideBipartite, [&](const OutputLeafRow& row) {
     if (states) {
       outFile << row.stateId << " " << row.moduleId << " " << row.flow << " " << row.physicalId;
       if (view.isMultilayer())
@@ -96,7 +96,7 @@ void writeTree(InfomapBase& im, const StateNetwork& network, std::ostream& outSt
     outStream << "# path flow name node_id\n";
   }
 
-  view.forEachLeaf(1, OutputLeafFilter::TreeNoFlowFilter, [&](const OutputLeafRow& row) {
+  view.forEachLeaf(1, OutputLeafPolicy::HideBipartiteUnlessFlowTree, [&](const OutputLeafRow& row) {
     outStream << io::stringify(row.path, ":") << " " << row.flow << " \"" << row.name << "\" ";
 
     if (states) {
@@ -317,7 +317,7 @@ void writeJsonTree(InfomapBase& im, const StateNetwork& network, std::ostream& o
   auto first = true;
 
   if (view.isHigherOrderPhysicalLevel()) {
-    view.forEachLeaf(1, OutputLeafFilter::Regular, [&](const OutputLeafRow& row) {
+    view.forEachLeaf(1, OutputLeafPolicy::HideBipartite, [&](const OutputLeafRow& row) {
       const auto path = io::stringify(row.path, ",");
 
       if (first) {
@@ -336,7 +336,7 @@ void writeJsonTree(InfomapBase& im, const StateNetwork& network, std::ostream& o
   } else {
     const auto multilevelModules = im.getMultilevelModules(states);
 
-    view.forEachLeaf(1, OutputLeafFilter::Regular, [&](const OutputLeafRow& row) {
+    view.forEachLeaf(1, OutputLeafPolicy::HideBipartite, [&](const OutputLeafRow& row) {
       if (first) {
         first = false;
       } else {
@@ -452,7 +452,7 @@ void writeCsvTree(InfomapBase& im, const StateNetwork& network, std::ostream& ou
     outStream << "node_id\n";
   }
 
-  view.forEachLeaf(1, OutputLeafFilter::Regular, [&](const OutputLeafRow& row) {
+  view.forEachLeaf(1, OutputLeafPolicy::HideBipartite, [&](const OutputLeafRow& row) {
     const auto path = io::stringify(row.path, ":");
     outStream << path << ',' << row.flow << ",\"" << row.name << "\",";
 

--- a/src/io/Output.cpp
+++ b/src/io/Output.cpp
@@ -8,6 +8,7 @@
  ******************************************************************************/
 
 #include "Output.h"
+#include "OutputView.h"
 #include "../core/InfomapBase.h"
 #include "../core/StateNetwork.h"
 #include "../io/SafeFile.h"
@@ -45,19 +46,11 @@ std::string getOutputFileHeader(const InfomapBase& im, const StateNetwork& netwo
                    << (network.isBipartite() ? bipartiteInfo : "");
 }
 
-std::string getNodeName(const std::map<unsigned int, std::string>& names, const InfoNode& node)
-{
-  try {
-    return names.at(node.physicalId);
-  } catch (...) {
-    return io::stringify(node.physicalId);
-  }
-}
-
 std::string writeClu(InfomapBase& im, const StateNetwork& network, const std::string& filename, bool states, int moduleIndexLevel)
 {
   auto outputFilename = getOutputFilename(im, filename, ".clu", states);
   SafeOutFile outFile { outputFilename };
+  OutputView view(im, network, states);
 
   outFile << std::setprecision(9);
   outFile << getOutputFileHeader(im, network, states) << "\n";
@@ -66,104 +59,55 @@ std::string writeClu(InfomapBase& im, const StateNetwork& network, const std::st
 
   if (states) {
     outFile << "# state_id module flow node_id";
-    if (im.isMultilayerNetwork())
+    if (view.isMultilayer())
       outFile << " layer_id";
     outFile << '\n';
   } else {
     outFile << "# node_id module flow\n";
   }
 
-  const auto shouldHideBipartiteNodes = im.isBipartite() && im.hideBipartiteNodes;
-  const auto bipartiteStartId = shouldHideBipartiteNodes ? network.bipartiteStartId() : 0;
-
-  if (im.haveMemory() && !states) {
-    for (auto it(im.iterTreePhysical(moduleIndexLevel)); !it.isEnd(); ++it) {
-      InfoNode& node = *it;
-      if (node.isLeaf()) {
-        if (shouldHideBipartiteNodes && node.physicalId >= bipartiteStartId) {
-          continue;
-        }
-
-        outFile << node.physicalId << " " << it.moduleId() << " " << node.data.flow << "\n";
-      }
+  view.forEachLeaf(moduleIndexLevel, OutputLeafFilter::Regular, [&](const OutputLeafRow& row) {
+    if (states) {
+      outFile << row.stateId << " " << row.moduleId << " " << row.flow << " " << row.physicalId;
+      if (view.isMultilayer())
+        outFile << " " << row.layerId;
+      outFile << "\n";
+    } else {
+      outFile << row.physicalId << " " << row.moduleId << " " << row.flow << "\n";
     }
-  } else {
-    for (auto it(im.iterTree(moduleIndexLevel)); !it.isEnd(); ++it) {
-      InfoNode& node = *it;
-      if (node.isLeaf()) {
-        if (shouldHideBipartiteNodes && node.physicalId >= bipartiteStartId) {
-          continue;
-        }
-
-        if (states) {
-          outFile << node.stateId << " " << it.moduleId() << " " << node.data.flow << " " << node.physicalId;
-          if (im.isMultilayerNetwork())
-            outFile << " " << node.layerId;
-          outFile << "\n";
-        } else
-          outFile << node.physicalId << " " << it.moduleId() << " " << node.data.flow << "\n";
-      }
-    }
-  }
+  });
   return outputFilename;
 }
 
 void writeTree(InfomapBase& im, const StateNetwork& network, std::ostream& outStream, bool states)
 {
   auto oldPrecision = outStream.precision();
+  OutputView view(im, network, states);
   outStream << std::setprecision(9);
   outStream << getOutputFileHeader(im, network, states) << "\n";
   outStream << std::setprecision(6);
 
   if (states) {
     outStream << "# path flow name state_id node_id";
-    if (im.isMultilayerNetwork())
+    if (view.isMultilayer())
       outStream << " layer_id";
     outStream << '\n';
   } else {
     outStream << "# path flow name node_id\n";
   }
 
-  const auto shouldHideBipartiteNodes = !im.printFlowTree && im.isBipartite() && im.hideBipartiteNodes;
-  const auto bipartiteStartId = shouldHideBipartiteNodes ? network.bipartiteStartId() : 0;
+  view.forEachLeaf(1, OutputLeafFilter::TreeNoFlowFilter, [&](const OutputLeafRow& row) {
+    outStream << io::stringify(row.path, ":") << " " << row.flow << " \"" << row.name << "\" ";
 
-  // TODO: Make a general iterator where merging physical nodes depend on a parameter rather than type to be able to DRY here
-  if (im.haveMemory() && !states) {
-    for (auto it(im.iterTreePhysical()); !it.isEnd(); ++it) {
-      InfoNode& node = *it;
-      if (node.isLeaf()) {
-        if (shouldHideBipartiteNodes && node.physicalId >= bipartiteStartId) {
-          continue;
-        }
-
-        auto& path = it.path();
-
-        outStream << io::stringify(path, ":") << " " << node.data.flow << " \"" << getNodeName(network.names(), node) << "\" " << node.physicalId << '\n';
-      }
+    if (states) {
+      outStream << row.stateId << " " << row.physicalId;
+      if (view.isMultilayer())
+        outStream << " " << row.layerId;
+      outStream << '\n';
+    } else {
+      outStream << row.physicalId << '\n';
     }
-  } else {
-    for (auto it(im.iterTree()); !it.isEnd(); ++it) {
-      InfoNode& node = *it;
-      if (node.isLeaf()) {
-        if (shouldHideBipartiteNodes && node.physicalId >= bipartiteStartId) {
-          continue;
-        }
-
-        auto& path = it.path();
-
-        outStream << io::stringify(path, ":") << " " << node.data.flow << " \"" << getNodeName(network.names(), node) << "\" ";
-
-        if (states) {
-          outStream << node.stateId << " " << node.physicalId;
-          if (im.isMultilayerNetwork())
-            outStream << " " << node.layerId;
-          outStream << '\n';
-        } else {
-          outStream << node.physicalId << '\n';
-        }
-      }
-    }
-  }
+  });
 
   outStream << std::setprecision(oldPrecision);
 }
@@ -171,49 +115,29 @@ void writeTree(InfomapBase& im, const StateNetwork& network, std::ostream& outSt
 using Link = std::pair<unsigned int, unsigned int>;
 using LinkMap = std::map<Link, double>;
 
-std::map<std::string, LinkMap> aggregateModuleLinks(InfomapBase& im, bool states)
+std::map<std::string, LinkMap> aggregateModuleLinks(InfomapBase& im, OutputView& view)
 {
   // Aggregate links between each module. Rest is aggregated as exit flow
 
   // Links on nodes within sub infomap instances doesn't have links outside the root
   // so iterate over links on main instance and map to infomap tree iterator
-  bool mergePhysicalNodes = im.haveMemory() && !states;
-
-  // Map state id to parent in infomap tree iterator
-  std::map<unsigned int, InfoNode*> stateIdToParent;
-  std::map<unsigned int, unsigned int> stateIdToChildIndex;
-
-  if (mergePhysicalNodes) {
-    for (auto it(im.iterTreePhysical()); !it.isEnd(); ++it) {
-      if (it->isLeaf()) {
-        for (auto stateId : it->stateNodes) {
-          stateIdToParent[stateId] = it->parent;
-          stateIdToChildIndex[stateId] = it.childIndex();
-        }
-      }
-    }
-  } else {
-    for (auto it(im.iterTree()); !it.isEnd(); ++it) {
-      if (it->isLeaf()) {
-        stateIdToParent[it->stateId] = it->parent;
-        stateIdToChildIndex[it->stateId] = it.childIndex();
-      }
-    }
-  }
+  auto stateTargets = view.stateNodeTargets();
 
   std::map<std::string, LinkMap> moduleLinks;
 
   for (auto& leaf : im.leafNodes()) {
     for (auto& link : leaf->outEdges()) {
       double flow = link->data.flow;
-      InfoNode* sourceParent = stateIdToParent[link->source->stateId];
-      InfoNode* targetParent = stateIdToParent[link->target->stateId];
+      auto& sourceTarget = stateTargets[link->source->stateId];
+      auto& targetTarget = stateTargets[link->target->stateId];
+      InfoNode* sourceParent = sourceTarget.parent;
+      InfoNode* targetParent = targetTarget.parent;
 
       auto sourceDepth = sourceParent->calculatePath().size() + 1;
       auto targetDepth = targetParent->calculatePath().size() + 1;
 
-      auto sourceChildIndex = stateIdToChildIndex[link->source->stateId];
-      auto targetChildIndex = stateIdToChildIndex[link->target->stateId];
+      auto sourceChildIndex = sourceTarget.childIndex;
+      auto targetChildIndex = targetTarget.childIndex;
 
       auto sourceParentIt = InfomapParentIterator(sourceParent);
       auto targetParentIt = InfomapParentIterator(targetParent);
@@ -263,7 +187,8 @@ void writeTreeLinks(InfomapBase& im, std::ostream& outStream, bool states)
   auto oldPrecision = outStream.precision();
   outStream << std::setprecision(6);
 
-  auto moduleLinks = aggregateModuleLinks(im, states);
+  OutputView view(im, im.network(), states);
+  auto moduleLinks = aggregateModuleLinks(im, view);
 
   outStream << "*Links " << (im.isUndirectedFlow() ? "undirected" : "directed") << "\n";
   outStream << "#*Links path enterFlow exitFlow numEdges numChildren\n";
@@ -289,23 +214,26 @@ void writeTreeLinks(InfomapBase& im, std::ostream& outStream, bool states)
 void writeNewickTree(InfomapBase& im, std::ostream& outStream, bool states)
 {
   auto oldPrecision = outStream.precision();
+  OutputView view(im, im.network(), states);
   outStream << std::setprecision(6);
 
   auto isRoot = true;
   unsigned int lastDepth = 0;
   std::vector<double> flowStack;
 
-  auto writeNewickNode = [&](const InfoNode& node, unsigned int depth) {
+  auto writeNewickNode = [&](const OutputTreeRow& row) {
+    const auto& node = row.node;
+    const auto depth = row.depth;
     if (depth > lastDepth || isRoot) {
       outStream << "(";
-      flowStack.push_back(node.data.flow);
+      flowStack.push_back(row.flow);
       if (node.isLeaf())
-        outStream << (states ? node.stateId : node.physicalId) << ":" << node.data.flow;
+        outStream << (states ? row.stateId : row.physicalId) << ":" << row.flow;
     } else if (depth == lastDepth) {
       outStream << ",";
-      flowStack[flowStack.size() - 1] = node.data.flow;
+      flowStack[flowStack.size() - 1] = row.flow;
       if (node.isLeaf()) {
-        outStream << (states ? node.stateId : node.physicalId) << ":" << node.data.flow;
+        outStream << (states ? row.stateId : row.physicalId) << ":" << row.flow;
       }
     } else {
       // depth < lastDepth
@@ -313,23 +241,14 @@ void writeNewickTree(InfomapBase& im, std::ostream& outStream, bool states)
         flowStack.pop_back();
         outStream << "):" << flowStack.back();
       }
-      flowStack[flowStack.size() - 1] = node.data.flow;
+      flowStack[flowStack.size() - 1] = row.flow;
       outStream << ",";
     }
     lastDepth = depth;
     isRoot = false;
   };
 
-  // TODO: Make a general iterator where merging physical nodes depend on a parameter rather than type to be able to DRY here
-  if (im.haveMemory() && !states) {
-    for (auto it(im.iterTreePhysical()); !it.isEnd(); ++it) {
-      writeNewickNode(*it, it.depth());
-    }
-  } else {
-    for (auto it(im.iterTree()); !it.isEnd(); ++it) {
-      writeNewickNode(*it, it.depth());
-    }
-  }
+  view.forEachTreeNode(writeNewickNode);
   while (flowStack.size() > 1) {
     flowStack.pop_back();
     outStream << "):" << flowStack.back();
@@ -341,6 +260,7 @@ void writeNewickTree(InfomapBase& im, std::ostream& outStream, bool states)
 void writeJsonTree(InfomapBase& im, const StateNetwork& network, std::ostream& outStream, bool states, bool writeLinks)
 {
   auto oldPrecision = outStream.precision();
+  OutputView view(im, network, states);
   std::vector<detail::PerLevelStat> perLevelStats;
   aggregatePerLevelCodelength(im.root(), perLevelStats);
 
@@ -380,9 +300,6 @@ void writeJsonTree(InfomapBase& im, const StateNetwork& network, std::ostream& o
 
   outStream << "\"nodes\":[";
 
-  const auto shouldHideBipartiteNodes = im.isBipartite() && im.hideBipartiteNodes;
-  const auto bipartiteStartId = shouldHideBipartiteNodes ? network.bipartiteStartId() : 0;
-
   auto metaData = network.metaData();
   auto writeMeta = [&metaData](auto& outStream, auto nodeId) {
     outStream << "\"metadata\":{";
@@ -399,70 +316,56 @@ void writeJsonTree(InfomapBase& im, const StateNetwork& network, std::ostream& o
   // don't append a comma after the last entry
   auto first = true;
 
-  if (im.haveMemory() && !states) {
-    for (auto it(im.iterTreePhysical()); !it.isEnd(); ++it) {
-      InfoNode& node = *it;
-      if (node.isLeaf()) {
-        if (shouldHideBipartiteNodes && node.physicalId >= bipartiteStartId) {
-          continue;
-        }
+  if (view.isHigherOrderPhysicalLevel()) {
+    view.forEachLeaf(1, OutputLeafFilter::Regular, [&](const OutputLeafRow& row) {
+      const auto path = io::stringify(row.path, ",");
 
-        const auto path = io::stringify(it.path(), ",");
-
-        if (first) {
-          first = false;
-        } else {
-          outStream << ",";
-        }
-
-        outStream << "{"
-                  << "\"path\":[" << path << "],"
-                  << "\"name\":\"" << getNodeName(network.names(), node) << "\","
-                  << "\"flow\":" << node.data.flow << ","
-                  << "\"mec\":" << it.modularCentrality() << ","
-                  << "\"id\":" << node.physicalId << "}";
+      if (first) {
+        first = false;
+      } else {
+        outStream << ",";
       }
-    }
+
+      outStream << "{"
+                << "\"path\":[" << path << "],"
+                << "\"name\":\"" << row.name << "\","
+                << "\"flow\":" << row.flow << ","
+                << "\"mec\":" << row.modularCentrality << ","
+                << "\"id\":" << row.physicalId << "}";
+    });
   } else {
     const auto multilevelModules = im.getMultilevelModules(states);
 
-    for (auto it(im.iterTree()); !it.isEnd(); ++it) {
-      InfoNode& node = *it;
-      if (node.isLeaf()) {
-        if (shouldHideBipartiteNodes && node.physicalId >= bipartiteStartId) {
-          continue;
-        }
-
-        if (first) {
-          first = false;
-        } else {
-          outStream << ",";
-        }
-
-        const auto path = io::stringify(it.path(), ", ");
-        const auto modules = im.haveModules() ? io::stringify(multilevelModules.at(states ? node.stateId : node.physicalId), ", ") : "1";
-
-        outStream << "{"
-                  << "\"path\":[" << path << "],"
-                  << "\"modules\":[" << modules << "],"
-                  << "\"name\":\"" << getNodeName(network.names(), node) << "\","
-                  << "\"flow\":" << node.data.flow << ","
-                  << "\"mec\":" << it.modularCentrality() << ",";
-
-        // can't currently use both memory and meta map equation
-        if (im.haveMetaData() && !states) {
-          writeMeta(outStream, node.physicalId);
-        }
-
-        if (states) {
-          outStream << "\"stateId\":" << node.stateId << ",";
-          if (im.isMultilayerNetwork())
-            outStream << "\"layerId\":" << node.layerId << ",";
-        }
-
-        outStream << "\"id\":" << node.physicalId << "}";
+    view.forEachLeaf(1, OutputLeafFilter::Regular, [&](const OutputLeafRow& row) {
+      if (first) {
+        first = false;
+      } else {
+        outStream << ",";
       }
-    }
+
+      const auto path = io::stringify(row.path, ", ");
+      const auto modules = im.haveModules() ? io::stringify(multilevelModules.at(states ? row.stateId : row.physicalId), ", ") : "1";
+
+      outStream << "{"
+                << "\"path\":[" << path << "],"
+                << "\"modules\":[" << modules << "],"
+                << "\"name\":\"" << row.name << "\","
+                << "\"flow\":" << row.flow << ","
+                << "\"mec\":" << row.modularCentrality << ",";
+
+      // can't currently use both memory and meta map equation
+      if (view.hasMetaData() && !states) {
+        writeMeta(outStream, row.physicalId);
+      }
+
+      if (states) {
+        outStream << "\"stateId\":" << row.stateId << ",";
+        if (view.isMultilayer())
+          outStream << "\"layerId\":" << row.layerId << ",";
+      }
+
+      outStream << "\"id\":" << row.physicalId << "}";
+    });
   }
 
   outStream << "],"; // tree
@@ -472,7 +375,7 @@ void writeJsonTree(InfomapBase& im, const StateNetwork& network, std::ostream& o
   // -------------
 
   // Uses stateId to store depth on modules to optimize link aggregation
-  auto moduleLinks = aggregateModuleLinks(im, states);
+  auto moduleLinks = aggregateModuleLinks(im, view);
 
   first = true;
 
@@ -533,57 +436,34 @@ void writeJsonTree(InfomapBase& im, const StateNetwork& network, std::ostream& o
 void writeCsvTree(InfomapBase& im, const StateNetwork& network, std::ostream& outStream, bool states)
 {
   auto oldPrecision = outStream.precision();
+  OutputView view(im, network, states);
   outStream << std::setprecision(6);
 
   outStream << "path,flow,name,";
 
-  if (im.haveMemory() && !states) {
+  if (view.isHigherOrderPhysicalLevel()) {
     outStream << "node_id\n";
   } else {
     if (states) {
       outStream << "state_id,";
-      if (im.isMultilayerNetwork())
+      if (view.isMultilayer())
         outStream << "layer_id,";
     }
     outStream << "node_id\n";
   }
 
-  const auto shouldHideBipartiteNodes = im.isBipartite() && im.hideBipartiteNodes;
-  const auto bipartiteStartId = shouldHideBipartiteNodes ? network.bipartiteStartId() : 0;
+  view.forEachLeaf(1, OutputLeafFilter::Regular, [&](const OutputLeafRow& row) {
+    const auto path = io::stringify(row.path, ":");
+    outStream << path << ',' << row.flow << ",\"" << row.name << "\",";
 
-  if (im.haveMemory() && !states) {
-    for (auto it(im.iterTreePhysical()); !it.isEnd(); ++it) {
-      InfoNode& node = *it;
-      if (node.isLeaf()) {
-        if (shouldHideBipartiteNodes && node.physicalId >= bipartiteStartId) {
-          continue;
-        }
-
-        const auto path = io::stringify(it.path(), ":");
-        outStream << path << ',' << node.data.flow << ",\"" << getNodeName(network.names(), node) << "\"," << node.physicalId << '\n';
-      }
+    if (states) {
+      outStream << row.stateId << ',';
+      if (view.isMultilayer())
+        outStream << row.layerId << ',';
     }
-  } else {
-    for (auto it(im.iterTree()); !it.isEnd(); ++it) {
-      InfoNode& node = *it;
-      if (node.isLeaf()) {
-        if (shouldHideBipartiteNodes && node.physicalId >= bipartiteStartId) {
-          continue;
-        }
 
-        const auto path = io::stringify(it.path(), ":");
-        outStream << path << ',' << node.data.flow << ",\"" << getNodeName(network.names(), node) << "\",";
-
-        if (states) {
-          outStream << node.stateId << ',';
-          if (im.isMultilayerNetwork())
-            outStream << node.layerId << ',';
-        }
-
-        outStream << node.physicalId << '\n';
-      }
-    }
-  }
+    outStream << row.physicalId << '\n';
+  });
 
   outStream << std::setprecision(oldPrecision);
 }

--- a/src/io/OutputFormats.cpp
+++ b/src/io/OutputFormats.cpp
@@ -26,9 +26,9 @@ namespace {
     return { resultKey, displayName, states, suffix, extension, mimeType, resultOrder };
   }
 
-  OutputFormat format(const std::string& optionName, OutputFormatFlag flag, std::vector<OutputFileFormat> files)
+  OutputFormat format(const std::string& optionName, OutputKind kind, std::vector<OutputFileFormat> files)
   {
-    return { optionName, flag, std::move(files) };
+    return { optionName, kind, std::move(files) };
   }
 
   std::string jsonString(const std::string& value)
@@ -64,41 +64,41 @@ namespace {
 const std::vector<OutputFormat>& outputFormats()
 {
   static const std::vector<OutputFormat> formats = {
-    format("clu", OutputFormatFlag::Clu, {
-                                             file("clu", "Clu", false, "", "clu", textMimeType, 0),
-                                             file("clu_states", "Clu", true, "_states", "clu", textMimeType, 5),
+    format("clu", OutputKind::Clu, {
+                                       file("clu", "Clu", false, "", "clu", textMimeType, 0),
+                                       file("clu_states", "Clu", true, "_states", "clu", textMimeType, 5),
+                                   }),
+    format("tree", OutputKind::Tree, {
+                                         file("tree", "Tree", false, "", "tree", textMimeType, 1),
+                                         file("tree_states", "Tree", true, "_states", "tree", textMimeType, 6),
+                                     }),
+    format("ftree", OutputKind::FlowTree, {
+                                              file("ftree", "Ftree", false, "", "ftree", textMimeType, 2),
+                                              file("ftree_states", "Ftree", true, "_states", "ftree", textMimeType, 7),
+                                          }),
+    format("newick", OutputKind::Newick, {
+                                             file("newick", "Newick", false, "", "nwk", textMimeType, 11),
+                                             file("newick_states", "Newick", true, "_states", "nwk", textMimeType, 12),
                                          }),
-    format("tree", OutputFormatFlag::Tree, {
-                                               file("tree", "Tree", false, "", "tree", textMimeType, 1),
-                                               file("tree_states", "Tree", true, "_states", "tree", textMimeType, 6),
-                                           }),
-    format("ftree", OutputFormatFlag::FlowTree, {
-                                                    file("ftree", "Ftree", false, "", "ftree", textMimeType, 2),
-                                                    file("ftree_states", "Ftree", true, "_states", "ftree", textMimeType, 7),
+    format("json", OutputKind::Json, {
+                                         file("json", "JSON", false, "", "json", jsonMimeType, 13),
+                                         file("json_states", "JSON", true, "_states", "json", jsonMimeType, 14),
+                                     }),
+    format("csv", OutputKind::Csv, {
+                                       file("csv", "CSV", false, "", "csv", textMimeType, 15),
+                                       file("csv_states", "CSV", true, "_states", "csv", textMimeType, 16),
+                                   }),
+    format("network", OutputKind::PajekNetwork, {
+                                                    file("net", "Network", false, "", "net", textMimeType, 3),
+                                                    file("states_as_physical", "States as physical", false, "_states_as_physical", "net", textMimeType, 4),
                                                 }),
-    format("newick", OutputFormatFlag::Newick, {
-                                                   file("newick", "Newick", false, "", "nwk", textMimeType, 11),
-                                                   file("newick_states", "Newick", true, "_states", "nwk", textMimeType, 12),
+    format("states", OutputKind::StateNetwork, {
+                                                   file("states", "States", true, "_states", "net", textMimeType, 8),
                                                }),
-    format("json", OutputFormatFlag::Json, {
-                                               file("json", "JSON", false, "", "json", jsonMimeType, 13),
-                                               file("json_states", "JSON", true, "_states", "json", jsonMimeType, 14),
-                                           }),
-    format("csv", OutputFormatFlag::Csv, {
-                                             file("csv", "CSV", false, "", "csv", textMimeType, 15),
-                                             file("csv_states", "CSV", true, "_states", "csv", textMimeType, 16),
-                                         }),
-    format("network", OutputFormatFlag::PajekNetwork, {
-                                                          file("net", "Network", false, "", "net", textMimeType, 3),
-                                                          file("states_as_physical", "States as physical", false, "_states_as_physical", "net", textMimeType, 4),
-                                                      }),
-    format("states", OutputFormatFlag::StateNetwork, {
-                                                         file("states", "States", true, "_states", "net", textMimeType, 8),
-                                                     }),
-    format("flow", OutputFormatFlag::FlowNetwork, {
-                                                      file("flow", "Flow", false, "_flow", "net", textMimeType, 9),
-                                                      file("flow_as_physical", "Flow states as physical", true, "_states_as_physical_flow", "net", textMimeType, 10),
-                                                  }),
+    format("flow", OutputKind::FlowNetwork, {
+                                                file("flow", "Flow", false, "_flow", "net", textMimeType, 9),
+                                                file("flow_as_physical", "Flow states as physical", true, "_states_as_physical_flow", "net", textMimeType, 10),
+                                            }),
   };
   return formats;
 }

--- a/src/io/OutputFormats.h
+++ b/src/io/OutputFormats.h
@@ -16,7 +16,7 @@
 
 namespace infomap {
 
-enum class OutputFormatFlag : std::uint8_t {
+enum class OutputKind : std::uint8_t {
   Clu,
   Tree,
   FlowTree,
@@ -40,7 +40,7 @@ struct OutputFileFormat {
 
 struct OutputFormat {
   std::string optionName;
-  OutputFormatFlag flag;
+  OutputKind kind;
   std::vector<OutputFileFormat> files;
 };
 

--- a/src/io/OutputPlan.cpp
+++ b/src/io/OutputPlan.cpp
@@ -1,0 +1,276 @@
+/*******************************************************************************
+ Infomap software package for multi-level network clustering
+ Copyright (c) 2013, 2014 Daniel Edler, Anton Holmgren, Martin Rosvall
+
+ This file is part of the Infomap software package.
+ See file LICENSE_GPLv3.txt for full license details.
+ For more information, see <http://www.mapequation.org>
+ ******************************************************************************/
+
+#include "OutputPlan.h"
+#include "Network.h"
+#include "OutputFormats.h"
+#include "../core/InfomapBase.h"
+#include "../utils/Log.h"
+#include "../utils/PrettyOutput.h"
+#include "../utils/convert.h"
+
+#include <algorithm>
+#include <stdexcept>
+#include <utility>
+
+namespace infomap {
+
+namespace {
+
+  OutputArtifact artifact(const Config& config,
+                          const std::string& basename,
+                          OutputPhase phase,
+                          OutputKind kind,
+                          const std::string& resultKey,
+                          const std::string& label,
+                          bool states = false,
+                          bool printFlow = false)
+  {
+    OutputArtifact output;
+    output.resultKey = resultKey;
+    output.label = label;
+    output.filename = outputFilenameForResultKey(basename, resultKey);
+    output.phase = phase;
+    output.kind = kind;
+    output.states = states;
+    output.cluLevel = config.cluLevel;
+    output.printFlow = printFlow;
+    return output;
+  }
+
+  void addPhysicalAndStateArtifacts(std::vector<OutputArtifact>& artifacts,
+                                    const Config& config,
+                                    const std::string& basename,
+                                    OutputKind kind,
+                                    const std::string& physicalResultKey,
+                                    const std::string& stateResultKey,
+                                    const std::string& label,
+                                    const std::string& physicalLabel,
+                                    const std::string& stateLabel)
+  {
+    if (!config.printStates()) {
+      artifacts.push_back(artifact(config, basename, OutputPhase::AfterPartition, kind, physicalResultKey, label));
+      return;
+    }
+
+    artifacts.push_back(artifact(config, basename, OutputPhase::AfterPartition, kind, physicalResultKey, physicalLabel));
+    artifacts.push_back(artifact(config, basename, OutputPhase::AfterPartition, kind, stateResultKey, stateLabel, true));
+  }
+
+  std::pair<std::string, std::string> splitExtension(const std::string& filename)
+  {
+    const auto slashPos = filename.find_last_of("/\\");
+    const auto dotPos = filename.find_last_of('.');
+    if (dotPos == std::string::npos || (slashPos != std::string::npos && dotPos < slashPos)) {
+      return { filename, "" };
+    }
+    return { filename.substr(0, dotPos), filename.substr(dotPos + 1) };
+  }
+
+  std::vector<std::string> summarizeOutputFiles(const std::vector<std::pair<std::string, std::string>>& outputFiles)
+  {
+    std::vector<std::pair<std::string, std::vector<std::string>>> groups;
+    for (const auto& outputFile : outputFiles) {
+      const auto parts = splitExtension(outputFile.second);
+      auto it = std::find_if(groups.begin(), groups.end(), [&parts](const std::pair<std::string, std::vector<std::string>>& group) {
+        return group.first == parts.first;
+      });
+      if (it == groups.end()) {
+        groups.push_back({ parts.first, { parts.second } });
+      } else {
+        it->second.push_back(parts.second);
+      }
+    }
+
+    std::vector<std::string> summaries;
+    summaries.reserve(groups.size());
+    for (const auto& group : groups) {
+      if (group.second.size() == 1) {
+        summaries.push_back(group.second.front().empty() ? group.first : io::Str() << group.first << "." << group.second.front());
+        continue;
+      }
+      io::Str suffixes;
+      for (unsigned int i = 0; i < group.second.size(); ++i) {
+        if (i > 0)
+          suffixes << ",";
+        suffixes << group.second[i];
+      }
+      summaries.push_back(io::Str() << group.first << ".{" << std::string(suffixes) << "}");
+    }
+    return summaries;
+  }
+
+  void writeModularOutput(InfomapBase& infomap, const OutputArtifact& output)
+  {
+    switch (output.kind) {
+    case OutputKind::Tree:
+      infomap.writeTree(output.filename, output.states);
+      break;
+    case OutputKind::FlowTree:
+      infomap.writeFlowTree(output.filename, output.states);
+      break;
+    case OutputKind::Newick:
+      infomap.writeNewickTree(output.filename, output.states);
+      break;
+    case OutputKind::Json:
+      infomap.writeJsonTree(output.filename, output.states, output.writeLinks);
+      break;
+    case OutputKind::Csv:
+      infomap.writeCsvTree(output.filename, output.states);
+      break;
+    case OutputKind::Clu:
+      infomap.writeClu(output.filename, output.states, output.cluLevel);
+      break;
+    default:
+      throw std::logic_error("Output artifact is not a modular result");
+    }
+  }
+
+  void writeNetworkOutput(Network& network, const OutputArtifact& output)
+  {
+    switch (output.kind) {
+    case OutputKind::StateNetwork:
+      network.writeStateNetwork(output.filename);
+      break;
+    case OutputKind::PajekNetwork:
+    case OutputKind::FlowNetwork:
+      network.writePajekNetwork(output.filename, output.printFlow);
+      break;
+    default:
+      throw std::logic_error("Output artifact is not a network result");
+    }
+  }
+
+} // namespace
+
+std::string outputPlanBasename(const Config& config, int trial)
+{
+  io::Str basename;
+  basename << config.outDirectory + config.outName;
+
+  if (config.printAllTrials && trial != -1 && config.numTrials > 1) {
+    basename << "_trial_" << trial;
+  }
+
+  return basename;
+}
+
+std::vector<OutputArtifact> planOutputArtifacts(const Config& config, const std::string& basename, OutputPhase phase)
+{
+  if (config.noFileOutput) {
+    return {};
+  }
+
+  std::vector<OutputArtifact> artifacts;
+
+  if (phase == OutputPhase::BeforeFlow) {
+    if (config.printStateNetwork) {
+      artifacts.push_back(artifact(config, basename, phase, OutputKind::StateNetwork, "states", "state network", true));
+    }
+    if (config.printPajekNetwork) {
+      artifacts.push_back(config.printStates()
+                              ? artifact(config, basename, phase, OutputKind::PajekNetwork, "states_as_physical", "state network as Pajek")
+                              : artifact(config, basename, phase, OutputKind::PajekNetwork, "net", "Pajek network"));
+    }
+    return artifacts;
+  }
+
+  if (phase == OutputPhase::AfterFlow) {
+    if (config.printFlowNetwork) {
+      artifacts.push_back(config.printStates()
+                              ? artifact(config, basename, phase, OutputKind::FlowNetwork, "flow_as_physical", "flow state network as Pajek", true, true)
+                              : artifact(config, basename, phase, OutputKind::FlowNetwork, "flow", "flow network", false, true));
+    }
+    return artifacts;
+  }
+
+  if (phase != OutputPhase::AfterPartition) {
+    return artifacts;
+  }
+
+  if (config.printTree) {
+    addPhysicalAndStateArtifacts(artifacts, config, basename, OutputKind::Tree, "tree", "tree_states", "tree", "physical tree", "state tree");
+  }
+  if (config.printFlowTree) {
+    addPhysicalAndStateArtifacts(artifacts, config, basename, OutputKind::FlowTree, "ftree", "ftree_states", "flow tree", "physical flow tree", "state flow tree");
+  }
+  if (config.printNewick) {
+    addPhysicalAndStateArtifacts(artifacts, config, basename, OutputKind::Newick, "newick", "newick_states", "Newick tree", "physical Newick tree", "state Newick tree");
+  }
+  if (config.printJson) {
+    addPhysicalAndStateArtifacts(artifacts, config, basename, OutputKind::Json, "json", "json_states", "JSON tree", "physical JSON tree", "state JSON tree");
+  }
+  if (config.printCsv) {
+    addPhysicalAndStateArtifacts(artifacts, config, basename, OutputKind::Csv, "csv", "csv_states", "CSV tree", "physical CSV tree", "state CSV tree");
+  }
+  if (config.printClu) {
+    addPhysicalAndStateArtifacts(artifacts, config, basename, OutputKind::Clu, "clu", "clu_states", "node modules", "physical node modules", "state node modules");
+  }
+
+  return artifacts;
+}
+
+std::vector<OutputArtifact> planOutputArtifacts(const Config& config, OutputPhase phase, int trial)
+{
+  return planOutputArtifacts(config, outputPlanBasename(config, trial), phase);
+}
+
+void writeOutputArtifact(InfomapBase& infomap, Network& network, const OutputArtifact& output)
+{
+  if (output.phase == OutputPhase::AfterPartition) {
+    const auto write = [&]() { writeModularOutput(infomap, output); };
+    if (infomap.prettyOutput) {
+      write();
+      return;
+    }
+
+    Log() << "Write " << output.label << " to " << output.filename << "... ";
+    write();
+    Log() << "done!\n";
+    return;
+  }
+
+  Log() << "Writing " << output.label << " to '" << output.filename << "'... ";
+  writeNetworkOutput(network, output);
+  Log() << "done!\n";
+}
+
+void writeOutputArtifacts(InfomapBase& infomap, Network& network, OutputPhase phase, int trial)
+{
+  const auto artifacts = planOutputArtifacts(infomap, phase, trial);
+  std::vector<std::pair<std::string, std::string>> prettyOutputFiles;
+
+  for (const auto& output : artifacts) {
+    writeOutputArtifact(infomap, network, output);
+    if (infomap.prettyOutput) {
+      if (phase != OutputPhase::AfterPartition) {
+        PrettyOutput(true).status("Output", io::Str() << output.label << " -> " << output.filename);
+        continue;
+      }
+      prettyOutputFiles.emplace_back(output.label, output.filename);
+    }
+  }
+
+  if (!infomap.prettyOutput || prettyOutputFiles.empty()) {
+    return;
+  }
+
+  if (prettyOutputFiles.size() == 1) {
+    PrettyOutput(true).status("Output", io::Str() << prettyOutputFiles.front().first << " -> " << prettyOutputFiles.front().second);
+    return;
+  }
+
+  const auto summaries = summarizeOutputFiles(prettyOutputFiles);
+  for (unsigned int i = 0; i < summaries.size(); ++i) {
+    const std::string prefix = i == 0 ? std::string(io::Str() << prettyOutputFiles.size() << " files -> ") : "         ";
+    PrettyOutput(true).status("Output", io::Str() << prefix << summaries[i]);
+  }
+}
+
+} // namespace infomap

--- a/src/io/OutputPlan.h
+++ b/src/io/OutputPlan.h
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ Infomap software package for multi-level network clustering
+ Copyright (c) 2013, 2014 Daniel Edler, Anton Holmgren, Martin Rosvall
+
+ This file is part of the Infomap software package.
+ See file LICENSE_GPLv3.txt for full license details.
+ For more information, see <http://www.mapequation.org>
+ ******************************************************************************/
+
+#ifndef OUTPUT_PLAN_H_
+#define OUTPUT_PLAN_H_
+
+#include "Config.h"
+#include "OutputFormats.h"
+
+#include <string>
+#include <vector>
+
+namespace infomap {
+
+class InfomapBase;
+class Network;
+
+enum class OutputPhase : std::uint8_t {
+  BeforeFlow,
+  AfterFlow,
+  AfterPartition
+};
+
+struct OutputArtifact {
+  std::string resultKey;
+  std::string label;
+  std::string filename;
+  OutputPhase phase = OutputPhase::AfterPartition;
+  OutputKind kind = OutputKind::Tree;
+  bool states = false;
+  int cluLevel = 1;
+  bool writeLinks = false;
+  bool printFlow = false;
+};
+
+std::string outputPlanBasename(const Config& config, int trial = -1);
+
+std::vector<OutputArtifact> planOutputArtifacts(const Config& config, const std::string& basename, OutputPhase phase);
+
+std::vector<OutputArtifact> planOutputArtifacts(const Config& config, OutputPhase phase, int trial = -1);
+
+void writeOutputArtifact(InfomapBase& infomap, Network& network, const OutputArtifact& artifact);
+
+void writeOutputArtifacts(InfomapBase& infomap, Network& network, OutputPhase phase, int trial = -1);
+
+} // namespace infomap
+
+#endif // OUTPUT_PLAN_H_

--- a/src/io/OutputView.cpp
+++ b/src/io/OutputView.cpp
@@ -33,7 +33,7 @@ bool OutputView::hasMetaData() const
   return m_infomap.haveMetaData();
 }
 
-void OutputView::forEachLeaf(int moduleIndexLevel, OutputLeafFilter filter, const LeafCallback& callback)
+void OutputView::forEachLeaf(int moduleIndexLevel, OutputLeafPolicy filter, const LeafCallback& callback)
 {
   if (isHigherOrderPhysicalLevel()) {
     for (auto it(m_infomap.iterTreePhysical(moduleIndexLevel)); !it.isEnd(); ++it) {
@@ -91,9 +91,9 @@ std::map<unsigned int, OutputStateNodeTarget> OutputView::stateNodeTargets()
   return targets;
 }
 
-bool OutputView::shouldIncludeLeaf(const InfoNode& node, OutputLeafFilter filter) const
+bool OutputView::shouldIncludeLeaf(const InfoNode& node, OutputLeafPolicy filter) const
 {
-  const auto shouldHideBipartiteNodes = filter == OutputLeafFilter::TreeNoFlowFilter
+  const auto shouldHideBipartiteNodes = filter == OutputLeafPolicy::HideBipartiteUnlessFlowTree
       ? !m_infomap.printFlowTree && m_infomap.isBipartite() && m_infomap.hideBipartiteNodes
       : m_infomap.isBipartite() && m_infomap.hideBipartiteNodes;
 

--- a/src/io/OutputView.cpp
+++ b/src/io/OutputView.cpp
@@ -115,11 +115,11 @@ OutputTreeRow OutputView::treeRow(const InfoNode& node, unsigned int depth) cons
 
 std::string OutputView::nodeName(const InfoNode& node) const
 {
-  try {
-    return m_network.names().at(node.physicalId);
-  } catch (...) {
-    return io::stringify(node.physicalId);
+  const auto nameIt = m_network.names().find(node.physicalId);
+  if (nameIt != m_network.names().end()) {
+    return nameIt->second;
   }
+  return io::stringify(node.physicalId);
 }
 
 } // namespace infomap

--- a/src/io/OutputView.cpp
+++ b/src/io/OutputView.cpp
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ Infomap software package for multi-level network clustering
+ Copyright (c) 2013, 2014 Daniel Edler, Anton Holmgren, Martin Rosvall
+
+ This file is part of the Infomap software package.
+ See file LICENSE_GPLv3.txt for full license details.
+ For more information, see <http://www.mapequation.org>
+ ******************************************************************************/
+
+#include "OutputView.h"
+#include "../core/InfomapBase.h"
+#include "../core/InfoNode.h"
+#include "../core/StateNetwork.h"
+#include "../utils/convert.h"
+
+namespace infomap {
+
+OutputView::OutputView(InfomapBase& infomap, const StateNetwork& network, bool states)
+    : m_infomap(infomap), m_network(network), m_states(states) {}
+
+bool OutputView::isHigherOrderPhysicalLevel() const
+{
+  return m_infomap.haveMemory() && !m_states;
+}
+
+bool OutputView::isMultilayer() const
+{
+  return m_infomap.isMultilayerNetwork();
+}
+
+bool OutputView::hasMetaData() const
+{
+  return m_infomap.haveMetaData();
+}
+
+void OutputView::forEachLeaf(int moduleIndexLevel, OutputLeafFilter filter, const LeafCallback& callback)
+{
+  if (isHigherOrderPhysicalLevel()) {
+    for (auto it(m_infomap.iterTreePhysical(moduleIndexLevel)); !it.isEnd(); ++it) {
+      InfoNode& node = *it;
+      if (node.isLeaf() && shouldIncludeLeaf(node, filter)) {
+        callback(leafRow(node, it.path(), it.moduleId(), it.modularCentrality()));
+      }
+    }
+    return;
+  }
+
+  for (auto it(m_infomap.iterTree(moduleIndexLevel)); !it.isEnd(); ++it) {
+    InfoNode& node = *it;
+    if (node.isLeaf() && shouldIncludeLeaf(node, filter)) {
+      callback(leafRow(node, it.path(), it.moduleId(), it.modularCentrality()));
+    }
+  }
+}
+
+void OutputView::forEachTreeNode(const TreeCallback& callback)
+{
+  if (isHigherOrderPhysicalLevel()) {
+    for (auto it(m_infomap.iterTreePhysical()); !it.isEnd(); ++it) {
+      callback(treeRow(*it, it.depth()));
+    }
+    return;
+  }
+
+  for (auto it(m_infomap.iterTree()); !it.isEnd(); ++it) {
+    callback(treeRow(*it, it.depth()));
+  }
+}
+
+std::map<unsigned int, OutputStateNodeTarget> OutputView::stateNodeTargets()
+{
+  std::map<unsigned int, OutputStateNodeTarget> targets;
+
+  if (isHigherOrderPhysicalLevel()) {
+    for (auto it(m_infomap.iterTreePhysical()); !it.isEnd(); ++it) {
+      if (it->isLeaf()) {
+        for (auto stateId : it->stateNodes) {
+          targets[stateId] = { it->parent, it.childIndex() };
+        }
+      }
+    }
+    return targets;
+  }
+
+  for (auto it(m_infomap.iterTree()); !it.isEnd(); ++it) {
+    if (it->isLeaf()) {
+      targets[it->stateId] = { it->parent, it.childIndex() };
+    }
+  }
+
+  return targets;
+}
+
+bool OutputView::shouldIncludeLeaf(const InfoNode& node, OutputLeafFilter filter) const
+{
+  const auto shouldHideBipartiteNodes = filter == OutputLeafFilter::TreeNoFlowFilter
+      ? !m_infomap.printFlowTree && m_infomap.isBipartite() && m_infomap.hideBipartiteNodes
+      : m_infomap.isBipartite() && m_infomap.hideBipartiteNodes;
+
+  return !shouldHideBipartiteNodes || node.physicalId < m_network.bipartiteStartId();
+}
+
+OutputLeafRow OutputView::leafRow(const InfoNode& node,
+                                  const std::deque<unsigned int>& path,
+                                  unsigned int moduleId,
+                                  double modularCentrality) const
+{
+  return { node, path, moduleId, modularCentrality, node.stateId, node.physicalId, node.layerId, node.data.flow, nodeName(node) };
+}
+
+OutputTreeRow OutputView::treeRow(const InfoNode& node, unsigned int depth) const
+{
+  return { node, depth, node.stateId, node.physicalId, node.data.flow };
+}
+
+std::string OutputView::nodeName(const InfoNode& node) const
+{
+  try {
+    return m_network.names().at(node.physicalId);
+  } catch (...) {
+    return io::stringify(node.physicalId);
+  }
+}
+
+} // namespace infomap

--- a/src/io/OutputView.h
+++ b/src/io/OutputView.h
@@ -29,7 +29,7 @@ enum class OutputLeafPolicy : std::uint8_t {
 
 struct OutputLeafRow {
   const InfoNode& node;
-  const std::deque<unsigned int>& path;
+  std::deque<unsigned int> path;
   unsigned int moduleId = 0;
   double modularCentrality = 0.0;
   unsigned int stateId = 0;

--- a/src/io/OutputView.h
+++ b/src/io/OutputView.h
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ Infomap software package for multi-level network clustering
+ Copyright (c) 2013, 2014 Daniel Edler, Anton Holmgren, Martin Rosvall
+
+ This file is part of the Infomap software package.
+ See file LICENSE_GPLv3.txt for full license details.
+ For more information, see <http://www.mapequation.org>
+ ******************************************************************************/
+
+#ifndef OUTPUT_VIEW_H_
+#define OUTPUT_VIEW_H_
+
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <map>
+#include <string>
+
+namespace infomap {
+
+class InfomapBase;
+class InfoNode;
+class StateNetwork;
+
+enum class OutputLeafFilter : std::uint8_t {
+  Regular,
+  TreeNoFlowFilter
+};
+
+struct OutputLeafRow {
+  const InfoNode& node;
+  const std::deque<unsigned int>& path;
+  unsigned int moduleId = 0;
+  double modularCentrality = 0.0;
+  unsigned int stateId = 0;
+  unsigned int physicalId = 0;
+  unsigned int layerId = 0;
+  double flow = 0.0;
+  std::string name;
+};
+
+struct OutputTreeRow {
+  const InfoNode& node;
+  unsigned int depth = 0;
+  unsigned int stateId = 0;
+  unsigned int physicalId = 0;
+  double flow = 0.0;
+};
+
+struct OutputStateNodeTarget {
+  InfoNode* parent = nullptr;
+  unsigned int childIndex = 0;
+};
+
+class OutputView {
+public:
+  using LeafCallback = std::function<void(const OutputLeafRow&)>;
+  using TreeCallback = std::function<void(const OutputTreeRow&)>;
+
+  OutputView(InfomapBase& infomap, const StateNetwork& network, bool states);
+
+  bool isStateLevel() const { return m_states; }
+  bool isPhysicalLevel() const { return !m_states; }
+  bool isHigherOrderPhysicalLevel() const;
+  bool isMultilayer() const;
+  bool hasMetaData() const;
+
+  void forEachLeaf(int moduleIndexLevel, OutputLeafFilter filter, const LeafCallback& callback);
+  void forEachTreeNode(const TreeCallback& callback);
+
+  std::map<unsigned int, OutputStateNodeTarget> stateNodeTargets();
+
+private:
+  bool shouldIncludeLeaf(const InfoNode& node, OutputLeafFilter filter) const;
+  OutputLeafRow leafRow(const InfoNode& node,
+                        const std::deque<unsigned int>& path,
+                        unsigned int moduleId,
+                        double modularCentrality) const;
+  OutputTreeRow treeRow(const InfoNode& node, unsigned int depth) const;
+  std::string nodeName(const InfoNode& node) const;
+
+  InfomapBase& m_infomap;
+  const StateNetwork& m_network;
+  bool m_states = false;
+};
+
+} // namespace infomap
+
+#endif // OUTPUT_VIEW_H_

--- a/src/io/OutputView.h
+++ b/src/io/OutputView.h
@@ -22,9 +22,9 @@ class InfomapBase;
 class InfoNode;
 class StateNetwork;
 
-enum class OutputLeafFilter : std::uint8_t {
-  Regular,
-  TreeNoFlowFilter
+enum class OutputLeafPolicy : std::uint8_t {
+  HideBipartite,
+  HideBipartiteUnlessFlowTree
 };
 
 struct OutputLeafRow {
@@ -65,13 +65,13 @@ public:
   bool isMultilayer() const;
   bool hasMetaData() const;
 
-  void forEachLeaf(int moduleIndexLevel, OutputLeafFilter filter, const LeafCallback& callback);
+  void forEachLeaf(int moduleIndexLevel, OutputLeafPolicy filter, const LeafCallback& callback);
   void forEachTreeNode(const TreeCallback& callback);
 
   std::map<unsigned int, OutputStateNodeTarget> stateNodeTargets();
 
 private:
-  bool shouldIncludeLeaf(const InfoNode& node, OutputLeafFilter filter) const;
+  bool shouldIncludeLeaf(const InfoNode& node, OutputLeafPolicy filter) const;
   OutputLeafRow leafRow(const InfoNode& node,
                         const std::deque<unsigned int>& path,
                         unsigned int moduleId,

--- a/test/cpp/test_config.cpp
+++ b/test/cpp/test_config.cpp
@@ -3,6 +3,7 @@
 #include "io/ConfigBuilder.h"
 #include "io/Config.h"
 #include "io/OutputFormats.h"
+#include "io/OutputPlan.h"
 #include "io/ParameterCatalog.h"
 
 #include <map>
@@ -11,6 +12,16 @@
 namespace {
 
 using infomap::Config;
+
+std::vector<std::string> resultKeysFor(const Config& config, infomap::OutputPhase phase)
+{
+  std::vector<std::string> keys;
+  for (const auto& artifact : infomap::planOutputArtifacts(config, phase)) {
+    keys.push_back(artifact.resultKey);
+  }
+  return keys;
+}
+
 TEST_CASE("Config accepts no-file-output without an output directory [fast][core][config][cli]")
 {
   CHECK_NOTHROW(Config("input.net --silent --no-file-output", true));
@@ -142,6 +153,81 @@ TEST_CASE("Output format manifest result keys stay unique [fast][core][config][c
   }
   CHECK(resultKeys.count("json_states") == 1);
   CHECK(resultKeys.count("flow_as_physical") == 1);
+}
+
+TEST_CASE("Output plan expands first-order modular artifacts [fast][core][config][output]")
+{
+  Config config;
+  config.outName = "network";
+  config.printTree = true;
+
+  const auto artifacts = infomap::planOutputArtifacts(config, infomap::OutputPhase::AfterPartition);
+
+  REQUIRE(artifacts.size() == 1);
+  CHECK(artifacts.front().resultKey == "tree");
+  CHECK(artifacts.front().label == "tree");
+  CHECK(artifacts.front().filename == "network.tree");
+  CHECK(artifacts.front().phase == infomap::OutputPhase::AfterPartition);
+  CHECK(artifacts.front().kind == infomap::OutputKind::Tree);
+  CHECK_FALSE(artifacts.front().states);
+}
+
+TEST_CASE("Output plan expands state and physical modular artifacts [fast][core][config][output]")
+{
+  Config config;
+  config.outName = "network";
+  config.printTree = true;
+  config.setStateOutput();
+
+  const auto artifacts = infomap::planOutputArtifacts(config, infomap::OutputPhase::AfterPartition);
+
+  REQUIRE(artifacts.size() == 2);
+  CHECK(resultKeysFor(config, infomap::OutputPhase::AfterPartition) == std::vector<std::string> { "tree", "tree_states" });
+  CHECK(artifacts[0].label == "physical tree");
+  CHECK(artifacts[0].filename == "network.tree");
+  CHECK_FALSE(artifacts[0].states);
+  CHECK(artifacts[1].label == "state tree");
+  CHECK(artifacts[1].filename == "network_states.tree");
+  CHECK(artifacts[1].states);
+}
+
+TEST_CASE("Output plan assigns network artifacts to write phases [fast][core][config][output]")
+{
+  Config config;
+  config.outName = "network";
+  config.printClu = true;
+  config.printTree = true;
+  config.printFlowNetwork = true;
+  config.printPajekNetwork = true;
+  config.printStateNetwork = true;
+  config.setStateOutput();
+
+  CHECK(resultKeysFor(config, infomap::OutputPhase::BeforeFlow) == std::vector<std::string> { "states", "states_as_physical" });
+  CHECK(resultKeysFor(config, infomap::OutputPhase::AfterFlow) == std::vector<std::string> { "flow_as_physical" });
+  CHECK(resultKeysFor(config, infomap::OutputPhase::AfterPartition) == std::vector<std::string> { "tree", "tree_states", "clu", "clu_states" });
+
+  for (const auto phase : { infomap::OutputPhase::BeforeFlow, infomap::OutputPhase::AfterFlow, infomap::OutputPhase::AfterPartition }) {
+    for (const auto& artifact : infomap::planOutputArtifacts(config, phase)) {
+      CHECK(artifact.phase == phase);
+      CHECK(infomap::findOutputFileFormat(artifact.resultKey) != nullptr);
+    }
+  }
+}
+
+TEST_CASE("Output plan applies trial suffix before format suffix [fast][core][config][output]")
+{
+  Config config;
+  config.outDirectory = "out/";
+  config.outName = "network";
+  config.printTree = true;
+  config.printAllTrials = true;
+  config.numTrials = 3;
+
+  const auto artifacts = infomap::planOutputArtifacts(config, infomap::OutputPhase::AfterPartition, 2);
+
+  REQUIRE(artifacts.size() == 1);
+  CHECK(infomap::outputPlanBasename(config, 2) == "out/network_trial_2");
+  CHECK(artifacts.front().filename == "out/network_trial_2.tree");
 }
 
 TEST_CASE("Parameter catalog owns option choices and binding names [fast][core][config][cli]")

--- a/test/cpp/test_infomap_wrapper.cpp
+++ b/test/cpp/test_infomap_wrapper.cpp
@@ -74,7 +74,7 @@ std::vector<OutputRowIdentity> outputViewIdentities(InfomapWrapper& im, bool sta
 {
   infomap::OutputView view(im, im.network(), states);
   std::vector<OutputRowIdentity> rows;
-  view.forEachLeaf(1, infomap::OutputLeafFilter::Regular, [&](const infomap::OutputLeafRow& row) {
+  view.forEachLeaf(1, infomap::OutputLeafPolicy::HideBipartite, [&](const infomap::OutputLeafRow& row) {
     rows.emplace_back(row.stateId, row.physicalId, row.layerId);
   });
   std::sort(rows.begin(), rows.end());
@@ -518,7 +518,7 @@ TEST_CASE("OutputView projects first-order leaf rows [fast][core][output]")
   infomap::OutputView view(*im, im->network(), false);
   std::vector<unsigned int> physicalIds;
   unsigned int nonEmptyPaths = 0;
-  view.forEachLeaf(1, infomap::OutputLeafFilter::Regular, [&](const infomap::OutputLeafRow& row) {
+  view.forEachLeaf(1, infomap::OutputLeafPolicy::HideBipartite, [&](const infomap::OutputLeafRow& row) {
     physicalIds.push_back(row.physicalId);
     CHECK(row.stateId == row.physicalId);
     CHECK(row.moduleId > 0);
@@ -562,7 +562,7 @@ TEST_CASE("OutputView exposes multilayer state layer ids [fast][core][output]")
 
   infomap::OutputView view(*im, im->network(), true);
   bool foundLayer = false;
-  view.forEachLeaf(1, infomap::OutputLeafFilter::Regular, [&](const infomap::OutputLeafRow& row) {
+  view.forEachLeaf(1, infomap::OutputLeafPolicy::HideBipartite, [&](const infomap::OutputLeafRow& row) {
     CHECK(row.physicalId != 0);
     if (row.layerId != 0) {
       foundLayer = true;
@@ -581,7 +581,7 @@ TEST_CASE("OutputView applies bipartite hide filter centrally [fast][core][outpu
 
   infomap::OutputView view(*im, im->network(), false);
   std::vector<unsigned int> physicalIds;
-  view.forEachLeaf(1, infomap::OutputLeafFilter::Regular, [&](const infomap::OutputLeafRow& row) {
+  view.forEachLeaf(1, infomap::OutputLeafPolicy::HideBipartite, [&](const infomap::OutputLeafRow& row) {
     physicalIds.push_back(row.physicalId);
   });
 

--- a/test/cpp/test_infomap_wrapper.cpp
+++ b/test/cpp/test_infomap_wrapper.cpp
@@ -61,6 +61,13 @@ std::string temporaryOutputPath(const std::string& prefix, const std::string& su
   return prefix + suffix;
 }
 
+void removeFiles(const std::vector<std::string>& paths)
+{
+  for (const auto& path : paths) {
+    std::remove(path.c_str());
+  }
+}
+
 TEST_CASE("Infomap partitions the unweighted two-triangle fixture into two modules [fast][core][lifecycle]")
 {
   InfomapWrapper im(infomap::test::defaultFlags());
@@ -508,6 +515,90 @@ TEST_CASE("writeFlowTree is stable across repeated calls on the same instance [f
 
   std::remove(firstPath.c_str());
   std::remove(secondPath.c_str());
+}
+
+TEST_CASE("writeResult renders selected first-order output artifacts [fast][core][output]")
+{
+  auto im = infomap::test::makeRunningInfomap(
+      [&](InfomapWrapper& infomap) { infomap::test::addEdgeFixtureLinks(infomap, "graphs/twotriangles_unweighted.edges"); });
+
+  im->noFileOutput = false;
+  im->outDirectory = "";
+  im->outName = "output_result_first_order";
+  im->printTree = true;
+  im->printClu = true;
+  im->printJson = true;
+  im->printCsv = true;
+
+  const std::vector<std::string> paths = {
+    "output_result_first_order.tree",
+    "output_result_first_order.clu",
+    "output_result_first_order.json",
+    "output_result_first_order.csv",
+  };
+  removeFiles(paths);
+
+  im->writeResult();
+
+  const auto treeText = infomap::test::readTextFile(paths[0]);
+  const auto cluText = infomap::test::readTextFile(paths[1]);
+  const auto jsonText = infomap::test::readTextFile(paths[2]);
+  const auto csvText = infomap::test::readTextFile(paths[3]);
+
+  CHECK(treeText.find("# path flow name node_id") != std::string::npos);
+  CHECK(cluText.find("# node_id module flow") != std::string::npos);
+  CHECK(jsonText.find("\"nodes\":[") != std::string::npos);
+  CHECK(csvText.find("path,flow,name,node_id") != std::string::npos);
+
+  removeFiles(paths);
+}
+
+TEST_CASE("writeResult renders selected physical and state output artifacts [fast][core][output]")
+{
+  auto im = infomap::test::makeRunningInfomap(
+      [&](InfomapWrapper& infomap) { infomap::test::readNetworkFixture(infomap, "states.net"); });
+
+  im->noFileOutput = false;
+  im->outDirectory = "";
+  im->outName = "output_result_states";
+  im->printTree = true;
+  im->printClu = true;
+  im->printJson = true;
+  im->printCsv = true;
+
+  const std::vector<std::string> paths = {
+    "output_result_states.tree",
+    "output_result_states_states.tree",
+    "output_result_states.clu",
+    "output_result_states_states.clu",
+    "output_result_states.json",
+    "output_result_states_states.json",
+    "output_result_states.csv",
+    "output_result_states_states.csv",
+  };
+  removeFiles(paths);
+
+  im->writeResult();
+
+  const auto physicalTreeText = infomap::test::readTextFile(paths[0]);
+  const auto stateTreeText = infomap::test::readTextFile(paths[1]);
+  const auto physicalCluText = infomap::test::readTextFile(paths[2]);
+  const auto stateCluText = infomap::test::readTextFile(paths[3]);
+  const auto physicalJsonText = infomap::test::readTextFile(paths[4]);
+  const auto stateJsonText = infomap::test::readTextFile(paths[5]);
+  const auto physicalCsvText = infomap::test::readTextFile(paths[6]);
+  const auto stateCsvText = infomap::test::readTextFile(paths[7]);
+
+  CHECK(physicalTreeText.find("# path flow name node_id") != std::string::npos);
+  CHECK(stateTreeText.find("# path flow name state_id node_id") != std::string::npos);
+  CHECK(physicalCluText.find("# node_id module flow") != std::string::npos);
+  CHECK(stateCluText.find("# state_id module flow node_id") != std::string::npos);
+  CHECK(physicalJsonText.find("\"stateLevel\":false") != std::string::npos);
+  CHECK(stateJsonText.find("\"stateLevel\":true") != std::string::npos);
+  CHECK(physicalCsvText.find("path,flow,name,node_id") != std::string::npos);
+  CHECK(stateCsvText.find("path,flow,name,state_id,node_id") != std::string::npos);
+
+  removeFiles(paths);
 }
 
 } // namespace

--- a/test/cpp/test_infomap_wrapper.cpp
+++ b/test/cpp/test_infomap_wrapper.cpp
@@ -1,6 +1,7 @@
 #include "vendor/doctest.h"
 
 #include "Infomap.h"
+#include "io/OutputView.h"
 
 #include "TestUtils.h"
 
@@ -15,6 +16,7 @@ using infomap::InfomapWrapper;
 
 using InternalEdge = std::tuple<unsigned int, unsigned int, double, double>;
 using NodeIdentity = std::tuple<unsigned int, unsigned int, std::vector<int>>;
+using OutputRowIdentity = std::tuple<unsigned int, unsigned int, unsigned int>;
 
 std::multiset<InternalEdge> internalEdgesForModule(infomap::InfoNode& module)
 {
@@ -66,6 +68,17 @@ void removeFiles(const std::vector<std::string>& paths)
   for (const auto& path : paths) {
     std::remove(path.c_str());
   }
+}
+
+std::vector<OutputRowIdentity> outputViewIdentities(InfomapWrapper& im, bool states)
+{
+  infomap::OutputView view(im, im.network(), states);
+  std::vector<OutputRowIdentity> rows;
+  view.forEachLeaf(1, infomap::OutputLeafFilter::Regular, [&](const infomap::OutputLeafRow& row) {
+    rows.emplace_back(row.stateId, row.physicalId, row.layerId);
+  });
+  std::sort(rows.begin(), rows.end());
+  return rows;
 }
 
 TEST_CASE("Infomap partitions the unweighted two-triangle fixture into two modules [fast][core][lifecycle]")
@@ -495,6 +508,85 @@ TEST_CASE("writeTree and writeClu render higher-order state output [fast][core][
 
   std::remove(treePath.c_str());
   std::remove(cluPath.c_str());
+}
+
+TEST_CASE("OutputView projects first-order leaf rows [fast][core][output]")
+{
+  auto im = infomap::test::makeRunningInfomap(
+      [&](InfomapWrapper& infomap) { infomap::test::addEdgeFixtureLinks(infomap, "graphs/twotriangles_unweighted.edges"); });
+
+  infomap::OutputView view(*im, im->network(), false);
+  std::vector<unsigned int> physicalIds;
+  unsigned int nonEmptyPaths = 0;
+  view.forEachLeaf(1, infomap::OutputLeafFilter::Regular, [&](const infomap::OutputLeafRow& row) {
+    physicalIds.push_back(row.physicalId);
+    CHECK(row.stateId == row.physicalId);
+    CHECK(row.moduleId > 0);
+    if (!row.path.empty()) {
+      ++nonEmptyPaths;
+    }
+  });
+
+  std::sort(physicalIds.begin(), physicalIds.end());
+  CHECK(physicalIds == std::vector<unsigned int> { 1, 2, 3, 4, 5, 6 });
+  CHECK(nonEmptyPaths == physicalIds.size());
+}
+
+TEST_CASE("OutputView separates higher-order physical and state rows [fast][core][output]")
+{
+  auto im = infomap::test::makeRunningInfomap(
+      [&](InfomapWrapper& infomap) { infomap::test::readNetworkFixture(infomap, "states.net"); });
+
+  infomap::OutputView physicalView(*im, im->network(), false);
+  infomap::OutputView stateView(*im, im->network(), true);
+
+  CHECK(physicalView.isHigherOrderPhysicalLevel());
+  CHECK_FALSE(stateView.isHigherOrderPhysicalLevel());
+
+  const auto physicalRows = outputViewIdentities(*im, false);
+  const auto stateRows = outputViewIdentities(*im, true);
+  std::set<unsigned int> physicalIds;
+  for (const auto& row : stateRows) {
+    physicalIds.insert(std::get<1>(row));
+  }
+
+  CHECK(physicalRows.size() <= stateRows.size());
+  CHECK(physicalIds.size() == 5);
+  CHECK(stateRows.size() == 6);
+}
+
+TEST_CASE("OutputView exposes multilayer state layer ids [fast][core][output]")
+{
+  auto im = infomap::test::makeRunningInfomap(
+      [&](InfomapWrapper& infomap) { infomap::test::readNetworkFixture(infomap, "multilayer.net"); });
+
+  infomap::OutputView view(*im, im->network(), true);
+  bool foundLayer = false;
+  view.forEachLeaf(1, infomap::OutputLeafFilter::Regular, [&](const infomap::OutputLeafRow& row) {
+    CHECK(row.physicalId != 0);
+    if (row.layerId != 0) {
+      foundLayer = true;
+    }
+  });
+
+  CHECK(view.isMultilayer());
+  CHECK(foundLayer);
+}
+
+TEST_CASE("OutputView applies bipartite hide filter centrally [fast][core][output]")
+{
+  auto im = infomap::test::makeRunningInfomap(
+      [&](InfomapWrapper& infomap) { infomap.readInputData(infomap::test::repoPath("examples/networks/bipartite.net")); });
+  im->hideBipartiteNodes = true;
+
+  infomap::OutputView view(*im, im->network(), false);
+  std::vector<unsigned int> physicalIds;
+  view.forEachLeaf(1, infomap::OutputLeafFilter::Regular, [&](const infomap::OutputLeafRow& row) {
+    physicalIds.push_back(row.physicalId);
+  });
+
+  std::sort(physicalIds.begin(), physicalIds.end());
+  CHECK(physicalIds == std::vector<unsigned int> { 1, 2, 3 });
 }
 
 TEST_CASE("writeFlowTree is stable across repeated calls on the same instance [fast][core][output][regression]")


### PR DESCRIPTION
## Summary
- centralize output artifact planning in OutputPlan with phase-aware artifact dispatch
- consolidate output format/artifact kind into a shared OutputKind
- keep OutputFormats as static manifest metadata and preserve existing writer APIs/output behavior

## Tests
- rtk make test-native
- rtk make test-python-unit PYTEST_ARGS='test/python/test_wrapper_args.py test/python/test_api.py -q'
- git diff --check