### PR TITLE
ci: include docs and docker jobs in ci-summary gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,7 +330,7 @@ jobs:
 
   ci-summary:
     name: CI Summary
-    needs: [changes, policy, cxx-format, sanitizers, clang-tidy, native, python, notebooks, javascript, r]
+    needs: [changes, policy, cxx-format, sanitizers, clang-tidy, native, python, notebooks, javascript, r, docs, docker]
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 10


### PR DESCRIPTION
## What

`ci-summary.needs` omitted the `docs` and `docker` jobs, so a failure in either would **not** fail the aggregate CI gate (the gate could go green while docs or docker were red).

This adds both to the `needs` list so their results are enforced by the summary check.

```diff
-    needs: [changes, policy, cxx-format, sanitizers, clang-tidy, native, python, notebooks, javascript, r]
+    needs: [changes, policy, cxx-format, sanitizers, clang-tidy, native, python, notebooks, javascript, r, docs, docker]
```

## Notes

Both jobs are path-gated and resolve to `skipped` when their paths are untouched; the summary check already treats `skipped` as passing, so this only changes behaviour when docs/docker actually run and fail.

First of a small series improving the release/CI split (see plan).