### PR TITLE
fix(python): support PyTorch with macOS OpenMP wheels

### DIFF
--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -240,6 +240,18 @@ jobs:
             CPPFLAGS="-I$(brew --prefix libomp)/include"
             LDFLAGS="-L$(brew --prefix libomp)/lib"
 
+      - name: Patch macOS OpenMP wheel loading
+        if: startsWith(matrix.os, 'macos')
+        run: python scripts/patch_macos_torch_libomp_rpath.py wheelhouse/*.whl
+
+      - name: Smoke test wheel with PyTorch
+        if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'windows')
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install wheelhouse/infomap-*-cp314-cp314-*.whl pytest torch
+          python -m pytest test/python/test_torch_interop.py
+
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/scripts/patch_macos_torch_libomp_rpath.py
+++ b/scripts/patch_macos_torch_libomp_rpath.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+import base64
+import csv
+import hashlib
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+from shutil import which
+
+
+TORCH_LIBOMP_RPATH = "@loader_path/../torch/lib"
+VENDORED_LIBOMP_RPATH = "@loader_path/.dylibs"
+LIBOMP_LOAD_NAME = "@rpath/libomp.dylib"
+REQUIRED_TOOLS = ("otool", "install_name_tool", "codesign")
+
+
+def run(*args):
+    subprocess.run(args, check=True)
+
+
+def output(*args):
+    return subprocess.check_output(args, text=True)
+
+
+def current_libomp_dependency(binary):
+    for line in output("otool", "-L", str(binary)).splitlines()[1:]:
+        dependency = line.strip().split(" ", 1)[0]
+        if dependency.endswith("/libomp.dylib") or dependency == LIBOMP_LOAD_NAME:
+            return dependency
+    return ""
+
+
+def current_rpaths(binary):
+    rpaths = []
+    lines = output("otool", "-l", str(binary)).splitlines()
+    for index, line in enumerate(lines):
+        if line.strip() == "cmd LC_RPATH":
+            for rpath_line in lines[index + 1 : index + 4]:
+                stripped = rpath_line.strip()
+                if stripped.startswith("path "):
+                    rpaths.append(stripped.split(" ", 2)[1])
+                    break
+    return rpaths
+
+
+def add_rpath(binary, rpath):
+    if rpath not in current_rpaths(binary):
+        run("install_name_tool", "-add_rpath", rpath, str(binary))
+
+
+def patch_extension(binary):
+    dependency = current_libomp_dependency(binary)
+    if not dependency:
+        raise RuntimeError(f"{binary} does not link to libomp.dylib")
+
+    if dependency != LIBOMP_LOAD_NAME:
+        run("install_name_tool", "-change", dependency, LIBOMP_LOAD_NAME, str(binary))
+
+    add_rpath(binary, TORCH_LIBOMP_RPATH)
+    add_rpath(binary, VENDORED_LIBOMP_RPATH)
+    run("codesign", "--force", "--sign", "-", str(binary))
+
+
+def digest(path):
+    data = path.read_bytes()
+    value = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=")
+    return f"sha256={value.decode()}", str(len(data))
+
+
+def rewrite_record(root):
+    record_paths = list(root.glob("*.dist-info/RECORD"))
+    if len(record_paths) != 1:
+        raise RuntimeError(f"expected one RECORD file, found {len(record_paths)}")
+
+    record = record_paths[0]
+    rows = []
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        relpath = path.relative_to(root).as_posix()
+        if path == record:
+            rows.append((relpath, "", ""))
+        else:
+            file_hash, size = digest(path)
+            rows.append((relpath, file_hash, size))
+
+    with record.open("w", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerows(rows)
+
+
+def repack_wheel(root, wheel):
+    tmp_wheel = wheel.with_suffix(".tmp.whl")
+    if tmp_wheel.exists():
+        tmp_wheel.unlink()
+
+    with zipfile.ZipFile(tmp_wheel, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for path in sorted(p for p in root.rglob("*") if p.is_file()):
+            archive.write(path, path.relative_to(root).as_posix())
+
+    tmp_wheel.replace(wheel)
+
+
+def patch_wheel(wheel):
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp) / "wheel"
+        root.mkdir()
+        with zipfile.ZipFile(wheel) as archive:
+            archive.extractall(root)
+
+        extensions = list((root / "infomap").glob("_infomap*.so"))
+        if len(extensions) != 1:
+            raise RuntimeError(
+                f"expected one infomap extension, found {len(extensions)}"
+            )
+
+        patch_extension(extensions[0])
+        rewrite_record(root)
+        repack_wheel(root, wheel)
+
+
+def main(argv):
+    if len(argv) < 2:
+        raise SystemExit("usage: patch_macos_torch_libomp_rpath.py WHEEL [...]")
+
+    if sys.platform != "darwin":
+        raise SystemExit("patch_macos_torch_libomp_rpath.py only runs on macOS")
+
+    missing_tools = [tool for tool in REQUIRED_TOOLS if which(tool) is None]
+    if missing_tools:
+        tools = ", ".join(missing_tools)
+        raise SystemExit(f"missing required macOS tool(s): {tools}")
+
+    for arg in argv[1:]:
+        wheel = Path(arg)
+        if not wheel.exists():
+            raise FileNotFoundError(wheel)
+        patch_wheel(wheel)
+        print(f"Patched {wheel}")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/test/python/test_torch_interop.py
+++ b/test/python/test_torch_interop.py
@@ -1,0 +1,57 @@
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+pytestmark = [pytest.mark.crash]
+
+
+SMOKE_SCRIPT = """
+from infomap import Infomap
+import torch
+
+_ = torch.ones((64, 64)) @ torch.ones((64, 64))
+im = Infomap("--directed --silent --num-trials 1 --seed 1 --two-level")
+for source, target, weight in [
+    (0, 1, 1.0),
+    (1, 2, 1.0),
+    (2, 0, 1.0),
+    (3, 4, 1.0),
+    (4, 5, 1.0),
+    (5, 3, 1.0),
+    (2, 3, 0.01),
+    (3, 2, 0.01),
+]:
+    im.add_link(source, target, weight)
+im.run()
+if not 1.0 < im.codelength < 2.0:
+    raise AssertionError(f"unexpected codelength: {im.codelength}")
+"""
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        pytest.param("import infomap\n", id="infomap-first"),
+        pytest.param("import torch\n", id="torch-first"),
+    ],
+)
+def test_torch_and_infomap_run_in_same_process(prefix):
+    pytest.importorskip("torch")
+
+    code = prefix + textwrap.dedent(SMOKE_SCRIPT)
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, (
+        f"subprocess failed with exit code {result.returncode}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )


### PR DESCRIPTION
## Summary

Fixes the macOS Python wheel packaging path so Infomap can run in the same Python process as PyTorch while keeping OpenMP enabled.

The macOS wheel repair now patches `infomap/_infomap*.so` to load `libomp.dylib` through `@rpath`, preferring `torch/lib` when PyTorch is installed and falling back to Infomap's vendored `infomap/.dylibs` runtime otherwise. The patch script also re-signs the extension and rewrites wheel `RECORD` metadata after modifying the wheel.

## Validation

- Reproduced the original `OMP: Error #15` crash locally with an OpenMP-enabled, delocated macOS wheel and `torch==2.12.0`.
- Verified the patched wheel runs `Infomap.run()` without PyTorch installed.
- Verified the patched wheel runs with `infomap` imported before `torch`.
- Verified the patched wheel runs with `torch` imported before `infomap`.
- Verified uninstalling `torch` falls back to Infomap's vendored `libomp.dylib`.
- Added CI smoke coverage for built wheels with PyTorch on macOS, Ubuntu, and Windows.

Closes #588
