### PR TITLE
ci: speed up python ci and quiet notices

### DIFF
--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -11,6 +11,18 @@ on:
         required: false
         type: boolean
         default: true
+      mode:
+        required: false
+        type: string
+        default: full
+      run-swig-freshness:
+        required: false
+        type: boolean
+        default: true
+      run-release-smoke:
+        required: false
+        type: boolean
+        default: true
       build-release-artifacts:
         required: false
         type: boolean
@@ -25,7 +37,7 @@ permissions:
 
 jobs:
   swig-freshness:
-    if: inputs.run-tests
+    if: inputs.run-tests && (inputs.mode == 'full' || inputs.run-swig-freshness)
     name: Python SWIG freshness
     runs-on: ubuntu-24.04
     timeout-minutes: 20
@@ -41,8 +53,17 @@ jobs:
         with:
           python-version: "3.14"
 
+      - name: Cache SWIG 4.4.1 install
+        id: swig-cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ runner.tool_cache }}/swig/4.4.1/${{ runner.arch }}
+          key: swig-4.4.1-${{ runner.os }}-${{ runner.arch }}-v2
+
       - name: Install SWIG 4.4.1
+        if: steps.swig-cache.outputs.cache-hit != 'true'
         run: |
+          swig_prefix="$RUNNER_TOOL_CACHE/swig/4.4.1/$RUNNER_ARCH"
           sudo apt-get update
           sudo apt-get install -y ca-certificates curl build-essential libpcre2-dev
           curl -L --retry 3 --output /tmp/swig.tar.gz \
@@ -50,16 +71,82 @@ jobs:
           mkdir -p /tmp/swig-src
           tar -xzf /tmp/swig.tar.gz -C /tmp/swig-src --strip-components=1
           cd /tmp/swig-src
-          ./configure
+          ./configure --prefix="$swig_prefix"
           make -j"$(nproc)"
-          sudo make install
-          swig -version
+          make install
+
+      - name: Add SWIG to PATH
+        run: echo "$RUNNER_TOOL_CACHE/swig/4.4.1/$RUNNER_ARCH/bin" >> "$GITHUB_PATH"
+
+      - name: Verify SWIG version
+        run: swig -version
 
       - name: Verify tracked SWIG outputs
         run: make test-python-swig-freshness
 
-  tests:
-    if: inputs.run-tests
+  tests-quick:
+    if: ${{ always() && inputs.run-tests && inputs.mode == 'quick' && (needs.swig-freshness.result == 'success' || needs.swig-freshness.result == 'skipped') }}
+    name: Python ${{ matrix.os }} / ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    needs: swig-freshness
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            python-version: "3.14"
+            smoke-only: false
+          - os: windows-2025-vs2026
+            python-version: "3.14"
+            smoke-only: true
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Set up Python
+        uses: ./.github/actions/setup-python-build
+        with:
+          python-version: ${{ matrix.python-version }}
+          install-build-tooling: "true"
+
+      - name: Build Python wheel from repo root
+        run: make build-python
+        env:
+          FEATURES: ${{ inputs.features }}
+
+      - name: Install editable package
+        run: make dev-python-install
+        env:
+          FEATURES: ${{ inputs.features }}
+
+      - name: Run Python smoke test
+        if: matrix.smoke-only
+        run: |
+          python - <<'PY'
+          import os
+          from infomap import Infomap, build_info
+          print(Infomap(silent=True).num_top_modules)
+          features = os.environ.get("INFOMAP_EXPECTED_FEATURES", "")
+          if "regularized-multilayer" in features.replace(",", " ").split():
+              assert "regularized-multilayer" in build_info()["enabled_features"]
+          PY
+        env:
+          INFOMAP_EXPECTED_FEATURES: ${{ inputs.features }}
+
+      - name: Run Python unit tests
+        if: ${{ !matrix.smoke-only }}
+        run: make test-python-unit
+
+  tests-full:
+    if: ${{ always() && inputs.run-tests && inputs.mode == 'full' && (needs.swig-freshness.result == 'success' || needs.swig-freshness.result == 'skipped') }}
     name: Python ${{ matrix.os }} / ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
@@ -142,7 +229,7 @@ jobs:
         run: make test-python-examples
 
   release-smoke:
-    if: inputs.run-tests && !inputs.build-release-artifacts
+    if: inputs.run-tests && !inputs.build-release-artifacts && (inputs.mode == 'full' || inputs.run-release-smoke)
     name: Python release smoke
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -255,7 +342,7 @@ jobs:
         run: python -m cibuildwheel . --output-dir wheelhouse
         env:
           CIBW_BUILD: "cp311-* cp312-* cp313-* cp314-*"
-          CIBW_SKIP: "*-musllinux* pp*"
+          CIBW_SKIP: "*-musllinux*"
           CIBW_TEST_COMMAND: >-
             python -c "from infomap import Infomap, build_info; print(Infomap(silent=True).num_top_modules); assert ('regularized-multilayer' not in '${{ inputs.features }}'.replace(',', ' ').split()) or ('regularized-multilayer' in build_info()['enabled_features'])"
           CIBW_ENVIRONMENT: >-
