### PR TITLE
refactor: move config lifecycle into builder

### DIFF
--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -10,7 +10,6 @@
 #include "Config.h"
 #include "ConfigBuilder.h"
 #include "OutputFormats.h"
-#include "../utils/Log.h"
 #include "../utils/convert.h"
 #include <vector>
 #include <stdexcept>
@@ -110,23 +109,7 @@ const char* flowModelToString(const FlowModel& flowModel)
 
 Config::Config(const std::string& flags, bool isCLI) : isCLI(isCLI)
 {
-  const auto parsed = ConfigBuilder::parseRaw(*this, flags, isCLI);
-  ConfigBuilder::applyParsed(*this, parsed, isCLI);
-
-  parsedString = flags;
-  parsedOptions = parsed.usedOptions;
-
-  if (verbosity > 0) {
-    prettyOutput = false;
-  }
-
-  if (printAllTrials && numTrials < 2) {
-    printAllTrials = false;
-  }
-
-  adaptDefaults();
-
-  Log::init(verbosity, silent, verboseNumberPrecision, prettyOutput);
+  ConfigBuilder::buildFromFlags(*this, flags, isCLI);
 }
 
 void Config::adaptDefaults()

--- a/src/io/ConfigBuilder.cpp
+++ b/src/io/ConfigBuilder.cpp
@@ -12,6 +12,7 @@
 #include "ProgramInterface.h"
 #include "SafeFile.h"
 #include "../utils/FileURI.h"
+#include "../utils/Log.h"
 #include "../utils/convert.h"
 
 #include <stdexcept>
@@ -44,6 +45,17 @@ namespace {
     }
   }
 
+  void applyRuntimeOutputInteractions(Config& config)
+  {
+    if (config.verbosity > 0) {
+      config.prettyOutput = false;
+    }
+
+    if (config.printAllTrials && config.numTrials < 2) {
+      config.printAllTrials = false;
+    }
+  }
+
   void normalizeOutputDirectory(Config& config)
   {
     if (!config.haveOutput() || config.outDirectory.empty())
@@ -66,7 +78,25 @@ namespace {
     }
   }
 
+  void initializeLogging(const Config& config)
+  {
+    Log::init(config.verbosity, config.silent, config.verboseNumberPrecision, config.prettyOutput);
+  }
+
 } // namespace
+
+void ConfigBuilder::buildFromFlags(Config& config, const std::string& flags, bool isCLI)
+{
+  config = Config {};
+  config.isCLI = isCLI;
+  config.parsedString = flags;
+
+  const auto parsed = parseRaw(config, flags, isCLI);
+  config.parsedOptions = parsed.usedOptions;
+  applyParsed(config, parsed, isCLI);
+
+  initializeLogging(config);
+}
 
 ParsedConfigParameters ConfigBuilder::parseRaw(Config& config, const std::string& flags, bool isCLI)
 {
@@ -87,6 +117,7 @@ ParsedConfigParameters ConfigBuilder::parseRaw(Config& config, const std::string
 
 void ConfigBuilder::applyParsed(Config& config, const ParsedConfigParameters& parsed, bool isCLI)
 {
+  config.isCLI = isCLI;
   applyParsedParameters(config, parsed);
   applyLibraryOutputDefaults(config, isCLI);
   validateRequiredCliOutput(config, isCLI);
@@ -94,6 +125,8 @@ void ConfigBuilder::applyParsed(Config& config, const ParsedConfigParameters& pa
   normalizeOutputDirectory(config);
   validateOutputDirectory(config);
   applyOutputNameDefault(config);
+  applyRuntimeOutputInteractions(config);
+  config.adaptDefaults();
 }
 
 } // namespace infomap

--- a/src/io/ConfigBuilder.h
+++ b/src/io/ConfigBuilder.h
@@ -12,6 +12,8 @@
 
 #include "ParameterCatalog.h"
 
+#include <string>
+
 namespace infomap {
 
 struct Config;
@@ -20,6 +22,7 @@ using ParsedConfigParameters = ParsedParameterSet;
 
 class ConfigBuilder {
 public:
+  static void buildFromFlags(Config& config, const std::string& flags, bool isCLI);
   static ParsedConfigParameters parseRaw(Config& config, const std::string& flags, bool isCLI);
   static void applyParsed(Config& config, const ParsedConfigParameters& parsed, bool isCLI);
 };

--- a/test/cpp/test_config.cpp
+++ b/test/cpp/test_config.cpp
@@ -105,9 +105,9 @@ TEST_CASE("Config adapts parsed runtime defaults after registration [fast][core]
 TEST_CASE("ConfigBuilder exposes raw parse state before runtime adaptation [fast][core][config][cli]")
 {
   Config raw;
-  raw.isCLI = true;
 
   const auto parsed = infomap::ConfigBuilder::parseRaw(raw, "input.net --silent --no-file-output --flow-model directed --regularized --num-trials 4", true);
+  CHECK_FALSE(raw.isCLI);
   CHECK(raw.networkFile == "input.net");
   CHECK(raw.noFileOutput);
   CHECK(raw.regularized);
@@ -117,8 +117,29 @@ TEST_CASE("ConfigBuilder exposes raw parse state before runtime adaptation [fast
   CHECK_FALSE(parsed.usedOptions.empty());
 
   infomap::ConfigBuilder::applyParsed(raw, parsed, true);
+  CHECK(raw.isCLI);
   CHECK(infomap::flowModelToString(raw.flowModel) == std::string("directed"));
   CHECK(raw.recordedTeleportation);
+}
+
+TEST_CASE("ConfigBuilder owns full flags-to-runtime config lifecycle [fast][core][config][cli]")
+{
+  Config config;
+  config.printTree = true;
+  config.outName = "stale";
+  config.parsedString = "stale flags";
+
+  infomap::ConfigBuilder::buildFromFlags(config, "input.net --silent --no-file-output --verbose --pretty --print-all-trials --num-trials 1 --output json", true);
+
+  CHECK(config.isCLI);
+  CHECK(config.parsedString == "input.net --silent --no-file-output --verbose --pretty --print-all-trials --num-trials 1 --output json");
+  CHECK_FALSE(config.parsedOptions.empty());
+  CHECK(config.verbosity == 1);
+  CHECK_FALSE(config.prettyOutput);
+  CHECK_FALSE(config.printAllTrials);
+  CHECK(config.printJson);
+  CHECK_FALSE(config.printTree);
+  CHECK(config.outName == "input");
 }
 
 TEST_CASE("Config parses pretty output flag [fast][core][config][cli]")


### PR DESCRIPTION
## Summary

- Add a ConfigBuilder entry point for full flags-to-runtime config construction
- Move remaining config lifecycle adaptation and logging initialization behind ConfigBuilder
- Cover the lifecycle interface with a focused C++ config test

## Verification

- make format-native
- /opt/homebrew/bin/clang-format -i test/cpp/test_config.cpp
- cmake --build build/cmake --target infomap_cpp_config_tests
- ctest --test-dir build/cmake -R infomap_cpp_config_tests --output-on-failure
- make build-native