### PR TITLE
refactor: deepen output projection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,7 @@ if(BUILD_TESTING)
     add_infomap_cpp_test(infomap_cpp_program_interface_tests test/cpp/test_program_interface.cpp "fast;core;parser;cli")
     add_infomap_cpp_test(infomap_cpp_config_tests test/cpp/test_config.cpp "fast;core;config;cli")
     add_infomap_cpp_test(infomap_cpp_no_output_tests test/cpp/test_no_output.cpp "fast;core;output;library")
+    add_infomap_cpp_test(infomap_cpp_output_view_tests test/cpp/test_output_view.cpp "fast;core;output")
 
     add_test(
         NAME print_json_parameters
@@ -207,6 +208,7 @@ if(BUILD_TESTING)
             infomap_cpp_program_interface_tests
             infomap_cpp_config_tests
             infomap_cpp_no_output_tests
+            infomap_cpp_output_view_tests
             infomap_cli
     )
 endif()

--- a/src/io/Output.cpp
+++ b/src/io/Output.cpp
@@ -58,12 +58,12 @@ std::string writeClu(InfomapBase& im, const StateNetwork& network, const std::st
   outFile << std::resetiosflags(std::ios::floatfield) << std::setprecision(6);
 
   if (states) {
-    outFile << "# state_id module flow node_id";
+    outFile << "# " << view.nodeIdHeaderName() << " module flow node_id";
     if (view.isMultilayer())
       outFile << " layer_id";
     outFile << '\n';
   } else {
-    outFile << "# node_id module flow\n";
+    outFile << "# " << view.nodeIdHeaderName() << " module flow\n";
   }
 
   view.forEachLeaf(moduleIndexLevel, OutputLeafPolicy::HideBipartite, [&](const OutputLeafRow& row) {
@@ -88,12 +88,12 @@ void writeTree(InfomapBase& im, const StateNetwork& network, std::ostream& outSt
   outStream << std::setprecision(6);
 
   if (states) {
-    outStream << "# path flow name state_id node_id";
+    outStream << "# path flow name " << view.nodeIdHeaderName() << " node_id";
     if (view.isMultilayer())
       outStream << " layer_id";
     outStream << '\n';
   } else {
-    outStream << "# path flow name node_id\n";
+    outStream << "# path flow name " << view.nodeIdHeaderName() << "\n";
   }
 
   view.forEachLeaf(1, OutputLeafPolicy::HideBipartiteUnlessFlowTree, [&](const OutputLeafRow& row) {
@@ -112,83 +112,13 @@ void writeTree(InfomapBase& im, const StateNetwork& network, std::ostream& outSt
   outStream << std::setprecision(oldPrecision);
 }
 
-using Link = std::pair<unsigned int, unsigned int>;
-using LinkMap = std::map<Link, double>;
-
-std::map<std::string, LinkMap> aggregateModuleLinks(InfomapBase& im, OutputView& view)
-{
-  // Aggregate links between each module. Rest is aggregated as exit flow
-
-  // Links on nodes within sub infomap instances doesn't have links outside the root
-  // so iterate over links on main instance and map to infomap tree iterator
-  auto stateTargets = view.stateNodeTargets();
-
-  std::map<std::string, LinkMap> moduleLinks;
-
-  for (auto& leaf : im.leafNodes()) {
-    for (auto& link : leaf->outEdges()) {
-      double flow = link->data.flow;
-      auto& sourceTarget = stateTargets[link->source->stateId];
-      auto& targetTarget = stateTargets[link->target->stateId];
-      InfoNode* sourceParent = sourceTarget.parent;
-      InfoNode* targetParent = targetTarget.parent;
-
-      auto sourceDepth = sourceParent->calculatePath().size() + 1;
-      auto targetDepth = targetParent->calculatePath().size() + 1;
-
-      auto sourceChildIndex = sourceTarget.childIndex;
-      auto targetChildIndex = targetTarget.childIndex;
-
-      auto sourceParentIt = InfomapParentIterator(sourceParent);
-      auto targetParentIt = InfomapParentIterator(targetParent);
-
-      // Iterate to same depth
-      // First raise target
-      while (targetDepth > sourceDepth) {
-        ++targetParentIt;
-        --targetDepth;
-      }
-
-      // Raise source to same depth
-      while (sourceDepth > targetDepth) {
-        ++sourceParentIt;
-        --sourceDepth;
-      }
-
-      auto currentDepth = sourceDepth;
-      // Add link if same parent
-
-      while (currentDepth > 0) {
-        if (sourceParentIt == targetParentIt) {
-          // Skip self-links
-          if (sourceChildIndex != targetChildIndex) {
-            auto parentId = io::stringify(sourceParentIt->calculatePath(), ":");
-            auto& linkMap = moduleLinks[parentId];
-            linkMap[std::make_pair(sourceChildIndex + 1, targetChildIndex + 1)] += flow;
-          }
-        }
-
-        sourceChildIndex = sourceParentIt->childIndex();
-        targetChildIndex = targetParentIt->childIndex();
-
-        ++sourceParentIt;
-        ++targetParentIt;
-
-        --currentDepth;
-      }
-    }
-  }
-
-  return moduleLinks;
-}
-
 void writeTreeLinks(InfomapBase& im, std::ostream& outStream, bool states)
 {
   auto oldPrecision = outStream.precision();
   outStream << std::setprecision(6);
 
   OutputView view(im, im.network(), states);
-  auto moduleLinks = aggregateModuleLinks(im, view);
+  auto moduleLinks = view.moduleLinks();
 
   outStream << "*Links " << (im.isUndirectedFlow() ? "undirected" : "directed") << "\n";
   outStream << "#*Links path enterFlow exitFlow numEdges numChildren\n";
@@ -228,12 +158,12 @@ void writeNewickTree(InfomapBase& im, std::ostream& outStream, bool states)
       outStream << "(";
       flowStack.push_back(row.flow);
       if (node.isLeaf())
-        outStream << (states ? row.stateId : row.physicalId) << ":" << row.flow;
+        outStream << view.leafId(row) << ":" << row.flow;
     } else if (depth == lastDepth) {
       outStream << ",";
       flowStack[flowStack.size() - 1] = row.flow;
       if (node.isLeaf()) {
-        outStream << (states ? row.stateId : row.physicalId) << ":" << row.flow;
+        outStream << view.leafId(row) << ":" << row.flow;
       }
     } else {
       // depth < lastDepth
@@ -344,7 +274,7 @@ void writeJsonTree(InfomapBase& im, const StateNetwork& network, std::ostream& o
       }
 
       const auto path = io::stringify(row.path, ", ");
-      const auto modules = im.haveModules() ? io::stringify(multilevelModules.at(states ? row.stateId : row.physicalId), ", ") : "1";
+      const auto modules = im.haveModules() ? io::stringify(multilevelModules.at(view.leafId(row)), ", ") : "1";
 
       outStream << "{"
                 << "\"path\":[" << path << "],"
@@ -375,7 +305,7 @@ void writeJsonTree(InfomapBase& im, const StateNetwork& network, std::ostream& o
   // -------------
 
   // Uses stateId to store depth on modules to optimize link aggregation
-  auto moduleLinks = aggregateModuleLinks(im, view);
+  auto moduleLinks = view.moduleLinks();
 
   first = true;
 
@@ -442,10 +372,10 @@ void writeCsvTree(InfomapBase& im, const StateNetwork& network, std::ostream& ou
   outStream << "path,flow,name,";
 
   if (view.isHigherOrderPhysicalLevel()) {
-    outStream << "node_id\n";
+    outStream << view.nodeIdHeaderName() << "\n";
   } else {
     if (states) {
-      outStream << "state_id,";
+      outStream << view.nodeIdHeaderName() << ",";
       if (view.isMultilayer())
         outStream << "layer_id,";
     }

--- a/src/io/Output.cpp
+++ b/src/io/Output.cpp
@@ -304,7 +304,9 @@ void writeJsonTree(InfomapBase& im, const StateNetwork& network, std::ostream& o
   // Write modules
   // -------------
 
-  // Uses stateId to store depth on modules to optimize link aggregation
+  // Module links are pre-aggregated by OutputView::moduleLinks() using
+  // state-node target mapping and parent iteration, and are looked up here
+  // by each module's path/id while serializing the module list.
   auto moduleLinks = view.moduleLinks();
 
   first = true;

--- a/src/io/OutputView.cpp
+++ b/src/io/OutputView.cpp
@@ -10,6 +10,7 @@
 #include "OutputView.h"
 #include "../core/InfomapBase.h"
 #include "../core/InfoNode.h"
+#include "../core/iterators/InfomapIterator.h"
 #include "../core/StateNetwork.h"
 #include "../utils/convert.h"
 
@@ -31,6 +32,21 @@ bool OutputView::isMultilayer() const
 bool OutputView::hasMetaData() const
 {
   return m_infomap.haveMetaData();
+}
+
+const char* OutputView::nodeIdHeaderName() const
+{
+  return m_states ? "state_id" : "node_id";
+}
+
+unsigned int OutputView::leafId(const OutputLeafRow& row) const
+{
+  return m_states ? row.stateId : row.physicalId;
+}
+
+unsigned int OutputView::leafId(const OutputTreeRow& row) const
+{
+  return m_states ? row.stateId : row.physicalId;
 }
 
 void OutputView::forEachLeaf(int moduleIndexLevel, OutputLeafPolicy filter, const LeafCallback& callback)
@@ -89,6 +105,60 @@ std::map<unsigned int, OutputStateNodeTarget> OutputView::stateNodeTargets()
   }
 
   return targets;
+}
+
+OutputModuleLinks OutputView::moduleLinks()
+{
+  auto stateTargets = stateNodeTargets();
+  OutputModuleLinks moduleLinks;
+
+  for (auto& leaf : m_infomap.leafNodes()) {
+    for (auto& link : leaf->outEdges()) {
+      const double flow = link->data.flow;
+      auto& sourceTarget = stateTargets[link->source->stateId];
+      auto& targetTarget = stateTargets[link->target->stateId];
+      InfoNode* sourceParent = sourceTarget.parent;
+      InfoNode* targetParent = targetTarget.parent;
+
+      auto sourceDepth = sourceParent->calculatePath().size() + 1;
+      auto targetDepth = targetParent->calculatePath().size() + 1;
+
+      auto sourceChildIndex = sourceTarget.childIndex;
+      auto targetChildIndex = targetTarget.childIndex;
+
+      auto sourceParentIt = InfomapParentIterator(sourceParent);
+      auto targetParentIt = InfomapParentIterator(targetParent);
+
+      while (targetDepth > sourceDepth) {
+        ++targetParentIt;
+        --targetDepth;
+      }
+
+      while (sourceDepth > targetDepth) {
+        ++sourceParentIt;
+        --sourceDepth;
+      }
+
+      auto currentDepth = sourceDepth;
+      while (currentDepth > 0) {
+        if (sourceParentIt == targetParentIt && sourceChildIndex != targetChildIndex) {
+          const auto parentId = io::stringify(sourceParentIt->calculatePath(), ":");
+          auto& linkMap = moduleLinks[parentId];
+          linkMap[std::make_pair(sourceChildIndex + 1, targetChildIndex + 1)] += flow;
+        }
+
+        sourceChildIndex = sourceParentIt->childIndex();
+        targetChildIndex = targetParentIt->childIndex();
+
+        ++sourceParentIt;
+        ++targetParentIt;
+
+        --currentDepth;
+      }
+    }
+  }
+
+  return moduleLinks;
 }
 
 bool OutputView::shouldIncludeLeaf(const InfoNode& node, OutputLeafPolicy filter) const

--- a/src/io/OutputView.h
+++ b/src/io/OutputView.h
@@ -15,6 +15,7 @@
 #include <functional>
 #include <map>
 #include <string>
+#include <utility>
 
 namespace infomap {
 
@@ -52,6 +53,11 @@ struct OutputStateNodeTarget {
   unsigned int childIndex = 0;
 };
 
+using OutputModulePath = std::string;
+using OutputModuleLink = std::pair<unsigned int, unsigned int>;
+using OutputModuleLinkMap = std::map<OutputModuleLink, double>;
+using OutputModuleLinks = std::map<OutputModulePath, OutputModuleLinkMap>;
+
 class OutputView {
 public:
   using LeafCallback = std::function<void(const OutputLeafRow&)>;
@@ -64,11 +70,15 @@ public:
   bool isHigherOrderPhysicalLevel() const;
   bool isMultilayer() const;
   bool hasMetaData() const;
+  const char* nodeIdHeaderName() const;
+  unsigned int leafId(const OutputLeafRow& row) const;
+  unsigned int leafId(const OutputTreeRow& row) const;
 
   void forEachLeaf(int moduleIndexLevel, OutputLeafPolicy filter, const LeafCallback& callback);
   void forEachTreeNode(const TreeCallback& callback);
 
   std::map<unsigned int, OutputStateNodeTarget> stateNodeTargets();
+  OutputModuleLinks moduleLinks();
 
 private:
   bool shouldIncludeLeaf(const InfoNode& node, OutputLeafPolicy filter) const;

--- a/test/cpp/test_output_view.cpp
+++ b/test/cpp/test_output_view.cpp
@@ -1,0 +1,176 @@
+#include "vendor/doctest.h"
+
+#include "Infomap.h"
+#include "io/OutputView.h"
+
+#include "TestUtils.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <memory>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using infomap::InfomapWrapper;
+
+struct ProjectedLeaf {
+  unsigned int stateId = 0;
+  unsigned int physicalId = 0;
+  unsigned int layerId = 0;
+  unsigned int moduleId = 0;
+  double flow = 0.0;
+  std::string name;
+};
+
+std::vector<ProjectedLeaf> leafRows(InfomapWrapper& im, bool states)
+{
+  infomap::OutputView view(im, im.network(), states);
+  std::vector<ProjectedLeaf> rows;
+  view.forEachLeaf(1, infomap::OutputLeafPolicy::HideBipartite, [&](const infomap::OutputLeafRow& row) {
+    rows.push_back({ row.stateId, row.physicalId, row.layerId, row.moduleId, row.flow, row.name });
+  });
+  std::sort(rows.begin(), rows.end(), [](const ProjectedLeaf& lhs, const ProjectedLeaf& rhs) {
+    return std::make_pair(lhs.stateId, lhs.physicalId) < std::make_pair(rhs.stateId, rhs.physicalId);
+  });
+  return rows;
+}
+
+std::unique_ptr<InfomapWrapper> runTwoTriangles()
+{
+  return infomap::test::makeRunningInfomap(
+      [&](InfomapWrapper& infomap) { infomap::test::addEdgeFixtureLinks(infomap, "graphs/twotriangles_unweighted.edges"); });
+}
+
+std::string outputPath(const std::string& name)
+{
+  return "output_view_" + name;
+}
+
+void removeOutput(const std::string& path)
+{
+  std::remove(path.c_str());
+}
+
+} // namespace
+
+TEST_CASE("OutputView projects first-order leaf rows [fast][core][output]")
+{
+  auto im = runTwoTriangles();
+
+  const auto rows = leafRows(*im, false);
+
+  REQUIRE(rows.size() == 6);
+  for (const auto& row : rows) {
+    CHECK(row.stateId == row.physicalId);
+    CHECK(row.moduleId > 0);
+    CHECK(row.flow > 0.0);
+    CHECK(row.name == std::to_string(row.physicalId));
+  }
+}
+
+TEST_CASE("OutputView projects state leaf rows separately from physical ids [fast][core][output]")
+{
+  auto im = infomap::test::makeRunningInfomap(
+      [&](InfomapWrapper& infomap) { infomap::test::readNetworkFixture(infomap, "states.net"); });
+
+  const auto physicalRows = leafRows(*im, false);
+  const auto stateRows = leafRows(*im, true);
+
+  std::set<unsigned int> physicalIdsFromStates;
+  for (const auto& row : stateRows) {
+    physicalIdsFromStates.insert(row.physicalId);
+  }
+
+  CHECK(physicalRows.size() <= stateRows.size());
+  CHECK(stateRows.size() == 6);
+  CHECK(physicalIdsFromStates.size() == 5);
+}
+
+TEST_CASE("OutputView preserves multilayer layer ids in state projection [fast][core][output]")
+{
+  auto im = infomap::test::makeRunningInfomap(
+      [&](InfomapWrapper& infomap) { infomap::test::readNetworkFixture(infomap, "multilayer.net"); });
+
+  infomap::OutputView view(*im, im->network(), true);
+  bool foundLayer = false;
+  view.forEachLeaf(1, infomap::OutputLeafPolicy::HideBipartite, [&](const infomap::OutputLeafRow& row) {
+    if (row.layerId != 0) {
+      foundLayer = true;
+    }
+  });
+
+  CHECK(view.isMultilayer());
+  CHECK(foundLayer);
+}
+
+TEST_CASE("OutputView applies bipartite leaf filtering [fast][core][output]")
+{
+  auto im = infomap::test::makeRunningInfomap(
+      [&](InfomapWrapper& infomap) { infomap.readInputData(infomap::test::repoPath("examples/networks/bipartite.net")); });
+  im->hideBipartiteNodes = true;
+
+  infomap::OutputView view(*im, im->network(), false);
+  std::vector<unsigned int> physicalIds;
+  view.forEachLeaf(1, infomap::OutputLeafPolicy::HideBipartite, [&](const infomap::OutputLeafRow& row) {
+    physicalIds.push_back(row.physicalId);
+  });
+
+  std::sort(physicalIds.begin(), physicalIds.end());
+  CHECK(physicalIds == std::vector<unsigned int> { 1, 2, 3 });
+}
+
+TEST_CASE("OutputView owns module-link projection [fast][core][output]")
+{
+  auto im = runTwoTriangles();
+  infomap::OutputView view(*im, im->network(), false);
+
+  const auto moduleLinks = view.moduleLinks();
+
+  REQUIRE(!moduleLinks.empty());
+  bool foundPositiveFlow = false;
+  for (const auto& moduleEntry : moduleLinks) {
+    for (const auto& linkEntry : moduleEntry.second) {
+      CHECK(linkEntry.first.first != linkEntry.first.second);
+      CHECK(linkEntry.second >= 0.0);
+      foundPositiveFlow = foundPositiveFlow || linkEntry.second > 0.0;
+    }
+  }
+  CHECK(foundPositiveFlow);
+}
+
+TEST_CASE("OutputView refactor preserves stable tree output fields [fast][core][output]")
+{
+  auto im = runTwoTriangles();
+  const auto treePath = outputPath("tree.tree");
+  removeOutput(treePath);
+
+  im->writeTree(treePath);
+  const auto treeText = infomap::test::readTextFile(treePath);
+
+  CHECK(treeText.find("# path flow name node_id") != std::string::npos);
+  CHECK(treeText.find("\"1\" 1") != std::string::npos);
+  CHECK(treeText.find("\"6\" 6") != std::string::npos);
+
+  removeOutput(treePath);
+}
+
+TEST_CASE("OutputView refactor preserves stable JSON output fields [fast][core][output]")
+{
+  auto im = runTwoTriangles();
+  const auto jsonPath = outputPath("tree.json");
+  removeOutput(jsonPath);
+
+  im->writeJsonTree(jsonPath);
+  const auto jsonText = infomap::test::readTextFile(jsonPath);
+
+  CHECK(jsonText.find("\"nodes\":[") != std::string::npos);
+  CHECK(jsonText.find("\"modules\":[") != std::string::npos);
+  CHECK(jsonText.find("\"directed\":false") != std::string::npos);
+  CHECK(jsonText.find("\"flowModel\": \"undirected\"") != std::string::npos);
+
+  removeOutput(jsonPath);
+}


### PR DESCRIPTION
## Summary
- move module-link aggregation behind the OutputView projection module
- reuse OutputView helpers in output writers while preserving public write methods
- add focused C++ coverage in test/cpp/test_output_view.cpp and register it in CMakeLists.txt
