### PR TITLE
refactor: deepen parameter catalog lifecycle

### DIFF
--- a/src/io/ConfigBuilder.cpp
+++ b/src/io/ConfigBuilder.cpp
@@ -12,6 +12,7 @@
 #include "ProgramInterface.h"
 #include "SafeFile.h"
 #include "../utils/FileURI.h"
+#include "../utils/convert.h"
 
 #include <stdexcept>
 

--- a/src/io/ConfigBuilder.cpp
+++ b/src/io/ConfigBuilder.cpp
@@ -9,30 +9,15 @@
 
 #include "ConfigBuilder.h"
 #include "Config.h"
-#include "ParameterCatalog.h"
 #include "ProgramInterface.h"
 #include "SafeFile.h"
 #include "../utils/FileURI.h"
-#include "../utils/convert.h"
 
 #include <stdexcept>
 
 namespace infomap {
 
 namespace {
-
-  void rejectDeprecatedAliases(const ParsedConfigParameters& parsed)
-  {
-    if (parsed.deprecatedIncludeSelfLinks) {
-      throw std::runtime_error("The --include-self-links flag is deprecated; self-links are included by default. Use --no-self-links to exclude them.");
-    }
-  }
-
-  void applyOutputDirectory(Config& config, const ParsedConfigParameters& parsed)
-  {
-    if (!parsed.optionalOutputDir.empty())
-      config.outDirectory = parsed.optionalOutputDir[0];
-  }
 
   void applyLibraryOutputDefaults(Config& config, bool isCLI)
   {
@@ -45,24 +30,6 @@ namespace {
     if (!config.noFileOutput && config.outDirectory.empty() && isCLI) {
       throw std::runtime_error("Missing out_directory");
     }
-  }
-
-  void applyFlowModelSelection(Config& config, const ParsedConfigParameters& parsed)
-  {
-    if (config.directed) {
-      config.setFlowModel(FlowModel::directed);
-      return;
-    }
-
-    if (parsed.flowModelArg.empty()) {
-      return;
-    }
-
-    FlowModel flowModel = FlowModel::undirected;
-    if (!parseFlowModel(parsed.flowModelArg, flowModel)) {
-      throw std::runtime_error(io::Str() << "Unrecognized flow model: '" << parsed.flowModelArg << "'");
-    }
-    config.setFlowModel(flowModel);
   }
 
   void applyOptionInteractions(Config& config)
@@ -110,7 +77,7 @@ ParsedConfigParameters ConfigBuilder::parseRaw(Config& config, const std::string
   api.setJsonParametersProvider(parameterCatalogJson);
 
   ParsedConfigParameters parsed;
-  registerConfigParameters(api, { config, parsed.flowModelArg, parsed.deprecatedIncludeSelfLinks, parsed.optionalOutputDir }, isCLI);
+  registerConfigParameters(api, { config, parsed }, isCLI);
 
   api.parseArgs(flags);
   parsed.usedOptions = api.getUsedOptionArguments();
@@ -119,11 +86,9 @@ ParsedConfigParameters ConfigBuilder::parseRaw(Config& config, const std::string
 
 void ConfigBuilder::applyParsed(Config& config, const ParsedConfigParameters& parsed, bool isCLI)
 {
-  rejectDeprecatedAliases(parsed);
-  applyOutputDirectory(config, parsed);
+  applyParsedParameters(config, parsed);
   applyLibraryOutputDefaults(config, isCLI);
   validateRequiredCliOutput(config, isCLI);
-  applyFlowModelSelection(config, parsed);
   applyOptionInteractions(config);
   normalizeOutputDirectory(config);
   validateOutputDirectory(config);

--- a/src/io/ConfigBuilder.h
+++ b/src/io/ConfigBuilder.h
@@ -10,21 +10,13 @@
 #ifndef CONFIG_BUILDER_H_
 #define CONFIG_BUILDER_H_
 
-#include "ParsedOption.h"
-
-#include <string>
-#include <vector>
+#include "ParameterCatalog.h"
 
 namespace infomap {
 
 struct Config;
 
-struct ParsedConfigParameters {
-  std::string flowModelArg;
-  bool deprecatedIncludeSelfLinks = false;
-  std::vector<std::string> optionalOutputDir;
-  std::vector<ParsedOption> usedOptions;
-};
+using ParsedConfigParameters = ParsedParameterSet;
 
 class ConfigBuilder {
 public:

--- a/src/io/ParameterCatalog.cpp
+++ b/src/io/ParameterCatalog.cpp
@@ -201,7 +201,7 @@ namespace {
     SpecBuilder& flowModelTarget()
     {
       parameter_.registrar = [](ProgramInterface& api, ConfigParameterTargets& targets, const ParameterSpec& parameter) {
-        registerOptionForTarget(api, targets.flowModelArg, parameter);
+        registerOptionForTarget(api, targets.parsed.flowModelArg, parameter);
       };
       return *this;
     }
@@ -209,7 +209,7 @@ namespace {
     SpecBuilder& deprecatedIncludeSelfLinksTarget()
     {
       parameter_.registrar = [](ProgramInterface& api, ConfigParameterTargets& targets, const ParameterSpec& parameter) {
-        registerOptionForTarget(api, targets.deprecatedIncludeSelfLinks, parameter);
+        registerOptionForTarget(api, targets.parsed.deprecatedIncludeSelfLinks, parameter);
       };
       return *this;
     }
@@ -225,7 +225,7 @@ namespace {
     SpecBuilder& outputDirectoryArgument()
     {
       parameter_.registrar = [](ProgramInterface& api, ConfigParameterTargets& targets, const ParameterSpec& parameter) {
-        api.addOptionalNonOptionArguments(targets.optionalOutputDir, "out_directory", parameter.description, parameter.group);
+        api.addOptionalNonOptionArguments(targets.parsed.optionalOutputDir, "out_directory", parameter.description, parameter.group);
       };
       return *this;
     }
@@ -343,6 +343,37 @@ namespace {
   void registerIncrementalOptionForTarget(ProgramInterface& api, unsigned int& target, const ParameterSpec& parameter)
   {
     addConfiguredOption(api.addIncrementalOptionArgument(target, parameter.shortName, parameter.longName, parameter.description, parameter.group, parameter.isAdvanced), parameter);
+  }
+
+  void rejectDeprecatedAliases(const ParsedParameterSet& parsed)
+  {
+    if (parsed.deprecatedIncludeSelfLinks) {
+      throw std::runtime_error("The --include-self-links flag is deprecated; self-links are included by default. Use --no-self-links to exclude them.");
+    }
+  }
+
+  void applyOutputDirectory(Config& config, const ParsedParameterSet& parsed)
+  {
+    if (!parsed.optionalOutputDir.empty())
+      config.outDirectory = parsed.optionalOutputDir[0];
+  }
+
+  void applyFlowModelSelection(Config& config, const ParsedParameterSet& parsed)
+  {
+    if (config.directed) {
+      config.setFlowModel(FlowModel::directed);
+      return;
+    }
+
+    if (parsed.flowModelArg.empty()) {
+      return;
+    }
+
+    FlowModel flowModel = FlowModel::undirected;
+    if (!parseFlowModel(parsed.flowModelArg, flowModel)) {
+      throw std::runtime_error(io::Str() << "Unrecognized flow model: '" << parsed.flowModelArg << "'");
+    }
+    config.setFlowModel(flowModel);
   }
 
 } // namespace
@@ -871,6 +902,13 @@ void registerConfigParameters(ProgramInterface& api, ConfigParameterTargets targ
     }
     parameter.registrar(api, targets, parameter);
   }
+}
+
+void applyParsedParameters(Config& config, const ParsedParameterSet& parsed)
+{
+  rejectDeprecatedAliases(parsed);
+  applyOutputDirectory(config, parsed);
+  applyFlowModelSelection(config, parsed);
 }
 
 std::string parameterCatalogJson()

--- a/src/io/ParameterCatalog.h
+++ b/src/io/ParameterCatalog.h
@@ -10,6 +10,8 @@
 #ifndef PARAMETER_CATALOG_H_
 #define PARAMETER_CATALOG_H_
 
+#include "ParsedOption.h"
+
 #include <functional>
 #include <string>
 #include <vector>
@@ -19,11 +21,16 @@ namespace infomap {
 struct Config;
 class ProgramInterface;
 
+struct ParsedParameterSet {
+  std::string flowModelArg;
+  bool deprecatedIncludeSelfLinks = false;
+  std::vector<std::string> optionalOutputDir;
+  std::vector<ParsedOption> usedOptions;
+};
+
 struct ConfigParameterTargets {
   Config& config;
-  std::string& flowModelArg;
-  bool& deprecatedIncludeSelfLinks;
-  std::vector<std::string>& optionalOutputDir;
+  ParsedParameterSet& parsed;
 };
 
 struct ParameterSpec {
@@ -57,6 +64,7 @@ struct ParameterSpec {
 // mutable runtime state that receives parsed values and applies adaptation rules.
 const std::vector<ParameterSpec>& parameterCatalog();
 void registerConfigParameters(ProgramInterface& api, ConfigParameterTargets targets, bool isCli);
+void applyParsedParameters(Config& config, const ParsedParameterSet& parsed);
 std::string parameterCatalogJson();
 
 } // namespace infomap


### PR DESCRIPTION
## Summary
Refactor parameter parsing so catalog-owned parsed state and catalog-specific post-parse behavior live in ParameterCatalog.

## Verification
- make format-native
- make test-native CMAKE_TEST_TARGET=infomap_cpp_config_tests CTEST_ARGS='-R infomap_cpp_config_tests --output-on-failure'
- make test-native CMAKE_TEST_TARGET=infomap_cli CTEST_ARGS='-R print_json_parameters --output-on-failure'
- git diff --check
- make test-cpp-stream-policy