@@ -280,6 +367,7 @@ jobs:
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             wheel_pattern="wheelhouse/infomap-*-cp314-cp314-win_amd64.whl"
           fi
+          # shellcheck disable=SC2086
           python -m pip install $wheel_pattern pytest torch
           python -m pytest test/python/test_torch_interop.py
 

--- a/.github/workflows/_r-package.yml
+++ b/.github/workflows/_r-package.yml
@@ -40,14 +40,13 @@ jobs:
         id: swig-cache
         uses: actions/cache@v5
         with:
-          path: |
-            /usr/local/bin/swig
-            /usr/local/share/swig
-          key: swig-4.4.1-${{ runner.os }}-${{ runner.arch }}-v1
+          path: ${{ runner.tool_cache }}/swig/4.4.1/${{ runner.arch }}
+          key: swig-4.4.1-${{ runner.os }}-${{ runner.arch }}-v2
 
       - name: Install SWIG 4.4.1
         if: steps.swig-cache.outputs.cache-hit != 'true'
         run: |
+          swig_prefix="$RUNNER_TOOL_CACHE/swig/4.4.1/$RUNNER_ARCH"
           sudo apt-get update
           sudo apt-get install -y ca-certificates curl build-essential libpcre2-dev
           curl -L --retry 3 --output /tmp/swig.tar.gz \
@@ -55,9 +54,12 @@ jobs:
           mkdir -p /tmp/swig-src
           tar -xzf /tmp/swig.tar.gz -C /tmp/swig-src --strip-components=1
           cd /tmp/swig-src
-          ./configure
+          ./configure --prefix="$swig_prefix"
           make -j"$(nproc)"
-          sudo make install
+          make install
+
+      - name: Add SWIG to PATH
+        run: echo "$RUNNER_TOOL_CACHE/swig/4.4.1/$RUNNER_ARCH/bin" >> "$GITHUB_PATH"
 
       - name: Verify SWIG version
         run: swig -version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,9 @@ jobs:
     outputs:
       policy: ${{ steps.filter.outputs.policy }}
       native: ${{ steps.filter.outputs.native }}
-      python: ${{ steps.filter.outputs.python }}
+      python-core: ${{ steps.filter.outputs.python-core }}
+      python-packaging: ${{ steps.filter.outputs.python-packaging }}
+      python-swig: ${{ steps.filter.outputs.python-swig }}
       javascript: ${{ steps.filter.outputs.javascript }}
       r: ${{ steps.filter.outputs.r }}
       docs: ${{ steps.filter.outputs.docs }}
@@ -60,7 +62,7 @@ jobs:
               - "test/fixtures/**"
               - ".github/workflows/ci.yml"
               - ".github/workflows/_native-build.yml"
-            python:
+            python-core:
               - "CMakeLists.txt"
               - "Makefile"
               - "mk/**"
@@ -71,6 +73,7 @@ jobs:
               - ".github/workflows/_native-build.yml"
               - "pyproject.toml"
               - "setup.py"
+              - "interfaces/swig/**"
               - "interfaces/python/**"
               - "examples/python/**"
               - "examples/notebooks/**"
@@ -80,6 +83,20 @@ jobs:
               - "scripts/generate_python_swig.py"
               - "scripts/notebook_manifest.py"
               - ".github/actions/setup-python-build/action.yml"
+              - ".github/workflows/_python-package.yml"
+            python-packaging:
+              - "Makefile"
+              - "mk/**"
+              - "pyproject.toml"
+              - "setup.py"
+              - "scripts/build_config.py"
+              - ".github/actions/setup-python-build/action.yml"
+              - ".github/workflows/_python-package.yml"
+            python-swig:
+              - "interfaces/swig/**"
+              - "interfaces/python/generated/**"
+              - "interfaces/python/src/infomap/_swig.py"
+              - "scripts/generate_python_swig.py"
               - ".github/workflows/_python-package.yml"
             javascript:
               - "CMakeLists.txt"
@@ -135,10 +152,8 @@ jobs:
               - "scripts/build_config.py"
               - "README.rst"
             notebooks:
-              - "Makefile"
-              - "mk/**"
-              - "pyproject.toml"
-              - "setup.py"
+              - "interfaces/python/**"
+              - "test/python/**"
               - "examples/notebooks/**"
               - "scripts/notebook_manifest.py"
               - ".github/actions/setup-python-build/action.yml"
@@ -233,15 +248,18 @@ jobs:
 
   python:
     needs: changes
-    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.python == 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.python-core == 'true' || needs.changes.outputs.python-swig == 'true'
     uses: ./.github/workflows/_python-package.yml
     with:
       run-tests: true
