### PR TITLE
build(R): add R formatting targets

### DIFF
--- a/examples/R/example-igraph.R
+++ b/examples/R/example-igraph.R
@@ -14,7 +14,9 @@ im$run()
 
 cat(sprintf(
   "Partitioned %d-node network in %d modules with codelength %.4f bits.\n",
-  im$num_nodes, im$num_top_modules, im$codelength
+  im$num_nodes,
+  im$num_top_modules,
+  im$codelength
 ))
 
 comm <- im$as_communities(g)

--- a/examples/R/example-minimal.R
+++ b/examples/R/example-minimal.R
@@ -29,7 +29,8 @@ im$run()
 
 cat(sprintf(
   "[R6]     %d modules, codelength %.4f bits.\n",
-  im$num_top_modules, im$codelength
+  im$num_top_modules,
+  im$codelength
 ))
 print(im$modules)
 
@@ -42,10 +43,16 @@ edges <- data.frame(
   target = c(1, 2, 3, 0, 2, 1, 0, 0, 4, 5, 3, 5, 4, 3)
 )
 
-result <- cluster_infomap(edges, silent = TRUE, two_level = TRUE, directed = TRUE)
+result <- cluster_infomap(
+  edges,
+  silent = TRUE,
+  two_level = TRUE,
+  directed = TRUE
+)
 
 cat(sprintf(
   "[helper] %d modules, codelength %.4f bits.\n",
-  result$num_top_modules, result$codelength
+  result$num_top_modules,
+  result$codelength
 ))
 print(result$modules)

