### PR TITLE
perf: optimize module link consolidation

### DIFF
--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -20,6 +20,8 @@
 #include <set>
 #include <utility>
 #include <algorithm>
+#include <cstddef>
+#include <vector>
 
 namespace infomap {
 
@@ -712,9 +714,23 @@ inline void InfomapOptimizer<Objective>::consolidateModules(bool replaceExisting
     modules[moduleIndex]->addChild(node);
   }
 
-  using NodePair = std::pair<unsigned int, unsigned int>;
-  using EdgeMap = std::map<NodePair, double>;
-  EdgeMap moduleLinks;
+  struct ModuleLink {
+    unsigned int source;
+    unsigned int target;
+    double flow;
+  };
+
+  std::size_t numInterModuleLinks = 0;
+  for (auto& node : network) {
+    const unsigned int module1 = node->index;
+    for (auto& e : node->outEdges()) {
+      if (module1 != e->target->index)
+        ++numInterModuleLinks;
+    }
+  }
+
+  std::vector<ModuleLink> moduleLinks;
+  moduleLinks.reserve(numInterModuleLinks);
 
   for (auto& node : network) {
     unsigned int module1 = node->index;
@@ -727,18 +743,26 @@ inline void InfomapOptimizer<Objective>::consolidateModules(bool replaceExisting
         // If undirected, the order may be swapped to aggregate the edge on an opposite one
         if (m_infomap->isUndirectedClustering() && m1 > m2)
           std::swap(m1, m2);
-        auto ret = moduleLinks.insert(std::make_pair(NodePair(m1, m2), edge.data.flow));
-        if (!ret.second) {
-          ret.first->second += edge.data.flow;
-        }
+        moduleLinks.push_back({ m1, m2, edge.data.flow });
       }
     }
   }
 
+  std::stable_sort(moduleLinks.begin(), moduleLinks.end(), [](const ModuleLink& a, const ModuleLink& b) {
+    return a.source < b.source || (a.source == b.source && a.target < b.target);
+  });
+
   // Add the aggregated edge flow structure to the new modules