+      mode: ${{ github.event_name == 'pull_request' && 'quick' || 'full' }}
+      run-swig-freshness: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.python-swig == 'true' }}
+      run-release-smoke: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.python-packaging == 'true' }}
       build-release-artifacts: false
 
   notebooks:
     needs: changes
-    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.python == 'true' || needs.changes.outputs.notebooks == 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.notebooks == 'true' || (github.event_name == 'push' && needs.changes.outputs.python-core == 'true')
     name: Tutorial notebook smoke tests
     runs-on: ubuntu-24.04
     timeout-minutes: 45

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -56,6 +56,7 @@ jobs:
     with:
       ref: ${{ github.event_name == 'workflow_dispatch' && (inputs.ref || github.sha) || github.ref }}
       run-tests: true
+      mode: full
       build-release-artifacts: true
       features: ${{ github.event_name == 'workflow_dispatch' && inputs.features || '' }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
     with:
       ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
       run-tests: true
+      mode: full
       build-release-artifacts: true
 
   javascript:

--- a/BUILD.md
+++ b/BUILD.md
@@ -197,6 +197,12 @@ More targeted checks are available when you only need one slice:
 - `make test-python-doctest`
 - `make test-python-examples`
 
+CI uses two Python coverage tiers. Pull requests run the quick tier: Python
+3.14 on Ubuntu with unit tests, plus a Windows smoke test. The full tier keeps
+the broader Python version matrix, doctests, examples, and release smoke checks
+for `master`, release, prerelease, and manual workflow runs. Release and
+prerelease workflows still build the Python sdist and platform wheels.
+
 To build the Python extension in debug mode, pass the same mode override:
 
 ```bash

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -85,7 +85,7 @@ Configure these integrations before the first release:
 5. Release Please creates the `vX.Y.Z` tag and the GitHub Release.
 6. `.github/workflows/release.yml` runs for that tag and:
    - builds the native release assets
-   - builds the Python sdist and wheels
+   - builds the Python sdist and wheels through the full Python workflow tier
    - builds the R source tarball once, then builds macOS and Windows R
      binaries from that exact tarball for both R `release` and `oldrel`
    - builds and verifies the npm package

--- a/examples/notebooks/README.md
+++ b/examples/notebooks/README.md
@@ -17,7 +17,8 @@ broken examples are caught by the normal maintenance workflow.
 
 The tier for each notebook is listed in `notebooks.toml`.
 
-- `smoke`: deterministic notebooks that run in pull-request CI.
+- `smoke`: deterministic notebooks that run in pull-request CI for notebook
+  and Python API changes, and in full notebook CI.
 - `full`: reproducible notebooks that run in the scheduled full notebook CI.
 - `manual`: notebooks that currently require external repositories, compiled
   helper tools, large geospatial dependencies, or other setup outside CI.

--- a/scripts/stage_r_package.py
+++ b/scripts/stage_r_package.py
@@ -97,6 +97,13 @@ def copy_skeleton(skeleton: Path, dest: Path) -> None:
     shutil.copytree(skeleton, dest)
 
 
+def normalize_configure_permissions(pkg_root: Path) -> None:
+    for name in ("configure", "configure.win"):
+        path = pkg_root / name
+        if path.exists():
+            path.chmod(0o755)
+
+
 def remove_compiled_artifacts(pkg_src: Path) -> None:
     for pattern in ("*.o", "*.so", "*.dll", "*.dylib"):
         for path in pkg_src.rglob(pattern):
@@ -120,6 +127,8 @@ def stage(
             raise RuntimeError("--in-place requires out_dir == skeleton")
     else:
         copy_skeleton(skeleton, out_dir)
+
+    normalize_configure_permissions(out_dir)
 
     generated_cpp = generated / "infomap_wrap.cpp"
     generated_r = generated / "infomap.R"


### PR DESCRIPTION
## Summary

- add quick/full Python workflow modes so pull requests run a smaller Python matrix while master, release, prerelease, and manual runs keep full coverage
- split CI path filters for Python core, packaging, SWIG, and notebook smoke coverage
- move SWIG install caches under the runner tool cache and remove the redundant cibuildwheel `pp*` skip selector
- normalize staged R `configure` script permissions and document the updated CI coverage policy

## Verification

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/_python-package.yml .github/workflows/ci.yml .github/workflows/_r-package.yml .github/workflows/release.yml .github/workflows/prerelease.yml`
- `actionlint -ignore 'constant expression "false" in condition' .github/workflows/_python-package.yml .github/workflows/ci.yml .github/workflows/_r-package.yml .github/workflows/release.yml .github/workflows/prerelease.yml`
- static path-filter check for Python API, core, SWIG, packaging, and notebook scenarios
- `python3 scripts/stage_r_package.py --out-dir build/R/infomap`
- checked `build/R/infomap/configure` and `build/R/infomap/configure.win` are executable
- `python3 -m compileall -q scripts/stage_r_package.py`
- `git diff --check`

## Not run

- `cibuildwheel` dry run; `cibuildwheel` is not installed locally