--- a/examples/R/example-multilayer.R
+++ b/examples/R/example-multilayer.R
@@ -13,14 +13,16 @@ library(infomap)
 # via `multilayer_relax_rate` (default 0.15).
 
 intra <- data.frame(
-  layer     = c(1, 1, 1, 2, 2, 2),
+  layer = c(1, 1, 1, 2, 2, 2),
   node_from = c(1, 2, 3, 1, 2, 3),
-  node_to   = c(2, 3, 1, 2, 3, 1)
+  node_to = c(2, 3, 1, 2, 3, 1)
 )
 
 result_intra <- cluster_infomap_multilayer(
   intra,
-  silent = TRUE, num_trials = 5, two_level = TRUE
+  silent = TRUE,
+  num_trials = 5,
+  two_level = TRUE
 )
 
 cat(sprintf(
@@ -37,20 +39,23 @@ print(result_intra$nodes)
 
 edges <- data.frame(
   layer_from = c(1, 1, 1, 2, 2, 2, 1, 1, 1),
-  node_from  = c(1, 2, 3, 1, 2, 3, 1, 2, 3),
-  layer_to   = c(1, 1, 1, 2, 2, 2, 2, 2, 2),
-  node_to    = c(2, 3, 1, 2, 3, 1, 1, 2, 3),
-  weight     = c(1, 1, 1, 1, 1, 1, 0.5, 0.5, 0.5)
+  node_from = c(1, 2, 3, 1, 2, 3, 1, 2, 3),
+  layer_to = c(1, 1, 1, 2, 2, 2, 2, 2, 2),
+  node_to = c(2, 3, 1, 2, 3, 1, 1, 2, 3),
+  weight = c(1, 1, 1, 1, 1, 1, 0.5, 0.5, 0.5)
 )
 
 result_full <- cluster_infomap_multilayer(
   edges,
-  silent = TRUE, num_trials = 5, two_level = TRUE
+  silent = TRUE,
+  num_trials = 5,
+  two_level = TRUE
 )
 
 cat(sprintf(
   "[full]   %d modules, codelength %.4f bits.\n",
-  result_full$num_top_modules, result_full$codelength
+  result_full$num_top_modules,
+  result_full$codelength
 ))
 print(result_full$nodes)
 
@@ -74,6 +79,7 @@ im$run()
 
 cat(sprintf(
   "[R6]     %d modules, codelength %.4f bits.\n",
-  im$num_top_modules, im$codelength
+  im$num_top_modules,
+  im$codelength
 ))
 print(as.data.frame(im))

--- a/interfaces/R/infomap/R/Infomap.R
+++ b/interfaces/R/infomap/R/Infomap.R
@@ -53,7 +53,11 @@ Infomap <- function(args = NULL, opts = NULL, ...) {
 
 .network_input_weights <- function(input, weight_index, count, message) {
   if (ncol(input) == weight_index) {
-    weights <- if (is.matrix(input)) input[, weight_index] else input[[weight_index]]
+    weights <- if (is.matrix(input)) {
+      input[, weight_index]
+    } else {
+      input[[weight_index]]
+    }
     if (!is.numeric(weights)) {
       stop(message, call. = FALSE)
     }
@@ -71,7 +75,12 @@ Infomap <- function(args = NULL, opts = NULL, ...) {
   lengths
 }
 
-.network_input_scalar_numeric <- function(entry, index, scalar_message, numeric_message) {
+.network_input_scalar_numeric <- function(
+  entry,
+  index,
+  scalar_message,
+  numeric_message
+) {
   value <- entry[[index]]
   if (length(value) != 1L) {
     stop(scalar_message, call. = FALSE)
@@ -82,9 +91,15 @@ Infomap <- function(args = NULL, opts = NULL, ...) {
   value
 }
 
-.network_input_table <- function(input, allowed_columns, shape_message,
-                                 id_columns, id_message,
-                                 weight_column, weight_message) {
+.network_input_table <- function(
+  input,
+  allowed_columns,
+  shape_message,
+  id_columns,
+  id_message,
+  weight_column,
+  weight_message
+) {
   ncol_input <- ncol(input)
   if (!ncol_input %in% allowed_columns) {
     stop(shape_message, call. = FALSE)
@@ -93,16 +108,29 @@ Infomap <- function(args = NULL, opts = NULL, ...) {
   values <- .network_input_columns(input, id_columns)
   .network_input_require_numeric(values, id_message)
   weights <- .network_input_weights(
-    input, weight_column, length(values[[1L]]), weight_message
+    input,
+    weight_column,
+    length(values[[1L]]),
+    weight_message
   )
   c(values, list(weights))
 }
 
-.network_input_flat_rows <- function(entries, allowed_lengths, length_message,
-                                     value_names, row_name,
-                                     id_message, weight_scalar_message,
-                                     weight_numeric_message) {
-  .network_input_validate_entry_lengths(entries, allowed_lengths, length_message)
+.network_input_flat_rows <- function(
+  entries,
+  allowed_lengths,
+  length_message,
+  value_names,
+  row_name,
+  id_message,
+  weight_scalar_message,
+  weight_numeric_message
+) {
+  .network_input_validate_entry_lengths(
+    entries,
+    allowed_lengths,
+    length_message
+  )
 
   values <- lapply(
     seq_along(value_names),
@@ -113,7 +141,13 @@ Infomap <- function(args = NULL, opts = NULL, ...) {
           .network_input_scalar_numeric(
             entry,
             index,
-            paste0("Each ", row_name, " ", value_names[[index]], " value must be scalar."),
+            paste0(
+              "Each ",
+              row_name,
+              " ",
+              value_names[[index]],
+              " value must be scalar."
+            ),
             id_message
           )
         },
@@ -124,9 +158,16 @@ Infomap <- function(args = NULL, opts = NULL, ...) {
   weights <- vapply(
     entries,
     function(entry) {
-      value <- if (length(entry) == length(value_names) + 1L) entry[[length(entry)]] else 1.0
+      value <- if (length(entry) == length(value_names) + 1L) {
+        entry[[length(entry)]]
+      } else {
+        1.0
+      }
       .network_input_scalar_numeric(
-        list(value), 1L, weight_scalar_message, weight_numeric_message
+        list(value),
+        1L,
+        weight_scalar_message,
+        weight_numeric_message
       )
     },
     numeric(1L)
@@ -136,8 +177,10 @@ Infomap <- function(args = NULL, opts = NULL, ...) {
 
 .network_input_multilayer_node_value <- function(node, name, index) {
   if (length(node) != 2L) {
-    stop("Each multilayer node must contain 2 values: layer id and node id.",
-         call. = FALSE)
+    stop(
+      "Each multilayer node must contain 2 values: layer id and node id.",
+      call. = FALSE
+    )
   }
   .network_input_scalar_numeric(
     node,
@@ -176,7 +219,9 @@ InfomapClass <- R6::R6Class(
       if (is.null(opts)) {
         opts <- do.call(infomap_options, overrides)
       } else if (length(overrides) > 0L) {
-        for (name in names(overrides)) opts[[name]] <- overrides[[name]]
+        for (name in names(overrides)) {
+          opts[[name]] <- overrides[[name]]
+        }
       }
       cli <- construct_args(args, opts)
       private$.swig <- InfomapWrapper(cli)
@@ -195,7 +240,10 @@ InfomapClass <- R6::R6Class(
     #' @param filename Path to a network file (`.net`, `.txt`, `.tree`, etc.).
     #' @param accumulate If `TRUE` (default), accumulate to existing nodes/links.
     read_file = function(filename, accumulate = TRUE) {
-      private$.swig$readInputData(as.character(filename), as.logical(accumulate))
+      private$.swig$readInputData(
+        as.character(filename),
+        as.logical(accumulate)
+      )
       invisible(self)
     },
 
@@ -206,7 +254,11 @@ InfomapClass <- R6::R6Class(
     add_node = function(node_id, name = NULL, teleportation_weight = NULL) {
       id <- as.integer(node_id)
       if (!is.null(name) && !is.null(teleportation_weight)) {
-        private$.swig$addNode(id, as.character(name), as.numeric(teleportation_weight))
+        private$.swig$addNode(
+          id,
+          as.character(name),
+          as.numeric(teleportation_weight)
+        )
       } else if (!is.null(name)) {
         private$.swig$addNode(id, as.character(name))
       } else if (!is.null(teleportation_weight)) {
@@ -239,8 +291,11 @@ InfomapClass <- R6::R6Class(
           if (is.character(attr) && length(attr) == 1L) {
             self$add_node(id, name = attr)
           } else if (is.list(attr) || length(attr) > 1L) {
-            self$add_node(id, name = as.character(attr[[1]]),
-                          teleportation_weight = as.numeric(attr[[2]]))
+            self$add_node(
+              id,
+              name = as.character(attr[[1]]),
+              teleportation_weight = as.numeric(attr[[2]])
+            )
           } else {
             self$add_node(id, name = as.character(attr))
           }
@@ -277,7 +332,9 @@ InfomapClass <- R6::R6Class(
     #' @param node_id Integer node id.
     #' @param name Node name (character). `NULL` clears the name.
     set_name = function(node_id, name) {
-      if (is.null(name)) name <- ""
+      if (is.null(name)) {
+        name <- ""
+      }
       private$.swig$addName(as.integer(node_id), as.character(name))
       invisible(self)
     },
@@ -287,7 +344,9 @@ InfomapClass <- R6::R6Class(
     #'   list/vector mapping `node_id` to `name`.
     set_names = function(mapping) {
       if (is.null(names(mapping))) {
-        for (entry in mapping) self$set_name(entry[[1L]], entry[[2L]])
+        for (entry in mapping) {
+          self$set_name(entry[[1L]], entry[[2L]])
+        }
       } else {
         for (id_str in names(mapping)) {
           self$set_name(as.integer(id_str), mapping[[id_str]])
@@ -301,7 +360,11 @@ InfomapClass <- R6::R6Class(
     #' @param target_id Target node id.
     #' @param weight Link weight.
     add_link = function(source_id, target_id, weight = 1.0) {
-      private$.swig$addLink(as.integer(source_id), as.integer(target_id), as.numeric(weight))
+      private$.swig$addLink(
+        as.integer(source_id),
+        as.integer(target_id),
+        as.numeric(weight)
+      )
       invisible(self)
     },
 
@@ -314,8 +377,11 @@ InfomapClass <- R6::R6Class(
       if (is.matrix(links) || is.data.frame(links)) {
         ncol_links <- ncol(links)
         if (!ncol_links %in% c(2L, 3L)) {
-          stop("`links` matrix/data.frame must have 2 or 3 columns ",
-               "(source, target, [weight]).", call. = FALSE)
+          stop(
+            "`links` matrix/data.frame must have 2 or 3 columns ",
+            "(source, target, [weight]).",
+            call. = FALSE
+          )
         }
         id_columns <- .network_input_columns(links, c(1L, 2L))
         .network_input_require_numeric(
@@ -325,7 +391,10 @@ InfomapClass <- R6::R6Class(
         sources <- id_columns[[1L]]
         targets <- id_columns[[2L]]
         weights <- .network_input_weights(
-          links, 3L, length(sources), "`links` weight column must be numeric."
+          links,
+          3L,
+          length(sources),
+          "`links` weight column must be numeric."
         )
       } else {
         link_lengths <- .network_input_validate_entry_lengths(
@@ -372,7 +441,11 @@ InfomapClass <- R6::R6Class(
         )
       }
 
-      private$.swig$addLinks(as.integer(sources), as.integer(targets), as.numeric(weights))
+      private$.swig$addLinks(
+        as.integer(sources),
+        as.integer(targets),
+        as.numeric(weights)
+      )
       invisible(self)
     },
 
@@ -380,14 +453,19 @@ InfomapClass <- R6::R6Class(
     #' @param source_id Source node id.
     #' @param target_id Target node id.
     remove_link = function(source_id, target_id) {
-      private$.swig$network()$removeLink(as.integer(source_id), as.integer(target_id))
+      private$.swig$network()$removeLink(
+        as.integer(source_id),
+        as.integer(target_id)
+      )
       invisible(self)
     },
 
     #' @description Remove many links at once.
     #' @param links A list of `c(source, target)` vectors.
     remove_links = function(links) {
-      for (entry in links) self$remove_link(entry[[1L]], entry[[2L]])
+      for (entry in links) {
+        self$remove_link(entry[[1L]], entry[[2L]])
+      }
       invisible(self)
     },
 
@@ -397,10 +475,20 @@ InfomapClass <- R6::R6Class(
     #' @param target_multilayer_node A `c(layer_id, node_id)` vector or
     #'   the result of [multilayer_node()].
     #' @param weight Link weight.
-    add_multilayer_link = function(source_multilayer_node, target_multilayer_node, weight = 1.0) {
+    add_multilayer_link = function(
+      source_multilayer_node,
+      target_multilayer_node,
+      weight = 1.0
+    ) {
       src <- as.integer(source_multilayer_node)
       tgt <- as.integer(target_multilayer_node)
-      private$.swig$addMultilayerLink(src[[1L]], src[[2L]], tgt[[1L]], tgt[[2L]], as.numeric(weight))
+      private$.swig$addMultilayerLink(
+        src[[1L]],
+        src[[2L]],
+        tgt[[1L]],
+        tgt[[2L]],
+        as.numeric(weight)
+      )
       invisible(self)
     },
 
@@ -409,10 +497,17 @@ InfomapClass <- R6::R6Class(
     #' @param source_node_id Source node id.
     #' @param target_node_id Target node id.
     #' @param weight Link weight.
-    add_multilayer_intra_link = function(layer_id, source_node_id, target_node_id, weight = 1.0) {
+    add_multilayer_intra_link = function(
+      layer_id,
+      source_node_id,
+      target_node_id,
+      weight = 1.0
+    ) {
       private$.swig$addMultilayerIntraLink(
-        as.integer(layer_id), as.integer(source_node_id),
-        as.integer(target_node_id), as.numeric(weight)
+        as.integer(layer_id),
+        as.integer(source_node_id),
+        as.integer(target_node_id),
+        as.numeric(weight)
       )
       invisible(self)
     },
@@ -454,7 +549,10 @@ InfomapClass <- R6::R6Class(
       }
 
       private$.swig$addMultilayerIntraLinks(
-        as.integer(layers), as.integer(sources), as.integer(targets), as.numeric(weights)
+        as.integer(layers),
+        as.integer(sources),
+        as.integer(targets),
+        as.numeric(weights)
       )
       invisible(self)
     },
@@ -464,10 +562,17 @@ InfomapClass <- R6::R6Class(
     #' @param node_id Physical node id (same in both layers).
     #' @param target_layer_id Target layer id.
     #' @param weight Link weight.
-    add_multilayer_inter_link = function(source_layer_id, node_id, target_layer_id, weight = 1.0) {
+    add_multilayer_inter_link = function(
+      source_layer_id,
+      node_id,
+      target_layer_id,
+      weight = 1.0
+    ) {
       private$.swig$addMultilayerInterLink(
-        as.integer(source_layer_id), as.integer(node_id),
-        as.integer(target_layer_id), as.numeric(weight)
+        as.integer(source_layer_id),
+        as.integer(node_id),
+        as.integer(target_layer_id),
+        as.numeric(weight)
       )
       invisible(self)
     },
@@ -509,8 +614,10 @@ InfomapClass <- R6::R6Class(
       }
 
       private$.swig$addMultilayerInterLinks(
-        as.integer(source_layers), as.integer(nodes),
-        as.integer(target_layers), as.numeric(weights)
+        as.integer(source_layers),
+        as.integer(nodes),
+        as.integer(target_layers),
+        as.numeric(weights)
       )
       invisible(self)
     },
@@ -546,22 +653,38 @@ InfomapClass <- R6::R6Class(
 
         source_layers <- vapply(
           links,
-          function(entry) .network_input_multilayer_node_value(entry[[1L]], "source layer", 1L),
+          function(entry) {
+            .network_input_multilayer_node_value(
+              entry[[1L]],
+              "source layer",
+              1L
+            )
+          },
           numeric(1L)
         )
         source_nodes <- vapply(
           links,
-          function(entry) .network_input_multilayer_node_value(entry[[1L]], "source node", 2L),
+          function(entry) {
+            .network_input_multilayer_node_value(entry[[1L]], "source node", 2L)
+          },
           numeric(1L)
         )
         target_layers <- vapply(
           links,
-          function(entry) .network_input_multilayer_node_value(entry[[2L]], "target layer", 1L),
+          function(entry) {
+            .network_input_multilayer_node_value(
+              entry[[2L]],
+              "target layer",
+              1L
+            )
+          },
           numeric(1L)
         )
         target_nodes <- vapply(
           links,
-          function(entry) .network_input_multilayer_node_value(entry[[2L]], "target node", 2L),
+          function(entry) {
+            .network_input_multilayer_node_value(entry[[2L]], "target node", 2L)
+          },
           numeric(1L)
         )
         weights <- vapply(
@@ -580,8 +703,11 @@ InfomapClass <- R6::R6Class(
       }
 
       private$.swig$addMultilayerLinks(
-        as.integer(source_layers), as.integer(source_nodes),
-        as.integer(target_layers), as.integer(target_nodes), as.numeric(weights)
+        as.integer(source_layers),
+        as.integer(source_nodes),
+        as.integer(target_layers),
+        as.integer(target_nodes),
+        as.numeric(weights)
       )
       invisible(self)
     },
@@ -590,7 +716,10 @@ InfomapClass <- R6::R6Class(
     #' @param node_id Integer node id.
     #' @param meta_category Integer meta category.
     set_meta_data = function(node_id, meta_category) {
-      private$.swig$network()$addMetaData(as.integer(node_id), as.integer(meta_category))
+      private$.swig$network()$addMetaData(
+        as.integer(node_id),
+        as.integer(meta_category)
+      )
       invisible(self)
     },
 
@@ -607,15 +736,20 @@ InfomapClass <- R6::R6Class(
       if (is.null(opts)) {
         opts <- do.call(infomap_options, overrides)
       } else if (length(overrides) > 0L) {
-        for (name in names(overrides)) opts[[name]] <- overrides[[name]]
+        for (name in names(overrides)) {
+          opts[[name]] <- overrides[[name]]
+        }
       }
       # Mirror Python: if add_igraph() saw a directed graph and the user
       # never set a flow model (at construction or here, in opts or args),
       # treat the network as directed.
-      if (isTRUE(private$.directed_from_igraph) &&
+      if (
+        isTRUE(private$.directed_from_igraph) &&
           !private$.flow_model_set &&
-          is.null(opts$flow_model) && is.null(opts$directed) &&
-          !.flow_model_in_args(args)) {
+          is.null(opts$flow_model) &&
+          is.null(opts$directed) &&
+          !.flow_model_in_args(args)
+      ) {
         opts$directed <- TRUE
       }
       cli <- construct_args(args, opts)
@@ -683,11 +817,13 @@ InfomapClass <- R6::R6Class(
     #'   networks with non-numeric `phys_id` labels, the returned vector has
     #'   a `"phys_id"` attribute mapping internal physical ids to original
     #'   labels. Useful for joining Infomap results back to the original graph.
-    add_igraph = function(g,
-                          weight = "weight",
-                          phys_id = "phys_id",
-                          layer_id = "layer_id",
-                          multilayer_inter_intra_format = TRUE) {
+    add_igraph = function(
+      g,
+      weight = "weight",
+      phys_id = "phys_id",
+      layer_id = "layer_id",
+      multilayer_inter_intra_format = TRUE
+    ) {
       if (!requireNamespace("igraph", quietly = TRUE)) {
         stop(
           "The 'igraph' package is required for add_igraph(). ",
@@ -700,8 +836,10 @@ InfomapClass <- R6::R6Class(
       }
 
       is_directed <- igraph::is_directed(g)
-      has_phys <- length(phys_id) == 1L && phys_id %in% igraph::vertex_attr_names(g)
-      has_layer <- length(layer_id) == 1L && layer_id %in% igraph::vertex_attr_names(g)
+      has_phys <- length(phys_id) == 1L &&
+        phys_id %in% igraph::vertex_attr_names(g)
+      has_layer <- length(layer_id) == 1L &&
+        layer_id %in% igraph::vertex_attr_names(g)
 
       vertex_names <- igraph::V(g)$name
       if (is.null(vertex_names)) {
@@ -758,7 +896,9 @@ InfomapClass <- R6::R6Class(
             intra_targets <- edge_targets[same_layer]
             self$add_multilayer_intra_links(
               cbind(
-                layers[intra_sources], phys[intra_sources], phys[intra_targets],
+                layers[intra_sources],
+                phys[intra_sources],
+                phys[intra_targets],
                 weights[same_layer]
               )
             )
@@ -768,7 +908,9 @@ InfomapClass <- R6::R6Class(
             inter_targets <- edge_targets[!same_layer]
             self$add_multilayer_inter_links(
               cbind(
-                layers[inter_sources], phys[inter_sources], layers[inter_targets],
+                layers[inter_sources],
+                phys[inter_sources],
+                layers[inter_targets],
                 weights[!same_layer]
               )
             )
@@ -777,7 +919,11 @@ InfomapClass <- R6::R6Class(
           for (e in seq_len(nrow(edges))) {
             s <- edges[e, 1L]
             t <- edges[e, 2L]
-            self$add_multilayer_link(c(layers[s], phys[s]), c(layers[t], phys[t]), weights[e])
+            self$add_multilayer_link(
+              c(layers[s], phys[s]),
+              c(layers[t], phys[t]),
+              weights[e]
+            )
           }
         }
       } else if (has_phys) {
@@ -818,8 +964,10 @@ InfomapClass <- R6::R6Class(
       if (!inherits(g, "igraph")) {
         stop("`g` must be an igraph graph.", call. = FALSE)
       }
-      if (!is.null(private$.igraph_vcount) &&
-          igraph::vcount(g) != private$.igraph_vcount) {
+      if (
+        !is.null(private$.igraph_vcount) &&
+          igraph::vcount(g) != private$.igraph_vcount
+      ) {
         stop(
           "`g` must be the same igraph graph passed to add_igraph().",
           call. = FALSE
@@ -847,7 +995,7 @@ InfomapClass <- R6::R6Class(
       igraph::make_clusters(
         g,
         membership = membership,
-        algorithm  = "Infomap",
+        algorithm = "Infomap",
         modularity = FALSE
       )
     },
@@ -880,7 +1028,9 @@ InfomapClass <- R6::R6Class(
       while (!it$isEnd()) {
         if (it$isLeaf()) {
           i <- i + 1L
-          ids[i] <- as.integer(if (isTRUE(states)) it$stateId else it$physicalId)
+          ids[i] <- as.integer(
+            if (isTRUE(states)) it$stateId else it$physicalId
+          )
           modules[i] <- as.integer(it$moduleId())
         }
         it$stepForward()
@@ -900,7 +1050,9 @@ InfomapClass <- R6::R6Class(
       if (depth < 1L) {
         return(structure(list(), names = character()))
       }
-      per_level <- lapply(seq_len(depth), function(d) self$get_modules(d, states))
+      per_level <- lapply(seq_len(depth), function(d) {
+        self$get_modules(d, states)
+      })
       ids <- names(per_level[[1L]])
       out <- lapply(ids, function(id) {
         vapply(per_level, function(m) m[[id]], integer(1L))
@@ -941,12 +1093,14 @@ InfomapClass <- R6::R6Class(
         it$stepForward()
       }
       out <- list(
-        state_id  = state_id[seq_len(i)],
-        node_id   = node_id[seq_len(i)],
+        state_id = state_id[seq_len(i)],
+        node_id = node_id[seq_len(i)],
         module_id = module_id[seq_len(i)],
-        flow      = flow[seq_len(i)]
+        flow = flow[seq_len(i)]
       )
-      if (has_layer) out$layer_id <- layer_id[seq_len(i)]
+      if (has_layer) {
+        out$layer_id <- layer_id[seq_len(i)]
+      }
       out
     },
 
@@ -990,7 +1144,9 @@ InfomapClass <- R6::R6Class(
     #' @return Character (or `default`).
     get_name = function(node_id, default = NULL) {
       name <- private$.swig$getName(as.integer(node_id))
-      if (identical(name, "")) return(default)
+      if (identical(name, "")) {
+        return(default)
+      }
       name
     },
 
@@ -1001,10 +1157,14 @@ InfomapClass <- R6::R6Class(
       # and ask for each name individually.
       ids <- self$get_nodes(depth_level = 1L, states = TRUE)$node_id
       ids <- unique(ids)
-      out <- vapply(ids, function(id) {
-        name <- private$.swig$getName(as.integer(id))
-        if (is.null(name)) "" else name
-      }, character(1L))
+      out <- vapply(
+        ids,
+        function(id) {
+          name <- private$.swig$getName(as.integer(id))
+          if (is.null(name)) "" else name
+        },
+        character(1L)
+      )
       names(out) <- as.character(ids)
       out[nzchar(out)]
     },
@@ -1018,7 +1178,11 @@ InfomapClass <- R6::R6Class(
     #' @param states Whether to write state ids (default `FALSE`).
     #' @param depth_level Tree depth used for the module id.
     write_clu = function(filename, states = FALSE, depth_level = 1L) {
-      private$.swig$writeClu(as.character(filename), as.logical(states), as.integer(depth_level))
+      private$.swig$writeClu(
+        as.character(filename),
+        as.logical(states),
+        as.integer(depth_level)
+      )
       invisible(filename)
     },
 
@@ -1066,7 +1230,10 @@ InfomapClass <- R6::R6Class(
     #' @param filename Output path.
     #' @param flow Whether to write computed flow values per link.
     write_pajek = function(filename, flow = FALSE) {
-      private$.swig$network()$writePajekNetwork(as.character(filename), as.logical(flow))
+      private$.swig$network()$writePajekNetwork(
+        as.character(filename),
+        as.logical(flow)
+      )
       invisible(filename)
     },
 
@@ -1084,10 +1251,11 @@ InfomapClass <- R6::R6Class(
     #' @param ... Forwarded to the chosen writer.
     write = function(filename, ...) {
       ext <- tolower(tools::file_ext(filename))
-      ext <- switch(ext,
+      ext <- switch(
+        ext,
         "ftree" = "flow_tree",
-        "nwk"   = "newick",
-        "net"   = "pajek",
+        "nwk" = "newick",
+        "net" = "pajek",
         ext
       )
       method_name <- paste0("write_", ext)
@@ -1108,15 +1276,21 @@ InfomapClass <- R6::R6Class(
     codelengths = function() {
       v <- private$.swig$codelengths()
       n <- v$size()
-      if (n == 0L) return(numeric(0L))
-      vapply(seq_len(n) - 1L,
-             function(i) v$"__getitem__"(as.integer(i)),
-             numeric(1L))
+      if (n == 0L) {
+        return(numeric(0L))
+      }
+      vapply(
+        seq_len(n) - 1L,
+        function(i) v$"__getitem__"(as.integer(i)),
+        numeric(1L)
+      )
     },
     #' @field num_top_modules Number of top modules in the tree.
     num_top_modules = function() private$.swig$numTopModules(),
     #' @field num_non_trivial_top_modules Number of non-trivial top modules.
-    num_non_trivial_top_modules = function() private$.swig$numNonTrivialTopModules(),
+    num_non_trivial_top_modules = function() {
+      private$.swig$numNonTrivialTopModules()
+    },
     #' @field num_levels Number of levels in the tree.
     num_levels = function() private$.swig$numLevels(),
     #' @field max_tree_depth Maximum depth of the tree.
@@ -1136,19 +1310,26 @@ InfomapClass <- R6::R6Class(
     #' @field module_codelength Module codelength (within-module part).
     module_codelength = function() private$.swig$getModuleCodelength(),
     #' @field hierarchical_codelength Hierarchical codelength.
-    hierarchical_codelength = function() private$.swig$getHierarchicalCodelength(),
+    hierarchical_codelength = function() {
+      private$.swig$getHierarchicalCodelength()
+    },
     #' @field one_level_codelength One-level codelength baseline.
     one_level_codelength = function() private$.swig$getOneLevelCodelength(),
     #' @field relative_codelength_savings Relative codelength savings.
-    relative_codelength_savings = function() private$.swig$getRelativeCodelengthSavings(),
+    relative_codelength_savings = function() {
+      private$.swig$getRelativeCodelengthSavings()
+    },
     #' @field entropy_rate Entropy rate of the network.
     entropy_rate = function() private$.swig$getEntropyRate(),
     #' @field max_entropy Maximum possible entropy.
     max_entropy = function() private$.swig$getMaxEntropy(),
     #' @field bipartite_start_id Get or set the bipartite start id.
     bipartite_start_id = function(value) {
-      if (missing(value)) self$get_bipartite_start_id()
-      else self$set_bipartite_start_id(value)
+      if (missing(value)) {
+        self$get_bipartite_start_id()
+      } else {
+        self$set_bipartite_start_id(value)
+      }
     },
     #' @field modules Top-level module assignment per node (named integer vector).
     modules = function() {
@@ -1199,7 +1380,9 @@ InfomapClass <- R6::R6Class(
 # greedily on -d), but covers the relevant flags. Used to avoid
 # overriding user-supplied flags when add_igraph() sees a directed graph.
 .flow_model_in_args <- function(args) {
-  if (is.null(args) || !nzchar(args)) return(FALSE)
+  if (is.null(args) || !nzchar(args)) {
+    return(FALSE)
+  }
   grepl("(^|\\s)(--directed|-d\\b|--flow-model|-f\\b)", args)
 }
 
@@ -1229,14 +1412,20 @@ InfomapClass <- R6::R6Class(
     stop("`weight` edge attribute must be numeric.", call. = FALSE)
   }
   if (anyNA(weights)) {
-    stop("`weight` edge attribute cannot contain missing values.", call. = FALSE)
+    stop(
+      "`weight` edge attribute cannot contain missing values.",
+      call. = FALSE
+    )
   }
   as.numeric(weights)
 }
 
 .map_igraph_phys_ids <- function(values) {
   if (anyNA(values)) {
-    stop("`phys_id` vertex attribute cannot contain missing values.", call. = FALSE)
+    stop(
+      "`phys_id` vertex attribute cannot contain missing values.",
+      call. = FALSE
+    )
   }
 
   if (is.numeric(values)) {
@@ -1252,11 +1441,17 @@ InfomapClass <- R6::R6Class(
 
   labels <- as.character(values)
   if (anyNA(labels)) {
-    stop("`phys_id` vertex attribute cannot contain missing values.", call. = FALSE)
+    stop(
+      "`phys_id` vertex attribute cannot contain missing values.",
+      call. = FALSE
+    )
   }
 
   unique_labels <- unique(labels)
   ids <- match(labels, unique_labels)
-  mapping <- stats::setNames(unique_labels, as.character(seq_along(unique_labels)))
+  mapping <- stats::setNames(
+    unique_labels,
+    as.character(seq_along(unique_labels))
+  )
   list(ids = as.integer(ids), mapping = mapping)
 }

--- a/interfaces/R/infomap/R/as_data_frame.R
+++ b/interfaces/R/infomap/R/as_data_frame.R
@@ -26,28 +26,37 @@
 #' im$run()
 #' as.data.frame(im)
 #' @export
-as.data.frame.Infomap <- function(x,
-                                  row.names = NULL,
-                                  optional = FALSE,
-                                  states = TRUE,
-                                  depth_level = 1L,
-                                  tibble = FALSE,
-                                  ...) {
-  raw <- x$get_nodes(depth_level = as.integer(depth_level), states = isTRUE(states))
+as.data.frame.Infomap <- function(
+  x,
+  row.names = NULL,
+  optional = FALSE,
+  states = TRUE,
+  depth_level = 1L,
+  tibble = FALSE,
+  ...
+) {
+  raw <- x$get_nodes(
+    depth_level = as.integer(depth_level),
+    states = isTRUE(states)
+  )
   df <- data.frame(
-    state_id  = raw$state_id,
-    node_id   = raw$node_id,
+    state_id = raw$state_id,
+    node_id = raw$node_id,
     module_id = raw$module_id,
-    flow      = raw$flow,
+    flow = raw$flow,
     stringsAsFactors = FALSE
   )
   if (!is.null(raw$layer_id)) {
     df$layer_id <- raw$layer_id
   }
-  df$name <- vapply(raw$node_id, function(id) {
-    nm <- x$get_name(id, default = NA_character_)
-    if (is.null(nm) || is.na(nm)) NA_character_ else as.character(nm)
-  }, character(1L))
+  df$name <- vapply(
+    raw$node_id,
+    function(id) {
+      nm <- x$get_name(id, default = NA_character_)
+      if (is.null(nm) || is.na(nm)) NA_character_ else as.character(nm)
+    },
+    character(1L)
+  )
 
   if (isTRUE(tibble)) {
     if (!requireNamespace("tibble", quietly = TRUE)) {

--- a/interfaces/R/infomap/R/cluster_infomap.R
+++ b/interfaces/R/infomap/R/cluster_infomap.R
@@ -50,15 +50,17 @@
 #' result$modules
 #' as.data.frame(result)
 #' @export
-cluster_infomap <- function(edges,
-                            weight = NULL,
-                            e.weights = NULL,
-                            v.weights = NULL,
-                            nb.trials = NULL,
-                            args = NULL,
-                            opts = NULL,
-                            tibble = FALSE,
-                            ...) {
+cluster_infomap <- function(
+  edges,
+  weight = NULL,
+  e.weights = NULL,
+  v.weights = NULL,
+  nb.trials = NULL,
+  args = NULL,
+  opts = NULL,
+  tibble = FALSE,
+  ...
+) {
   call_options <- list(...)
   if (!is.null(e.weights)) {
     if (!is.null(weight)) {
@@ -141,10 +143,12 @@ summary.infomap_result <- function(object, ...) {
 #' @rdname cluster_infomap
 #' @method as.data.frame infomap_result
 #' @export
-as.data.frame.infomap_result <- function(x,
-                                         row.names = NULL,
-                                         optional = FALSE,
-                                         ...) {
+as.data.frame.infomap_result <- function(
+  x,
+  row.names = NULL,
+  optional = FALSE,
+  ...
+) {
   x$nodes
 }
 
@@ -218,12 +222,14 @@ as.data.frame.infomap_result <- function(x,
 #' result <- cluster_infomap_multilayer(edges, silent = TRUE, num_trials = 3)
 #' result$num_top_modules
 #' @export
-cluster_infomap_multilayer <- function(multilayer_edges,
-                                       weight = NULL,
-                                       args = NULL,
-                                       opts = NULL,
-                                       tibble = FALSE,
-                                       ...) {
+cluster_infomap_multilayer <- function(
+  multilayer_edges,
+  weight = NULL,
+  args = NULL,
+  opts = NULL,
+  tibble = FALSE,
+  ...
+) {
   call_options <- list(...)
   im <- do.call(Infomap, c(list(args = args, opts = opts), call_options))
   .add_multilayer_input(im, multilayer_edges, weight)
@@ -309,7 +315,11 @@ as_communities.infomap_result <- function(x, graph, ...) {
     while (edge_weight_attr %in% igraph::edge_attr_names(graph)) {
       edge_weight_attr <- paste0(".", edge_weight_attr)
     }
-    graph <- igraph::set_edge_attr(graph, edge_weight_attr, value = igraph_weight)
+    graph <- igraph::set_edge_attr(
+      graph,
+      edge_weight_attr,
+      value = igraph_weight
+    )
     igraph_weight <- edge_weight_attr
   }
   im$add_igraph(graph, weight = igraph_weight)
@@ -317,19 +327,31 @@ as_communities.infomap_result <- function(x, graph, ...) {
 
 .normalize_edge_list <- function(edges, weight) {
   if (!is.data.frame(edges) && !is.matrix(edges)) {
-    stop("`edges` must be a data.frame, matrix, or igraph graph.", call. = FALSE)
+    stop(
+      "`edges` must be a data.frame, matrix, or igraph graph.",
+      call. = FALSE
+    )
   }
   if (ncol(edges) < 2L) {
-    stop("`edges` must have at least two columns (source, target).", call. = FALSE)
+    stop(
+      "`edges` must have at least two columns (source, target).",
+      call. = FALSE
+    )
   }
 
   source <- if (is.matrix(edges)) edges[, 1L] else edges[[1L]]
   target <- if (is.matrix(edges)) edges[, 2L] else edges[[2L]]
   if (!is.numeric(source) || !is.numeric(target)) {
-    stop("`edges` source/target columns must be numeric/integer.", call. = FALSE)
+    stop(
+      "`edges` source/target columns must be numeric/integer.",
+      call. = FALSE
+    )
   }
   if (anyNA(source) || anyNA(target)) {
-    stop("`edges` source/target columns cannot contain missing values.", call. = FALSE)
+    stop(
+      "`edges` source/target columns cannot contain missing values.",
+      call. = FALSE
+    )
   }
 
   weight_values <- .edge_weights(edges, weight)
@@ -374,16 +396,21 @@ as_communities.infomap_result <- function(x, graph, ...) {
     return(if (is.matrix(edges)) edges[, index] else edges[[index]])
   }
 
-  stop("`weight` must be NULL, FALSE, a column name, or a column index.", call. = FALSE)
+  stop(
+    "`weight` must be NULL, FALSE, a column name, or a column index.",
+    call. = FALSE
+  )
 }
 
-.MULTILAYER_FULL_COLS  <- c("layer_from", "node_from", "layer_to", "node_to")
+.MULTILAYER_FULL_COLS <- c("layer_from", "node_from", "layer_to", "node_to")
 .MULTILAYER_INTRA_COLS <- c("layer", "node_from", "node_to")
 
 .add_multilayer_input <- function(im, edges, weight) {
   if (!is.data.frame(edges) && !is.matrix(edges)) {
-    stop("`multilayer_edges` must be a data.frame, tibble, or matrix.",
-         call. = FALSE)
+    stop(
+      "`multilayer_edges` must be a data.frame, tibble, or matrix.",
+      call. = FALSE
+    )
   }
   if (nrow(edges) == 0L) {
     stop("`multilayer_edges` must have at least one row.", call. = FALSE)
@@ -403,8 +430,12 @@ as_communities.infomap_result <- function(x, graph, ...) {
 .detect_multilayer_format <- function(edges) {
   if (is.matrix(edges)) {
     nc <- ncol(edges)
-    if (nc == 3L) return("intra")
-    if (nc %in% c(4L, 5L)) return("full")
+    if (nc == 3L) {
+      return("intra")
+    }
+    if (nc %in% c(4L, 5L)) {
+      return("full")
+    }
     stop(
       "Multilayer matrix input must have 3 columns ",
       "(layer, node_from, node_to) for unweighted intra-layer links or ",
@@ -416,12 +447,16 @@ as_communities.infomap_result <- function(x, graph, ...) {
   }
 
   cols <- names(edges)
-  has_full  <- all(.MULTILAYER_FULL_COLS  %in% cols)
+  has_full <- all(.MULTILAYER_FULL_COLS %in% cols)
   has_intra <- all(.MULTILAYER_INTRA_COLS %in% cols) &&
     !any(c("layer_from", "layer_to") %in% cols)
 
-  if (has_full)  return("full")
-  if (has_intra) return("intra")
+  if (has_full) {
+    return("full")
+  }
+  if (has_intra) {
+    return("intra")
+  }
 
   stop(
     "`multilayer_edges` must have either columns ",
@@ -435,50 +470,54 @@ as_communities.infomap_result <- function(x, graph, ...) {
 .normalize_multilayer_full <- function(edges, weight) {
   if (is.matrix(edges)) {
     layer_from <- edges[, 1L]
-    node_from  <- edges[, 2L]
-    layer_to   <- edges[, 3L]
-    node_to    <- edges[, 4L]
+    node_from <- edges[, 2L]
+    layer_to <- edges[, 3L]
+    node_to <- edges[, 4L]
     weights <- .multilayer_weights(edges, weight, default_index = 5L)
   } else {
     layer_from <- edges[["layer_from"]]
-    node_from  <- edges[["node_from"]]
-    layer_to   <- edges[["layer_to"]]
-    node_to    <- edges[["node_to"]]
+    node_from <- edges[["node_from"]]
+    layer_to <- edges[["layer_to"]]
+    node_to <- edges[["node_to"]]
     weights <- .multilayer_weights(
-      edges, weight,
+      edges,
+      weight,
       reserved = .MULTILAYER_FULL_COLS
     )
   }
 
   .check_multilayer_ids(
     list(
-      layer_from = layer_from, node_from = node_from,
-      layer_to = layer_to, node_to = node_to
+      layer_from = layer_from,
+      node_from = node_from,
+      layer_to = layer_to,
+      node_to = node_to
     )
   )
 
   data.frame(
     layer_from = layer_from,
-    node_from  = node_from,
-    layer_to   = layer_to,
-    node_to    = node_to,
-    weight     = as.numeric(weights),
+    node_from = node_from,
+    layer_to = layer_to,
+    node_to = node_to,
+    weight = as.numeric(weights),
     stringsAsFactors = FALSE
   )
 }
 
 .normalize_multilayer_intra <- function(edges, weight) {
   if (is.matrix(edges)) {
-    layer     <- edges[, 1L]
+    layer <- edges[, 1L]
     node_from <- edges[, 2L]
-    node_to   <- edges[, 3L]
+    node_to <- edges[, 3L]
     weights <- .multilayer_weights(edges, weight)
   } else {
-    layer     <- edges[["layer"]]
+    layer <- edges[["layer"]]
     node_from <- edges[["node_from"]]
-    node_to   <- edges[["node_to"]]
+    node_to <- edges[["node_to"]]
     weights <- .multilayer_weights(
-      edges, weight,
+      edges,
+      weight,
       reserved = .MULTILAYER_INTRA_COLS
     )
   }
@@ -488,10 +527,10 @@ as_communities.infomap_result <- function(x, graph, ...) {
   )
 
   data.frame(
-    layer     = layer,
+    layer = layer,
     node_from = node_from,
-    node_to   = node_to,
-    weight    = as.numeric(weights),
+    node_to = node_to,
+    weight = as.numeric(weights),
     stringsAsFactors = FALSE
   )
 }
@@ -508,9 +547,12 @@ as_communities.infomap_result <- function(x, graph, ...) {
   }
 }
 
-.multilayer_weights <- function(edges, weight,
-                                reserved = NULL,
-                                default_index = NULL) {
+.multilayer_weights <- function(
+  edges,
+  weight,
+  reserved = NULL,
+  default_index = NULL
+) {
   n <- nrow(edges)
 
   if (identical(weight, FALSE)) {
@@ -522,8 +564,11 @@ as_communities.infomap_result <- function(x, graph, ...) {
     # else fall back to a trailing positional column on matrices.
     if (is.data.frame(edges) && "weight" %in% names(edges)) {
       w <- edges[["weight"]]
-    } else if (is.matrix(edges) && !is.null(default_index) &&
-               ncol(edges) >= default_index) {
+    } else if (
+      is.matrix(edges) &&
+        !is.null(default_index) &&
+        ncol(edges) >= default_index
+    ) {
       w <- edges[, default_index]
     } else if (is.data.frame(edges) && !is.null(reserved)) {
       extras <- setdiff(names(edges), reserved)
@@ -535,8 +580,9 @@ as_communities.infomap_result <- function(x, graph, ...) {
     } else {
       return(rep(1.0, n))
     }
-  } else if (is.character(weight) && length(weight) == 1L &&
-             is.data.frame(edges)) {
+  } else if (
+    is.character(weight) && length(weight) == 1L && is.data.frame(edges)
+  ) {
     if (!weight %in% names(edges)) {
       stop("`weight` column not found in `multilayer_edges`.", call. = FALSE)
     }

--- a/interfaces/R/infomap/R/helpers.R
+++ b/interfaces/R/infomap/R/helpers.R
@@ -15,7 +15,7 @@ entropy <- function(p) {
 
 #' @noRd
 perplexity <- function(p) {
-  2 ^ entropy(p)
+  2^entropy(p)
 }
 
 # Top-level helpers exported alongside the Infomap class.
@@ -53,7 +53,9 @@ multilayer_node <- function(layer_id, node_id) {
 #' @return Invisibly returns the resulting `Infomap` instance.
 #' @export
 main <- function(args = NULL) {
-  if (is.null(args)) args <- commandArgs(trailingOnly = TRUE)
+  if (is.null(args)) {
+    args <- commandArgs(trailingOnly = TRUE)
+  }
   args <- as.character(args)
   cli <- paste(shQuote(args), collapse = " ")
   im <- Infomap(args = cli)

--- a/interfaces/R/infomap/R/swig_delete_aliases.R
+++ b/interfaces/R/infomap/R/swig_delete_aliases.R
@@ -3,7 +3,9 @@
 # hand-written R code so R CMD check can resolve the methods statically.
 delete_infomap__Config <- function(obj) delete_Config(obj)
 delete_infomap__DeltaFlow <- function(obj) delete_DeltaFlow(obj)
-delete_infomap__detail__PartitionQueue <- function(obj) delete_PartitionQueue(obj)
+delete_infomap__detail__PartitionQueue <- function(obj) {
+  delete_PartitionQueue(obj)
+}
 delete_infomap__detail__PerLevelStat <- function(obj) delete_PerLevelStat(obj)
 delete_infomap__EdgeData <- function(obj) delete_EdgeData(obj)
 delete_infomap__FlowData <- function(obj) delete_FlowData(obj)
@@ -11,14 +13,28 @@ delete_infomap__FlowModel <- function(obj) delete_FlowModel(obj)
 delete_infomap__InfoEdge <- function(obj) delete_InfoEdge(obj)
 delete_infomap__LinkResult <- function(obj) delete_LinkResult(obj)
 delete_infomap__InfomapBase <- function(obj) delete_InfomapBase(obj)
-delete_infomap__InfomapConfigT_infomap__InfomapBase_t <- function(obj) delete_InfomapConfigInfomapBase(obj)
+delete_infomap__InfomapConfigT_infomap__InfomapBase_t <- function(obj) {
+  delete_InfomapConfigInfomapBase(obj)
+}
 delete_infomap__InfomapIterator <- function(obj) delete_InfomapIterator(obj)
-delete_infomap__InfomapIteratorPhysical <- function(obj) delete_InfomapIteratorPhysical(obj)
-delete_infomap__InfomapLeafIterator <- function(obj) delete_InfomapLeafIterator(obj)
-delete_infomap__InfomapLeafIteratorPhysical <- function(obj) delete_InfomapLeafIteratorPhysical(obj)
-delete_infomap__InfomapLeafModuleIterator <- function(obj) delete_InfomapLeafModuleIterator(obj)
-delete_infomap__InfomapModuleIterator <- function(obj) delete_InfomapModuleIterator(obj)
-delete_infomap__InfomapParentIterator <- function(obj) delete_InfomapParentIterator(obj)
+delete_infomap__InfomapIteratorPhysical <- function(obj) {
+  delete_InfomapIteratorPhysical(obj)
+}
+delete_infomap__InfomapLeafIterator <- function(obj) {
+  delete_InfomapLeafIterator(obj)
+}
+delete_infomap__InfomapLeafIteratorPhysical <- function(obj) {
+  delete_InfomapLeafIteratorPhysical(obj)
+}
+delete_infomap__InfomapLeafModuleIterator <- function(obj) {
+  delete_InfomapLeafModuleIterator(obj)
+}
+delete_infomap__InfomapModuleIterator <- function(obj) {
+  delete_InfomapModuleIterator(obj)
+}
+delete_infomap__InfomapParentIterator <- function(obj) {
+  delete_InfomapParentIterator(obj)
+}
 delete_infomap__InfomapWrapper <- function(obj) delete_InfomapWrapper(obj)
 delete_infomap__InfoNode <- function(obj) delete_InfoNode(obj)
 delete_infomap__LayerNode <- function(obj) delete_LayerNode(obj)
@@ -27,11 +43,27 @@ delete_infomap__Network <- function(obj) delete_Network(obj)
 delete_infomap__PhysData <- function(obj) delete_PhysData(obj)
 delete_infomap__StateNetwork <- function(obj) delete_StateNetwork(obj)
 delete_std__dequeT_unsigned_int_t <- function(obj) delete_deque_uint(obj)
-delete_std__mapT_std__pairT_unsigned_int_unsigned_int_t_double_t <- function(obj) delete_map_pair_uint_uint_double(obj)
-delete_std__mapT_unsigned_int_std__string_t <- function(obj) delete_map_uint_string(obj)
-delete_std__mapT_unsigned_int_std__vectorT_unsigned_int_t_t <- function(obj) delete_map_uint_vector_uint(obj)
-delete_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t <- function(obj) delete_map_uint_uint(obj)
-delete_std__pairT_unsigned_int_unsigned_int_t <- function(obj) delete_pair_uint_uint(obj)
+delete_std__mapT_std__pairT_unsigned_int_unsigned_int_t_double_t <- function(
+  obj
+) {
+  delete_map_pair_uint_uint_double(obj)
+}
+delete_std__mapT_unsigned_int_std__string_t <- function(obj) {
+  delete_map_uint_string(obj)
+}
+delete_std__mapT_unsigned_int_std__vectorT_unsigned_int_t_t <- function(obj) {
+  delete_map_uint_vector_uint(obj)
+}
+delete_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t <- function(
+  obj
+) {
+  delete_map_uint_uint(obj)
+}
+delete_std__pairT_unsigned_int_unsigned_int_t <- function(obj) {
+  delete_pair_uint_uint(obj)
+}
 delete_std__vectorT_double_t <- function(obj) delete_vector_double(obj)
-delete_std__vectorT_infomap__LinkResult_t <- function(obj) delete_vector_link_result(obj)
+delete_std__vectorT_infomap__LinkResult_t <- function(obj) {
+  delete_vector_link_result(obj)
+}
 delete_std__vectorT_unsigned_int_t <- function(obj) delete_vector_uint(obj)

--- a/interfaces/R/infomap/tests/testthat/test-cluster-infomap.R
+++ b/interfaces/R/infomap/tests/testthat/test-cluster-infomap.R
@@ -4,7 +4,12 @@ test_that("cluster_infomap accepts data.frame edge lists", {
     target = c(2, 3, 3, 4, 5, 6, 6)
   )
 
-  result <- cluster_infomap(edges, silent = TRUE, num_trials = 5, two_level = TRUE)
+  result <- cluster_infomap(
+    edges,
+    silent = TRUE,
+    num_trials = 5,
+    two_level = TRUE
+  )
 
   expect_s3_class(result, "infomap_result")
   expect_s3_class(result$model, "Infomap")
@@ -19,17 +24,17 @@ test_that("cluster_infomap accepts data.frame edge lists", {
 
 test_that("cluster_infomap accepts matrix edge lists", {
   edges <- matrix(
-    c(1, 2,
-      1, 3,
-      2, 3,
-      4, 5,
-      4, 6,
-      5, 6),
+    c(1, 2, 1, 3, 2, 3, 4, 5, 4, 6, 5, 6),
     ncol = 2L,
     byrow = TRUE
   )
 
-  result <- cluster_infomap(edges, silent = TRUE, num_trials = 5, two_level = TRUE)
+  result <- cluster_infomap(
+    edges,
+    silent = TRUE,
+    num_trials = 5,
+    two_level = TRUE
+  )
 
   expect_s3_class(result, "infomap_result")
   expect_equal(result$num_nodes, 6L)
@@ -45,8 +50,18 @@ test_that("cluster_infomap accepts weighted edge lists", {
   )
 
   default_weight <- cluster_infomap(edges, silent = TRUE, two_level = TRUE)
-  named_weight <- cluster_infomap(edges, weight = "w", silent = TRUE, two_level = TRUE)
-  unweighted <- cluster_infomap(edges, weight = FALSE, silent = TRUE, two_level = TRUE)
+  named_weight <- cluster_infomap(
+    edges,
+    weight = "w",
+    silent = TRUE,
+    two_level = TRUE
+  )
+  unweighted <- cluster_infomap(
+    edges,
+    weight = FALSE,
+    silent = TRUE,
+    two_level = TRUE
+  )
 
   expect_equal(default_weight$num_links, 7L)
   expect_equal(named_weight$num_links, 7L)
@@ -69,11 +84,22 @@ test_that("infomap_result methods expose node table and summary", {
 test_that("cluster_infomap accepts igraph input", {
   skip_if_not_installed("igraph")
 
-  graph <- igraph::make_graph(c(1, 2, 1, 3, 2, 3, 4, 5, 4, 6, 5, 6), directed = FALSE)
-  result <- cluster_infomap(graph, silent = TRUE, nb.trials = 5, two_level = TRUE)
+  graph <- igraph::make_graph(
+    c(1, 2, 1, 3, 2, 3, 4, 5, 4, 6, 5, 6),
+    directed = FALSE
+  )
+  result <- cluster_infomap(
+    graph,
+    silent = TRUE,
+    nb.trials = 5,
+    two_level = TRUE
+  )
 
   expect_s3_class(result, "infomap_result")
-  expect_equal(names(result$mapping), as.character(seq_len(igraph::vcount(graph))))
+  expect_equal(
+    names(result$mapping),
+    as.character(seq_len(igraph::vcount(graph)))
+  )
   expect_setequal(result$nodes$node_id, seq_len(igraph::vcount(graph)))
 
   communities <- as_communities(result, graph)
@@ -120,17 +146,27 @@ test_that("cluster_infomap rejects conflicting or unsupported igraph-style alias
 })
 
 test_that("cluster_infomap rejects invalid edge-list inputs", {
-  expect_error(cluster_infomap(data.frame(source = 1), silent = TRUE), "at least two columns")
+  expect_error(
+    cluster_infomap(data.frame(source = 1), silent = TRUE),
+    "at least two columns"
+  )
   expect_error(
     cluster_infomap(data.frame(source = "a", target = "b"), silent = TRUE),
     "numeric/integer"
   )
   expect_error(
-    cluster_infomap(data.frame(source = 1, target = 2, w = "bad"), silent = TRUE),
+    cluster_infomap(
+      data.frame(source = 1, target = 2, w = "bad"),
+      silent = TRUE
+    ),
     "weight.*numeric"
   )
   expect_error(
-    cluster_infomap(data.frame(source = 1, target = 2), weight = "missing", silent = TRUE),
+    cluster_infomap(
+      data.frame(source = 1, target = 2),
+      weight = "missing",
+      silent = TRUE
+    ),
     "not found"
   )
 })

--- a/interfaces/R/infomap/tests/testthat/test-directed.R
+++ b/interfaces/R/infomap/tests/testthat/test-directed.R
@@ -23,8 +23,10 @@ test_that("directed and undirected runs produce different codelengths", {
 
 test_that("add_igraph propagates directed graphs to run() by default", {
   skip_if_not_installed("igraph")
-  g <- igraph::make_graph(c(1, 2, 2, 3, 3, 1, 3, 4, 4, 5, 5, 6, 6, 4),
-                          directed = TRUE)
+  g <- igraph::make_graph(
+    c(1, 2, 2, 3, 3, 1, 3, 4, 4, 5, 5, 6, 6, 4),
+    directed = TRUE
+  )
 
   im <- Infomap(silent = TRUE, num_trials = 3)
   im$add_igraph(g)

--- a/interfaces/R/infomap/tests/testthat/test-errors.R
+++ b/interfaces/R/infomap/tests/testthat/test-errors.R
@@ -10,8 +10,12 @@ test_that("add_links rejects character columns in a data.frame", {
 
 test_that("add_links rejects a non-numeric weight column", {
   im <- Infomap(silent = TRUE)
-  bad <- data.frame(s = c(1, 2), t = c(2, 3), w = c("a", "b"),
-                    stringsAsFactors = FALSE)
+  bad <- data.frame(
+    s = c(1, 2),
+    t = c(2, 3),
+    w = c("a", "b"),
+    stringsAsFactors = FALSE
+  )
   expect_error(im$add_links(bad), "weight column must be numeric")
 })
 
@@ -26,10 +30,22 @@ test_that("add_links rejects malformed list entries", {
   expect_error(im$add_links(list(c(1))), "2 or 3 values")
   expect_error(im$add_links(list(c(1, 2, 3, 4))), "2 or 3 values")
   expect_error(im$add_links(list(c("a", "b"))), "numeric/integer")
-  expect_error(im$add_links(list(list(1, 2, "bad"))), "weight values must be numeric")
-  expect_error(im$add_links(list(list(c(1, 2), 3))), "source value must be scalar")
-  expect_error(im$add_links(list(list(1, c(2, 3)))), "target value must be scalar")
-  expect_error(im$add_links(list(list(1, 2, c(3, 4)))), "weight value must be scalar")
+  expect_error(
+    im$add_links(list(list(1, 2, "bad"))),
+    "weight values must be numeric"
+  )
+  expect_error(
+    im$add_links(list(list(c(1, 2), 3))),
+    "source value must be scalar"
+  )
+  expect_error(
+    im$add_links(list(list(1, c(2, 3)))),
+    "target value must be scalar"
+  )
+  expect_error(
+    im$add_links(list(list(1, 2, c(3, 4)))),
+    "weight value must be scalar"
+  )
 })
 
 test_that("add_multilayer_links rejects malformed matrix/data.frame input", {
@@ -91,11 +107,20 @@ test_that("add_multilayer_intra_links rejects malformed matrix/data.frame input"
     "3 or 4 columns"
   )
   expect_error(
-    im$add_multilayer_intra_links(data.frame(layer = "x", source = 1, target = 2)),
+    im$add_multilayer_intra_links(data.frame(
+      layer = "x",
+      source = 1,
+      target = 2
+    )),
     "numeric/integer"
   )
   expect_error(
-    im$add_multilayer_intra_links(data.frame(layer = 1, source = 1, target = 2, weight = "bad")),
+    im$add_multilayer_intra_links(data.frame(
+      layer = 1,
+      source = 1,
+      target = 2,
+      weight = "bad"
+    )),
     "weight column must be numeric"
   )
 })
@@ -104,12 +129,18 @@ test_that("add_multilayer_intra_links rejects malformed list entries", {
   im <- Infomap(silent = TRUE)
 
   expect_error(im$add_multilayer_intra_links(list(c(1, 2))), "3 or 4 values")
-  expect_error(im$add_multilayer_intra_links(list(c(1, 2, 3, 4, 5))), "3 or 4 values")
+  expect_error(
+    im$add_multilayer_intra_links(list(c(1, 2, 3, 4, 5))),
+    "3 or 4 values"
+  )
   expect_error(
     im$add_multilayer_intra_links(list(list(c(1, 2), 2, 3))),
     "layer value must be scalar"
   )
-  expect_error(im$add_multilayer_intra_links(list(c("a", 2, 3))), "numeric/integer")
+  expect_error(
+    im$add_multilayer_intra_links(list(c("a", 2, 3))),
+    "numeric/integer"
+  )
   expect_error(
     im$add_multilayer_intra_links(list(list(1, 2, 3, c(1, 2)))),
     "weight value must be scalar"
@@ -128,11 +159,20 @@ test_that("add_multilayer_inter_links rejects malformed matrix/data.frame input"
     "3 or 4 columns"
   )
   expect_error(
-    im$add_multilayer_inter_links(data.frame(source_layer = "x", node = 1, target_layer = 2)),
+    im$add_multilayer_inter_links(data.frame(
+      source_layer = "x",
+      node = 1,
+      target_layer = 2
+    )),
     "numeric/integer"
   )
   expect_error(
-    im$add_multilayer_inter_links(data.frame(source_layer = 1, node = 1, target_layer = 2, weight = "bad")),
+    im$add_multilayer_inter_links(data.frame(
+      source_layer = 1,
+      node = 1,
+      target_layer = 2,
+      weight = "bad"
+    )),
     "weight column must be numeric"
   )
 })
@@ -141,12 +181,18 @@ test_that("add_multilayer_inter_links rejects malformed list entries", {
   im <- Infomap(silent = TRUE)
 
   expect_error(im$add_multilayer_inter_links(list(c(1, 2))), "3 or 4 values")
-  expect_error(im$add_multilayer_inter_links(list(c(1, 2, 3, 4, 5))), "3 or 4 values")
+  expect_error(
+    im$add_multilayer_inter_links(list(c(1, 2, 3, 4, 5))),
+    "3 or 4 values"
+  )
   expect_error(
     im$add_multilayer_inter_links(list(list(c(1, 2), 2, 3))),
     "source layer value must be scalar"
   )
-  expect_error(im$add_multilayer_inter_links(list(c("a", 2, 3))), "numeric/integer")
+  expect_error(
+    im$add_multilayer_inter_links(list(c("a", 2, 3))),
+    "numeric/integer"
+  )
   expect_error(
     im$add_multilayer_inter_links(list(list(1, 2, 3, c(1, 2)))),
     "weight value must be scalar"

--- a/interfaces/R/infomap/tests/testthat/test-igraph.R
+++ b/interfaces/R/infomap/tests/testthat/test-igraph.R
@@ -1,7 +1,10 @@
 test_that("add_igraph imports edges from an igraph graph", {
   skip_if_not_installed("igraph")
 
-  g <- igraph::make_graph(c(1, 2, 1, 3, 2, 3, 4, 5, 4, 6, 5, 6), directed = FALSE)
+  g <- igraph::make_graph(
+    c(1, 2, 1, 3, 2, 3, 4, 5, 4, 6, 5, 6),
+    directed = FALSE
+  )
 
   im <- Infomap(silent = TRUE, num_trials = 5)
   mapping <- im$add_igraph(g)
@@ -54,7 +57,10 @@ test_that("add_igraph rejects invalid igraph weights", {
 test_that("as_communities aligns membership with igraph vertex ids", {
   skip_if_not_installed("igraph")
 
-  g <- igraph::make_graph(c(1, 2, 1, 3, 2, 3, 4, 5, 4, 6, 5, 6), directed = FALSE)
+  g <- igraph::make_graph(
+    c(1, 2, 1, 3, 2, 3, 4, 5, 4, 6, 5, 6),
+    directed = FALSE
+  )
 
   im <- Infomap(silent = TRUE, num_trials = 5)
   im$add_igraph(g)

--- a/interfaces/R/infomap/tests/testthat/test-modules.R
+++ b/interfaces/R/infomap/tests/testthat/test-modules.R
@@ -1,6 +1,14 @@
 test_that("get_modules returns a named integer vector", {
   im <- Infomap(silent = TRUE, num_trials = 3)
-  im$add_links(list(c(1, 2), c(1, 3), c(2, 3), c(3, 4), c(4, 5), c(4, 6), c(5, 6)))
+  im$add_links(list(
+    c(1, 2),
+    c(1, 3),
+    c(2, 3),
+    c(3, 4),
+    c(4, 5),
+    c(4, 6),
+    c(5, 6)
+  ))
   im$run()
 
   m <- im$get_modules()
@@ -12,7 +20,15 @@ test_that("get_modules returns a named integer vector", {
 
 test_that("get_multilevel_modules returns a list of integer paths", {
   im <- Infomap(silent = TRUE, num_trials = 3)
-  im$add_links(list(c(1, 2), c(1, 3), c(2, 3), c(3, 4), c(4, 5), c(4, 6), c(5, 6)))
+  im$add_links(list(
+    c(1, 2),
+    c(1, 3),
+    c(2, 3),
+    c(3, 4),
+    c(4, 5),
+    c(4, 6),
+    c(5, 6)
+  ))
   im$run()
 
   ml <- im$get_multilevel_modules()

--- a/interfaces/R/infomap/tests/testthat/test-multilayer.R
+++ b/interfaces/R/infomap/tests/testthat/test-multilayer.R
@@ -8,7 +8,9 @@ test_that("multilayer intra/inter format clusters across layers", {
       im$add_multilayer_intra_link(layer, e[1], e[2], 1.0)
     }
   }
-  for (n in 1:3) im$add_multilayer_inter_link(1, n, 2, 1.0)
+  for (n in 1:3) {
+    im$add_multilayer_inter_link(1, n, 2, 1.0)
+  }
 
   im$run()
   expect_true(im$have_memory)
@@ -26,12 +28,18 @@ expect_same_multilayer_links <- function(actual, expected) {
 }
 
 intra_links <- list(
-  c(1, 1, 2, 1.0), c(1, 2, 3, 1.0), c(1, 3, 1, 1.0),
-  c(2, 1, 2, 2.0), c(2, 2, 3, 2.0), c(2, 3, 1, 2.0)
+  c(1, 1, 2, 1.0),
+  c(1, 2, 3, 1.0),
+  c(1, 3, 1, 1.0),
+  c(2, 1, 2, 2.0),
+  c(2, 2, 3, 2.0),
+  c(2, 3, 1, 2.0)
 )
 
 inter_links <- list(
-  c(1, 1, 2, 0.5), c(1, 2, 2, 0.5), c(1, 3, 2, 0.5)
+  c(1, 1, 2, 0.5),
+  c(1, 2, 2, 0.5),
+  c(1, 3, 2, 0.5)
 )
 
 expect_same_multilayer_run <- function(actual, expected) {
@@ -44,7 +52,12 @@ expect_same_multilayer_run <- function(actual, expected) {
 test_that("add_multilayer_intra_links list input matches repeated add_multilayer_intra_link", {
   baseline <- Infomap(silent = TRUE, num_trials = 1L, two_level = TRUE)
   for (link in intra_links) {
-    baseline$add_multilayer_intra_link(link[[1L]], link[[2L]], link[[3L]], link[[4L]])
+    baseline$add_multilayer_intra_link(
+      link[[1L]],
+      link[[2L]],
+      link[[3L]],
+      link[[4L]]
+    )
   }
 
   im <- Infomap(silent = TRUE, num_trials = 1L, two_level = TRUE)
@@ -58,7 +71,12 @@ test_that("add_multilayer_intra_links accepts matrix input", {
 
   baseline <- Infomap(silent = TRUE, num_trials = 1L, two_level = TRUE)
   for (i in seq_len(nrow(links))) {
-    baseline$add_multilayer_intra_link(links[i, 1], links[i, 2], links[i, 3], links[i, 4])
+    baseline$add_multilayer_intra_link(
+      links[i, 1],
+      links[i, 2],
+      links[i, 3],
+      links[i, 4]
+    )
   }
 
   im <- Infomap(silent = TRUE, num_trials = 1L, two_level = TRUE)
@@ -85,11 +103,21 @@ test_that("add_multilayer_inter_links list input matches repeated add_multilayer
   baseline <- Infomap(silent = TRUE, num_trials = 1L, two_level = TRUE)
   im <- Infomap(silent = TRUE, num_trials = 1L, two_level = TRUE)
   for (link in intra_links) {
-    baseline$add_multilayer_intra_link(link[[1L]], link[[2L]], link[[3L]], link[[4L]])
+    baseline$add_multilayer_intra_link(
+      link[[1L]],
+      link[[2L]],
+      link[[3L]],
+      link[[4L]]
+    )
     im$add_multilayer_intra_link(link[[1L]], link[[2L]], link[[3L]], link[[4L]])
   }
   for (link in inter_links) {
-    baseline$add_multilayer_inter_link(link[[1L]], link[[2L]], link[[3L]], link[[4L]])
+    baseline$add_multilayer_inter_link(
+      link[[1L]],
+      link[[2L]],
+      link[[3L]],
+      link[[4L]]
+    )
   }
   im$add_multilayer_inter_links(inter_links)
 
@@ -104,7 +132,12 @@ test_that("add_multilayer_inter_links accepts matrix input", {
   baseline$add_multilayer_intra_links(intra_links)
   im$add_multilayer_intra_links(intra_links)
   for (i in seq_len(nrow(links))) {
-    baseline$add_multilayer_inter_link(links[i, 1], links[i, 2], links[i, 3], links[i, 4])
+    baseline$add_multilayer_inter_link(
+      links[i, 1],
+      links[i, 2],
+      links[i, 3],
+      links[i, 4]
+    )
   }
   im$add_multilayer_inter_links(links)
 
@@ -153,9 +186,7 @@ test_that("add_multilayer_links list input matches repeated add_multilayer_link"
 
 test_that("add_multilayer_links accepts matrix input through bulk path", {
   links <- matrix(
-    c(1, 1, 1, 2, 2,
-      1, 2, 2, 1, 1,
-      2, 1, 2, 2, 3),
+    c(1, 1, 1, 2, 2, 1, 2, 2, 1, 1, 2, 1, 2, 2, 3),
     ncol = 5L,
     byrow = TRUE
   )
@@ -173,9 +204,7 @@ test_that("add_multilayer_links accepts matrix input through bulk path", {
 
 test_that("add_multilayer_links accepts unweighted matrix input", {
   links <- matrix(
-    c(1, 1, 1, 2,
-      1, 2, 2, 1,
-      2, 1, 2, 2),
+    c(1, 1, 1, 2, 1, 2, 2, 1, 2, 1, 2, 2),
     ncol = 4L,
     byrow = TRUE
   )
@@ -197,7 +226,7 @@ test_that("add_igraph rejects diagonal multilayer links by default", {
   # Build an igraph with vertex attrs phys_id and layer_id, with a single
   # diagonal edge between (layer=1, phys=1) and (layer=2, phys=2).
   g <- igraph::make_empty_graph(4, directed = FALSE)
-  g <- igraph::set_vertex_attr(g, "phys_id",  value = c(1, 2, 1, 2))
+  g <- igraph::set_vertex_attr(g, "phys_id", value = c(1, 2, 1, 2))
   g <- igraph::set_vertex_attr(g, "layer_id", value = c(1, 1, 2, 2))
   # Edge between vertex 1 (layer=1, phys=1) and vertex 4 (layer=2, phys=2)
   g <- igraph::add_edges(g, c(1, 4))
@@ -214,13 +243,31 @@ test_that("add_igraph accepts intra/inter-compatible multilayer links", {
   skip_if_not_installed("igraph")
 
   g <- igraph::make_empty_graph(6, directed = TRUE)
-  g <- igraph::set_vertex_attr(g, "phys_id",  value = c(1, 2, 3, 1, 2, 3))
+  g <- igraph::set_vertex_attr(g, "phys_id", value = c(1, 2, 3, 1, 2, 3))
   g <- igraph::set_vertex_attr(g, "layer_id", value = c(1, 1, 1, 2, 2, 2))
-  g <- igraph::add_edges(g, c(
-    1, 2, 2, 3, 3, 1,
-    4, 5, 5, 6, 6, 4,
-    1, 4, 2, 5, 3, 6
-  ))
+  g <- igraph::add_edges(
+    g,
+    c(
+      1,
+      2,
+      2,
+      3,
+      3,
+      1,
+      4,
+      5,
+      5,
+      6,
+      6,
+      4,
+      1,
+      4,
+      2,
+      5,
+      3,
+      6
+    )
+  )
 
   im <- Infomap(silent = TRUE, num_trials = 1L, two_level = TRUE)
   expect_silent(im$add_igraph(g, multilayer_inter_intra_format = TRUE))
@@ -232,22 +279,26 @@ test_that("add_igraph accepts intra/inter-compatible multilayer links", {
 
 test_that("cluster_infomap_multilayer matches R6 path on intra-layer-only data.frame", {
   edges <- data.frame(
-    layer     = c(1, 1, 1, 2, 2, 2),
+    layer = c(1, 1, 1, 2, 2, 2),
     node_from = c(1, 2, 3, 1, 2, 3),
-    node_to   = c(2, 3, 1, 2, 3, 1)
+    node_to = c(2, 3, 1, 2, 3, 1)
   )
 
   baseline <- Infomap(silent = TRUE, num_trials = 1L, two_level = TRUE)
   for (i in seq_len(nrow(edges))) {
     baseline$add_multilayer_intra_link(
-      edges$layer[i], edges$node_from[i], edges$node_to[i]
+      edges$layer[i],
+      edges$node_from[i],
+      edges$node_to[i]
     )
   }
   baseline$run()
 
   result <- cluster_infomap_multilayer(
     edges,
-    silent = TRUE, num_trials = 1L, two_level = TRUE
+    silent = TRUE,
+    num_trials = 1L,
+    two_level = TRUE
   )
 
   expect_s3_class(result, "infomap_result")
@@ -260,17 +311,17 @@ test_that("cluster_infomap_multilayer matches R6 path on intra-layer-only data.f
 test_that("cluster_infomap_multilayer matches R6 path on full multilayer data.frame", {
   edges <- data.frame(
     layer_from = c(1, 1, 1, 2, 2, 2, 1, 1, 1),
-    node_from  = c(1, 2, 3, 1, 2, 3, 1, 2, 3),
-    layer_to   = c(1, 1, 1, 2, 2, 2, 2, 2, 2),
-    node_to    = c(2, 3, 1, 2, 3, 1, 1, 2, 3),
-    weight     = c(1, 1, 1, 1, 1, 1, 0.5, 0.5, 0.5)
+    node_from = c(1, 2, 3, 1, 2, 3, 1, 2, 3),
+    layer_to = c(1, 1, 1, 2, 2, 2, 2, 2, 2),
+    node_to = c(2, 3, 1, 2, 3, 1, 1, 2, 3),
+    weight = c(1, 1, 1, 1, 1, 1, 0.5, 0.5, 0.5)
   )
 
   baseline <- Infomap(silent = TRUE, num_trials = 1L, two_level = TRUE)
   for (i in seq_len(nrow(edges))) {
     baseline$add_multilayer_link(
       c(edges$layer_from[i], edges$node_from[i]),
-      c(edges$layer_to[i],   edges$node_to[i]),
+      c(edges$layer_to[i], edges$node_to[i]),
       edges$weight[i]
     )
   }
@@ -278,7 +329,9 @@ test_that("cluster_infomap_multilayer matches R6 path on full multilayer data.fr
 
   result <- cluster_infomap_multilayer(
     edges,
-    silent = TRUE, num_trials = 1L, two_level = TRUE
+    silent = TRUE,
+    num_trials = 1L,
+    two_level = TRUE
   )
 
   expect_equal(result$num_links, baseline$num_links)
@@ -289,14 +342,24 @@ test_that("cluster_infomap_multilayer matches R6 path on full multilayer data.fr
 test_that("cluster_infomap_multilayer is column-order independent", {
   ordered <- data.frame(
     layer_from = c(1, 1, 2, 2),
-    node_from  = c(1, 2, 1, 2),
-    layer_to   = c(1, 1, 2, 2),
-    node_to    = c(2, 3, 2, 3)
+    node_from = c(1, 2, 1, 2),
+    layer_to = c(1, 1, 2, 2),
+    node_to = c(2, 3, 2, 3)
   )
   shuffled <- ordered[, c("node_to", "layer_from", "node_from", "layer_to")]
 
-  a <- cluster_infomap_multilayer(ordered,  silent = TRUE, num_trials = 1L, two_level = TRUE)
-  b <- cluster_infomap_multilayer(shuffled, silent = TRUE, num_trials = 1L, two_level = TRUE)
+  a <- cluster_infomap_multilayer(
+    ordered,
+    silent = TRUE,
+    num_trials = 1L,
+    two_level = TRUE
+  )
+  b <- cluster_infomap_multilayer(
+    shuffled,
+    silent = TRUE,
+    num_trials = 1L,
+    two_level = TRUE
+  )
 
   expect_equal(a$codelength, b$codelength, tolerance = 1e-10)
   expect_equal(a$num_links, b$num_links)
@@ -304,23 +367,28 @@ test_that("cluster_infomap_multilayer is column-order independent", {
 
 test_that("cluster_infomap_multilayer reads weight column by name", {
   edges <- data.frame(
-    layer     = c(1, 1, 2, 2),
+    layer = c(1, 1, 2, 2),
     node_from = c(1, 2, 1, 2),
-    node_to   = c(2, 3, 2, 3),
-    weight    = c(2, 2, 3, 3)
+    node_to = c(2, 3, 2, 3),
+    weight = c(2, 2, 3, 3)
   )
 
   baseline <- Infomap(silent = TRUE, num_trials = 1L, two_level = TRUE)
   for (i in seq_len(nrow(edges))) {
     baseline$add_multilayer_intra_link(
-      edges$layer[i], edges$node_from[i], edges$node_to[i], edges$weight[i]
+      edges$layer[i],
+      edges$node_from[i],
+      edges$node_to[i],
+      edges$weight[i]
     )
   }
   baseline$run()
 
   result <- cluster_infomap_multilayer(
     edges,
-    silent = TRUE, num_trials = 1L, two_level = TRUE
+    silent = TRUE,
+    num_trials = 1L,
+    two_level = TRUE
   )
 
   expect_equal(result$codelength, baseline$codelength, tolerance = 1e-10)
@@ -328,16 +396,19 @@ test_that("cluster_infomap_multilayer reads weight column by name", {
 
 test_that("cluster_infomap_multilayer can ignore weight column explicitly", {
   edges <- data.frame(
-    layer     = c(1, 1, 2, 2),
+    layer = c(1, 1, 2, 2),
     node_from = c(1, 2, 1, 2),
-    node_to   = c(2, 3, 2, 3),
-    weight    = c(100, 100, 1, 1)
+    node_to = c(2, 3, 2, 3),
+    weight = c(100, 100, 1, 1)
   )
 
   baseline <- Infomap(silent = TRUE, num_trials = 1L, two_level = TRUE)
   for (i in seq_len(nrow(edges))) {
     baseline$add_multilayer_intra_link(
-      edges$layer[i], edges$node_from[i], edges$node_to[i], 1.0
+      edges$layer[i],
+      edges$node_from[i],
+      edges$node_to[i],
+      1.0
     )
   }
   baseline$run()
@@ -345,7 +416,9 @@ test_that("cluster_infomap_multilayer can ignore weight column explicitly", {
   result <- cluster_infomap_multilayer(
     edges,
     weight = FALSE,
-    silent = TRUE, num_trials = 1L, two_level = TRUE
+    silent = TRUE,
+    num_trials = 1L,
+    two_level = TRUE
   )
 
   expect_equal(result$num_links, baseline$num_links)
@@ -354,30 +427,33 @@ test_that("cluster_infomap_multilayer can ignore weight column explicitly", {
 
 test_that("cluster_infomap_multilayer accepts matrix input positionally", {
   m_full <- matrix(
-    c(1, 1, 1, 2,
-      1, 2, 2, 1,
-      2, 1, 2, 2),
-    ncol = 4L, byrow = TRUE
+    c(1, 1, 1, 2, 1, 2, 2, 1, 2, 1, 2, 2),
+    ncol = 4L,
+    byrow = TRUE
   )
 
   expect_silent(
     res <- cluster_infomap_multilayer(
-      m_full, silent = TRUE, num_trials = 1L, two_level = TRUE
+      m_full,
+      silent = TRUE,
+      num_trials = 1L,
+      two_level = TRUE
     )
   )
   expect_s3_class(res, "infomap_result")
 
   m_intra <- matrix(
-    c(1, 1, 2,
-      1, 2, 3,
-      2, 1, 2,
-      2, 2, 3),
-    ncol = 3L, byrow = TRUE
+    c(1, 1, 2, 1, 2, 3, 2, 1, 2, 2, 2, 3),
+    ncol = 3L,
+    byrow = TRUE
   )
 
   expect_silent(
     res2 <- cluster_infomap_multilayer(
-      m_intra, silent = TRUE, num_trials = 1L, two_level = TRUE
+      m_intra,
+      silent = TRUE,
+      num_trials = 1L,
+      two_level = TRUE
     )
   )
   expect_s3_class(res2, "infomap_result")
@@ -396,7 +472,8 @@ test_that("add_igraph supports non-numeric physical ids", {
 
   g <- igraph::make_empty_graph(4, directed = TRUE)
   g <- igraph::set_vertex_attr(
-    g, "phys_id",
+    g,
+    "phys_id",
     value = factor(c("alpha", "beta", "alpha", "beta"))
   )
   g <- igraph::set_vertex_attr(g, "layer_id", value = c(1, 1, 2, 2))
@@ -420,7 +497,7 @@ test_that("add_igraph supports non-numeric physical ids", {
 test_that("add_igraph accepts diagonal links with multilayer_inter_intra_format = FALSE", {
   skip_if_not_installed("igraph")
   g <- igraph::make_empty_graph(4, directed = FALSE)
-  g <- igraph::set_vertex_attr(g, "phys_id",  value = c(1, 2, 1, 2))
+  g <- igraph::set_vertex_attr(g, "phys_id", value = c(1, 2, 1, 2))
   g <- igraph::set_vertex_attr(g, "layer_id", value = c(1, 1, 2, 2))
   g <- igraph::add_edges(g, c(1, 4))
 

--- a/interfaces/R/infomap/tests/testthat/test-options.R
+++ b/interfaces/R/infomap/tests/testthat/test-options.R
@@ -17,20 +17,41 @@ test_that("non-default values are rendered", {
 test_that("default values are skipped (not rendered)", {
   rendered <- construct_args(NULL, infomap_options(seed = 123L))
   expect_false(grepl("--seed", rendered))
-  rendered <- construct_args(NULL, infomap_options(teleportation_probability = 0.15))
+  rendered <- construct_args(
+    NULL,
+    infomap_options(teleportation_probability = 0.15)
+  )
   expect_false(grepl("--teleportation-probability", rendered))
 })
 
 test_that("directed flag renders correctly", {
-  expect_match(construct_args(NULL, infomap_options(directed = TRUE)), "--directed")
-  expect_match(construct_args(NULL, infomap_options(directed = FALSE)), "--flow-model undirected")
-  expect_false(grepl("--directed|--flow-model", construct_args(NULL, infomap_options(directed = NULL))))
+  expect_match(
+    construct_args(NULL, infomap_options(directed = TRUE)),
+    "--directed"
+  )
+  expect_match(
+    construct_args(NULL, infomap_options(directed = FALSE)),
+    "--flow-model undirected"
+  )
+  expect_false(grepl(
+    "--directed|--flow-model",
+    construct_args(NULL, infomap_options(directed = NULL))
+  ))
 })
 
 test_that("verbosity_level renders -vv style flag", {
-  expect_match(construct_args(NULL, infomap_options(verbosity_level = 2L)), "-vv")
-  expect_match(construct_args(NULL, infomap_options(verbosity_level = 3L)), "-vvv")
-  expect_false(grepl("-vv", construct_args(NULL, infomap_options(verbosity_level = 1L))))
+  expect_match(
+    construct_args(NULL, infomap_options(verbosity_level = 2L)),
+    "-vv"
+  )
+  expect_match(
+    construct_args(NULL, infomap_options(verbosity_level = 3L)),
+    "-vvv"
+  )
+  expect_false(grepl(
+    "-vv",
+    construct_args(NULL, infomap_options(verbosity_level = 1L))
+  ))
 })
 
 test_that("output sequence renders comma-separated", {
@@ -39,8 +60,14 @@ test_that("output sequence renders comma-separated", {
 })
 
 test_that("fast_hierarchical_solution renders -F repetition", {
-  expect_match(construct_args(NULL, infomap_options(fast_hierarchical_solution = 2L)), "-FF")
-  expect_match(construct_args(NULL, infomap_options(fast_hierarchical_solution = 3L)), "-FFF")
+  expect_match(
+    construct_args(NULL, infomap_options(fast_hierarchical_solution = 2L)),
+    "-FF"
+  )
+  expect_match(
+    construct_args(NULL, infomap_options(fast_hierarchical_solution = 3L)),
+    "-FFF"
+  )
 })
 
 test_that("multilayer_relax_limit defaults to NULL and is not rendered", {
@@ -49,12 +76,18 @@ test_that("multilayer_relax_limit defaults to NULL and is not rendered", {
 })
 
 test_that("explicit multilayer_relax_limit = -1L is rendered", {
-  rendered <- construct_args(NULL, infomap_options(multilayer_relax_limit = -1L))
+  rendered <- construct_args(
+    NULL,
+    infomap_options(multilayer_relax_limit = -1L)
+  )
   expect_match(rendered, "--multilayer-relax-limit -1")
 })
 
 test_that("variable_markov_min_scale renders when non-default", {
-  rendered <- construct_args(NULL, infomap_options(variable_markov_min_scale = 0.5))
+  rendered <- construct_args(
+    NULL,
+    infomap_options(variable_markov_min_scale = 0.5)
+  )
   expect_match(rendered, "--variable-markov-min-scale 0.5")
 })
 

--- a/interfaces/R/infomap/tests/testthat/test-smoke.R
+++ b/interfaces/R/infomap/tests/testthat/test-smoke.R
@@ -1,9 +1,13 @@
 test_that("Infomap clusters two triangles into two modules", {
   im <- Infomap(silent = TRUE, num_trials = 5, two_level = TRUE)
   im$add_links(list(
-    c(1, 2), c(1, 3), c(2, 3),
+    c(1, 2),
+    c(1, 3),
+    c(2, 3),
     c(3, 4),
-    c(4, 5), c(4, 6), c(5, 6)
+    c(4, 5),
+    c(4, 6),
+    c(5, 6)
   ))
   im$run()
 
@@ -22,9 +26,7 @@ test_that("Infomap clusters two triangles into two modules", {
 test_that("add_links accepts matrix input through bulk path", {
   im <- Infomap(silent = TRUE)
   links <- matrix(
-    c(1, 2, 2,
-      2, 3, 1,
-      3, 1, 1),
+    c(1, 2, 2, 2, 3, 1, 3, 1, 1),
     ncol = 3L,
     byrow = TRUE
   )
@@ -37,8 +39,15 @@ test_that("add_links accepts matrix input through bulk path", {
 })
 
 test_that("add_links list input matches repeated add_link", {
-  links <- list(c(1, 2, 2), c(1, 3, 2), c(2, 3, 2), c(3, 4, 1),
-                c(4, 5, 3), c(4, 6, 3), c(5, 6, 3))
+  links <- list(
+    c(1, 2, 2),
+    c(1, 3, 2),
+    c(2, 3, 2),
+    c(3, 4, 1),
+    c(4, 5, 3),
+    c(4, 6, 3),
+    c(5, 6, 3)
+  )
 
   baseline <- Infomap(silent = TRUE, num_trials = 3, two_level = TRUE)
   for (link in links) {
@@ -85,7 +94,15 @@ test_that("Infomap accepts named-argument keyword overrides", {
 
 test_that("as.data.frame returns one row per leaf node", {
   im <- Infomap(silent = TRUE)
-  im$add_links(list(c(1, 2), c(2, 3), c(3, 1), c(3, 4), c(4, 5), c(5, 6), c(6, 4)))
+  im$add_links(list(
+    c(1, 2),
+    c(2, 3),
+    c(3, 1),
+    c(3, 4),
+    c(4, 5),
+    c(5, 6),
+    c(6, 4)
+  ))
   im$run()
   df <- as.data.frame(im)
   expect_s3_class(df, "data.frame")
@@ -96,7 +113,10 @@ test_that("as.data.frame returns one row per leaf node", {
 })
 
 test_that("named arguments mirror Infomap CLI flags", {
-  args <- construct_args(NULL, infomap_options(silent = TRUE, two_level = TRUE, num_trials = 4L))
+  args <- construct_args(
+    NULL,
+    infomap_options(silent = TRUE, two_level = TRUE, num_trials = 4L)
+  )
   expect_match(args, "--silent")
   expect_match(args, "--two-level")
   expect_match(args, "--num-trials 4")

--- a/interfaces/R/infomap/tests/testthat/test-writers.R
+++ b/interfaces/R/infomap/tests/testthat/test-writers.R
@@ -1,8 +1,14 @@
 test_that("write_tree round-trips through read_file", {
   im <- Infomap(silent = TRUE, num_trials = 3)
-  im$add_links(list(c(1, 2), c(1, 3), c(2, 3),
-                    c(3, 4),
-                    c(4, 5), c(4, 6), c(5, 6)))
+  im$add_links(list(
+    c(1, 2),
+    c(1, 3),
+    c(2, 3),
+    c(3, 4),
+    c(4, 5),
+    c(4, 6),
+    c(5, 6)
+  ))
   im$run()
   expected_modules <- im$num_top_modules
 
@@ -13,9 +19,15 @@ test_that("write_tree round-trips through read_file", {
   expect_gt(file.size(tmp), 0L)
 
   im2 <- Infomap(silent = TRUE, no_infomap = TRUE, cluster_data = tmp)
-  im2$add_links(list(c(1, 2), c(1, 3), c(2, 3),
-                     c(3, 4),
-                     c(4, 5), c(4, 6), c(5, 6)))
+  im2$add_links(list(
+    c(1, 2),
+    c(1, 3),
+    c(2, 3),
+    c(3, 4),
+    c(4, 5),
+    c(4, 6),
+    c(5, 6)
+  ))
   im2$run()
   expect_equal(im2$num_top_modules, expected_modules)
 })

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -26,6 +26,7 @@ SWIG ?= swig
 EMXX ?= em++
 R ?= R
 RSCRIPT ?= Rscript
+AIR ?= $(shell command -v air 2>/dev/null || command -v /opt/homebrew/bin/air 2>/dev/null || echo air)
 SPHINX_BUILD_BIN := $(shell command -v sphinx-build 2>/dev/null || true)
 SPHINX_BUILD ?= $(if $(SPHINX_BUILD_BIN),$(SPHINX_BUILD_BIN),$(PYTHON) -m sphinx)
 CMAKE ?= $(shell command -v cmake 2>/dev/null || command -v /opt/homebrew/bin/cmake 2>/dev/null || echo cmake)
@@ -149,6 +150,8 @@ help:
 		"  configure-cpp-dev     Configure a clangd-friendly CMake dev build." \
 		"  format-native         Rewrite C++ sources with clang-format." \
 		"  format-native-check   Verify C++ sources are clang-format clean." \
+		"  format-r              Rewrite R sources with Air." \
+		"  format-r-check        Verify R sources are Air-format clean." \
 		"  tidy-native           Run clang-tidy over C++ source files." \
 		"  dev-cpp-check         Run the fast C++ developer feedback suite." \
 		"  dev-bootstrap         Install Python dev dependencies and run npm ci." \
@@ -204,6 +207,8 @@ doctor:
 	@printf "R (%s): %s\n" "$(R)" "$$(command -v $(R) 2>/dev/null || echo missing)"
 	@printf "R version: %s\n" "$$($(R) --version 2>/dev/null | sed -nE 's/^R version ([0-9.]+).*/\1/p' | head -1 || echo missing)"
 	@printf "Rscript (%s): %s\n" "$(RSCRIPT)" "$$(command -v $(RSCRIPT) 2>/dev/null || echo missing)"
+	@printf "air (%s): %s\n" "$(AIR)" "$$(command -v $(AIR) 2>/dev/null || echo missing)"
+	@printf "air version: %s\n" "$$($(AIR) --version 2>/dev/null || echo missing)"
 	@printf "R packages:\n"
 	@if command -v $(RSCRIPT) >/dev/null 2>&1; then \
 		for pkg in R6 methods roxygen2 rcmdcheck testthat igraph tibble; do \

--- a/mk/python.mk
+++ b/mk/python.mk
@@ -133,7 +133,7 @@ clean-python:
 	@find build -maxdepth 1 -type d \( -name 'bdist.*' -o -name 'lib.*' -o -name 'temp.*' \) -exec rm -rf {} + 2>/dev/null || true
 
 format-python:
-	$(RUFF) format $(PYTHON_FORMAT_TARGETS) || true
+	$(RUFF) format $(PYTHON_FORMAT_TARGETS)
 
 release-python-dist:
 	@$(MAKE) --no-print-directory clean-python-build-cache

--- a/mk/r.mk
+++ b/mk/r.mk
@@ -10,6 +10,13 @@ R_TARBALL := $(R_DIST_DIR)/infomap_$(R_VERSION).tar.gz
 
 R_STAGE_SCRIPT := scripts/stage_r_package.py
 R_SWIG_SCRIPT := scripts/generate_r_swig.py
+R_SOURCE_FILES := $(filter-out $(R_SKELETON_DIR)/R/options.R $(R_SKELETON_DIR)/R/swig_bindings.R,$(wildcard $(R_SKELETON_DIR)/R/*.R))
+R_TEST_FILES := $(wildcard $(R_SKELETON_DIR)/tests/*.R) $(wildcard $(R_SKELETON_DIR)/tests/testthat/*.R)
+R_EXAMPLE_FILES := $(wildcard examples/R/*.R)
+R_FORMAT_TARGETS := \
+	$(R_SOURCE_FILES) \
+	$(R_TEST_FILES) \
+	$(R_EXAMPLE_FILES)
 
 # On macOS, Homebrew LLVM clang++ may be first in PATH but Homebrew R uses
 # Apple's libc++ at runtime.  Compilation with LLVM clang++ produces a .so
@@ -41,6 +48,8 @@ endif
 	test-r \
 	test-r-examples \
 	dev-r-install \
+	format-r \
+	format-r-check \
 	clean-r \
 	release-r-dist
 
@@ -86,6 +95,12 @@ test-r-examples: dev-r-install
 		echo "Running $$f"; \
 		$(RSCRIPT) "$$f" > /dev/null || exit 1; \
 	done
+
+format-r:
+	$(AIR) format $(R_FORMAT_TARGETS)
+
+format-r-check:
+	$(AIR) format $(R_FORMAT_TARGETS) --check
 
 clean-r:
 	$(RM) -r $(R_BUILD_DIR) $(R_DIST_DIR)


### PR DESCRIPTION
## Summary
- Add `make format-r` and `make format-r-check` using Air for handwritten R sources, tests, and examples.
- Report Air availability and version in `make doctor`.
- Stop `make format-python` from masking formatter failures.
- Apply Air formatting to `interfaces/R/infomap/R`, `interfaces/R/infomap/tests`, and `examples/R` while excluding generated SWIG bindings.

## Test Plan
- `make format-r`
- `make format-r-check`
- `make doctor`
- `make format-python`
- `make -n format-native format-native-check format-python format-js`
- `make test-r-examples`
- `git diff --check`

## Notes
- `make test-r` reached package build, examples, and testthat successfully, but exited non-zero because local R CMD check reported an environment warning for missing `checkbashisms`/`pandoc` and an existing URL redirect note.