-  for (auto& e : moduleLinks) {
-    const auto& nodePair = e.first;
-    modules[nodePair.first]->addOutEdge(*modules[nodePair.second], 0.0, e.second);
+  for (std::size_t i = 0; i < moduleLinks.size();) {
+    const auto source = moduleLinks[i].source;
+    const auto target = moduleLinks[i].target;
+    double flow = 0.0;
+    do {
+      flow += moduleLinks[i].flow;
+      ++i;
+    } while (i < moduleLinks.size() && moduleLinks[i].source == source && moduleLinks[i].target == target);
+
+    modules[source]->addOutEdge(*modules[target], 0.0, flow);
   }
 
   if (replaceExistingModules) {

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -64,6 +64,49 @@ std::map<EdgeKey, double> aggregatedModuleFlow(InfoNode& root, bool undirected)
   return flows;
 }
 
+struct ConsolidatedSnapshot {
+  std::map<EdgeKey, double> moduleFlows;
+  unsigned int numTopModules = 0;
+  unsigned int rootChildDegree = 0;
+  double codelength = 0.0;
+  double indexCodelength = 0.0;
+};
+
+void addConsolidationTestLinks(InfomapWrapper& im)
+{
+  im.addLink(1, 2);
+  im.addLink(2, 1);
+  im.addLink(3, 4);
+  im.addLink(4, 3);
+  im.addLink(1, 3);
+  im.addLink(2, 3);
+  im.addLink(2, 4);
+  im.addLink(3, 1);
+  im.addLink(4, 2);
+}
+
+ConsolidatedSnapshot consolidateFourNodeFixture(const std::string& extraFlags)
+{
+  InfomapWrapper im(infomap::test::defaultFlags(extraFlags));
+  addConsolidationTestLinks(im);
+  im.initNetwork(im.network());
+  im.setActiveNetworkFromLeafs();
+  im.initPartition();
+
+  std::vector<unsigned int> modules { 0, 0, 1, 1 };
+  im.moveActiveNodesToPredefinedModules(modules);
+
+  im.consolidateModules(false);
+
+  return {
+    aggregatedModuleFlow(im.root(), im.isUndirectedClustering()),
+    im.numTopModules(),
+    im.root().childDegree(),
+    im.codelength(),
+    im.getIndexCodelength(),
+  };
+}
+
 TEST_CASE("Cluster-data clu fixture initializes a two-level partition [fast][core][partition]")
 {
   InfomapWrapper im(infomap::test::defaultFlags());
@@ -545,6 +588,60 @@ TEST_CASE("Consolidate modules preserves aggregated inter-module flow [fast][cor
   CHECK(im.numTopModules() == 2);
   CHECK(im.root().childDegree() == 2);
   CHECK(aggregatedModuleFlow(im.root(), im.isUndirectedClustering()) == expectedFlows);
+}
+
+TEST_CASE("Consolidate modules keeps directed opposite module links separate [fast][core][partition][tree]")
+{
+  InfomapWrapper im(infomap::test::defaultFlags("--directed"));
+  addConsolidationTestLinks(im);
+  im.initNetwork(im.network());
+  im.setActiveNetworkFromLeafs();
+  im.initPartition();
+
+  std::vector<unsigned int> modules { 0, 0, 1, 1 };
+  im.moveActiveNodesToPredefinedModules(modules);
+
+  const auto expectedFlows = aggregatedInterModuleFlow(im.activeNetwork(), im.isUndirectedClustering());
+  REQUIRE(expectedFlows.size() == 2);
+
+  im.consolidateModules(false);
+
+  CHECK(im.numTopModules() == 2);
+  CHECK(im.root().childDegree() == 2);
+  CHECK(aggregatedModuleFlow(im.root(), im.isUndirectedClustering()) == expectedFlows);
+}
+
+TEST_CASE("Consolidate modules folds undirected opposite module links together [fast][core][partition][tree]")
+{
+  InfomapWrapper im(infomap::test::defaultFlags());
+  addConsolidationTestLinks(im);
+  im.initNetwork(im.network());
+  im.setActiveNetworkFromLeafs();
+  im.initPartition();
+
+  std::vector<unsigned int> modules { 0, 0, 1, 1 };
+  im.moveActiveNodesToPredefinedModules(modules);
+
+  const auto expectedFlows = aggregatedInterModuleFlow(im.activeNetwork(), im.isUndirectedClustering());
+  REQUIRE(expectedFlows.size() == 1);
+
+  im.consolidateModules(false);
+
+  CHECK(im.numTopModules() == 2);
+  CHECK(im.root().childDegree() == 2);
+  CHECK(aggregatedModuleFlow(im.root(), im.isUndirectedClustering()) == expectedFlows);
+}
+
+TEST_CASE("Consolidate modules remains deterministic on repeated setup [fast][core][partition][tree]")
+{
+  const auto first = consolidateFourNodeFixture("--directed");
+  const auto second = consolidateFourNodeFixture("--directed");
+
+  CHECK(second.moduleFlows == first.moduleFlows);
+  CHECK(second.numTopModules == first.numTopModules);
+  CHECK(second.rootChildDegree == first.rootChildDegree);
+  CHECK(second.codelength == doctest::Approx(first.codelength));
+  CHECK(second.indexCodelength == doctest::Approx(first.indexCodelength));
 }
 
 TEST_CASE("Invalid cluster-data fixtures fail deterministically [fast][core][partition][parser]")


### PR DESCRIPTION
## Summary
- replace map-based module-link aggregation in `src/core/InfomapOptimizer.h` with a reserved vector plus stable sort/reduce
- add directed, undirected, and determinism coverage in `test/cpp/test_partition.cpp`

## Verification
- `make format-native`
- `make test-native MODE=debug OPENMP=0 CMAKE_GENERATOR=Ninja CMAKE_TEST_BUILD_DIR=build/cmake-debug-ninja CTEST_ARGS="-R infomap_cpp_partition_tests"`
- `make bench-native MODE=release OPENMP=0 NATIVE_BENCHMARK_PROFILE=pr NATIVE_BENCHMARK_REPEATS=5 NATIVE_BENCHMARK_WARMUP_RUNS=1 NATIVE_BENCHMARK_OUTPUT=build/benchmarks/base-native.json`
- `make bench-native MODE=release OPENMP=0 NATIVE_BENCHMARK_PROFILE=pr NATIVE_BENCHMARK_REPEATS=5 NATIVE_BENCHMARK_WARMUP_RUNS=1 NATIVE_BENCHMARK_OUTPUT=build/benchmarks/head-native.json`
- `python3 scripts/benchmarks/compare_native_benchmarks.py --base build/benchmarks/base-native.json --head build/benchmarks/head-native.json --markdown-out build/benchmarks/consolidateModules-summary.md --json-out build/benchmarks/consolidateModules-comparison.json`

## Benchmark
- PR native benchmark comparison reported no regression
- `sparse_100k` median run: 3.125852s -> 2.918801s
- `ring_of_cliques_100k` median run: 2.669312s -> 2.653473s