### PR TITLE
refactor: deepen config parser seams

### DIFF
--- a/interfaces/swig/Config.i
+++ b/interfaces/swig/Config.i
@@ -7,5 +7,8 @@
 
 %include "std_string.i"
 
+%ignore infomap::flowModelNames;
+%ignore infomap::parseFlowModel;
+
 /* Parse the header file to generate wrappers */
 %include "src/io/Config.h"

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -26,6 +26,7 @@
 #include <deque>
 #include <map>
 #include <limits>
+#include <memory>
 #include <string>
 #include <ostream>
 #include <sstream>

--- a/src/core/MemMapEquation.cpp
+++ b/src/core/MemMapEquation.cpp
@@ -15,6 +15,7 @@
 #include <vector>
 #include <set>
 #include <map>
+#include <limits>
 #include <utility>
 #include <algorithm>
 #include <unordered_map>

--- a/src/core/MemMapEquation.cpp
+++ b/src/core/MemMapEquation.cpp
@@ -17,6 +17,7 @@
 #include <map>
 #include <utility>
 #include <algorithm>
+#include <unordered_map>
 
 namespace infomap {
 

--- a/src/core/StateNetwork.cpp
+++ b/src/core/StateNetwork.cpp
@@ -11,6 +11,7 @@
 #include "../utils/FlowCalculator.h"
 #include "../utils/Log.h"
 #include "../io/SafeFile.h"
+#include <deque>
 #include <stdexcept>
 #include <utility>
 

--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -11,8 +11,10 @@
 #include "ConfigBuilder.h"
 #include "OutputFormats.h"
 #include "../utils/Log.h"
+#include "../utils/convert.h"
 #include <vector>
 #include <stdexcept>
+#include <utility>
 
 namespace infomap {
 
@@ -24,6 +26,19 @@ constexpr int FlowModel::rawdir;
 constexpr int FlowModel::precomputed;
 
 namespace {
+
+  const std::vector<std::pair<std::string, FlowModel>>& flowModelMappings()
+  {
+    static const std::vector<std::pair<std::string, FlowModel>> mappings = {
+      { "undirected", FlowModel::undirected },
+      { "directed", FlowModel::directed },
+      { "undirdir", FlowModel::undirdir },
+      { "outdirdir", FlowModel::outdirdir },
+      { "rawdir", FlowModel::rawdir },
+      { "precomputed", FlowModel::precomputed },
+    };
+    return mappings;
+  }
 
   void enableOutputFormat(Config& config, const OutputFormat& format)
   {
@@ -59,6 +74,39 @@ namespace {
   }
 
 } // namespace
+
+const std::vector<std::string>& flowModelNames()
+{
+  static const std::vector<std::string> names = [] {
+    std::vector<std::string> values;
+    for (const auto& mapping : flowModelMappings()) {
+      values.push_back(mapping.first);
+    }
+    return values;
+  }();
+  return names;
+}
+
+bool parseFlowModel(const std::string& name, FlowModel& flowModel)
+{
+  for (const auto& mapping : flowModelMappings()) {
+    if (mapping.first == name) {
+      flowModel = mapping.second;
+      return true;
+    }
+  }
+  return false;
+}
+
+const char* flowModelToString(const FlowModel& flowModel)
+{
+  for (const auto& mapping : flowModelMappings()) {
+    if (mapping.second == flowModel) {
+      return mapping.first.c_str();
+    }
+  }
+  return "undirected";
+}
 
 Config::Config(const std::string& flags, bool isCLI) : isCLI(isCLI)
 {

--- a/src/io/Config.h
+++ b/src/io/Config.h
@@ -10,9 +10,9 @@
 #ifndef CONFIG_H_
 #define CONFIG_H_
 
+#include "ParsedOption.h"
 #include "../utils/Date.h"
 #include "../version.h"
-#include "ProgramInterface.h"
 
 #include <stdexcept>
 #include <iomanip>
@@ -46,25 +46,9 @@ struct FlowModel {
 };
 
 std::ostream& operator<<(std::ostream& out, FlowModel f);
-
-inline const char* flowModelToString(const FlowModel& flowModel)
-{
-  switch (flowModel) {
-  case FlowModel::directed:
-    return "directed";
-  case FlowModel::undirdir:
-    return "undirdir";
-  case FlowModel::outdirdir:
-    return "outdirdir";
-  case FlowModel::rawdir:
-    return "rawdir";
-  case FlowModel::precomputed:
-    return "precomputed";
-  case FlowModel::undirected:
-  default:
-    return "undirected";
-  }
-}
+const std::vector<std::string>& flowModelNames();
+bool parseFlowModel(const std::string& name, FlowModel& flowModel);
+const char* flowModelToString(const FlowModel& flowModel);
 
 // Mutable runtime state after parameter parsing and default adaptation. Add or
 // change parameter metadata in ParameterCatalog, not by editing this struct alone.

--- a/src/io/ConfigBuilder.cpp
+++ b/src/io/ConfigBuilder.cpp
@@ -21,22 +21,58 @@ namespace infomap {
 
 namespace {
 
-  void applyFlowModelSelection(Config& config, const std::string& flowModelArg)
+  void rejectDeprecatedAliases(const ParsedConfigParameters& parsed)
   {
-    if (flowModelArg == "directed" || config.directed) {
+    if (parsed.deprecatedIncludeSelfLinks) {
+      throw std::runtime_error("The --include-self-links flag is deprecated; self-links are included by default. Use --no-self-links to exclude them.");
+    }
+  }
+
+  void applyOutputDirectory(Config& config, const ParsedConfigParameters& parsed)
+  {
+    if (!parsed.optionalOutputDir.empty())
+      config.outDirectory = parsed.optionalOutputDir[0];
+  }
+
+  void applyLibraryOutputDefaults(Config& config, bool isCLI)
+  {
+    if (!isCLI && config.outDirectory.empty())
+      config.noFileOutput = true;
+  }
+
+  void validateRequiredCliOutput(const Config& config, bool isCLI)
+  {
+    if (!config.noFileOutput && config.outDirectory.empty() && isCLI) {
+      throw std::runtime_error("Missing out_directory");
+    }
+  }
+
+  void applyFlowModelSelection(Config& config, const ParsedConfigParameters& parsed)
+  {
+    if (config.directed) {
       config.setFlowModel(FlowModel::directed);
-    } else if (flowModelArg == "undirected") {
-      config.setFlowModel(FlowModel::undirected);
-    } else if (flowModelArg == "undirdir") {
-      config.setFlowModel(FlowModel::undirdir);
-    } else if (flowModelArg == "outdirdir") {
-      config.setFlowModel(FlowModel::outdirdir);
-    } else if (flowModelArg == "rawdir") {
-      config.setFlowModel(FlowModel::rawdir);
-    } else if (flowModelArg == "precomputed") {
-      config.setFlowModel(FlowModel::precomputed);
-    } else if (!flowModelArg.empty()) {
-      throw std::runtime_error(io::Str() << "Unrecognized flow model: '" << flowModelArg << "'");
+      return;
+    }
+
+    if (parsed.flowModelArg.empty()) {
+      return;
+    }
+
+    FlowModel flowModel = FlowModel::undirected;
+    if (!parseFlowModel(parsed.flowModelArg, flowModel)) {
+      throw std::runtime_error(io::Str() << "Unrecognized flow model: '" << parsed.flowModelArg << "'");
+    }
+    config.setFlowModel(flowModel);
+  }
+
+  void applyOptionInteractions(Config& config)
+  {
+    if (config.regularized) {
+      config.recordedTeleportation = true;
+    }
+
+    if (config.noInfomap) {
+      config.numTrials = 1;
     }
   }
 
@@ -53,6 +89,13 @@ namespace {
   {
     if (config.haveOutput() && !isDirectoryWritable(config.outDirectory))
       throw std::runtime_error(io::Str() << "Can't write to directory '" << config.outDirectory << "'. Check that the directory exists and that you have write permissions.");
+  }
+
+  void applyOutputNameDefault(Config& config)
+  {
+    if (config.outName.empty()) {
+      config.outName = !config.networkFile.empty() ? FileURI(config.networkFile).getName() : "no-name";
+    }
   }
 
 } // namespace
@@ -76,36 +119,15 @@ ParsedConfigParameters ConfigBuilder::parseRaw(Config& config, const std::string
 
 void ConfigBuilder::applyParsed(Config& config, const ParsedConfigParameters& parsed, bool isCLI)
 {
-  if (parsed.deprecatedIncludeSelfLinks) {
-    throw std::runtime_error("The --include-self-links flag is deprecated; self-links are included by default. Use --no-self-links to exclude them.");
-  }
-
-  if (!parsed.optionalOutputDir.empty())
-    config.outDirectory = parsed.optionalOutputDir[0];
-
-  if (!isCLI && config.outDirectory.empty())
-    config.noFileOutput = true;
-
-  if (!config.noFileOutput && config.outDirectory.empty() && isCLI) {
-    throw std::runtime_error("Missing out_directory");
-  }
-
-  applyFlowModelSelection(config, parsed.flowModelArg);
-
-  if (config.regularized) {
-    config.recordedTeleportation = true;
-  }
-
+  rejectDeprecatedAliases(parsed);
+  applyOutputDirectory(config, parsed);
+  applyLibraryOutputDefaults(config, isCLI);
+  validateRequiredCliOutput(config, isCLI);
+  applyFlowModelSelection(config, parsed);
+  applyOptionInteractions(config);
   normalizeOutputDirectory(config);
   validateOutputDirectory(config);
-
-  if (config.outName.empty()) {
-    config.outName = !config.networkFile.empty() ? FileURI(config.networkFile).getName() : "no-name";
-  }
-
-  if (config.noInfomap) {
-    config.numTrials = 1;
-  }
+  applyOutputNameDefault(config);
 }
 
 } // namespace infomap

--- a/src/io/ConfigBuilder.h
+++ b/src/io/ConfigBuilder.h
@@ -10,7 +10,7 @@
 #ifndef CONFIG_BUILDER_H_
 #define CONFIG_BUILDER_H_
 
-#include "ProgramInterface.h"
+#include "ParsedOption.h"
 
 #include <string>
 #include <vector>

--- a/src/io/ParameterCatalog.cpp
+++ b/src/io/ParameterCatalog.cpp
@@ -182,7 +182,7 @@ namespace {
     }
 
     template <typename T>
-    SpecBuilder& configTarget(T Config::*member)
+    SpecBuilder& configTarget(T Config::* member)
     {
       parameter_.registrar = [member](ProgramInterface& api, ConfigParameterTargets& targets, const ParameterSpec& parameter) {
         registerOptionForTarget(api, targets.config.*member, parameter);
@@ -190,7 +190,7 @@ namespace {
       return *this;
     }
 
-    SpecBuilder& incrementalTarget(unsigned int Config::*member)
+    SpecBuilder& incrementalTarget(unsigned int Config::* member)
     {
       parameter_.registrar = [member](ProgramInterface& api, ConfigParameterTargets& targets, const ParameterSpec& parameter) {
         registerIncrementalOptionForTarget(api, targets.config.*member, parameter);
@@ -269,23 +269,21 @@ namespace {
     return option;
   }
 
-  void registerBoolOption(ProgramInterface& api, bool& target, const ParameterSpec& parameter)
+  Option& addFlagOption(ProgramInterface& api, bool& target, const ParameterSpec& parameter)
   {
     if (parameter.shortName == '\0') {
-      addConfiguredOption(api.addOptionArgument(target, parameter.longName, parameter.description, parameter.group, parameter.isAdvanced), parameter);
-    } else {
-      addConfiguredOption(api.addOptionArgument(target, parameter.shortName, parameter.longName, parameter.description, parameter.group, parameter.isAdvanced), parameter);
+      return api.addOptionArgument(target, parameter.longName, parameter.description, parameter.group, parameter.isAdvanced);
     }
+    return api.addOptionArgument(target, parameter.shortName, parameter.longName, parameter.description, parameter.group, parameter.isAdvanced);
   }
 
   template <typename T>
-  void registerValueOption(ProgramInterface& api, T& target, const ParameterSpec& parameter)
+  Option& addValueOption(ProgramInterface& api, T& target, const ParameterSpec& parameter)
   {
     if (parameter.shortName == '\0') {
-      addConfiguredOption(api.addOptionArgument(target, parameter.longName, parameter.description, parameter.argumentName, parameter.group, parameter.isAdvanced), parameter);
-    } else {
-      addConfiguredOption(api.addOptionArgument(target, parameter.shortName, parameter.longName, parameter.description, parameter.argumentName, parameter.group, parameter.isAdvanced), parameter);
+      return api.addOptionArgument(target, parameter.longName, parameter.description, parameter.argumentName, parameter.group, parameter.isAdvanced);
     }
+    return api.addOptionArgument(target, parameter.shortName, parameter.longName, parameter.description, parameter.argumentName, parameter.group, parameter.isAdvanced);
   }
 
   template <typename T>
@@ -299,43 +297,47 @@ namespace {
   }
 
   template <typename T>
-  void registerLowerBoundOption(ProgramInterface& api, T& target, const ParameterSpec& parameter)
+  Option& addLowerBoundOption(ProgramInterface& api, T& target, const ParameterSpec& parameter)
   {
     const auto minValue = numericConstraint<T>(parameter, parameter.minValue, "minValue");
     if (parameter.shortName == '\0') {
-      addConfiguredOption(api.addOptionArgument(target, parameter.longName, parameter.description, parameter.argumentName, parameter.group, minValue, parameter.isAdvanced), parameter);
-    } else {
-      addConfiguredOption(api.addOptionArgument(target, parameter.shortName, parameter.longName, parameter.description, parameter.argumentName, parameter.group, minValue, parameter.isAdvanced), parameter);
+      return api.addOptionArgument(target, parameter.longName, parameter.description, parameter.argumentName, parameter.group, minValue, parameter.isAdvanced);
     }
+    return api.addOptionArgument(target, parameter.shortName, parameter.longName, parameter.description, parameter.argumentName, parameter.group, minValue, parameter.isAdvanced);
   }
 
   template <typename T>
-  void registerRangeOption(ProgramInterface& api, T& target, const ParameterSpec& parameter)
+  Option& addRangeOption(ProgramInterface& api, T& target, const ParameterSpec& parameter)
   {
     const auto minValue = numericConstraint<T>(parameter, parameter.minValue, "minValue");
     const auto maxValue = numericConstraint<T>(parameter, parameter.maxValue, "maxValue");
     if (parameter.shortName == '\0') {
-      addConfiguredOption(api.addOptionArgument(target, parameter.longName, parameter.description, parameter.argumentName, parameter.group, minValue, maxValue, parameter.isAdvanced), parameter);
-    } else {
-      addConfiguredOption(api.addOptionArgument(target, parameter.shortName, parameter.longName, parameter.description, parameter.argumentName, parameter.group, minValue, maxValue, parameter.isAdvanced), parameter);
+      return api.addOptionArgument(target, parameter.longName, parameter.description, parameter.argumentName, parameter.group, minValue, maxValue, parameter.isAdvanced);
     }
+    return api.addOptionArgument(target, parameter.shortName, parameter.longName, parameter.description, parameter.argumentName, parameter.group, minValue, maxValue, parameter.isAdvanced);
+  }
+
+  template <typename T>
+  Option& addValueOptionForSpec(ProgramInterface& api, T& target, const ParameterSpec& parameter)
+  {
+    if (!parameter.minValue.empty() && !parameter.maxValue.empty()) {
+      return addRangeOption(api, target, parameter);
+    }
+    if (!parameter.minValue.empty()) {
+      return addLowerBoundOption(api, target, parameter);
+    }
+    return addValueOption(api, target, parameter);
   }
 
   void registerOptionForTarget(ProgramInterface& api, bool& target, const ParameterSpec& parameter)
   {
-    registerBoolOption(api, target, parameter);
+    addConfiguredOption(addFlagOption(api, target, parameter), parameter);
   }
 
   template <typename T>
   void registerOptionForTarget(ProgramInterface& api, T& target, const ParameterSpec& parameter)
   {
-    if (!parameter.minValue.empty() && !parameter.maxValue.empty()) {
-      registerRangeOption(api, target, parameter);
-    } else if (!parameter.minValue.empty()) {
-      registerLowerBoundOption(api, target, parameter);
-    } else {
-      registerValueOption(api, target, parameter);
-    }
+    addConfiguredOption(addValueOptionForSpec(api, target, parameter), parameter);
   }
 
   void registerIncrementalOptionForTarget(ProgramInterface& api, unsigned int& target, const ParameterSpec& parameter)
@@ -552,7 +554,7 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .description("Choose how Infomap derives flow from the input links. Options: undirected, directed, undirdir, outdirdir, rawdir, precomputed.")
         .argument(ArgType::option)
         .group("Algorithm")
-        .choices({ "undirected", "directed", "undirdir", "outdirdir", "rawdir", "precomputed" })
+        .choices(flowModelNames())
         .flowModelTarget(),
     param()
         .shortName('d')

--- a/src/io/ParsedOption.h
+++ b/src/io/ParsedOption.h
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ Infomap software package for multi-level network clustering
+ Copyright (c) 2013, 2014 Daniel Edler, Anton Holmgren, Martin Rosvall
+
+ This file is part of the Infomap software package.
+ See file LICENSE_GPLv3.txt for full license details.
+ For more information, see <http://www.mapequation.org>
+ ******************************************************************************/
+
+#ifndef PARSED_OPTION_H_
+#define PARSED_OPTION_H_
+
+#include <ostream>
+#include <string>
+
+namespace infomap {
+
+struct ParsedOption {
+  char shortName = '\0';
+  std::string longName;
+  std::string description;
+  std::string group;
+  bool isAdvanced = false;
+  bool requireArgument = false;
+  bool incrementalArgument = false;
+  std::string argumentName;
+  bool negated = false;
+  std::string value;
+};
+
+inline std::ostream& operator<<(std::ostream& out, const ParsedOption& option)
+{
+  if (option.negated)
+    out << "no ";
+  out << option.longName;
+  if (option.requireArgument)
+    out << " = " << option.value;
+  return out;
+}
+
+} // namespace infomap
+
+#endif // PARSED_OPTION_H_

--- a/src/io/ProgramInterface.cpp
+++ b/src/io/ProgramInterface.cpp
@@ -524,8 +524,20 @@ std::vector<ParsedOption> ProgramInterface::getUsedOptionArguments() const
   unsigned int numFlags = m_optionArguments.size();
   for (unsigned int i = 0; i < numFlags; ++i) {
     auto& opt = *m_optionArguments[i];
-    if (opt.used && opt.longName != "negate-next")
-      opts.emplace_back(opt);
+    if (opt.used && opt.longName != "negate-next") {
+      opts.push_back({
+          opt.shortName,
+          opt.longName,
+          opt.description,
+          opt.group,
+          opt.isAdvanced,
+          opt.requireArgument,
+          opt.incrementalArgument,
+          opt.argumentName,
+          opt.negated,
+          opt.printValue(),
+      });
+    }
   }
   return opts;
 }

--- a/src/io/ProgramInterface.h
+++ b/src/io/ProgramInterface.h
@@ -10,6 +10,7 @@
 #ifndef PROGRAM_INTERFACE_H_
 #define PROGRAM_INTERFACE_H_
 
+#include "ParsedOption.h"
 #include "../utils/convert.h"
 
 #include <stdexcept>
@@ -212,41 +213,6 @@ struct ArgumentOption<bool> : Option {
   std::string printNumericValue() const override { return ""; }
 
   bool& target;
-};
-
-struct ParsedOption {
-  explicit ParsedOption(const Option& opt)
-      : shortName(opt.shortName),
-        longName(opt.longName),
-        description(opt.description),
-        group(opt.group),
-        isAdvanced(opt.isAdvanced),
-        requireArgument(opt.requireArgument),
-        incrementalArgument(opt.incrementalArgument),
-        argumentName(opt.argumentName),
-        negated(opt.negated),
-        value(opt.printValue()) {}
-
-  friend std::ostream& operator<<(std::ostream& out, const ParsedOption& option)
-  {
-    if (option.negated)
-      out << "no ";
-    out << option.longName;
-    if (option.requireArgument)
-      out << " = " << option.value;
-    return out;
-  }
-
-  char shortName;
-  std::string longName;
-  std::string description;
-  std::string group;
-  bool isAdvanced;
-  bool requireArgument;
-  bool incrementalArgument;
-  std::string argumentName;
-  bool negated;
-  std::string value;
 };
 
 struct TargetBase {

--- a/test/cpp/test_config.cpp
+++ b/test/cpp/test_config.cpp
@@ -8,6 +8,8 @@
 
 #include <map>
 #include <set>
+#include <utility>
+#include <vector>
 
 namespace {
 
@@ -38,6 +40,41 @@ TEST_CASE("Config parses flow model selection and output formats [fast][core][co
   CHECK(infomap::flowModelToString(config.flowModel) == std::string("precomputed"));
   CHECK(config.printJson);
   CHECK(config.printTree);
+}
+
+TEST_CASE("Flow model names map to runtime values [fast][core][config][cli]")
+{
+  const std::vector<std::pair<std::string, int>> expected = {
+    { "undirected", infomap::FlowModel::undirected },
+    { "directed", infomap::FlowModel::directed },
+    { "undirdir", infomap::FlowModel::undirdir },
+    { "outdirdir", infomap::FlowModel::outdirdir },
+    { "rawdir", infomap::FlowModel::rawdir },
+    { "precomputed", infomap::FlowModel::precomputed },
+  };
+
+  CHECK(infomap::flowModelNames().size() == expected.size());
+  for (const auto& entry : expected) {
+    infomap::FlowModel parsed = infomap::FlowModel::undirected;
+    CHECK(infomap::parseFlowModel(entry.first, parsed));
+    CHECK(parsed == entry.second);
+    CHECK(infomap::flowModelToString(parsed) == entry.first);
+  }
+}
+
+TEST_CASE("Parameter catalog flow model choices match runtime flow model names [fast][core][config][cli]")
+{
+  const auto& expected = infomap::flowModelNames();
+  bool foundFlowModel = false;
+
+  for (const auto& parameter : infomap::parameterCatalog()) {
+    if (parameter.longName == "flow-model") {
+      foundFlowModel = true;
+      CHECK(parameter.choices == expected);
+    }
+  }
+
+  CHECK(foundFlowModel);
 }
 
 TEST_CASE("Config treats directed shorthand as directed flow model [fast][core][config][cli]")
@@ -101,7 +138,7 @@ TEST_CASE("Config accepts zero sentinel limits [fast][core][config][cli]")
 
 TEST_CASE("Config rejects unknown flow models and output formats [fast][core][config][cli]")
 {
-  CHECK_THROWS_AS(Config("input.net --silent --no-file-output --flow-model unknown", true), std::runtime_error);
+  CHECK_THROWS_WITH_AS(Config("input.net --silent --no-file-output --flow-model unknown", true), "Unrecognized flow model: 'unknown'", std::runtime_error);
   CHECK_THROWS_AS(Config("input.net --silent --no-file-output --output tree,unknown", true), std::runtime_error);
 }
 

--- a/test/cpp/test_config.cpp
+++ b/test/cpp/test_config.cpp
@@ -45,12 +45,12 @@ TEST_CASE("Config parses flow model selection and output formats [fast][core][co
 TEST_CASE("Flow model names map to runtime values [fast][core][config][cli]")
 {
   const std::vector<std::pair<std::string, int>> expected = {
-    { "undirected", infomap::FlowModel::undirected },
-    { "directed", infomap::FlowModel::directed },
-    { "undirdir", infomap::FlowModel::undirdir },
-    { "outdirdir", infomap::FlowModel::outdirdir },
-    { "rawdir", infomap::FlowModel::rawdir },
-    { "precomputed", infomap::FlowModel::precomputed },
+    { "undirected", static_cast<int>(infomap::FlowModel::undirected) },
+    { "directed", static_cast<int>(infomap::FlowModel::directed) },
+    { "undirdir", static_cast<int>(infomap::FlowModel::undirdir) },
+    { "outdirdir", static_cast<int>(infomap::FlowModel::outdirdir) },
+    { "rawdir", static_cast<int>(infomap::FlowModel::rawdir) },
+    { "precomputed", static_cast<int>(infomap::FlowModel::precomputed) },
   };
 
   CHECK(infomap::flowModelNames().size() == expected.size());


### PR DESCRIPTION
## Summary

- centralize flow model names/parsing so ConfigBuilder and ParameterCatalog share the same source
- split ConfigBuilder runtime adaptation into focused steps for aliases, output defaults, flow model selection, and validation
- move ParsedOption into src/io/ParsedOption.h so src/io/Config.h no longer includes ProgramInterface.h

## Validation

- make format-native
- make test-native OPENMP=0 CTEST_ARGS='-R "config|program_interface"'
- make test-binding-options-freshness
- python3 test/scripts/check_print_json_parameters.py ./Infomap
- git diff --check
