### PR TITLE
refactor: deepen intake config and output modules

### DIFF
--- a/src/io/ConfigBuilder.cpp
+++ b/src/io/ConfigBuilder.cpp
@@ -78,7 +78,7 @@ ParsedConfigParameters ConfigBuilder::parseRaw(Config& config, const std::string
   api.setJsonParametersProvider(parameterCatalogJson);
 
   ParsedConfigParameters parsed;
-  registerConfigParameters(api, { config, parsed }, isCLI);
+  registerCatalogWithProgramInterface(api, { config, parsed }, isCLI);
 
   api.parseArgs(flags);
   parsed.usedOptions = api.getUsedOptionArguments();

--- a/src/io/Network.h
+++ b/src/io/Network.h
@@ -24,10 +24,10 @@
 namespace infomap {
 
 struct LayerNode;
-class NetworkInputSinkAdapter;
+class NetworkIntakeAdapter;
 
 class Network : public StateNetwork {
-  friend class NetworkInputSinkAdapter;
+  friend class NetworkIntakeAdapter;
 
 private:
   // Multilayer

--- a/src/io/NetworkBuilder.cpp
+++ b/src/io/NetworkBuilder.cpp
@@ -31,20 +31,14 @@ namespace {
 
 } // namespace
 
-class NetworkInputSinkAdapter {
+class NetworkIntakeAdapter {
 public:
-  explicit NetworkInputSinkAdapter(Network& network) : m_network(network) {}
+  explicit NetworkIntakeAdapter(Network& network) : m_network(network) {}
 
-  bool isUndirectedFlow() const { return m_network.m_config.isUndirectedFlow(); }
-  unsigned int matchableMultilayerIds() const { return m_network.m_config.matchableMultilayerIds; }
-  unsigned int numPhysicalNodes() const { return m_network.numPhysicalNodes(); }
-  unsigned int numLinks() const { return m_network.numLinks(); }
-  unsigned int numIntraLayerLinks() const { return m_network.m_numIntraLayerLinks; }
-  unsigned int numInterLayerLinks() const { return m_network.m_numInterLayerLinks; }
-  unsigned int numLayerLinks() const { return m_network.m_numIntraLayerLinks + m_network.m_numInterLayerLinks; }
-  unsigned int numLayers() const { return m_network.m_layers.size(); }
-  unsigned int numMetaDataColumns() const { return m_network.m_numMetaDataColumns; }
-  unsigned int numMetaDataRows() const { return m_network.m_metaData.size(); }
+  input::NetworkInputOptions inputOptions() const
+  {
+    return { m_network.m_config.isUndirectedFlow(), m_network.m_config.matchableMultilayerIds };
+  }
 
   void onFileInput() { m_network.m_haveFileInput = true; }
 
@@ -122,13 +116,15 @@ void buildNetworkFromInput(Network& network, const std::string& filename)
 {
   FileURI { filename, false };
 
-  NetworkInputSinkAdapter sink(network);
-  input::parseNetworkInput(filename, sink);
+  NetworkIntakeAdapter sink(network);
+  sink.onFileInput();
+  input::parseNetworkInput(filename, sink, sink.inputOptions());
+  sink.onNetworkParsed();
 }
 
 void buildMetaDataFromInput(Network& network, const std::string& filename)
 {
-  NetworkInputSinkAdapter sink(network);
+  NetworkIntakeAdapter sink(network);
   input::parseMetaDataInput(filename, sink);
 }
 

--- a/src/io/NetworkInputParser.h
+++ b/src/io/NetworkInputParser.h
@@ -15,6 +15,7 @@
 #include "../utils/Log.h"
 #include "../utils/convert.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <fstream>
 #include <limits>
@@ -27,6 +28,11 @@
 
 namespace infomap {
 namespace input {
+
+  struct NetworkInputOptions {
+    bool undirectedFlow = true;
+    unsigned int matchableMultilayerIds = 0;
+  };
 
   struct ParsedVertex {
     unsigned int id = 0;
@@ -71,6 +77,14 @@ namespace input {
   namespace detail {
 
     using InsensitiveStringSet = std::set<std::string, io::InsensitiveCompare>;
+
+    struct ParseProgress {
+      unsigned int numPhysicalNodes = 0;
+      unsigned int numLinks = 0;
+      unsigned int numIntraLayerLinks = 0;
+      unsigned int numInterLayerLinks = 0;
+      std::set<unsigned int> layers;
+    };
 
     inline bool isInputWhitespace(char c)
     {
@@ -213,7 +227,7 @@ namespace input {
     }
 
     template <typename Sink>
-    std::string parseVertices(std::ifstream& file, const std::string&, Sink& sink)
+    std::string parseVertices(std::ifstream& file, const std::string&, Sink& sink, ParseProgress& progress)
     {
       Log() << "  Parsing vertices...\n"
             << std::flush;
@@ -248,8 +262,9 @@ namespace input {
         }
 
         sink.onPhysicalNode(vertex);
+        ++progress.numPhysicalNodes;
       }
-      Log() << "  -> " << sink.numPhysicalNodes() << " physical nodes added\n";
+      Log() << "  -> " << progress.numPhysicalNodes << " physical nodes added\n";
       return line;
     }
 
@@ -276,7 +291,7 @@ namespace input {
     }
 
     template <typename Sink>
-    std::string parseLinks(std::ifstream& file, Sink& sink)
+    std::string parseLinks(std::ifstream& file, Sink& sink, ParseProgress& progress)
     {
       bool parsingLinks = false;
       std::string line;
@@ -294,20 +309,21 @@ namespace input {
         }
 
         sink.onLink(parseLink(line));
+        ++progress.numLinks;
       }
       if (parsingLinks)
-        Log() << "  -> " << sink.numLinks() << " links\n";
+        Log() << "  -> " << progress.numLinks << " links\n";
       return line;
     }
 
     template <typename Sink>
-    std::string parseMultilayerLinks(std::ifstream& file, Sink& sink)
+    std::string parseMultilayerLinks(std::ifstream& file, Sink& sink, const NetworkInputOptions& options, ParseProgress& progress)
     {
       Log() << "  Parsing multilayer links...\n"
             << std::flush;
 
-      if (sink.matchableMultilayerIds() > 0) {
-        Log() << "  Creating matchable state ids using: nodeId << (log2(" << sink.matchableMultilayerIds() << ") + 1) | layerId\n";
+      if (options.matchableMultilayerIds > 0) {
+        Log() << "  Creating matchable state ids using: nodeId << (log2(" << options.matchableMultilayerIds << ") + 1) | layerId\n";
       }
 
       std::string line;
@@ -318,22 +334,30 @@ namespace input {
         if (line[0] == '*')
           break;
 
-        sink.onMultilayerLink(parseMultilayerLink(line));
+        const auto link = parseMultilayerLink(line);
+        sink.onMultilayerLink(link);
+        progress.layers.insert(link.sourceLayer);
+        progress.layers.insert(link.targetLayer);
+        if (link.sourceLayer == link.targetLayer) {
+          ++progress.numIntraLayerLinks;
+        } else {
+          ++progress.numInterLayerLinks;
+        }
       }
-      Log() << "  -> " << sink.numLayerLinks() << " links in " << sink.numLayers() << " layers\n";
-      Log() << "    -> " << sink.numIntraLayerLinks() << " intra-layer links\n";
-      Log() << "    -> " << sink.numInterLayerLinks() << " inter-layer links\n";
+      Log() << "  -> " << (progress.numIntraLayerLinks + progress.numInterLayerLinks) << " links in " << progress.layers.size() << " layers\n";
+      Log() << "    -> " << progress.numIntraLayerLinks << " intra-layer links\n";
+      Log() << "    -> " << progress.numInterLayerLinks << " inter-layer links\n";
       return line;
     }
 
     template <typename Sink>
-    std::string parseMultilayerIntraLinks(std::ifstream& file, Sink& sink)
+    std::string parseMultilayerIntraLinks(std::ifstream& file, Sink& sink, const NetworkInputOptions& options, ParseProgress& progress)
     {
       Log() << "  Parsing intra-layer links...\n"
             << std::flush;
 
-      if (sink.matchableMultilayerIds() > 0) {
-        Log() << "  Creating matchable state ids using: nodeId << (log2(" << sink.matchableMultilayerIds() << ") + 1) | layerId\n";
+      if (options.matchableMultilayerIds > 0) {
+        Log() << "  Creating matchable state ids using: nodeId << (log2(" << options.matchableMultilayerIds << ") + 1) | layerId\n";
       }
 
       std::string line;
@@ -344,14 +368,17 @@ namespace input {
         if (line[0] == '*')
           break;
 
-        sink.onMultilayerIntraLink(parseMultilayerIntraLink(line));
+        const auto link = parseMultilayerIntraLink(line);
+        sink.onMultilayerIntraLink(link);
+        progress.layers.insert(link.layer);
+        ++progress.numIntraLayerLinks;
       }
-      Log() << "  -> " << sink.numIntraLayerLinks() << " intra-layer links\n";
+      Log() << "  -> " << progress.numIntraLayerLinks << " intra-layer links\n";
       return line;
     }
 
     template <typename Sink>
-    std::string parseMultilayerInterLinks(std::ifstream& file, Sink& sink)
+    std::string parseMultilayerInterLinks(std::ifstream& file, Sink& sink, ParseProgress& progress)
     {
       Log() << "  Parsing inter-layer links...\n"
             << std::flush;
@@ -363,9 +390,13 @@ namespace input {
         if (line[0] == '*')
           break;
 
-        sink.onMultilayerInterLink(parseMultilayerInterLink(line));
+        const auto link = parseMultilayerInterLink(line);
+        sink.onMultilayerInterLink(link);
+        progress.layers.insert(link.sourceLayer);
+        progress.layers.insert(link.targetLayer);
+        ++progress.numInterLayerLinks;
       }
-      Log() << "  -> " << sink.numInterLayerLinks() << " inter-layer links\n";
+      Log() << "  -> " << progress.numInterLayerLinks << " inter-layer links\n";
       return line;
     }
 
@@ -406,12 +437,17 @@ namespace input {
     }
 
     template <typename Sink>
-    void parseNetwork(const std::string& filename, const InsensitiveStringSet& validHeadings, const InsensitiveStringSet& ignoreHeadings, Sink& sink, const std::string& startHeading = "")
+    void parseNetwork(const std::string& filename,
+                      const InsensitiveStringSet& validHeadings,
+                      const InsensitiveStringSet& ignoreHeadings,
+                      Sink& sink,
+                      const NetworkInputOptions& options,
+                      const std::string& startHeading = "")
     {
-      sink.onFileInput();
       SafeInFile input(filename);
+      ParseProgress progress;
 
-      std::string heading = !startHeading.empty() ? startHeading : parseLinks(input, sink);
+      std::string heading = !startHeading.empty() ? startHeading : parseLinks(input, sink, progress);
 
       while (!heading.empty() && heading[0] == '*') {
         std::string headingLowerCase = io::tolower(io::firstWord(heading));
@@ -420,25 +456,25 @@ namespace input {
         }
         bool shouldIgnoreHeading = ignoreHeadings.count(headingLowerCase) > 0;
         if (!shouldIgnoreHeading && headingLowerCase == "*vertices") {
-          heading = parseVertices(input, heading, sink);
+          heading = parseVertices(input, heading, sink, progress);
         } else if (!shouldIgnoreHeading && headingLowerCase == "*states") {
           heading = parseStateNodes(input, heading, sink);
         } else if (!shouldIgnoreHeading && headingLowerCase == "*edges") {
-          if (!sink.isUndirectedFlow())
+          if (!options.undirectedFlow)
             Log() << "\n --> Notice: Links marked as undirected but parsed as directed.\n";
-          heading = parseLinks(input, sink);
+          heading = parseLinks(input, sink, progress);
         } else if (!shouldIgnoreHeading && headingLowerCase == "*arcs") {
-          if (sink.isUndirectedFlow())
+          if (options.undirectedFlow)
             Log() << "\n --> Notice: Links marked as directed but parsed as undirected.\n";
-          heading = parseLinks(input, sink);
+          heading = parseLinks(input, sink, progress);
         } else if (!shouldIgnoreHeading && headingLowerCase == "*links") {
-          heading = parseLinks(input, sink);
+          heading = parseLinks(input, sink, progress);
         } else if (!shouldIgnoreHeading && (headingLowerCase == "*multilayer" || headingLowerCase == "*multiplex")) {
-          heading = parseMultilayerLinks(input, sink);
+          heading = parseMultilayerLinks(input, sink, options, progress);
         } else if (!shouldIgnoreHeading && headingLowerCase == "*intra") {
-          heading = parseMultilayerIntraLinks(input, sink);
+          heading = parseMultilayerIntraLinks(input, sink, options, progress);
         } else if (!shouldIgnoreHeading && headingLowerCase == "*inter") {
-          heading = parseMultilayerInterLinks(input, sink);
+          heading = parseMultilayerInterLinks(input, sink, progress);
         } else if (!shouldIgnoreHeading && headingLowerCase == "*bipartite") {
           heading = parseBipartiteLinks(input, heading, sink);
         } else {
@@ -446,17 +482,16 @@ namespace input {
         }
       }
 
-      sink.onNetworkParsed();
       Log() << "Done!\n";
     }
 
   } // namespace detail
 
   template <typename Sink>
-  void parseNetworkInput(const std::string& filename, Sink& sink)
+  void parseNetworkInput(const std::string& filename, Sink& sink, const NetworkInputOptions& options)
   {
-    Log() << "Parsing " << (sink.isUndirectedFlow() ? "undirected" : "directed") << " network from file '" << filename << "'...\n";
-    detail::parseNetwork(filename, detail::generalValidHeadings(), detail::generalIgnoredHeadings(), sink);
+    Log() << "Parsing " << (options.undirectedFlow ? "undirected" : "directed") << " network from file '" << filename << "'...\n";
+    detail::parseNetwork(filename, detail::generalValidHeadings(), detail::generalIgnoredHeadings(), sink, options);
   }
 
   template <typename Sink>
@@ -465,6 +500,8 @@ namespace input {
     Log() << "Parsing meta data from '" << filename << "'...\n";
     SafeInFile input(filename);
     std::string line;
+    unsigned int numMetaDataColumns = 0;
+    unsigned int numMetaDataRows = 0;
     while (!std::getline(input, line).fail()) {
       if (line.empty() || line[0] == '#')
         continue;
@@ -486,8 +523,10 @@ namespace input {
         throw std::runtime_error(io::Str() << "Can't parse any meta data from line '" << line << "'");
 
       sink.onMetaData(nodeId, metaData);
+      numMetaDataColumns = std::max<unsigned int>(numMetaDataColumns, metaData.size());
+      ++numMetaDataRows;
     }
-    Log() << " -> Parsed " << sink.numMetaDataColumns() << " columns of meta data for " << sink.numMetaDataRows() << " nodes.\n";
+    Log() << " -> Parsed " << numMetaDataColumns << " columns of meta data for " << numMetaDataRows << " nodes.\n";
   }
 
 } // namespace input

--- a/src/io/Output.cpp
+++ b/src/io/Output.cpp
@@ -118,25 +118,20 @@ void writeTreeLinks(InfomapBase& im, std::ostream& outStream, bool states)
   outStream << std::setprecision(6);
 
   OutputView view(im, im.network(), states);
-  auto moduleLinks = view.moduleLinks();
 
   outStream << "*Links " << (im.isUndirectedFlow() ? "undirected" : "directed") << "\n";
   outStream << "#*Links path enterFlow exitFlow numEdges numChildren\n";
 
-  for (auto it(im.iterModules()); !it.isEnd(); ++it) {
-    auto parentId = io::stringify(it.path(), ":");
-    auto& module = *it;
-    auto& links = moduleLinks[parentId];
+  view.forEachModule([&](const OutputModuleRow& module) {
+    outStream << "*Links " << module.linkPathLabel << " " << module.enterFlow << " " << module.exitFlow << " " << module.links.size() << " " << module.numChildren << "\n";
 
-    outStream << "*Links " << (parentId.empty() ? "root" : parentId) << " " << module.data.enterFlow << " " << module.data.exitFlow << " " << links.size() << " " << module.infomapChildDegree() << "\n";
-
-    for (auto itLink : links) {
+    for (auto itLink : module.links) {
       unsigned int sourceId = itLink.first.first;
       unsigned int targetId = itLink.first.second;
       double flow = itLink.second;
       outStream << sourceId << " " << targetId << " " << flow << "\n";
     }
-  }
+  });
 
   outStream << std::setprecision(oldPrecision);
 }
@@ -304,21 +299,11 @@ void writeJsonTree(InfomapBase& im, const StateNetwork& network, std::ostream& o
   // Write modules
   // -------------
 
-  // Module links are pre-aggregated by OutputView::moduleLinks() using
-  // state-node target mapping and parent iteration, and are looked up here
-  // by each module's path/id while serializing the module list.
-  auto moduleLinks = view.moduleLinks();
-
   first = true;
 
   outStream << "\"modules\":[";
 
-  for (auto it(im.iterModules()); !it.isEnd(); ++it) {
-    const auto parentId = io::stringify(it.path(), ":");
-    const auto& module = *it;
-    const auto& links = moduleLinks[parentId];
-    const auto path = io::stringify(it.path(), ",");
-
+  view.forEachModule([&](const OutputModuleRow& module) {
     if (first) {
       first = false;
     } else {
@@ -327,11 +312,11 @@ void writeJsonTree(InfomapBase& im, const StateNetwork& network, std::ostream& o
 
     outStream << "{";
 
-    outStream << "\"path\":[" << (parentId.empty() ? "0" : path) << "],"
-              << "\"enterFlow\":" << module.data.enterFlow << ','
-              << "\"exitFlow\":" << module.data.exitFlow << ','
-              << "\"numEdges\":" << links.size() << ','
-              << "\"numChildren\":" << module.infomapChildDegree() << ','
+    outStream << "\"path\":[" << (module.jsonPath.empty() ? "0" : module.jsonPath) << "],"
+              << "\"enterFlow\":" << module.enterFlow << ','
+              << "\"exitFlow\":" << module.exitFlow << ','
+              << "\"numEdges\":" << module.links.size() << ','
+              << "\"numChildren\":" << module.numChildren << ','
               << "\"codelength\":" << module.codelength;
 
     if (writeLinks) {
@@ -340,7 +325,7 @@ void writeJsonTree(InfomapBase& im, const StateNetwork& network, std::ostream& o
 
       auto firstLink = true;
 
-      for (auto itLink : links) {
+      for (auto itLink : module.links) {
         if (firstLink) {
           firstLink = false;
         } else {
@@ -356,7 +341,7 @@ void writeJsonTree(InfomapBase& im, const StateNetwork& network, std::ostream& o
     }
 
     outStream << "}";
-  }
+  });
 
   outStream << "]"; // modules
 

--- a/src/io/OutputView.cpp
+++ b/src/io/OutputView.cpp
@@ -83,6 +83,27 @@ void OutputView::forEachTreeNode(const TreeCallback& callback)
   }
 }
 
+void OutputView::forEachModule(const ModuleCallback& callback)
+{
+  auto linksByModulePath = moduleLinks();
+  const OutputModuleLinkMap emptyLinks;
+  for (auto it(m_infomap.iterModules()); !it.isEnd(); ++it) {
+    const auto path = io::stringify(it.path(), ":");
+    const auto& module = *it;
+    const auto linksIt = linksByModulePath.find(path);
+    const auto& links = linksIt == linksByModulePath.end() ? emptyLinks : linksIt->second;
+    callback({
+        io::stringify(it.path(), ","),
+        path.empty() ? "root" : path,
+        module.data.enterFlow,
+        module.data.exitFlow,
+        module.infomapChildDegree(),
+        module.codelength,
+        links,
+    });
+  }
+}
+
 std::map<unsigned int, OutputStateNodeTarget> OutputView::stateNodeTargets()
 {
   std::map<unsigned int, OutputStateNodeTarget> targets;

--- a/src/io/OutputView.h
+++ b/src/io/OutputView.h
@@ -58,10 +58,21 @@ using OutputModuleLink = std::pair<unsigned int, unsigned int>;
 using OutputModuleLinkMap = std::map<OutputModuleLink, double>;
 using OutputModuleLinks = std::map<OutputModulePath, OutputModuleLinkMap>;
 
+struct OutputModuleRow {
+  OutputModulePath jsonPath;
+  OutputModulePath linkPathLabel;
+  double enterFlow = 0.0;
+  double exitFlow = 0.0;
+  unsigned int numChildren = 0;
+  double codelength = 0.0;
+  const OutputModuleLinkMap& links;
+};
+
 class OutputView {
 public:
   using LeafCallback = std::function<void(const OutputLeafRow&)>;
   using TreeCallback = std::function<void(const OutputTreeRow&)>;
+  using ModuleCallback = std::function<void(const OutputModuleRow&)>;
 
   OutputView(InfomapBase& infomap, const StateNetwork& network, bool states);
 
@@ -76,6 +87,8 @@ public:
 
   void forEachLeaf(int moduleIndexLevel, OutputLeafPolicy filter, const LeafCallback& callback);
   void forEachTreeNode(const TreeCallback& callback);
+  // OutputModuleRow::links is valid only for the duration of the callback.
+  void forEachModule(const ModuleCallback& callback);
 
   std::map<unsigned int, OutputStateNodeTarget> stateNodeTargets();
   OutputModuleLinks moduleLinks();

--- a/src/io/ParameterCatalog.cpp
+++ b/src/io/ParameterCatalog.cpp
@@ -888,7 +888,7 @@ const std::vector<ParameterSpec>& parameterCatalog()
   return parameters;
 }
 
-void registerConfigParameters(ProgramInterface& api, ConfigParameterTargets targets, bool isCli)
+void registerCatalogWithProgramInterface(ProgramInterface& api, ConfigParameterTargets targets, bool isCli)
 {
   for (const auto& parameter : parameterCatalog()) {
     if (!parameter.registrar) {
@@ -902,6 +902,11 @@ void registerConfigParameters(ProgramInterface& api, ConfigParameterTargets targ
     }
     parameter.registrar(api, targets, parameter);
   }
+}
+
+void registerConfigParameters(ProgramInterface& api, ConfigParameterTargets targets, bool isCli)
+{
+  registerCatalogWithProgramInterface(api, targets, isCli);
 }
 
 void applyParsedParameters(Config& config, const ParsedParameterSet& parsed)

--- a/src/io/ParameterCatalog.h
+++ b/src/io/ParameterCatalog.h
@@ -63,6 +63,7 @@ struct ParameterSpec {
 // Declarative source of truth for Infomap parameter metadata. Config remains the
 // mutable runtime state that receives parsed values and applies adaptation rules.
 const std::vector<ParameterSpec>& parameterCatalog();
+void registerCatalogWithProgramInterface(ProgramInterface& api, ConfigParameterTargets targets, bool isCli);
 void registerConfigParameters(ProgramInterface& api, ConfigParameterTargets targets, bool isCli);
 void applyParsedParameters(Config& config, const ParsedParameterSet& parsed);
 std::string parameterCatalogJson();

--- a/test/cpp/test_config.cpp
+++ b/test/cpp/test_config.cpp
@@ -5,6 +5,7 @@
 #include "io/OutputFormats.h"
 #include "io/OutputPlan.h"
 #include "io/ParameterCatalog.h"
+#include "io/ProgramInterface.h"
 
 #include <map>
 #include <set>
@@ -323,6 +324,22 @@ TEST_CASE("Parameter catalog owns option choices and binding names [fast][core][
   REQUIRE(tuneIterationLimit != nullptr);
   CHECK(tuneIterationLimit->defaultValue == "0");
   CHECK(tuneIterationLimit->minValue == "0");
+}
+
+TEST_CASE("Parameter catalog registers with ProgramInterface through a named adapter [fast][core][config][cli]")
+{
+  Config config;
+  infomap::ParsedParameterSet parsed;
+  infomap::ProgramInterface api("Infomap", "Test parser", "1.0");
+
+  infomap::registerCatalogWithProgramInterface(api, { config, parsed }, true);
+  api.parseArgs("input.net --silent --no-file-output --flow-model directed");
+
+  CHECK(config.networkFile == "input.net");
+  CHECK(config.silent);
+  CHECK(config.noFileOutput);
+  CHECK(parsed.flowModelArg == "directed");
+  CHECK_FALSE(api.getUsedOptionArguments().empty());
 }
 
 } // namespace

--- a/test/cpp/test_network.cpp
+++ b/test/cpp/test_network.cpp
@@ -6,6 +6,8 @@
 
 #include "TestUtils.h"
 
+#include <cstdio>
+#include <fstream>
 #include <string>
 #include <vector>
 
@@ -13,6 +15,8 @@ namespace {
 
 using infomap::Config;
 using infomap::Network;
+
+const infomap::input::NetworkInputOptions defaultInputOptions {};
 
 struct FakeInputSink {
   bool undirectedFlow = true;
@@ -30,8 +34,6 @@ struct FakeInputSink {
   std::vector<infomap::input::ParsedLink> bipartiteLinks;
   std::vector<std::vector<int>> metaDataRows;
 
-  bool isUndirectedFlow() const { return undirectedFlow; }
-  unsigned int matchableMultilayerIds() const { return matchableIds; }
   unsigned int numPhysicalNodes() const { return vertices.size(); }
   unsigned int numLinks() const { return links.size(); }
   unsigned int numIntraLayerLinks() const { return intraLinks.size() + countExplicitIntraLinks(); }
@@ -127,25 +129,86 @@ TEST_CASE("Network rejects malformed multilayer fixture lines [fast][core][parse
       std::runtime_error);
 }
 
+TEST_CASE("NetworkBuilder validates bipartite intake while building Network state [fast][core][parser]")
+{
+  const std::string path = "invalid_bipartite_test.net";
+  {
+    std::ofstream out(path.c_str());
+    out << "*Bipartite 4\n";
+    out << "1 2 1\n";
+  }
+
+  Config config;
+  config.silent = true;
+  Network network(config);
+
+  CHECK_THROWS_WITH_AS(
+      network.readInputData(path),
+      "Bipartite link '1 2 1' must cross bipartite start id 4.",
+      std::runtime_error);
+
+  std::remove(path.c_str());
+}
+
+TEST_CASE("NetworkBuilder owns metadata and multilayer intake summaries [fast][core][parser]")
+{
+  Config config;
+  config.silent = true;
+  Network network(config);
+
+  network.readInputData(infomap::test::repoPath("test/fixtures/networks/intra_inter.net"));
+  CHECK(network.haveMemoryInput());
+  CHECK(network.isMultilayerNetwork());
+
+  network.readMetaData(infomap::test::repoPath("test/fixtures/meta/states.meta"));
+  CHECK(network.numMetaDataColumns() == 1);
+  CHECK(network.metaData().size() == 6);
+}
+
+TEST_CASE("NetworkBuilder accumulate=false replaces previous intake state [fast][core][parser]")
+{
+  Config config;
+  config.silent = true;
+  Network network(config);
+
+  network.readInputData(infomap::test::repoPath("test/fixtures/networks/accumulate_a.net"));
+  CHECK(network.nodes().count(1) == 1);
+  network.readInputData(infomap::test::repoPath("test/fixtures/networks/accumulate_b.net"), false);
+
+  CHECK(network.nodes().count(1) == 0);
+  CHECK(network.nodes().count(3) == 1);
+}
+
 TEST_CASE("NetworkInputParser emits events for link-list input [fast][core][parser]")
 {
   FakeInputSink sink;
 
-  infomap::input::parseNetworkInput(infomap::test::repoPath("test/fixtures/graphs/twotriangles_unweighted.edges"), sink);
+  infomap::input::parseNetworkInput(infomap::test::repoPath("test/fixtures/graphs/twotriangles_unweighted.edges"), sink, defaultInputOptions);
 
-  CHECK(sink.fileInput);
-  CHECK(sink.parsed);
+  CHECK_FALSE(sink.fileInput);
+  CHECK_FALSE(sink.parsed);
   CHECK(sink.links.size() == 7);
   CHECK(sink.links.front().source == 1);
   CHECK(sink.links.front().target == 2);
   CHECK(sink.links.front().weight == doctest::Approx(1.0));
 }
 
+TEST_CASE("NetworkInputParser accepts explicit parser options without querying sink state [fast][core][parser]")
+{
+  FakeInputSink sink;
+  const infomap::input::NetworkInputOptions options { false, 3 };
+
+  infomap::input::parseNetworkInput(infomap::test::repoPath("examples/networks/multilayer.net"), sink, options);
+
+  CHECK(sink.multilayerLinks.size() == 16);
+  CHECK(sink.matchableIds == 0);
+}
+
 TEST_CASE("NetworkInputParser emits vertex and bipartite events [fast][core][parser]")
 {
   FakeInputSink sink;
 
-  infomap::input::parseNetworkInput(infomap::test::repoPath("examples/networks/bipartite.net"), sink);
+  infomap::input::parseNetworkInput(infomap::test::repoPath("examples/networks/bipartite.net"), sink, defaultInputOptions);
 
   CHECK(sink.vertices.size() == 5);
   CHECK(sink.vertices.front().id == 1);
@@ -158,7 +221,7 @@ TEST_CASE("NetworkInputParser emits state-network events [fast][core][parser]")
 {
   FakeInputSink sink;
 
-  infomap::input::parseNetworkInput(infomap::test::repoPath("examples/networks/states.net"), sink);
+  infomap::input::parseNetworkInput(infomap::test::repoPath("examples/networks/states.net"), sink, defaultInputOptions);
 
   CHECK(sink.vertices.size() == 5);
   CHECK(sink.stateNodes.size() == 6);
@@ -171,7 +234,7 @@ TEST_CASE("NetworkInputParser emits explicit multilayer events [fast][core][pars
 {
   FakeInputSink sink;
 
-  infomap::input::parseNetworkInput(infomap::test::repoPath("examples/networks/multilayer.net"), sink);
+  infomap::input::parseNetworkInput(infomap::test::repoPath("examples/networks/multilayer.net"), sink, defaultInputOptions);
 
   CHECK(sink.vertices.size() == 5);
   CHECK(sink.multilayerLinks.size() == 16);
@@ -183,7 +246,7 @@ TEST_CASE("NetworkInputParser emits intra and inter events [fast][core][parser]"
 {
   FakeInputSink sink;
 
-  infomap::input::parseNetworkInput(infomap::test::repoPath("test/fixtures/networks/intra_inter.net"), sink);
+  infomap::input::parseNetworkInput(infomap::test::repoPath("test/fixtures/networks/intra_inter.net"), sink, defaultInputOptions);
 
   CHECK(sink.intraLinks.size() == 2);
   CHECK(sink.interLinks.size() == 2);
@@ -207,7 +270,7 @@ TEST_CASE("NetworkInputParser preserves malformed multilayer errors [fast][core]
   FakeInputSink sink;
 
   CHECK_THROWS_WITH_AS(
-      infomap::input::parseNetworkInput(infomap::test::repoPath("test/fixtures/networks/invalid_multilayer.net"), sink),
+      infomap::input::parseNetworkInput(infomap::test::repoPath("test/fixtures/networks/invalid_multilayer.net"), sink, defaultInputOptions),
       "Can't parse multilayer link data from line '1 1 broken'",
       std::runtime_error);
 }

--- a/test/cpp/test_output_view.cpp
+++ b/test/cpp/test_output_view.cpp
@@ -142,6 +142,30 @@ TEST_CASE("OutputView owns module-link projection [fast][core][output]")
   CHECK(foundPositiveFlow);
 }
 
+TEST_CASE("OutputView exposes serializable module rows for output adapters [fast][core][output]")
+{
+  auto im = runTwoTriangles();
+  infomap::OutputView view(*im, im->network(), false);
+
+  unsigned int numModules = 0;
+  bool foundRoot = false;
+  bool foundLinks = false;
+  view.forEachModule([&](const infomap::OutputModuleRow& module) {
+    ++numModules;
+    if (module.linkPathLabel == "root") {
+      foundRoot = true;
+      CHECK(module.jsonPath.empty());
+      CHECK(module.numChildren > 0);
+      CHECK(module.codelength >= 0.0);
+    }
+    foundLinks = foundLinks || !module.links.empty();
+  });
+
+  CHECK(numModules > 0);
+  CHECK(foundRoot);
+  CHECK(foundLinks);
+}
+
 TEST_CASE("OutputView refactor preserves stable tree output fields [fast][core][output]")
 {
   auto im = runTwoTriangles();


### PR DESCRIPTION
## Summary
- Move network input parser format decisions to explicit parser options and keep network intake lifecycle in NetworkBuilder.
- Add a named ParameterCatalog-to-ProgramInterface registration adapter and route ConfigBuilder through it.
- Move serializable module-row projection into OutputView so output writers stay focused on formatting.
- Extend C++ tests for network intake, catalog registration, and output module projection.

## Test Plan
- make format-native
- make test-native MODE=debug OPENMP=0
- make test-cpp-stream-policy
- make build-native
- make test-binding-options-freshness