### PR TITLE
ci: migrate Windows runners to VS 2026 image

### DIFF
--- a/.github/workflows/_native-build.yml
+++ b/.github/workflows/_native-build.yml
@@ -26,7 +26,7 @@ jobs:
         config:
           - {
               name: windows,
-              os: windows-2025,
+              os: windows-2025-vs2026,
               artifact: infomap-win,
               binary: Infomap.exe,
               cxxflags: -static,

--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -84,7 +84,7 @@ jobs:
             python-version: "3.14"
             smoke-only: false
             run-full-suite: true
-          - os: windows-2025
+          - os: windows-2025-vs2026
             python-version: "3.14"
             smoke-only: true
             run-full-suite: false
@@ -231,7 +231,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-2025, macos-15]
+        os: [ubuntu-24.04, windows-2025-vs2026, macos-15]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/_r-package.yml
+++ b/.github/workflows/_r-package.yml
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-15, windows-2025]
+        os: [ubuntu-24.04, macos-15, windows-2025-vs2026]
         r: [release, oldrel]
 
     defaults:
@@ -165,7 +165,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-15, windows-2025]
+        os: [macos-15, windows-2025-vs2026]
         r: [release, oldrel]
 
     defaults:


### PR DESCRIPTION
## Summary
- migrate native, Python, and R Windows workflow matrices to `windows-2025-vs2026`
- keep release artifact naming behavior unchanged

## Verification
- `git diff --check -- .github/workflows/_native-build.yml .github/workflows/_python-package.yml .github/workflows/_r-package.yml`
- exact `windows-2025` label search returned no matches
- `actionlint .github/workflows/_native-build.yml .github/workflows/_python-package.yml .github/workflows/_r-package.yml` was attempted, but it reports an existing ShellCheck SC2086 notice in `.github/workflows/_python-package.yml` unrelated to this label change

## Release artifact note
- Python prerelease wheels can be tested with `Prerelease` and `publish=false`
- native and R release artifacts are not safely verified through `release.yml` because that workflow also publishes assets