### PR TITLE
ci: release rehearsal, version preflight, and faster R PRs

### DIFF
--- a/.github/workflows/_r-package.yml
+++ b/.github/workflows/_r-package.yml
@@ -11,6 +11,10 @@ on:
         required: false
         type: boolean
         default: true
+      mode:
+        required: false
+        type: string
+        default: full
       build-release-artifacts:
         required: false
         type: boolean
@@ -20,6 +24,24 @@ permissions:
   contents: read
 
 jobs:
+  matrix-setup:
+    if: inputs.run-tests
+    name: Resolve R test matrix
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+
+    steps:
+      - name: Select matrix for mode
+        id: set
+        run: |
+          if [ "${{ inputs.mode }}" = "quick" ]; then
+            echo 'matrix={"os":["ubuntu-24.04"],"r":["release"]}' >> "$GITHUB_OUTPUT"
+          else
+            echo 'matrix={"os":["ubuntu-24.04","macos-15","windows-2025-vs2026"],"r":["release","oldrel"]}' >> "$GITHUB_OUTPUT"
+          fi
+
   swig-freshness:
     name: R SWIG freshness
     runs-on: ubuntu-24.04
@@ -72,12 +94,10 @@ jobs:
     name: R ${{ matrix.r }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
-    needs: swig-freshness
+    needs: [swig-freshness, matrix-setup]
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, macos-15, windows-2025-vs2026]
-        r: [release, oldrel]
+      matrix: ${{ fromJSON(needs.matrix-setup.outputs.matrix) }}
 
     defaults:
       run:
@@ -253,7 +273,7 @@ jobs:
           if-no-files-found: error
 
   r-universe-simulation:
-    if: inputs.run-tests
+    if: inputs.run-tests && inputs.mode == 'full'
     name: R r-universe simulation
     runs-on: ubuntu-24.04
     timeout-minutes: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,51 +196,6 @@ jobs:
       - name: Check C++ formatting
         run: make format-native-check
 
-  sanitizers:
-    needs: changes
-    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.native == 'true'
-    name: Linux sanitizers
-    runs-on: ubuntu-24.04
-    timeout-minutes: 45
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Install sanitizer toolchain
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang lld ninja-build
-        shell: bash
-
-      - name: Configure sanitizer build
-        run: make test-sanitizers CMAKE_GENERATOR=Ninja SANITIZER_CXX=clang++
-        shell: bash
-        env:
-          ASAN_OPTIONS: detect_leaks=1:strict_string_checks=1
-          UBSAN_OPTIONS: print_stacktrace=1
-
-  clang-tidy:
-    needs: changes
-    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.native == 'true'
-    name: Linux clang-tidy
-    runs-on: ubuntu-24.04
-    timeout-minutes: 45
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Install clang-tidy toolchain
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang-tidy ninja-build
-        shell: bash
-
-      - name: Run clang-tidy
-        run: make tidy-native CMAKE_DEV_GENERATOR=Ninja CLANG_TIDY_WARNINGS_AS_ERRORS='readability-*,performance-*,modernize-use-override,bugprone-branch-clone'
-        shell: bash
-
   native:
     needs: changes
     if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.native == 'true'
@@ -297,6 +252,7 @@ jobs:
     uses: ./.github/workflows/_r-package.yml
     with:
       run-tests: true
+      mode: ${{ github.event_name == 'pull_request' && 'quick' || 'full' }}
       build-release-artifacts: false
 
   docs:
@@ -330,7 +286,7 @@ jobs:
 
   ci-summary:
     name: CI Summary
-    needs: [changes, policy, cxx-format, sanitizers, clang-tidy, native, python, notebooks, javascript, r]
+    needs: [changes, policy, cxx-format, native, python, notebooks, javascript, r, docs, docker]
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 10

