### PR TITLE
ci: select 64-bit Windows wheel for smoke test

### DIFF
--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -276,7 +276,11 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          python -m pip install wheelhouse/infomap-*-cp314-cp314-*.whl pytest torch
+          wheel_pattern="wheelhouse/infomap-*-cp314-cp314-*.whl"
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            wheel_pattern="wheelhouse/infomap-*-cp314-cp314-win_amd64.whl"
+          fi
+          python -m pip install $wheel_pattern pytest torch
           python -m pytest test/python/test_torch_interop.py
 
       - name: Upload wheels


### PR DESCRIPTION
## Summary

- select the 64-bit Windows CPython 3.14 wheel for the PyTorch smoke test
- keep Linux and macOS wheel smoke installs unchanged
- keep publishing both Windows wheel architectures

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/_python-package.yml"); puts "YAML OK"'`\n- `git diff --check`