### PR TITLE
fix: prevent metadata inner parallel crash

### DIFF
--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -81,6 +81,8 @@ protected:
 
   unsigned int optimizeActiveNetwork() override;
 
+  bool shouldUseInnerParallelization() const;
+
   unsigned int tryMoveEachNodeIntoBestModule() override;
 
   unsigned int tryMoveEachNodeIntoBestModuleInParallel() override;
@@ -121,6 +123,18 @@ template <typename Objective>
 inline double InfomapOptimizer<Objective>::getMetaCodelength(bool /*unweighted*/) const
 {
   return 0.0;
+}
+
+template <>
+inline bool InfomapOptimizer<MetaMapEquation>::shouldUseInnerParallelization() const
+{
+  return false;
+}
+
+template <typename Objective>
+inline bool InfomapOptimizer<Objective>::shouldUseInnerParallelization() const
+{
+  return m_infomap->innerParallelization;
 }
 
 // ===================================================
@@ -274,7 +288,7 @@ INFOMAP_HOT inline unsigned int InfomapOptimizer<Objective>::optimizeActiveNetwo
 
   do {
     ++coreLoopCount;
-    unsigned int numNodesMoved = m_infomap->innerParallelization
+    unsigned int numNodesMoved = shouldUseInnerParallelization()
         ? tryMoveEachNodeIntoBestModuleInParallel()
         : tryMoveEachNodeIntoBestModule();
     // Break if not enough improvement

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -128,6 +128,8 @@ inline double InfomapOptimizer<Objective>::getMetaCodelength(bool /*unweighted*/
 template <>
 inline bool InfomapOptimizer<MetaMapEquation>::shouldUseInnerParallelization() const
 {
+  // MetaMapEquation's delta evaluation mutates shared metadata state while
+  // testing moves, so the lock-free inner parallel loop is not thread-safe.
   return false;
 }
 

--- a/test/cpp/test_flow.cpp
+++ b/test/cpp/test_flow.cpp
@@ -8,6 +8,10 @@
 #include <string>
 #include <vector>
 
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
 namespace {
 
 using infomap::InfomapWrapper;
@@ -94,6 +98,11 @@ TEST_CASE("Inner parallelization remains runnable and numerically sane on the di
 
 TEST_CASE("Inner parallelization with meta data falls back to stable serial optimization [fast][core][flow][openmp]")
 {
+#ifdef _OPENMP
+  omp_set_num_threads(8);
+  CHECK(omp_get_max_threads() > 1);
+#endif
+
   InfomapWrapper im(infomap::test::defaultFlags(
       "--inner-parallelization --meta-data " + infomap::test::fixturePath("meta/states.meta") + " --meta-data-rate 2"));
   infomap::test::readNetworkFixture(im, "states.net");
@@ -106,6 +115,7 @@ TEST_CASE("Inner parallelization with meta data falls back to stable serial opti
   CHECK(im.getMetaCodelength() >= 0.0);
   for (auto* leaf : im.leafNodes()) {
     CHECK_FALSE(leaf->metaData.empty());
+    CHECK(leaf->metaData[0] != -1);
   }
 }
 

--- a/test/cpp/test_flow.cpp
+++ b/test/cpp/test_flow.cpp
@@ -92,6 +92,23 @@ TEST_CASE("Inner parallelization remains runnable and numerically sane on the di
   CHECK(result.codelength >= result.indexCodelength);
 }
 
+TEST_CASE("Inner parallelization with meta data falls back to stable serial optimization [fast][core][flow][openmp]")
+{
+  InfomapWrapper im(infomap::test::defaultFlags(
+      "--inner-parallelization --meta-data " + infomap::test::fixturePath("meta/states.meta") + " --meta-data-rate 2"));
+  infomap::test::readNetworkFixture(im, "states.net");
+
+  im.run();
+
+  infomap::test::checkRunSanity(im);
+  CHECK(im.codelength() > 0.0);
+  CHECK(im.codelength() >= im.getIndexCodelength());
+  CHECK(im.getMetaCodelength() >= 0.0);
+  for (auto* leaf : im.leafNodes()) {
+    CHECK_FALSE(leaf->metaData.empty());
+  }
+}
+
 TEST_CASE("Precomputed flow rejects first-order input without vertex flows [fast][core][flow][parser]")
 {
   InfomapWrapper im(infomap::test::defaultFlags("--flow-model precomputed"));


### PR DESCRIPTION
## Summary
- Disable inner-loop parallelization for metadata map equation optimization to avoid unsafe shared metadata mutation.
- Keep inner parallelization unchanged for non-metadata objectives.
- Add a C++ regression covering `--inner-parallelization` with `--meta-data`.

## Root Cause
`MetaMapEquation::getDeltaCodelengthOnMovingNode` evaluates hypothetical metadata moves by mutating `m_moduleToMetaCollection`, which is unsafe from the lock-free section of the parallel node-move loop.

## Test Plan
- `OMP_NUM_THREADS=8 make test-native CTEST_ARGS='-R infomap_cpp_flow_tests --output-on-failure'`
- `OMP_NUM_THREADS=8 make test-native CTEST_ARGS='--output-on-failure'`
- `make build-native`
- `OMP_NUM_THREADS=8 ./Infomap examples/networks/states.net /tmp/infomap-589-out --inner-parallelization --meta-data test/fixtures/meta/states.meta --meta-data-rate 2 --silent --no-file-output --num-trials 1 --seed 123`

Closes #589