--- a/.github/workflows/release-rehearsal.yml
+++ b/.github/workflows/release-rehearsal.yml
@@ -1,0 +1,136 @@
+name: Release Rehearsal
+
+# Dry run of the release build against an existing tag. Reproduces every
+# artifact-producing step of release.yml -- native packaging, Python sdist +
+# cibuildwheel, npm pack, R source + binaries, and the multi-arch Docker build
+# -- but publishes nothing. Use before tagging (or to debug a failed release)
+# to confirm the release will build without touching PyPI/npm/GHCR.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing tag to rehearse the release build for (vX.Y.Z)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-rehearsal-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  check-versions:
+    name: Verify package versions match the tag
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: refs/tags/${{ inputs.tag }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.14"
+
+      - name: Check version consistency
+        run: python3 scripts/check_release_versions.py --tag "${{ inputs.tag }}"
+
+  native:
+    needs: [check-versions]
+    uses: ./.github/workflows/_native-build.yml
+    with:
+      ref: refs/tags/${{ inputs.tag }}
+      upload-artifacts: true
+
+  python:
+    needs: [check-versions]
+    uses: ./.github/workflows/_python-package.yml
+    with:
+      ref: refs/tags/${{ inputs.tag }}
+      run-tests: true
+      mode: full
+      build-release-artifacts: true
+
+  javascript:
+    needs: [check-versions]
+    uses: ./.github/workflows/_js-package.yml
+    with:
+      ref: refs/tags/${{ inputs.tag }}
+      run-tests: true
+      pack-artifact: true
+
+  r:
+    needs: [check-versions]
+    uses: ./.github/workflows/_r-package.yml
+    with:
+      ref: refs/tags/${{ inputs.tag }}
+      run-tests: true
+      mode: full
+      build-release-artifacts: true
+
+  docker-dry-run:
+    name: Docker multi-arch build (no push)
+    needs: [check-versions]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: refs/tags/${{ inputs.tag }}
+
+      - name: Resolve version
+        id: release
+        run: echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+        env:
+          TAG: ${{ inputs.tag }}
+
+      - name: Build and smoke-test supported Docker images
+        run: make test-docker-supported
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        with:
+          platforms: amd64,arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Build CLI image (no push)
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: docker/infomap.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: ghcr.io/mapequation/infomap:${{ steps.release.outputs.version }}
+
+      - name: Build notebook image (no push)
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: docker/notebook.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: ghcr.io/mapequation/infomap:notebook-${{ steps.release.outputs.version }}
+
+  rehearsal-summary:
+    name: Release Rehearsal Summary
+    needs: [check-versions, native, python, javascript, r, docker-dry-run]
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Check rehearsal results
+        run: |
+          results='${{ toJSON(needs) }}'
+          echo "$results"
+          echo "$results" | jq -e 'to_entries | all(.value.result == "success" or .value.result == "skipped")'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,15 +37,37 @@ jobs:
             exit 1
           fi
 
-  native:
+  check-versions:
+    name: Verify package versions match the tag
     needs: [validate-stable-tag]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.14"
+
+      - name: Check version consistency
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+        run: python3 scripts/check_release_versions.py --tag "$RELEASE_TAG"
+
+  native:
+    needs: [validate-stable-tag, check-versions]
     uses: ./.github/workflows/_native-build.yml
     with:
       ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
       upload-artifacts: true
 
   python:
-    needs: [validate-stable-tag]
+    needs: [validate-stable-tag, check-versions]
     uses: ./.github/workflows/_python-package.yml
     with:
       ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
@@ -54,7 +76,7 @@ jobs:
       build-release-artifacts: true
 
   javascript:
-    needs: [validate-stable-tag]
+    needs: [validate-stable-tag, check-versions]
     uses: ./.github/workflows/_js-package.yml
     with:
       ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
@@ -62,11 +84,12 @@ jobs:
       pack-artifact: true
 
   r:
-    needs: [validate-stable-tag]
+    needs: [validate-stable-tag, check-versions]
     uses: ./.github/workflows/_r-package.yml
     with:
       ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
       run-tests: true
+      mode: full
       build-release-artifacts: true
 
   publish-github-release:

--- a/.github/workflows/scheduled-ci.yml
+++ b/.github/workflows/scheduled-ci.yml
@@ -1,0 +1,133 @@
+name: Scheduled CI
+
+# Full-coverage CI that runs the heavier jobs kept out of the fast PR loop:
+# sanitizers, clang-tidy, the full R OS/version matrix, r-universe simulation,
+# and the full Python version matrix. Runs nightly on weekdays and can be
+# dispatched manually on any branch (e.g. before merging risky native changes).
+
+on:
+  schedule:
+    - cron: "17 3 * * 1-5"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: scheduled-ci-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  policy:
+    name: C++ stream policy
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check runtime stream policy
+        run: make test-cpp-stream-policy PYTHON=python3
+
+  sanitizers:
+    name: Linux sanitizers
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install sanitizer toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang lld ninja-build
+        shell: bash
+
+      - name: Configure sanitizer build
+        run: make test-sanitizers CMAKE_GENERATOR=Ninja SANITIZER_CXX=clang++
+        shell: bash
+        env:
+          ASAN_OPTIONS: detect_leaks=1:strict_string_checks=1
+          UBSAN_OPTIONS: print_stacktrace=1
+
+  clang-tidy:
+    name: Linux clang-tidy
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install clang-tidy toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-tidy ninja-build
+        shell: bash
+
+      - name: Run clang-tidy
+        run: make tidy-native CMAKE_DEV_GENERATOR=Ninja CLANG_TIDY_WARNINGS_AS_ERRORS='readability-*,performance-*,modernize-use-override,bugprone-branch-clone'
+        shell: bash
+
+  native:
+    uses: ./.github/workflows/_native-build.yml
+
+  python:
+    uses: ./.github/workflows/_python-package.yml
+    with:
+      run-tests: true
+      mode: full
+      build-release-artifacts: false
+
+  notebooks:
+    name: Tutorial notebook smoke tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: ./.github/actions/setup-python-build
+        with:
+          python-version: "3.14"
+          install-build-tooling: "true"
+
+      - name: Install package and notebook dependencies
+        run: |
+          make build-python
+          make dev-python-install
+          make dev-python-notebooks-install
+
+      - name: Run notebook smoke tests
+        run: make test-python-notebooks-smoke
+
+  javascript:
+    uses: ./.github/workflows/_js-package.yml
+    with:
+      run-tests: true
+      pack-artifact: false
+
+  r:
+    uses: ./.github/workflows/_r-package.yml
+    with:
+      run-tests: true
+      mode: full
+      build-release-artifacts: false
+
+  scheduled-summary:
+    name: Scheduled CI Summary
+    needs: [policy, sanitizers, clang-tidy, native, python, notebooks, javascript, r]
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Check scheduled CI results
+        run: |
+          results='${{ toJSON(needs) }}'
+          echo "$results"
+          echo "$results" | jq -e 'to_entries | all(.value.result == "success" or .value.result == "skipped")'

--- a/CI.md
+++ b/CI.md
@@ -1,0 +1,68 @@
+# CI strategy
+
+How the GitHub Actions workflows split work across the development lifecycle,
+and why a green PR is not the same as a green release. For the release
+procedure itself, see [RELEASING.md](RELEASING.md).
+
+## What runs where
+
+| Stage | Workflow | Trigger | Purpose |
+| ----- | -------- | ------- | ------- |
+| **PR** | `ci.yml` | `pull_request`, push to `master` | Fast feedback. Path-filtered; Python and R run in `quick` mode (Linux + latest version only). |
+| **Scheduled** | `scheduled-ci.yml` | nightly (weekdays 03:17 UTC) + manual | Full coverage: sanitizers, clang-tidy, the full Python and R OS/version matrices, and r-universe simulation. |
+| **Rehearsal** | `release-rehearsal.yml` | manual, against an existing tag | Dry run of the release build — all release artifacts, nothing published. |
+| **Release** | `release.yml` | push of a `vX.Y.Z` tag | Build release artifacts and publish to PyPI, npm, GHCR, and the GitHub release. |
+
+### Reusable workflows and `mode`
+
+`_native-build.yml`, `_python-package.yml`, `_js-package.yml`, and
+`_r-package.yml` hold the build/test logic and are called by the stages above.
+
+- `_python-package.yml` and `_r-package.yml` take a `mode` input (`quick` |
+  `full`, default `full`). PR CI passes `quick`; scheduled, release, and
+  rehearsal use `full`. `quick` runs Linux + the latest version only and skips
+  r-universe simulation.
+- `build-release-artifacts` / `upload-artifacts` / `pack-artifact` switch the
+  reusables into artifact-producing mode, which runs only at release and
+  rehearsal.
+
+Heavier native checks (sanitizers, clang-tidy) and the full matrices live in
+`scheduled-ci.yml`, not PR CI. To run them on demand for a risky branch,
+dispatch `scheduled-ci.yml` manually on that branch.
+
+## Why a green PR is not a green release
+
+PR CI never builds release artifacts. The artifact paths — cibuildwheel wheels,
+the R source tarball + platform binaries (including the rename step), native
+packaging, and the multi-arch Docker images — are exercised only when
+`build-release-artifacts` / `upload-artifacts` / `pack-artifact` are set, i.e.
+only at release time.
+
+`release-rehearsal.yml` closes that gap. Run it against the tag **before**
+pushing the release (`workflow_dispatch` → enter the tag); it reproduces every
+artifact build and the version preflight without publishing anything.
+
+## Version preflight
+
+`scripts/check_release_versions.py --tag vX.Y.Z` asserts that every tracked
+version-bearing file matches the tag and each other (`src/version.h`,
+`interfaces/python/src/infomap/_version.py`, `interfaces/R/infomap/DESCRIPTION`,
+`package.json`, `CITATION.cff` — the surfaces listed in
+[RELEASING.md](RELEASING.md)). It reads fixed paths only, never a repo-wide
+search, so a stale local build artifact cannot cause a false mismatch. It runs
+as the `check-versions` gate in both `release.yml` and `release-rehearsal.yml`.
+
+## Residual release-only risk
+
+A green rehearsal still cannot exercise the publish path: PyPI/npm trusted
+publishing and the `pypi-release`/`npm-release` environments, the downstream
+repo-dispatch tokens, and the `action-gh-release` file globs in `release.yml`
+(the rehearsal confirms artifacts exist, not that the globs match their names).
+These are configured and verified per the one-time setup and recovery sections
+of [RELEASING.md](RELEASING.md).
+
+## Measuring the PR speedup
+
+The `quick`/`full` split and moving sanitizers/clang-tidy/r-universe to
+`scheduled-ci.yml` aim to shorten PR wall-clock. To confirm, compare a
+representative PR's total runtime before and after on the Actions run page.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -62,6 +62,14 @@ Configure these integrations before the first release:
 
 ## Normal release flow
 
+> Pushing a `vX.Y.Z` tag triggers `release.yml`, which publishes immediately, so
+> there is no window to rehearse the new tag itself. To catch pipeline or
+> infrastructure regressions (runner image changes, dependency drift) before a
+> release cycle, run `.github/workflows/release-rehearsal.yml` (`workflow_dispatch`)
+> against the most recent existing tag first. It reproduces every release
+> artifact build and the version preflight without publishing. See
+> [CI.md](CI.md).
+
 1. Merge ordinary pull requests to `master` using Conventional Commit messages.
 2. Let `.github/workflows/release-please.yml` open or update the release PR.
 3. Review the release PR. Verify the main release version fields moved to the

--- a/scripts/check_release_versions.py
+++ b/scripts/check_release_versions.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Verify that all packaged version strings match a release tag.
+
+Release artifacts are built from several files that each carry their own
+version string. release-please keeps them in sync, but a botched bump (or a
+hand-edited tag) silently produces packages whose versions disagree with the
+tag, which only surfaces late in the release. This check compares every
+version-bearing file against the tag (and against each other) before any
+artifacts are built.
+
+Only fixed, tracked source paths are read -- never a repo-wide search -- so a
+stale local build artifact (e.g. a gitignored include/version.h) cannot cause
+a spurious mismatch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Callable, Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+TAG_RE = re.compile(r"^v(\d+\.\d+\.\d+)$")
+
+
+def _extract_regex(pattern: re.Pattern[str]) -> Callable[[str], Optional[str]]:
+    def extractor(text: str) -> Optional[str]:
+        match = pattern.search(text)
+        return match.group(1) if match else None
+
+    return extractor
+
+
+def _extract_json_version(text: str) -> Optional[str]:
+    try:
+        return json.loads(text).get("version")
+    except json.JSONDecodeError:
+        return None
+
+
+# (label, relative path, extractor). Authoritative list mirrors the
+# extra-files tracked in release-please-config.json plus the root package.json.
+SOURCES: tuple[tuple[str, str, Callable[[str], Optional[str]]], ...] = (
+    (
+        "src/version.h",
+        "src/version.h",
+        _extract_regex(re.compile(r'INFOMAP_VERSION\s*=\s*"([^"]+)"')),
+    ),
+    (
+        "python _version.py",
+        "interfaces/python/src/infomap/_version.py",
+        _extract_regex(re.compile(r'__version__\s*=\s*"([^"]+)"')),
+    ),
+    (
+        "R DESCRIPTION",
+        "interfaces/R/infomap/DESCRIPTION",
+        _extract_regex(re.compile(r"^Version:\s*(.+?)\s*$", re.MULTILINE)),
+    ),
+    (
+        "package.json",
+        "package.json",
+        _extract_json_version,
+    ),
+    (
+        "CITATION.cff",
+        "CITATION.cff",
+        _extract_regex(re.compile(r"^version:\s*(.+?)\s*$", re.MULTILINE)),
+    ),
+)
+
+
+def parse_tag(tag: str) -> str:
+    """Return the expected version for a stable vX.Y.Z tag, or exit on error."""
+    match = TAG_RE.match(tag)
+    if not match:
+        print(f"Expected stable release tag vX.Y.Z, got: {tag}", file=sys.stderr)
+        raise SystemExit(1)
+    return match.group(1)
+
+
+def collect() -> list[tuple[str, str, Optional[str]]]:
+    rows: list[tuple[str, str, Optional[str]]] = []
+    for label, rel_path, extractor in SOURCES:
+        path = REPO_ROOT / rel_path
+        if not path.is_file():
+            rows.append((label, rel_path, None))
+            continue
+        rows.append((label, rel_path, extractor(path.read_text(encoding="utf-8"))))
+    return rows
+
+
+def render_table(expected: str, rows: list[tuple[str, str, Optional[str]]]) -> str:
+    lines = [
+        f"Expected version (from tag): {expected}",
+        "",
+        f"| {'File':<20} | {'Version':<12} | Status |",
+        f"| {'-' * 20} | {'-' * 12} | ------ |",
+    ]
+    for label, _rel_path, found in rows:
+        if found is None:
+            status, shown = "MISSING", "-"
+        elif found == expected:
+            status, shown = "OK", found
+        else:
+            status, shown = "MISMATCH", found
+        lines.append(f"| {label:<20} | {shown:<12} | {status} |")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True, help="Release tag, e.g. v2.11.0")
+    args = parser.parse_args()
+
+    expected = parse_tag(args.tag)
+    rows = collect()
+    table = render_table(expected, rows)
+    print(table)
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as summary:
+            summary.write(table + "\n")
+
+    ok = all(found == expected for _label, _rel_path, found in rows)
+    if not ok:
+        print(
+            "\nVersion mismatch: every tracked version must equal the tag.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Improves the dev/release CI split. Grounded in how CI looks today; complements #604 (which already added the Python `quick`/`full` mode) and #605 (the ci-summary gate fix).

## Why

A green PR could not tell you the release would build: the artifact paths (cibuildwheel wheels, R source tarball + platform binaries, native packaging, multi-arch Docker) run **only** at release time, never in PR CI. Separately, native and R PRs were slow (sanitizers/clang-tidy 45 min each, full R matrix + r-universe).

## What

**Release correctness**
- **Version preflight** (`scripts/check_release_versions.py`): asserts every tracked version-bearing file (`src/version.h`, python `_version.py`, R `DESCRIPTION`, `package.json`, `CITATION.cff`) matches the tag and each other. Reads fixed paths only — never a repo-wide search — so a stale local build artifact can't cause a false mismatch. Wired as a `check-versions` gate before all release build jobs.
- **`release-rehearsal.yml`**: `workflow_dispatch` dry run against an existing tag. Reproduces every release artifact build + the preflight, including a multi-arch Docker build with `push: false`, and publishes nothing. Run it against the latest tag before a release cycle to catch pipeline/infra drift.

**Faster PRs**
- `_r-package.yml` gets a `mode: quick|full` input (mirrors the Python convention from #604). PR CI passes `quick` (Linux + R release only, skips r-universe); scheduled/release/rehearsal use `full`.
- `sanitizers` and `clang-tidy` move out of PR CI into a new **`scheduled-ci.yml`** (nightly on weekdays, dispatchable on any branch for risky native work). `ci-summary` needs updated accordingly (and now includes `docs`/`docker`).

**Docs**
- `CI.md` documents the PR/scheduled/rehearsal/release split; `RELEASING.md` gets a rehearsal pointer.

## Tradeoff

macOS/Windows/oldrel-R and sanitizer/clang-tidy regressions are now caught nightly (and by the pre-tag rehearsal) rather than per-PR. `scheduled-ci.yml` is dispatchable on any branch when per-PR coverage is wanted.

## Verification

- `actionlint` clean for all new/changed workflows (only pre-existing `if: false` on the disabled cxx-format job remains).
- Preflight: `v2.11.0` passes; `2.11.0` (no v) and `v0.0.0` (mismatch) exit 1.
- `release-rehearsal.yml` contains no publish patterns.
- Manual follow-up before merge: dispatch `scheduled-ci.yml`, and run `release-rehearsal.yml` against `v2.11.0` to confirm artifacts build and nothing publishes.

## Note

The `ci-summary` needs line overlaps with #605; whichever merges second resolves a one-line conflict to the final list.