### PR TITLE
build(ci): add prerelease publishing workflow

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,111 @@
+name: Prerelease
+
+on:
+  push:
+    tags:
+      - "v*.*.*-rc.*"
+      - "v*.*.*-beta.*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: prerelease-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  validate-prerelease-tag:
+    name: Validate prerelease tag
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Validate tag format
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-(rc|beta)\.[0-9]+$ ]]; then
+            echo "Expected prerelease tag vX.Y.Z-rc.N or vX.Y.Z-beta.N, got: $RELEASE_TAG" >&2
+            exit 1
+          fi
+
+  python:
+    needs: [validate-prerelease-tag]
+    uses: ./.github/workflows/_python-package.yml
+    with:
+      ref: ${{ github.ref }}
+      run-tests: true
+      build-release-artifacts: true
+
+  javascript:
+    needs: [validate-prerelease-tag]
+    uses: ./.github/workflows/_js-package.yml
+    with:
+      ref: ${{ github.ref }}
+      run-tests: true
+      pack-artifact: true
+
+  publish-pypi:
+    name: Publish prerelease to PyPI
+    needs: [python, javascript]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    environment:
+      name: pypi-prerelease
+      url: https://pypi.org/project/infomap/
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download Python distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python-sdist
+          path: dist/python
+
+      - name: Download Python wheels
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: python-wheels-*
+          path: dist/python
+          merge-multiple: true
+
+      - name: Verify Python distributions
+        run: ls -la dist/python
+
+      - name: Publish prerelease package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          packages-dir: dist/python
+
+  publish-npm:
+    name: Publish prerelease to npm
+    needs: [python, javascript]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    environment:
+      name: npm-prerelease
+      url: https://www.npmjs.com/package/@mapequation/infomap
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Download npm package artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: npm-package
+          path: dist/npm
+
+      - name: Publish npm prerelease package
+        run: npm publish --tag next --access public dist/npm/*.tgz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,6 @@ jobs:
           fi
 
   native:
-    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-') }}
     needs: [validate-stable-tag]
     uses: ./.github/workflows/_native-build.yml
     with:
@@ -46,7 +45,6 @@ jobs:
       upload-artifacts: true
 
   python:
-    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-') }}
     needs: [validate-stable-tag]
     uses: ./.github/workflows/_python-package.yml
     with:
@@ -55,7 +53,6 @@ jobs:
       build-release-artifacts: true
 
   javascript:
-    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-') }}
     needs: [validate-stable-tag]
     uses: ./.github/workflows/_js-package.yml
     with:
@@ -64,7 +61,6 @@ jobs:
       pack-artifact: true
 
   r:
-    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-') }}
     needs: [validate-stable-tag]
     uses: ./.github/workflows/_r-package.yml
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,35 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  validate-stable-tag:
+    name: Validate stable release tag
+    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-') }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Validate tag format
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Expected stable release tag vX.Y.Z, got: $RELEASE_TAG" >&2
+            exit 1
+          fi
+
   native:
+    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-') }}
+    needs: [validate-stable-tag]
     uses: ./.github/workflows/_native-build.yml
     with:
       ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
       upload-artifacts: true
 
   python:
+    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-') }}
+    needs: [validate-stable-tag]
     uses: ./.github/workflows/_python-package.yml
     with:
       ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
@@ -33,6 +55,8 @@ jobs:
       build-release-artifacts: true
 
   javascript:
+    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-') }}
+    needs: [validate-stable-tag]
     uses: ./.github/workflows/_js-package.yml
     with:
       ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
@@ -40,6 +64,8 @@ jobs:
       pack-artifact: true
 
   r:
+    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-') }}
+    needs: [validate-stable-tag]
     uses: ./.github/workflows/_r-package.yml
     with:
       ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}


### PR DESCRIPTION
## Summary

- add a tag-driven prerelease workflow for Python and npm prereleases
- publish prerelease builds to PyPI and npm only after both Python and JavaScript verification pass
- guard the stable release workflow so prerelease tags do not run the stable publishing path

## Verification

- `/opt/homebrew/bin/actionlint .github/workflows/release.yml .github/workflows/prerelease.yml`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "#{path}: ok" }' .github/workflows/release.yml .github/workflows/prerelease.yml`