### PR TITLE
feat(python): add Python quickstart notebook and infomap-shell

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,12 @@ Quick start with Python:
 
     print(communities)
 
+For Jupyter, start with the flagship
+`quickstart notebook <https://github.com/mapequation/infomap/blob/master/examples/notebooks/quickstart.ipynb>`_.
+It shows the notebook-native Infomap result summary, dataframe inspection, a
+copyable static network partition helper, and export paths for further
+analysis.
+
 For direct control over Infomap-specific options and result access:
 
 .. code-block:: python

--- a/examples/notebooks/README.md
+++ b/examples/notebooks/README.md
@@ -1,5 +1,10 @@
 # Infomap tutorial notebooks
 
+Start with [`quickstart.ipynb`](quickstart.ipynb). It is the flagship Python
+notebook for running Infomap in Jupyter, inspecting the notebook-native result
+summary, drawing a small readable partition, and exporting results for further
+analysis.
+
 Most numbered notebooks accompany [Community Detection with the Map Equation
 and Infomap: Theory and Applications](https://doi.org/10.1145/3779648).
 Descriptive, unnumbered notebooks cover practical Python workflows that are

--- a/examples/notebooks/notebooks.toml
+++ b/examples/notebooks/notebooks.toml
@@ -1,4 +1,9 @@
 [[notebooks]]
+path = "quickstart.ipynb"
+tier = "smoke"
+description = "Flagship Infomap Python quickstart with notebook-native summary and static network visualization."
+
+[[notebooks]]
 path = "3.1 The two-level map equation.ipynb"
 tier = "smoke"
 description = "Core two-level map equation example with local data only."

--- a/examples/notebooks/quickstart.ipynb
+++ b/examples/notebooks/quickstart.ipynb
@@ -140,7 +140,7 @@
    "outputs": [],
    "source": [
     "jazz = Infomap(silent=True, num_trials=20, seed=123)\n",
-    "jazz.read_file(Path(\"data/jazz.net\"))\n",
+    "jazz.read_file(\"data/jazz.net\")\n",
     "jazz.run()\n",
     "jazz"
    ]

--- a/examples/notebooks/quickstart.ipynb
+++ b/examples/notebooks/quickstart.ipynb
@@ -1,0 +1,230 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Infomap quickstart\n",
+    "\n",
+    "This notebook is the shortest path from a Python graph to an Infomap result you can inspect, summarize, visualize, and reuse."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import networkx as nx\n",
+    "import pandas as pd\n",
+    "\n",
+    "from infomap import Infomap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run Infomap on a familiar graph\n",
+    "\n",
+    "Start with Zachary's Karate Club graph. It is small enough to inspect directly and familiar enough to make the partition easy to judge."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graph = nx.karate_club_graph()\n",
+    "\n",
+    "im = Infomap(silent=True, num_trials=20, seed=123)\n",
+    "node_mapping = im.add_networkx_graph(graph)\n",
+    "im.run()\n",
+    "im"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `Infomap` object summarizes the result in place. Codelength and relative savings describe compression. Module counts describe the partition. The flow strip shows how much flow belongs to the largest top modules."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assignments = {\n",
+    "    node_mapping[node.state_id]: node.module_id\n",
+    "    for node in im.nodes\n",
+    "    if node.state_id in node_mapping\n",
+    "}\n",
+    "\n",
+    "result = im.to_dataframe(\n",
+    "    columns=[\"node_id\", \"module_id\", \"flow\", \"path\"],\n",
+    "    index=\"node_id\",\n",
+    ").rename(index=node_mapping)\n",
+    "result.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Draw a readable partition\n",
+    "\n",
+    "This helper is notebook-local. It is meant to be copied, changed, or deleted. It is not a public Infomap plotting API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def draw_network_partition(graph, modules, *, title=None, seed=7, ax=None):\n",
+    "    if ax is None:\n",
+    "        _, ax = plt.subplots(figsize=(6, 5))\n",
+    "\n",
+    "    pos = nx.spring_layout(graph, seed=seed)\n",
+    "    module_ids = sorted(set(modules.values()))\n",
+    "    palette = plt.get_cmap(\"tab20\")\n",
+    "    colors = {\n",
+    "        module_id: palette(index % 20)\n",
+    "        for index, module_id in enumerate(module_ids)\n",
+    "    }\n",
+    "    node_colors = [colors[modules[node]] for node in graph.nodes]\n",
+    "\n",
+    "    nx.draw_networkx_edges(graph, pos, ax=ax, alpha=0.25, width=1.0)\n",
+    "    nx.draw_networkx_nodes(\n",
+    "        graph,\n",
+    "        pos,\n",
+    "        ax=ax,\n",
+    "        node_color=node_colors,\n",
+    "        node_size=120,\n",
+    "        linewidths=0.8,\n",
+    "        edgecolors=\"white\",\n",
+    "    )\n",
+    "    nx.draw_networkx_labels(graph, pos, ax=ax, font_size=8)\n",
+    "    ax.set_title(title or \"Infomap partition\")\n",
+    "    ax.axis(\"off\")\n",
+    "    return ax\n",
+    "\n",
+    "\n",
+    "draw_network_partition(\n",
+    "    graph,\n",
+    "    assignments,\n",
+    "    title=f\"Karate Club: {im.num_top_modules} modules, {im.codelength:.3f} bits\",\n",
+    ");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Move from toy graph to research data\n",
+    "\n",
+    "For larger networks, the first view should usually be a result summary and a table, not a force-directed drawing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jazz = Infomap(silent=True, num_trials=20, seed=123)\n",
+    "jazz.read_file(Path(\"data/jazz.net\"))\n",
+    "jazz.run()\n",
+    "jazz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jazz_nodes = jazz.to_dataframe(columns=[\"node_id\", \"module_id\", \"flow\"])\n",
+    "\n",
+    "module_summary = (\n",
+    "    jazz_nodes.groupby(\"module_id\", as_index=False)\n",
+    "    .agg(nodes=(\"node_id\", \"count\"), flow=(\"flow\", \"sum\"))\n",
+    "    .sort_values(\"flow\", ascending=False)\n",
+    "    .reset_index(drop=True)\n",
+    ")\n",
+    "module_summary.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use the quick function when you only need assignments\n",
+    "\n",
+    "The `Infomap` object gives you the richest result. For scripts that only need a node-to-module mapping, use the NetworkX helper."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from infomap import find_communities\n",
+    "\n",
+    "communities = find_communities(graph, seed=123, num_trials=20)\n",
+    "pd.Series(communities, name=\"module_id\").head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Export results\n",
+    "\n",
+    "Use dataframes for analysis, annotated graph objects for Python workflows, and GraphML or GEXF when you want to continue in visualization tools."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "annotated_graph = graph.copy()\n",
+    "nx.set_node_attributes(annotated_graph, assignments, \"infomap_module\")\n",
+    "\n",
+    "result.to_csv(\"output/karate-infomap-nodes.csv\")\n",
+    "nx.write_graphml(annotated_graph, \"output/karate-infomap.graphml\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/interfaces/python/source/index.rst
+++ b/interfaces/python/source/index.rst
@@ -27,6 +27,11 @@ Quick start
 Continue to :doc:`installation` for optional integrations and shell completion,
 or jump to :doc:`quickstart` for the first end-to-end example.
 
+For Jupyter, start with the flagship
+`quickstart notebook <https://github.com/mapequation/infomap/blob/master/examples/notebooks/quickstart.ipynb>`_.
+It shows the notebook-native Infomap result summary, dataframe inspection, and
+a copyable static network partition helper.
+
 Where to go next
 ----------------
 

--- a/interfaces/python/source/installation.rst
+++ b/interfaces/python/source/installation.rst
@@ -56,6 +56,23 @@ For a list of available options, run:
 
     infomap --help
 
+Interactive shell
+-----------------
+
+Start a Python shell with Infomap preloaded:
+
+.. code-block:: bash
+
+    infomap-shell
+
+The shell imports ``Infomap``, ``InfomapOptions``, and ``MultilayerNode``.
+It also creates ``im = Infomap(pretty=True)`` and provides ``summary()`` and
+``options()`` helpers. Pass one network file to preload it:
+
+.. code-block:: bash
+
+    infomap-shell examples/networks/twotriangles.net
+
 Shell completion
 ----------------
 

--- a/interfaces/python/source/notebooks.rst
+++ b/interfaces/python/source/notebooks.rst
@@ -6,6 +6,11 @@ guided, exploratory introduction to the map equation and Infomap workflows.
 The notebooks were created as companion material for the paper
 `Community Detection with the Map Equation and Infomap: Theory and Applications`_.
 
+Start with the flagship quickstart notebook:
+`quickstart.ipynb <https://github.com/mapequation/infomap/blob/master/examples/notebooks/quickstart.ipynb>`_.
+It shows the notebook-native Infomap result summary, a copyable static network
+partition helper, dataframe inspection, and export paths for further analysis.
+
 They are useful when you want to:
 
 - connect the mathematical ideas in the map equation to executable examples;
@@ -18,7 +23,13 @@ They are useful when you want to:
 What's included
 ---------------
 
-The notebooks cover:
+The notebooks include:
+
+- a flagship Python quickstart for Jupyter-native Infomap workflows;
+- comparison tutorials for NetworkX, igraph, and Scanpy-style workflows;
+- companion material for the survey article.
+
+The numbered survey notebooks cover:
 
 - the two-level map equation;
 - the two-level search phase and solution landscapes;

--- a/interfaces/python/source/quickstart.rst
+++ b/interfaces/python/source/quickstart.rst
@@ -59,6 +59,16 @@ For direct control over Infomap-specific options and result access:
         if node.is_leaf:
             print(node.node_id, node.module_id)
 
+For interactive exploration, start:
+
+.. code-block:: bash
+
+    infomap-shell
+
+This opens a Python shell with ``im = Infomap(pretty=True)`` ready to use.
+Run ``options()`` to inspect the generated ``InfomapOptions`` reference and
+``summary()`` to print the current network or result state.
+
 Recommended researcher workflow
 -------------------------------
 

--- a/interfaces/python/source/usage.rst
+++ b/interfaces/python/source/usage.rst
@@ -39,6 +39,40 @@ configuration across multiple runs:
     im2.add_link(2, 3)
     im2.run_with_options(options)
 
+Inspecting state
+----------------
+
+``repr(im)`` shows a compact snapshot that is useful in a Python shell,
+notebook, debugger, or failed test output:
+
+.. code-block:: python
+
+    from infomap import Infomap
+
+    im = Infomap(silent=True)
+    im.add_link(1, 2)
+    im
+    # Infomap(nodes=2, links=1, physical_nodes=2, state_nodes=0, status='not run')
+
+    im.run()
+    im
+    # Infomap(nodes=2, links=1, physical_nodes=2, state_nodes=0, status='run', multilayer_network=False, levels=2, top_modules=1, codelength=1.0)
+
+Use :meth:`infomap.Infomap.summary` when you want the full inspection data as a
+dictionary:
+
+.. code-block:: python
+
+    im.summary()
+    # {
+    #     "nodes": 2,
+    #     "links": 1,
+    #     "physical_nodes": 2,
+    #     "state_nodes": 0,
+    #     "status": "run",
+    #     ...
+    # }
+
 NetworkX graphs
 ---------------
 

--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -1,6 +1,7 @@
 import sys
 from collections import namedtuple
 from contextlib import contextmanager
+from html import escape
 
 from ._bindings import *  # noqa: F401,F403
 from ._bindings import __all__ as _BINDINGS_ALL
@@ -33,6 +34,284 @@ def _package_construct_args():
 
 
 MultilayerNode = namedtuple("MultilayerNode", "layer_id, node_id")
+
+_REPR_MAX_FLOW_FRACTION = 0.90
+_REPR_MAX_MODULES = 12
+_REPR_COLORS = (
+    "#4477aa",
+    "#ee6677",
+    "#228833",
+    "#ccbb44",
+    "#66ccee",
+    "#aa3377",
+    "#bbbbbb",
+    "#000000",
+    "#994455",
+    "#ddcc77",
+    "#117733",
+    "#88ccee",
+)
+_REPR_OTHER_COLOR = "#8f9499"
+
+
+def _summary_data(im):
+    data = {
+        "nodes": im.num_nodes,
+        "links": im.num_links,
+        "physical_nodes": im.num_physical_nodes,
+        "state_nodes": im.num_nodes - im.num_physical_nodes,
+        "higher_order": im.num_nodes != im.num_physical_nodes,
+        "status": "not run",
+    }
+
+    if im.num_top_modules == 0:
+        return data
+
+    data.update(
+        {
+            "status": "run",
+            "state_input": im.stateInput,
+            "multilayer_input": im.multilayerInput,
+            "multilayer_network": im.isMultilayerNetwork(),
+            "levels": im.num_levels,
+            "leaf_nodes": im.numLeafNodes(),
+            "top_modules": im.num_top_modules,
+            "non_trivial_top_modules": im.num_non_trivial_top_modules,
+            "leaf_modules": im.num_leaf_modules,
+            "effective_top_modules": im.effective_num_top_modules,
+            "effective_leaf_modules": im.effective_num_leaf_modules,
+            "codelength": im.codelength,
+            "index_codelength": im.index_codelength,
+            "module_codelength": im.module_codelength,
+            "one_level_codelength": im.one_level_codelength,
+            "relative_codelength_savings": im.relative_codelength_savings,
+            "entropy_rate": im.entropy_rate,
+            "elapsed_time": im.elapsed_time,
+        }
+    )
+    if im.meta_codelength != 0:
+        data["meta_codelength"] = im.meta_codelength
+    return data
+
+
+def _format_summary_value(value):
+    if isinstance(value, bool):
+        return "Yes" if value else "No"
+    if isinstance(value, float):
+        return f"{value:.6g}"
+    return str(value)
+
+
+def _format_percent(value):
+    return f"{100 * value:.3g}%"
+
+
+def _top_module_flow_bars(im):
+    modules = [
+        (module.module_id, module.flow)
+        for module in im.get_tree(depth_level=1)
+        if module.depth == 1
+    ]
+    total_flow = sum(flow for _, flow in modules)
+    if total_flow <= 0:
+        return []
+
+    bars = []
+    cumulative_flow = 0.0
+    for module_id, flow in sorted(modules, key=lambda item: item[1], reverse=True):
+        if bars and (
+            cumulative_flow >= _REPR_MAX_FLOW_FRACTION * total_flow
+            or len(bars) >= _REPR_MAX_MODULES
+        ):
+            break
+        bars.append(
+            {
+                "label": f"Module {module_id}",
+                "flow": flow,
+                "fraction": flow / total_flow,
+                "color": _REPR_COLORS[len(bars) % len(_REPR_COLORS)],
+            }
+        )
+        cumulative_flow += flow
+
+    other_flow = total_flow - cumulative_flow
+    if other_flow > 1e-12:
+        bars.append(
+            {
+                "label": "Other modules",
+                "flow": other_flow,
+                "fraction": other_flow / total_flow,
+                "color": _REPR_OTHER_COLOR,
+            }
+        )
+    return bars
+
+
+def _html_metric(label, value, *, value_class=""):
+    return (
+        '<div class="infomap-metric">'
+        f'<span class="infomap-metric-label">{escape(label)}</span>'
+        f'<span class="infomap-metric-value {escape(value_class)}">'
+        f"{escape(_format_summary_value(value))}"
+        "</span>"
+        "</div>"
+    )
+
+
+def _html_flow_strip(bars):
+    if not bars:
+        return ""
+
+    segments = []
+    legend = []
+    for bar in bars:
+        label = escape(bar["label"])
+        percent = escape(_format_percent(bar["fraction"]))
+        color = escape(bar["color"])
+        width = max(bar["fraction"] * 100, 0.25)
+        segments.append(
+            '<span class="infomap-flow-segment" '
+            f'style="width: {width:.6g}%; background: {color};" '
+            f'title="{label}: {percent}"></span>'
+        )
+        legend.append(
+            '<span class="infomap-flow-item">'
+            f'<span class="infomap-flow-swatch" style="background: {color};"></span>'
+            f"{label} {percent}"
+            "</span>"
+        )
+
+    return (
+        '<div class="infomap-flow">'
+        '<div class="infomap-section-label">Top-module flow</div>'
+        f'<div class="infomap-flow-strip">{"".join(segments)}</div>'
+        f'<div class="infomap-flow-legend">{"".join(legend)}</div>'
+        "</div>"
+    )
+
+
+def _repr_html(im):
+    summary = im.summary()
+    is_run = summary["status"] == "run"
+    status = "Run" if is_run else "Not run"
+    status_class = "is-run" if is_run else "is-not-run"
+
+    primary_fields = []
+    secondary_fields = [
+        ("Nodes", summary["nodes"]),
+        ("Links", summary["links"]),
+        ("Higher-order", summary["higher_order"]),
+    ]
+    if summary["physical_nodes"] != summary["nodes"]:
+        secondary_fields.insert(1, ("Physical nodes", summary["physical_nodes"]))
+
+    if is_run:
+        primary_fields = [
+            ("Codelength", summary["codelength"]),
+            (
+                "Relative savings",
+                _format_percent(summary["relative_codelength_savings"]),
+            ),
+            ("Top modules", summary["top_modules"]),
+            ("Effective modules", summary["effective_top_modules"]),
+        ]
+        secondary_fields.extend(
+            [
+                ("Levels", summary["levels"]),
+                ("Elapsed time", f"{summary['elapsed_time']:.3g}s"),
+            ]
+        )
+
+    metrics = [_html_metric("Status", status, value_class=status_class)]
+    metrics.extend(_html_metric(label, value) for label, value in primary_fields)
+    metrics.extend(_html_metric(label, value) for label, value in secondary_fields)
+    flow_strip = _html_flow_strip(_top_module_flow_bars(im)) if is_run else ""
+
+    return f"""
+<style>
+.infomap-card {{
+  --infomap-border: color-mix(in srgb, currentColor 18%, transparent);
+  --infomap-muted: color-mix(in srgb, currentColor 62%, transparent);
+  --infomap-soft: color-mix(in srgb, currentColor 7%, transparent);
+  border: 1px solid var(--infomap-border);
+  border-radius: 8px;
+  color: inherit;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  max-width: 720px;
+  padding: 14px 16px 16px;
+}}
+.infomap-title {{
+  font-size: 16px;
+  font-weight: 650;
+  line-height: 1.25;
+  margin: 0 0 12px;
+}}
+.infomap-grid {{
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(auto-fit, minmax(128px, 1fr));
+}}
+.infomap-metric {{
+  background: var(--infomap-soft);
+  border-radius: 6px;
+  min-width: 0;
+  padding: 8px 10px;
+}}
+.infomap-metric-label {{
+  color: var(--infomap-muted);
+  display: block;
+  font-size: 11px;
+  line-height: 1.25;
+  margin-bottom: 3px;
+}}
+.infomap-metric-value {{
+  display: block;
+  font-size: 15px;
+  font-weight: 620;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}}
+.infomap-metric-value.is-run {{ color: #228833; }}
+.infomap-metric-value.is-not-run {{ color: var(--infomap-muted); }}
+.infomap-flow {{ margin-top: 14px; }}
+.infomap-section-label {{
+  color: var(--infomap-muted);
+  font-size: 11px;
+  margin-bottom: 6px;
+}}
+.infomap-flow-strip {{
+  border-radius: 999px;
+  display: flex;
+  height: 12px;
+  overflow: hidden;
+  width: 100%;
+}}
+.infomap-flow-segment {{ display: block; min-width: 1px; }}
+.infomap-flow-legend {{
+  color: var(--infomap-muted);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 11px;
+  gap: 6px 12px;
+  line-height: 1.3;
+  margin-top: 8px;
+}}
+.infomap-flow-item {{ white-space: nowrap; }}
+.infomap-flow-swatch {{
+  border-radius: 999px;
+  display: inline-block;
+  height: 8px;
+  margin-right: 4px;
+  vertical-align: -1px;
+  width: 8px;
+}}
+</style>
+<div class="infomap-card">
+  <div class="infomap-title">Infomap</div>
+  <div class="infomap-grid">{"".join(metrics)}</div>
+  {flow_strip}
+</div>
+"""
 
 
 __all__ = [
@@ -161,6 +440,37 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin, InfomapWrapper):  # no
         """
         options = InfomapOptions.from_mapping(locals())
         super().__init__(_package_construct_args()(args, **options.to_kwargs()))
+
+    def __repr__(self):
+        summary = _summary_data(self)
+        fields = (
+            "nodes",
+            "links",
+            "physical_nodes",
+            "state_nodes",
+            "status",
+            "multilayer_network",
+            "levels",
+            "top_modules",
+            "codelength",
+        )
+        details = [
+            f"{field}={summary[field]!r}" for field in fields if field in summary
+        ]
+        return f"Infomap({', '.join(details)})"
+
+    def summary(self):
+        """Return a compact dictionary with network and result state.
+
+        Before :meth:`run`, the summary contains loaded network counts and
+        higher-order state-node information. After :meth:`run`, it also
+        includes module counts, codelength components, entropy rate, and elapsed
+        time.
+        """
+        return _summary_data(self)
+
+    def _repr_html_(self):
+        return _repr_html(self)
 
     @classmethod
     def from_options(cls, options, args=None):

--- a/interfaces/python/src/infomap/shell.py
+++ b/interfaces/python/src/infomap/shell.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import argparse
+import code
+import sys
+from pathlib import Path
+
+import infomap
+from . import Infomap, InfomapOptions, MultilayerNode
+from ._facade import _summary_data
+
+
+def _format_value(value):
+    if isinstance(value, float):
+        return f"{value:.12g}"
+    return str(value)
+
+
+def _print_summary(data):
+    for key, value in data.items():
+        print(f"{key}: {_format_value(value)}")
+
+
+def _make_banner(network_file=None):
+    lines = [
+        "Infomap shell",
+        "Imported: infomap, Infomap, InfomapOptions, MultilayerNode",
+        "Created: im = Infomap(pretty=True)",
+        "Helpers: summary(), options()",
+    ]
+    if network_file is not None:
+        lines.append(f"Loaded: {network_file}")
+    return "\n".join(lines)
+
+
+def create_namespace(network_file=None):
+    im = Infomap(pretty=True)
+    if network_file is not None:
+        im.read_file(str(network_file))
+
+    namespace = {
+        "infomap": infomap,
+        "Infomap": Infomap,
+        "InfomapOptions": InfomapOptions,
+        "MultilayerNode": MultilayerNode,
+        "im": im,
+    }
+
+    def summary(obj=None):
+        target = namespace["im"] if obj is None else obj
+        data = target.summary() if hasattr(target, "summary") else _summary_data(target)
+        _print_summary(data)
+        return data
+
+    def options():
+        help(InfomapOptions)
+        return InfomapOptions
+
+    namespace["summary"] = summary
+    namespace["options"] = options
+    return namespace
+
+
+def launch_shell(namespace, banner, *, use_ipython=True):
+    if use_ipython:
+        try:
+            from IPython import start_ipython
+        except ImportError:
+            pass
+        else:
+            print(banner)
+            start_ipython(argv=[], user_ns=namespace)
+            return
+
+    code.interact(banner=banner, local=namespace)
+
+
+def _parser():
+    parser = argparse.ArgumentParser(
+        prog="infomap-shell",
+        description="Start an interactive Python shell with Infomap preloaded.",
+    )
+    parser.add_argument(
+        "--no-ipython",
+        action="store_true",
+        help="Use the standard Python REPL even when IPython is installed.",
+    )
+    parser.add_argument(
+        "network_file",
+        nargs="?",
+        help="Network file to load into the default im object.",
+    )
+    return parser
+
+
+def main(argv=None, *, launcher=launch_shell):
+    args = _parser().parse_args(argv)
+    network_file = None
+
+    if args.network_file is not None:
+        network_file = Path(args.network_file)
+        if not network_file.is_file():
+            print(f"Error: No such file: {network_file}", file=sys.stderr)
+            return 1
+
+    namespace = create_namespace(network_file)
+    banner = _make_banner(network_file)
+    launcher(namespace, banner, use_ipython=not args.no_ipython)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ release = [
 
 [project.scripts]
 infomap = "infomap:main"
+infomap-shell = "infomap.shell:main"
 
 [tool.setuptools]
 include-package-data = true

--- a/test/python/test_api.py
+++ b/test/python/test_api.py
@@ -6,6 +6,7 @@ import networkx as nx
 import pytest
 
 import infomap as infomap_module
+import infomap._facade as facade_module
 import infomap._results as results_module
 
 
@@ -344,3 +345,127 @@ def test_run_with_options_forwards_to_run(monkeypatch):
     assert captured["kwargs"]["initial_partition"] == {1: 1}
     assert captured["kwargs"]["variable_markov_time"] is True
     assert captured["kwargs"]["num_trials"] == 5
+
+
+def test_infomap_repr_shows_readable_state(make_infomap):
+    im = make_infomap()
+    im.add_link(1, 2)
+
+    assert (
+        repr(im)
+        == "Infomap(nodes=2, links=1, physical_nodes=2, state_nodes=0, status='not run')"
+    )
+    assert im.summary() == {
+        "nodes": 2,
+        "links": 1,
+        "physical_nodes": 2,
+        "state_nodes": 0,
+        "higher_order": False,
+        "status": "not run",
+    }
+
+    im.run()
+
+    representation = repr(im)
+
+    assert representation.startswith(
+        "Infomap(nodes=2, links=1, physical_nodes=2, state_nodes=0, status='run'"
+    )
+    assert "multilayer_network=False" in representation
+    assert "levels=2" in representation
+    assert "top_modules=1" in representation
+    assert "codelength=1.0" in representation
+
+    summary = im.summary()
+    assert summary["state_input"] is False
+    assert summary["multilayer_input"] is False
+    assert summary["multilayer_network"] is False
+    assert summary["levels"] == 2
+    assert summary["leaf_nodes"] == 2
+    assert summary["top_modules"] == 1
+    assert summary["non_trivial_top_modules"] == 0
+    assert summary["leaf_modules"] == 1
+    assert summary["index_codelength"] == 0.0
+    assert summary["module_codelength"] == 1.0
+    assert summary["one_level_codelength"] == 1.0
+    assert summary["relative_codelength_savings"] == 0.0
+    assert summary["entropy_rate"] == 0.0
+    assert summary["elapsed_time"] >= 0
+
+
+def test_infomap_html_repr_shows_not_run_state(make_infomap):
+    im = make_infomap()
+    im.add_link(1, 2)
+
+    html = im._repr_html_()
+
+    assert "Infomap" in html
+    assert "Status" in html
+    assert "Not run" in html
+    assert "Nodes" in html
+    assert "Links" in html
+    assert "Higher-order" in html
+    assert "Top-module flow" not in html
+
+
+def test_infomap_html_repr_shows_run_summary_and_flow(make_infomap):
+    im = make_infomap(num_trials=10)
+    im.add_links([(1, 2), (2, 3), (3, 1), (4, 5), (5, 6), (6, 4), (3, 4)])
+    im.run()
+
+    html = im._repr_html_()
+
+    assert "Codelength" in html
+    assert "Relative savings" in html
+    assert "Top modules" in html
+    assert "Effective modules" in html
+    assert "Top-module flow" in html
+    assert "Module 1" in html
+
+
+def test_infomap_html_repr_escapes_rendered_values(monkeypatch, make_infomap):
+    im = make_infomap()
+
+    def fake_summary():
+        return {
+            "nodes": "<script>",
+            "links": 0,
+            "physical_nodes": "<script>",
+            "higher_order": False,
+            "status": "not run",
+        }
+
+    monkeypatch.setattr(im, "summary", fake_summary)
+
+    html = im._repr_html_()
+
+    assert "&lt;script&gt;" in html
+    assert "<script>" not in html
+
+
+def test_top_module_flow_bars_caps_tail_as_other(monkeypatch):
+    class FakeModule:
+        def __init__(self, module_id, flow):
+            self.module_id = module_id
+            self.flow = flow
+            self.depth = 1
+
+    class FakeInfomap:
+        def get_tree(self, depth_level=1):
+            assert depth_level == 1
+            return [FakeModule(module_id, 1.0) for module_id in range(1, 21)]
+
+    monkeypatch.setattr(facade_module, "_REPR_MAX_FLOW_FRACTION", 0.5)
+    monkeypatch.setattr(facade_module, "_REPR_MAX_MODULES", 4)
+
+    bars = facade_module._top_module_flow_bars(FakeInfomap())
+
+    assert len(bars) == 5
+    assert [bar["label"] for bar in bars[:-1]] == [
+        "Module 1",
+        "Module 2",
+        "Module 3",
+        "Module 4",
+    ]
+    assert bars[-1]["label"] == "Other modules"
+    assert bars[-1]["fraction"] == pytest.approx(0.8)

--- a/test/python/test_shell.py
+++ b/test/python/test_shell.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+
+from infomap import shell
+
+
+class FakeInfomap:
+    def __init__(self, *, pretty=False):
+        self.pretty = pretty
+        self.loaded = []
+        self.num_nodes = 0
+        self.num_links = 0
+        self.num_physical_nodes = 0
+        self.num_top_modules = 0
+        self.stateInput = False
+        self.multilayerInput = False
+        self.num_levels = 0
+        self.num_non_trivial_top_modules = 0
+        self.num_leaf_modules = 0
+        self.effective_num_top_modules = 1.0
+        self.effective_num_leaf_modules = 1.0
+        self.codelength = 0.0
+        self.index_codelength = 0.0
+        self.module_codelength = 0.0
+        self.one_level_codelength = 0.0
+        self.relative_codelength_savings = 0.0
+        self.entropy_rate = 0.0
+        self.elapsed_time = 0.0
+        self.meta_codelength = 0.0
+
+    def read_file(self, filename):
+        self.loaded.append(filename)
+        self.num_nodes = 6
+        self.num_links = 7
+        self.num_physical_nodes = 6
+
+    def isMultilayerNetwork(self):
+        return False
+
+    def numLeafNodes(self):
+        return self.num_nodes
+
+
+def test_create_namespace_preloads_default_infomap(monkeypatch, tmp_path):
+    network_file = tmp_path / "network.net"
+    network_file.write_text("*Vertices 0\n", encoding="utf-8")
+    monkeypatch.setattr(shell, "Infomap", FakeInfomap)
+
+    namespace = shell.create_namespace(network_file)
+
+    assert namespace["im"].pretty is True
+    assert namespace["im"].loaded == [str(network_file)]
+    assert namespace["InfomapOptions"] is shell.InfomapOptions
+
+
+def test_summary_prints_partial_state_before_run(monkeypatch, capsys):
+    monkeypatch.setattr(shell, "Infomap", FakeInfomap)
+    namespace = shell.create_namespace()
+    namespace["im"].num_nodes = 3
+    namespace["im"].num_links = 2
+    namespace["im"].num_physical_nodes = 3
+
+    data = namespace["summary"]()
+
+    assert data == {
+        "nodes": 3,
+        "links": 2,
+        "physical_nodes": 3,
+        "state_nodes": 0,
+        "higher_order": False,
+        "status": "not run",
+    }
+    assert "status: not run" in capsys.readouterr().out
+
+
+def test_summary_prints_run_state(monkeypatch, capsys):
+    monkeypatch.setattr(shell, "Infomap", FakeInfomap)
+    namespace = shell.create_namespace()
+    namespace["im"].num_nodes = 6
+    namespace["im"].num_links = 7
+    namespace["im"].num_physical_nodes = 6
+    namespace["im"].num_top_modules = 2
+    namespace["im"].num_levels = 2
+    namespace["im"].num_non_trivial_top_modules = 2
+    namespace["im"].num_leaf_modules = 2
+    namespace["im"].effective_num_top_modules = 2.0
+    namespace["im"].effective_num_leaf_modules = 2.0
+    namespace["im"].codelength = 1.0
+    namespace["im"].index_codelength = 0.25
+    namespace["im"].module_codelength = 0.75
+    namespace["im"].one_level_codelength = 2.0
+    namespace["im"].relative_codelength_savings = 0.5
+    namespace["im"].entropy_rate = 1.25
+    namespace["im"].elapsed_time = 0.01
+
+    data = namespace["summary"]()
+
+    assert data["status"] == "run"
+    assert data["codelength"] == 1.0
+    assert data["index_codelength"] == 0.25
+    assert data["module_codelength"] == 0.75
+    assert data["top_modules"] == 2
+    assert data["levels"] == 2
+    assert data["entropy_rate"] == 1.25
+    output = capsys.readouterr().out
+    assert "codelength: 1" in output
+    assert "top_modules: 2" in output
+    assert "entropy_rate: 1.25" in output
+
+
+def test_options_delegates_to_generated_options(monkeypatch):
+    monkeypatch.setattr(shell, "Infomap", FakeInfomap)
+    namespace = shell.create_namespace()
+
+    assert namespace["options"]() is shell.InfomapOptions
+
+
+def test_main_loads_file_and_uses_injected_launcher(monkeypatch, tmp_path):
+    network_file = tmp_path / "network.net"
+    network_file.write_text("*Vertices 0\n", encoding="utf-8")
+    monkeypatch.setattr(shell, "Infomap", FakeInfomap)
+    launched = {}
+
+    def launcher(namespace, banner, *, use_ipython):
+        launched["namespace"] = namespace
+        launched["banner"] = banner
+        launched["use_ipython"] = use_ipython
+
+    result = shell.main(["--no-ipython", str(network_file)], launcher=launcher)
+
+    assert result == 0
+    assert launched["use_ipython"] is False
+    assert launched["namespace"]["im"].loaded == [str(network_file)]
+    assert f"Loaded: {network_file}" in launched["banner"]
+
+
+def test_main_rejects_missing_preload_file(capsys):
+    result = shell.main(["missing.net"], launcher=lambda *args, **kwargs: None)
+
+    assert result == 1
+    assert "Error: No such file: missing.net" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- add a notebook-native HTML summary for `Infomap` using the existing `summary()` state
- add `examples/notebooks/quickstart.ipynb` as the flagship Jupyter quickstart and smoke-test it in `examples/notebooks/notebooks.toml`
- promote the quickstart notebook from `README.rst`, `examples/notebooks/README.md`, and `interfaces/python/source/notebooks.rst`
- add `infomap-shell` and documentation for terminal exploration

## Verification

- `python3 -m ruff format interfaces/python/src/infomap/_facade.py test/python/test_api.py test/python/test_shell.py interfaces/python/src/infomap/shell.py`
- `python3 -m ruff check --fix interfaces/python/src/infomap/_facade.py test/python/test_api.py test/python/test_shell.py interfaces/python/src/infomap/shell.py`
- `make test-python-unit PYTEST_ARGS='test/python/test_api.py test/python/test_shell.py'` (184 passed, 20 skipped)
- `python3 -m json.tool examples/notebooks/quickstart.ipynb`
- `python -m pytest --nbmake --nbmake-timeout=300 examples/notebooks/quickstart.ipynb` from a repo-local `.venv`