### PR TITLE
build: speed up native, Python, R, and CI builds

### DIFF
--- a/.github/actions/setup-ccache/action.yml
+++ b/.github/actions/setup-ccache/action.yml
@@ -12,6 +12,7 @@ runs:
   using: composite
   steps:
     - name: Configure CCACHE_DIR
+      if: runner.os != 'Windows'
       shell: bash
       run: echo "CCACHE_DIR=$GITHUB_WORKSPACE/.ccache" >> "$GITHUB_ENV"
 

--- a/.github/actions/setup-ccache/action.yml
+++ b/.github/actions/setup-ccache/action.yml
@@ -1,0 +1,43 @@
+name: Set up ccache
+description: >-
+  Install ccache, point CCACHE_DIR at a workspace-local directory, and persist
+  it across runs with a rolling cache. No-op on Windows (the MSVC/MinGW builds
+  do not use ccache). The Make builds auto-detect ccache on PATH and use it as
+  the compiler launcher.
+inputs:
+  key-prefix:
+    description: Cache key namespace, e.g. "python-ubuntu-24.04-py3.14".
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Configure CCACHE_DIR
+      shell: bash
+      run: echo "CCACHE_DIR=$GITHUB_WORKSPACE/.ccache" >> "$GITHUB_ENV"
+
+    - name: Install ccache
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        if ! command -v ccache >/dev/null 2>&1; then
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            brew install ccache
+          else
+            sudo apt-get update && sudo apt-get install -y ccache
+          fi
+        fi
+        ccache --version
+
+    - name: Cache ccache directory
+      if: runner.os != 'Windows'
+      uses: actions/cache@v5
+      with:
+        path: ${{ github.workspace }}/.ccache
+        key: ccache-${{ inputs.key-prefix }}-${{ github.sha }}
+        restore-keys: |
+          ccache-${{ inputs.key-prefix }}-
+
+    - name: Reset ccache stats
+      if: runner.os != 'Windows'
+      shell: bash
+      run: command -v ccache >/dev/null 2>&1 && ccache -z || true

--- a/.github/workflows/_native-build.yml
+++ b/.github/workflows/_native-build.yml
@@ -20,6 +20,11 @@ jobs:
     name: ${{ matrix.config.os }}${{ matrix.target.name }}
     runs-on: ${{ matrix.config.os }}
     timeout-minutes: 30
+    env:
+      # Workspace-local, deterministic ccache location shared by the build and
+      # test steps and persisted across runs by the cache step below. The Make
+      # build auto-detects ccache on PATH and uses it as the compiler launcher.
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
     strategy:
       fail-fast: false
       matrix:
@@ -70,8 +75,35 @@ jobs:
           brew install libomp
           make ci-export-github-env >> "$GITHUB_ENV"
 
+      # Windows native CI uses MinGW g++ without ccache; skip there.
+      - name: Set up ccache
+        if: matrix.config.name != 'windows'
+        run: |
+          if ! command -v ccache >/dev/null 2>&1; then
+            if [ "$RUNNER_OS" = "macOS" ]; then
+              brew install ccache
+            else
+              sudo apt-get update && sudo apt-get install -y ccache
+            fi
+          fi
+          ccache --version
+        shell: bash
+
+      - name: Cache ccache directory
+        if: matrix.config.name != 'windows'
+        uses: actions/cache@v5
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: ccache-native-${{ matrix.config.name }}-omp${{ matrix.target.openmp }}-${{ github.sha }}
+          restore-keys: |
+            ccache-native-${{ matrix.config.name }}-omp${{ matrix.target.openmp }}-
+            ccache-native-${{ matrix.config.name }}-
+
       - name: Build native binary
-        run: make -j build-native OPENMP=${{ matrix.target.openmp }}
+        run: |
+          command -v ccache >/dev/null 2>&1 && ccache -z || true
+          make -j build-native OPENMP=${{ matrix.target.openmp }}
+          command -v ccache >/dev/null 2>&1 && ccache -s || true
         shell: bash
         env:
           CXX: ${{ matrix.config.compiler }}

--- a/.github/workflows/_native-build.yml
+++ b/.github/workflows/_native-build.yml
@@ -20,11 +20,6 @@ jobs:
     name: ${{ matrix.config.os }}${{ matrix.target.name }}
     runs-on: ${{ matrix.config.os }}
     timeout-minutes: 30
-    env:
-      # Workspace-local, deterministic ccache location shared by the build and
-      # test steps and persisted across runs by the cache step below. The Make
-      # build auto-detects ccache on PATH and uses it as the compiler launcher.
-      CCACHE_DIR: ${{ github.workspace }}/.ccache
     strategy:
       fail-fast: false
       matrix:
@@ -75,33 +70,14 @@ jobs:
           brew install libomp
           make ci-export-github-env >> "$GITHUB_ENV"
 
-      # Windows native CI uses MinGW g++ without ccache; skip there.
+      # Windows native CI uses MinGW g++ without ccache; the action no-ops there.
       - name: Set up ccache
-        if: matrix.config.name != 'windows'
-        run: |
-          if ! command -v ccache >/dev/null 2>&1; then
-            if [ "$RUNNER_OS" = "macOS" ]; then
-              brew install ccache
-            else
-              sudo apt-get update && sudo apt-get install -y ccache
-            fi
-          fi
-          ccache --version
-        shell: bash
-
-      - name: Cache ccache directory
-        if: matrix.config.name != 'windows'
-        uses: actions/cache@v5
+        uses: ./.github/actions/setup-ccache
         with:
-          path: ${{ github.workspace }}/.ccache
-          key: ccache-native-${{ matrix.config.name }}-omp${{ matrix.target.openmp }}-${{ github.sha }}
-          restore-keys: |
-            ccache-native-${{ matrix.config.name }}-omp${{ matrix.target.openmp }}-
-            ccache-native-${{ matrix.config.name }}-
+          key-prefix: native-${{ matrix.config.name }}-omp${{ matrix.target.openmp }}
 
       - name: Build native binary
         run: |
-          command -v ccache >/dev/null 2>&1 && ccache -z || true
           make -j build-native OPENMP=${{ matrix.target.openmp }}
           command -v ccache >/dev/null 2>&1 && ccache -s || true
         shell: bash

--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -128,7 +128,9 @@ jobs:
           FEATURES: ${{ inputs.features }}
 
       - name: Install editable package
-        run: make dev-python-install
+        run: |
+          make dev-python-install
+          command -v ccache >/dev/null 2>&1 && ccache -s || true
         env:
           FEATURES: ${{ inputs.features }}
 
@@ -208,7 +210,9 @@ jobs:
           FEATURES: ${{ inputs.features }}
 
       - name: Install editable package
-        run: make dev-python-install
+        run: |
+          make dev-python-install
+          command -v ccache >/dev/null 2>&1 && ccache -s || true
         env:
           FEATURES: ${{ inputs.features }}
 
@@ -262,7 +266,9 @@ jobs:
           key-prefix: python-release-smoke-${{ runner.os }}
 
       - name: Build release distributions
-        run: make release-python-dist
+        run: |
+          make release-python-dist
+          command -v ccache >/dev/null 2>&1 && ccache -s || true
         env:
           FEATURES: ${{ inputs.features }}
 

--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -117,22 +117,17 @@ jobs:
           python-version: ${{ matrix.python-version }}
           install-build-tooling: "true"
 
-      - name: Set up ccache
-        uses: ./.github/actions/setup-ccache
-        with:
-          key-prefix: python-${{ matrix.os }}-py${{ matrix.python-version }}
-
       - name: Build Python wheel from repo root
         run: make build-python
         env:
           FEATURES: ${{ inputs.features }}
 
       - name: Install editable package
-        run: |
-          make dev-python-install
-          command -v ccache >/dev/null 2>&1 && ccache -s || true
+        run: make dev-python-install
         env:
           FEATURES: ${{ inputs.features }}
+          # docs (sphinx/furo) is only needed by build-docs, not the test jobs.
+          PYTHON_DEV_EXTRAS: test,examples
 
       - name: Run Python smoke test
         if: matrix.smoke-only
@@ -199,22 +194,17 @@ jobs:
           python-version: ${{ matrix.python-version }}
           install-build-tooling: "true"
 
-      - name: Set up ccache
-        uses: ./.github/actions/setup-ccache
-        with:
-          key-prefix: python-${{ matrix.os }}-py${{ matrix.python-version }}
-
       - name: Build Python wheel from repo root
         run: make build-python
         env:
           FEATURES: ${{ inputs.features }}
 
       - name: Install editable package
-        run: |
-          make dev-python-install
-          command -v ccache >/dev/null 2>&1 && ccache -s || true
+        run: make dev-python-install
         env:
           FEATURES: ${{ inputs.features }}
+          # docs (sphinx/furo) is only needed by build-docs, not the test jobs.
+          PYTHON_DEV_EXTRAS: test,examples
 
       - name: Run Python smoke test
         if: matrix.smoke-only
@@ -260,15 +250,8 @@ jobs:
           python-version: "3.14"
           install-build-tooling: "true"
 
-      - name: Set up ccache
-        uses: ./.github/actions/setup-ccache
-        with:
-          key-prefix: python-release-smoke-${{ runner.os }}
-
       - name: Build release distributions
-        run: |
-          make release-python-dist
-          command -v ccache >/dev/null 2>&1 && ccache -s || true
+        run: make release-python-dist
         env:
           FEATURES: ${{ inputs.features }}
 

--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -117,6 +117,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
           install-build-tooling: "true"
 
+      - name: Set up ccache
+        uses: ./.github/actions/setup-ccache
+        with:
+          key-prefix: python-${{ matrix.os }}-py${{ matrix.python-version }}
+
       - name: Build Python wheel from repo root
         run: make build-python
         env:
@@ -192,6 +197,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
           install-build-tooling: "true"
 
+      - name: Set up ccache
+        uses: ./.github/actions/setup-ccache
+        with:
+          key-prefix: python-${{ matrix.os }}-py${{ matrix.python-version }}
+
       - name: Build Python wheel from repo root
         run: make build-python
         env:
@@ -245,6 +255,11 @@ jobs:
         with:
           python-version: "3.14"
           install-build-tooling: "true"
+
+      - name: Set up ccache
+        uses: ./.github/actions/setup-ccache
+        with:
+          key-prefix: python-release-smoke-${{ runner.os }}
 
       - name: Build release distributions
         run: make release-python-dist

--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -117,13 +117,20 @@ jobs:
           python-version: ${{ matrix.python-version }}
           install-build-tooling: "true"
 
+      - name: Set up ccache
+        uses: ./.github/actions/setup-ccache
+        with:
+          key-prefix: python-${{ matrix.os }}-py${{ matrix.python-version }}
+
       - name: Build Python wheel from repo root
         run: make build-python
         env:
           FEATURES: ${{ inputs.features }}
 
       - name: Install editable package
-        run: make dev-python-install
+        run: |
+          make dev-python-install
+          command -v ccache >/dev/null 2>&1 && ccache -s || true
         env:
           FEATURES: ${{ inputs.features }}
           # docs (sphinx/furo) is only needed by build-docs, not the test jobs.
@@ -194,13 +201,20 @@ jobs:
           python-version: ${{ matrix.python-version }}
           install-build-tooling: "true"
 
+      - name: Set up ccache
+        uses: ./.github/actions/setup-ccache
+        with:
+          key-prefix: python-${{ matrix.os }}-py${{ matrix.python-version }}
+
       - name: Build Python wheel from repo root
         run: make build-python
         env:
           FEATURES: ${{ inputs.features }}
 
       - name: Install editable package
-        run: make dev-python-install
+        run: |
+          make dev-python-install
+          command -v ccache >/dev/null 2>&1 && ccache -s || true
         env:
           FEATURES: ${{ inputs.features }}
           # docs (sphinx/furo) is only needed by build-docs, not the test jobs.
@@ -250,8 +264,15 @@ jobs:
           python-version: "3.14"
           install-build-tooling: "true"
 
+      - name: Set up ccache
+        uses: ./.github/actions/setup-ccache
+        with:
+          key-prefix: python-release-smoke-${{ runner.os }}
+
       - name: Build release distributions
-        run: make release-python-dist
+        run: |
+          make release-python-dist
+          command -v ccache >/dev/null 2>&1 && ccache -s || true
         env:
           FEATURES: ${{ inputs.features }}
 

--- a/.github/workflows/_r-package.yml
+++ b/.github/workflows/_r-package.yml
@@ -120,6 +120,11 @@ jobs:
             any::tibble
             any::rcmdcheck
 
+      - name: Set up ccache
+        uses: ./.github/actions/setup-ccache
+        with:
+          key-prefix: r-${{ matrix.os }}-${{ matrix.r }}
+
       - name: Stage and check the package
         run: make test-r
 

--- a/.github/workflows/_r-package.yml
+++ b/.github/workflows/_r-package.yml
@@ -120,8 +120,15 @@ jobs:
             any::tibble
             any::rcmdcheck
 
+      - name: Set up ccache
+        uses: ./.github/actions/setup-ccache
+        with:
+          key-prefix: r-${{ matrix.os }}-${{ matrix.r }}
+
       - name: Stage and check the package
-        run: make test-r
+        run: |
+          make test-r
+          command -v ccache >/dev/null 2>&1 && ccache -s || true
 
   build-source:
     if: inputs.build-release-artifacts

--- a/.github/workflows/_r-package.yml
+++ b/.github/workflows/_r-package.yml
@@ -120,15 +120,8 @@ jobs:
             any::tibble
             any::rcmdcheck
 
-      - name: Set up ccache
-        uses: ./.github/actions/setup-ccache
-        with:
-          key-prefix: r-${{ matrix.os }}-${{ matrix.r }}
-
       - name: Stage and check the package
-        run: |
-          make test-r
-          command -v ccache >/dev/null 2>&1 && ccache -s || true
+        run: make test-r
 
   build-source:
     if: inputs.build-release-artifacts

--- a/.github/workflows/_r-package.yml
+++ b/.github/workflows/_r-package.yml
@@ -126,7 +126,9 @@ jobs:
           key-prefix: r-${{ matrix.os }}-${{ matrix.r }}
 
       - name: Stage and check the package
-        run: make test-r
+        run: |
+          make test-r
+          command -v ccache >/dev/null 2>&1 && ccache -s || true
 
   build-source:
     if: inputs.build-release-artifacts

--- a/interfaces/R/infomap/configure
+++ b/interfaces/R/infomap/configure
@@ -49,12 +49,19 @@ fi
 # `override` is required: R loads src/Makevars first, then Makeconf, then
 # passes CXX on the make command line. Without `override`, both later steps
 # clobber our setting.
-if [ "$(uname)" = "Darwin" ] && ! grep -q 'override CXX17 = /usr/bin/clang++ -std=gnu++17' "$PKG_DIR/src/Makevars" 2>/dev/null; then
+# Optional compiler launcher (e.g. ccache) prefixed to the pinned compiler.
+# Unset (the CRAN / r-universe default) leaves the pinned command unchanged.
+LAUNCHER=""
+if [ -n "${INFOMAP_R_CXX_LAUNCHER:-}" ]; then
+  LAUNCHER="${INFOMAP_R_CXX_LAUNCHER} "
+fi
+
+if [ "$(uname)" = "Darwin" ] && ! grep -q '# Pinned by configure' "$PKG_DIR/src/Makevars" 2>/dev/null; then
   {
     printf '\n'
     printf '# Pinned by configure: Apple clang avoids LLVM libc++ ABI mismatch.\n'
-    printf 'override CC  = /usr/bin/clang\n'
-    printf 'override CXX = /usr/bin/clang++ -std=gnu++17\n'
-    printf 'override CXX17 = /usr/bin/clang++ -std=gnu++17\n'
+    printf 'override CC  = %s/usr/bin/clang\n' "$LAUNCHER"
+    printf 'override CXX = %s/usr/bin/clang++ -std=gnu++17\n' "$LAUNCHER"
+    printf 'override CXX17 = %s/usr/bin/clang++ -std=gnu++17\n' "$LAUNCHER"
   } >> "$PKG_DIR/src/Makevars"
 fi

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -73,21 +73,19 @@ MK_FILES := $(wildcard mk/*.mk)
 BINDING_OPTIONS_SCRIPT := scripts/generate_binding_options.py
 BUILD_CONFIG_SCRIPT := scripts/build_config.py
 
-define build_config_field
-$(if $(PYTHON_FOR_BUILD_CONFIG),$(strip $(eval BUILD_CONFIG_FIELD_VALUE := $(shell CPPFLAGS='$(CPPFLAGS)' CXXFLAGS='$(CXXFLAGS)' LDFLAGS='$(LDFLAGS)' MACOSX_DEPLOYMENT_TARGET='$(MACOSX_DEPLOYMENT_TARGET)' $(PYTHON_FOR_BUILD_CONFIG) $(BUILD_CONFIG_SCRIPT) field --field "$(1)" --mode "$(MODE)" --openmp "$(OPENMP)" --native-arch "$(NATIVE_ARCH)" --features "$(FEATURES)" --compiler "$(CXX)" --platform "$(UNAME_S)" || printf "__INFOMAP_BUILD_CONFIG_FAILED__"))$(if $(findstring __INFOMAP_BUILD_CONFIG_FAILED__,$(BUILD_CONFIG_FIELD_VALUE)),$(error Failed to resolve build config field '$(1)'),$(BUILD_CONFIG_FIELD_VALUE))),)
-endef
-
-BUILD_CONFIG_MODE := $(call build_config_field,mode)
-BUILD_CONFIG_OPENMP := $(call build_config_field,openmp)
-BUILD_CONFIG_ENABLED_FEATURES := $(call build_config_field,enabled_features)
-BUILD_CONFIG_PLATFORM := $(call build_config_field,platform)
-BUILD_CONFIG_COMPILER := $(call build_config_field,compiler)
-BUILD_CONFIG_COMPILER_FAMILY := $(call build_config_field,compiler_family)
-BUILD_CONFIG_BREW_PREFIX := $(call build_config_field,brew_prefix)
-BUILD_CONFIG_LIBOMP_PREFIX := $(call build_config_field,libomp_prefix)
-BUILD_CONFIG_DEPLOYMENT_TARGET := $(call build_config_field,deployment_target)
-NATIVE_CXXFLAGS := $(call build_config_field,compile_flags)
-NATIVE_LDFLAGS := $(call build_config_field,link_flags)
+# Resolve the whole build configuration in a single build_config.py invocation
+# and `include` the emitted Make assignments (BUILD_CONFIG_* plus NATIVE_CXXFLAGS
+# / NATIVE_LDFLAGS). build_config.py probes the compiler (`--version`) and shells
+# out to brew, so doing this once per `make` run instead of once per field cuts
+# the fixed cost paid by every build, including no-op incremental ones.
+BUILD_CONFIG_MK := build/build_config.generated.mk
+ifneq ($(PYTHON_FOR_BUILD_CONFIG),)
+BUILD_CONFIG_STATUS := $(shell mkdir -p $(dir $(BUILD_CONFIG_MK)) && CPPFLAGS='$(CPPFLAGS)' CXXFLAGS='$(CXXFLAGS)' LDFLAGS='$(LDFLAGS)' MACOSX_DEPLOYMENT_TARGET='$(MACOSX_DEPLOYMENT_TARGET)' $(PYTHON_FOR_BUILD_CONFIG) $(BUILD_CONFIG_SCRIPT) make-export --mode "$(MODE)" --openmp "$(OPENMP)" --native-arch "$(NATIVE_ARCH)" --features "$(FEATURES)" --compiler "$(CXX)" --platform "$(UNAME_S)" > $(BUILD_CONFIG_MK) 2>/dev/null && echo ok)
+ifneq ($(BUILD_CONFIG_STATUS),ok)
+$(error Failed to resolve build configuration via $(BUILD_CONFIG_SCRIPT))
+endif
+include $(BUILD_CONFIG_MK)
+endif
 FEATURE_CACHE_KEY := $(if $(BUILD_CONFIG_ENABLED_FEATURES),$(subst $(space),_,$(BUILD_CONFIG_ENABLED_FEATURES)),none)
 CXX_COMPILE := $(if $(and $(filter 1,$(USE_CCACHE)),$(CCACHE_BIN)),$(CCACHE_BIN) ,)$(CXX)
 

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -79,10 +79,12 @@ BUILD_CONFIG_SCRIPT := scripts/build_config.py
 # out to brew, so doing this once per `make` run instead of once per field cuts
 # the fixed cost paid by every build, including no-op incremental ones.
 #
-# Skip resolution when the only goals are clean targets: they don't need the
-# config, and generating it would recreate the build/ artifacts a clean is meant
-# to remove. (No explicit goal means the default target runs, which does need it.)
-BUILD_CONFIG_NEEDED := $(if $(MAKECMDGOALS),$(filter-out clean%,$(MAKECMDGOALS)),default)
+# Skip resolution when no requested goal consumes the build config — clean
+# targets (which would otherwise recreate the build/ artifacts a clean removes)
+# and `help`, the default goal. This keeps plain `make` / `make help` from
+# probing the compiler and brew, so they work even without a toolchain.
+BUILD_CONFIG_GOALS := $(if $(MAKECMDGOALS),$(MAKECMDGOALS),$(.DEFAULT_GOAL))
+BUILD_CONFIG_NEEDED := $(filter-out help clean%,$(BUILD_CONFIG_GOALS))
 BUILD_CONFIG_MK := build/build_config.generated.mk
 ifneq ($(BUILD_CONFIG_NEEDED),)
 ifneq ($(PYTHON_FOR_BUILD_CONFIG),)

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -78,13 +78,22 @@ BUILD_CONFIG_SCRIPT := scripts/build_config.py
 # / NATIVE_LDFLAGS). build_config.py probes the compiler (`--version`) and shells
 # out to brew, so doing this once per `make` run instead of once per field cuts
 # the fixed cost paid by every build, including no-op incremental ones.
+#
+# Skip resolution when the only goals are clean targets: they don't need the
+# config, and generating it would recreate the build/ artifacts a clean is meant
+# to remove. (No explicit goal means the default target runs, which does need it.)
+BUILD_CONFIG_NEEDED := $(if $(MAKECMDGOALS),$(filter-out clean%,$(MAKECMDGOALS)),default)
 BUILD_CONFIG_MK := build/build_config.generated.mk
+ifneq ($(BUILD_CONFIG_NEEDED),)
 ifneq ($(PYTHON_FOR_BUILD_CONFIG),)
-BUILD_CONFIG_STATUS := $(shell mkdir -p $(dir $(BUILD_CONFIG_MK)) && CPPFLAGS='$(CPPFLAGS)' CXXFLAGS='$(CXXFLAGS)' LDFLAGS='$(LDFLAGS)' MACOSX_DEPLOYMENT_TARGET='$(MACOSX_DEPLOYMENT_TARGET)' $(PYTHON_FOR_BUILD_CONFIG) $(BUILD_CONFIG_SCRIPT) make-export --mode "$(MODE)" --openmp "$(OPENMP)" --native-arch "$(NATIVE_ARCH)" --features "$(FEATURES)" --compiler "$(CXX)" --platform "$(UNAME_S)" > $(BUILD_CONFIG_MK) 2>/dev/null && echo ok)
+# stderr is left attached so a failing resolution surfaces the real diagnostic
+# (Python traceback / argparse error) rather than only the generic $(error) below.
+BUILD_CONFIG_STATUS := $(shell mkdir -p $(dir $(BUILD_CONFIG_MK)) && CPPFLAGS='$(CPPFLAGS)' CXXFLAGS='$(CXXFLAGS)' LDFLAGS='$(LDFLAGS)' MACOSX_DEPLOYMENT_TARGET='$(MACOSX_DEPLOYMENT_TARGET)' $(PYTHON_FOR_BUILD_CONFIG) $(BUILD_CONFIG_SCRIPT) make-export --mode "$(MODE)" --openmp "$(OPENMP)" --native-arch "$(NATIVE_ARCH)" --features "$(FEATURES)" --compiler "$(CXX)" --platform "$(UNAME_S)" > $(BUILD_CONFIG_MK) && echo ok)
 ifneq ($(BUILD_CONFIG_STATUS),ok)
 $(error Failed to resolve build configuration via $(BUILD_CONFIG_SCRIPT))
 endif
 include $(BUILD_CONFIG_MK)
+endif
 endif
 FEATURE_CACHE_KEY := $(if $(BUILD_CONFIG_ENABLED_FEATURES),$(subst $(space),_,$(BUILD_CONFIG_ENABLED_FEATURES)),none)
 CXX_COMPILE := $(if $(and $(filter 1,$(USE_CCACHE)),$(CCACHE_BIN)),$(CCACHE_BIN) ,)$(CXX)

--- a/mk/native.mk
+++ b/mk/native.mk
@@ -8,6 +8,18 @@ NATIVE_OBJECTS := $(SOURCES:src/%.cpp=$(NATIVE_OBJECT_DIR)/%.o)
 LIB_OBJECTS := $(SOURCES:src/%.cpp=$(LIB_OBJECT_DIR)/%.o)
 LIB_HEADERS := $(HEADERS:src/%.h=$(PUBLIC_INCLUDE_DIR)/%.h)
 
+# On clang/gnu, let the compiler emit a per-object .d file recording the headers
+# each translation unit actually includes (-MMD), with phony targets for headers
+# so a deleted/renamed header doesn't break the build (-MP). These deps replace
+# the blanket "every object depends on every header" prerequisite below, so an
+# edit to one header only rebuilds the TUs that include it. Other toolchains
+# (e.g. MSVC) keep the conservative $(HEADERS) prerequisite via NATIVE_HEADER_DEP.
+NATIVE_DEP_TRACKING := $(filter clang gnu,$(BUILD_CONFIG_COMPILER_FAMILY))
+DEP_FLAGS = $(if $(NATIVE_DEP_TRACKING),-MMD -MP -MF $(@:.o=.d))
+NATIVE_HEADER_DEP := $(if $(NATIVE_DEP_TRACKING),,$(HEADERS))
+NATIVE_DEPS := $(NATIVE_OBJECTS:.o=.d)
+LIB_DEPS := $(LIB_OBJECTS:.o=.d)
+
 .PHONY: build-native build-lib clean-native format-native format-native-check
 
 build-native: $(NATIVE_BINARY)
@@ -18,9 +30,9 @@ $(NATIVE_BINARY): $(NATIVE_OBJECTS)
 	$(CXX) $(NATIVE_LDFLAGS) -o $@ $^
 	@echo "-- Link finished --"
 
-$(NATIVE_OBJECT_DIR)/%.o: src/%.cpp $(HEADERS) $(MK_FILES) Makefile
+$(NATIVE_OBJECT_DIR)/%.o: src/%.cpp $(NATIVE_HEADER_DEP) $(MK_FILES) Makefile
 	@mkdir -p $(dir $@)
-	$(CXX_COMPILE) $(NATIVE_CXXFLAGS) -c $< -o $@
+	$(CXX_COMPILE) $(NATIVE_CXXFLAGS) $(DEP_FLAGS) -c $< -o $@
 
 build-lib: $(LIB_OUTPUT) $(LIB_HEADERS)
 	@echo "Wrote static library to lib/ and headers to include/"
@@ -34,9 +46,9 @@ $(PUBLIC_INCLUDE_DIR)/%.h: src/%.h
 	@mkdir -p $(dir $@)
 	@cp -a $^ $@
 
-$(LIB_OBJECT_DIR)/%.o: src/%.cpp $(HEADERS) $(MK_FILES) Makefile
+$(LIB_OBJECT_DIR)/%.o: src/%.cpp $(NATIVE_HEADER_DEP) $(MK_FILES) Makefile
 	@mkdir -p $(dir $@)
-	$(CXX_COMPILE) $(NATIVE_CXXFLAGS) -DNS_INFOMAP -DAS_LIB -c $< -o $@
+	$(CXX_COMPILE) $(NATIVE_CXXFLAGS) $(DEP_FLAGS) -DNS_INFOMAP -DAS_LIB -c $< -o $@
 
 format-native:
 	$(CLANG_FORMAT) -i $(HEADERS) $(SOURCES)
@@ -45,4 +57,12 @@ format-native-check:
 	$(CLANG_FORMAT) --dry-run --Werror $(HEADERS) $(SOURCES)
 
 clean-native:
-	$(RM) -r $(NATIVE_BINARY) build/native build/Infomap build/lib build/cmake build/cmake-sanitizers lib include
+	$(RM) -r $(NATIVE_BINARY) build/native build/Infomap build/lib build/cmake build/cmake-sanitizers build/build_config.generated.mk lib include
+
+# Pull in the auto-generated per-translation-unit header dependencies (no-op on
+# a fresh tree; populated after the first compile). Guarded so `clean` targets
+# don't regenerate them.
+ifeq ($(filter clean clean-native,$(MAKECMDGOALS)),)
+-include $(NATIVE_DEPS)
+-include $(LIB_DEPS)
+endif

--- a/mk/python.mk
+++ b/mk/python.mk
@@ -37,11 +37,18 @@ PYTEST_ARGS ?=
 PYTHON_DIST_DIR := dist/python
 PYPI_DIR := $(PYTHON_DIST_DIR)
 PYPI_SDIST := $(shell find $(PYPI_DIR) -name "*.tar.gz" 2>/dev/null)
-PYTHON_BUILD_CXX ?= $(if $(filter Windows_NT,$(OS)),cl,$(CXX))
+# Route Python extension compiles through ccache too (the native build already
+# does via CXX_COMPILE). distutils shlex-splits CC/CXX, so a "ccache c++" launcher
+# prefix works. Skipped on Windows (MSVC `cl`), matching the native build.
+ifeq ($(filter Windows_NT,$(OS)),)
+PYTHON_BUILD_CXX ?= $(if $(and $(filter 1,$(USE_CCACHE)),$(CCACHE_BIN)),$(CCACHE_BIN) ,)$(CXX)
+else
+PYTHON_BUILD_CXX ?= cl
+endif
 PYTHON_BUILD_CC ?= $(PYTHON_BUILD_CXX)
 PYTHON_BUILD_ENV = \
 	CC="$(PYTHON_BUILD_CC)" CXX="$(PYTHON_BUILD_CXX)" MODE="$(MODE)" OPENMP="$(OPENMP)" \
-	FEATURES="$(FEATURES)" \
+	FEATURES="$(FEATURES)" INFOMAP_BUILD_JOBS="$(JOBS)" \
 	CPPFLAGS="$(CPPFLAGS)" CXXFLAGS="$(CXXFLAGS)" LDFLAGS="$(LDFLAGS)" \
 	$(if $(MACOSX_DEPLOYMENT_TARGET),MACOSX_DEPLOYMENT_TARGET="$(MACOSX_DEPLOYMENT_TARGET)")
 

--- a/mk/python.mk
+++ b/mk/python.mk
@@ -87,8 +87,12 @@ build-python-swig:
 test-python-swig-freshness:
 	@SWIG="$(SWIG)" $(PYTHON) scripts/generate_python_swig.py --check --python-out $(PYTHON_SWIG_PY) --cpp-out $(PYTHON_SWIG_CPP)
 
+# Extras installed by dev-python-install. Defaults to the full local dev set;
+# CI test jobs override it (e.g. PYTHON_DEV_EXTRAS=test,examples) to skip docs.
+PYTHON_DEV_EXTRAS ?= test,docs,examples
+
 dev-python-install:
-	$(PYTHON_BUILD_ENV) $(PIP) install -e .[test,docs,examples]
+	$(PYTHON_BUILD_ENV) $(PIP) install -e ".[$(PYTHON_DEV_EXTRAS)]"
 
 dev-python-notebooks-install:
 	$(PYTHON_BUILD_ENV) $(PIP) install -e .[notebooks]

--- a/mk/r.mk
+++ b/mk/r.mk
@@ -18,24 +18,47 @@ R_FORMAT_TARGETS := \
 	$(R_TEST_FILES) \
 	$(R_EXAMPLE_FILES)
 
+# R compiles the package's ~25 translation units serially through the toolchain
+# from its Makeconf (no ccache). We speed both up:
+#   * MAKE="make -j$(JOBS)": R drives the SHLIB build via $(MAKE), so overriding
+#     it parallelizes the per-object compiles. (MAKEFLAGS=-j is NOT honored here.)
+#   * ccache as a compiler launcher, so repeat builds hit the cache — same idea
+#     as the native/Python builds. ccache execs the compiler unchanged for link
+#     steps, so it is safe as the CXX used to both compile and link the .so.
+CCACHE_LAUNCHER := $(if $(and $(filter 1,$(USE_CCACHE)),$(CCACHE_BIN)),$(CCACHE_BIN),)
+R_PARALLEL := MAKE="make -j$(JOBS)"
+R_MAKEVARS_FILE := $(CURDIR)/$(R_BUILD_DIR)/.Makevars.infomap
+
 # On macOS, Homebrew LLVM clang++ may be first in PATH but Homebrew R uses
 # Apple's libc++ at runtime.  Compilation with LLVM clang++ produces a .so
 # that references LLVM-only symbols (e.g. __ZNSt3__113__hash_memoryEPKvm)
-# that the Apple runtime cannot resolve.  Writing a temporary Makevars file
-# that pins CC/CXX to Apple's toolchain — and passing it via
-# R_MAKEVARS_USER — keeps the compiled .so ABI-compatible with R.
+# that the Apple runtime cannot resolve.  The package's configure script pins
+# CC/CXX to Apple's toolchain with GNU Make `override` (which beats both Makeconf
+# and a user Makevars), keeping the compiled .so ABI-compatible with R. We pass
+# the ccache launcher through INFOMAP_R_CXX_LAUNCHER so configure can prefix the
+# pinned compiler; we still write the user Makevars as a historical fallback.
 # REMOVE WHEN: Homebrew R links against the LLVM libc++ runtime, or the
 # CRAN macOS toolchain assumption changes such that LLVM-built .so files
 # load cleanly under R.
 ifeq ($(UNAME_S),Darwin)
-_R_APPLE_MV  := $(CURDIR)/$(R_BUILD_DIR)/.Makevars.apple
-R_CMD_ENV    := R_MAKEVARS_USER=$(_R_APPLE_MV)
-_write_apple_mv = @mkdir -p $(R_BUILD_DIR) && \
-	printf 'CC = /usr/bin/clang\nCXX = /usr/bin/clang++\nCXX17 = /usr/bin/clang++\n' \
-	> $(_R_APPLE_MV)
+_R_CC  := $(if $(CCACHE_LAUNCHER),$(CCACHE_LAUNCHER) ,)/usr/bin/clang
+_R_CXX := $(if $(CCACHE_LAUNCHER),$(CCACHE_LAUNCHER) ,)/usr/bin/clang++
+R_CMD_ENV := R_MAKEVARS_USER=$(R_MAKEVARS_FILE) $(R_PARALLEL) INFOMAP_R_CXX_LAUNCHER=$(CCACHE_LAUNCHER)
+_write_r_makevars = @mkdir -p $(R_BUILD_DIR) && \
+	printf 'CC = %s\nCXX = %s\nCXX17 = %s\n' '$(_R_CC)' '$(_R_CXX)' '$(_R_CXX)' \
+	> $(R_MAKEVARS_FILE)
+else ifneq ($(CCACHE_LAUNCHER),)
+# Other unix: no configure override, so route R's configured compiler through
+# ccache via a user Makevars.
+R_CMD_ENV := R_MAKEVARS_USER=$(R_MAKEVARS_FILE) $(R_PARALLEL)
+_write_r_makevars = @mkdir -p $(R_BUILD_DIR) && \
+	cc="$$($(R) CMD config CC)"; cxx="$$($(R) CMD config CXX)"; cxx17="$$($(R) CMD config CXX17)"; \
+	printf 'CC = %s %s\nCXX = %s %s\nCXX17 = %s %s\n' \
+	'$(CCACHE_LAUNCHER)' "$$cc" '$(CCACHE_LAUNCHER)' "$$cxx" '$(CCACHE_LAUNCHER)' "$$cxx17" \
+	> $(R_MAKEVARS_FILE)
 else
-R_CMD_ENV       :=
-_write_apple_mv := @true
+R_CMD_ENV := $(R_PARALLEL)
+_write_r_makevars := @true
 endif
 
 .PHONY: \
@@ -72,21 +95,21 @@ build-r-binary: build-r
 	$(MAKE) build-r-binary-from-tarball
 
 build-r-binary-from-tarball:
-	$(_write_apple_mv)
+	$(_write_r_makevars)
 	@mkdir -p $(R_DIST_DIR)
 	@test -f $(R_TARBALL)
 	cd $(R_DIST_DIR) && $(R_CMD_ENV) $(R) CMD INSTALL --build $(CURDIR)/$(R_TARBALL)
 	@echo "Built R binary in $(R_DIST_DIR)/"
 
 test-r: build-r-stage
-	$(_write_apple_mv)
+	$(_write_r_makevars)
 	@mkdir -p $(R_BUILD_DIR)/check
 	$(R_CMD_ENV) _R_CHECK_FORCE_SUGGESTS_=false \
 		$(RSCRIPT) scripts/r_check.R $(R_STAGED_DIR) $(R_BUILD_DIR)/check \
 		--no-manual --no-vignettes --as-cran
 
 dev-r-install: build-r-stage
-	$(_write_apple_mv)
+	$(_write_r_makevars)
 	$(R_CMD_ENV) $(R) CMD INSTALL $(R_STAGED_DIR)
 
 test-r-examples: dev-r-install

--- a/mk/r.mk
+++ b/mk/r.mk
@@ -26,7 +26,7 @@ R_FORMAT_TARGETS := \
 #     as the native/Python builds. ccache execs the compiler unchanged for link
 #     steps, so it is safe as the CXX used to both compile and link the .so.
 CCACHE_LAUNCHER := $(if $(and $(filter 1,$(USE_CCACHE)),$(CCACHE_BIN)),$(CCACHE_BIN),)
-R_PARALLEL := MAKE="make -j$(JOBS)"
+R_PARALLEL := MAKE="$(MAKE) -j$(JOBS)"
 R_MAKEVARS_FILE := $(CURDIR)/$(R_BUILD_DIR)/.Makevars.infomap
 
 # On macOS, Homebrew LLVM clang++ may be first in PATH but Homebrew R uses

--- a/scripts/build_config.py
+++ b/scripts/build_config.py
@@ -370,9 +370,10 @@ MAKE_EXPORT_FIELDS = (
 def _make_export(config):
     lines = []
     for make_var, field in MAKE_EXPORT_FIELDS:
-        # Escape `$` so Make treats flag/path values literally on `include`,
-        # matching the old per-field `:=` capture which did not re-expand them.
-        value = _field_value(config, field).replace("$", "$$")
+        # Escape characters Make would otherwise interpret on `include`: `$`
+        # (variable expansion) and `#` (starts a comment, truncating the value).
+        # Flag/path values can contain either via user CPPFLAGS/CXXFLAGS/paths.
+        value = _field_value(config, field).replace("$", "$$").replace("#", "\\#")
         lines.append(f"{make_var} := {value}")
     return "\n".join(lines)
 

--- a/scripts/build_config.py
+++ b/scripts/build_config.py
@@ -349,9 +349,37 @@ def _field_value(config, field):
     return str(value)
 
 
+# Maps each Make variable to the config field that supplies its value. Used by
+# the `make-export` format so the Makefile can resolve the whole build config in
+# a single invocation instead of one process per field.
+MAKE_EXPORT_FIELDS = (
+    ("BUILD_CONFIG_MODE", "mode"),
+    ("BUILD_CONFIG_OPENMP", "openmp"),
+    ("BUILD_CONFIG_ENABLED_FEATURES", "enabled_features"),
+    ("BUILD_CONFIG_PLATFORM", "platform"),
+    ("BUILD_CONFIG_COMPILER", "compiler"),
+    ("BUILD_CONFIG_COMPILER_FAMILY", "compiler_family"),
+    ("BUILD_CONFIG_BREW_PREFIX", "brew_prefix"),
+    ("BUILD_CONFIG_LIBOMP_PREFIX", "libomp_prefix"),
+    ("BUILD_CONFIG_DEPLOYMENT_TARGET", "deployment_target"),
+    ("NATIVE_CXXFLAGS", "compile_flags"),
+    ("NATIVE_LDFLAGS", "link_flags"),
+)
+
+
+def _make_export(config):
+    lines = []
+    for make_var, field in MAKE_EXPORT_FIELDS:
+        # Escape `$` so Make treats flag/path values literally on `include`,
+        # matching the old per-field `:=` capture which did not re-expand them.
+        value = _field_value(config, field).replace("$", "$$")
+        lines.append(f"{make_var} := {value}")
+    return "\n".join(lines)
+
+
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("format", choices=["json", "field"])
+    parser.add_argument("format", choices=["json", "field", "make-export"])
     parser.add_argument(
         "--field",
         choices=[
@@ -403,6 +431,9 @@ def main():
 
     if args.format == "json":
         json.dump(config, sys.stdout)
+        sys.stdout.write("\n")
+    elif args.format == "make-export":
+        sys.stdout.write(_make_export(config))
         sys.stdout.write("\n")
     else:
         if not args.field:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import importlib.util
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from setuptools import Extension, setup
@@ -38,9 +39,17 @@ def swig_warning_suppression(compiler_family):
     return []
 
 
+def resolve_build_jobs():
+    env_jobs = os.environ.get("INFOMAP_BUILD_JOBS", "").strip()
+    if env_jobs.isdigit() and int(env_jobs) > 0:
+        return int(env_jobs)
+    return os.cpu_count() or 1
+
+
 class BuildExt(build_ext):
     def build_extensions(self):
-        original_compile = self.compiler._compile
+        compiler = self.compiler
+        original_compile = compiler._compile
         quiet_swig_flags = swig_warning_suppression(shared_build["compiler_family"])
         swig_source = str(SWIG_CPP_SOURCE)
 
@@ -53,11 +62,57 @@ class BuildExt(build_ext):
                 compile_args.extend(quiet_swig_flags)
             return original_compile(obj, src, ext, cc_args, compile_args, pp_opts)
 
-        self.compiler._compile = compile_with_source_overrides
+        compiler._compile = compile_with_source_overrides
+
+        # Compile this extension's ~30 translation units concurrently.
+        # setuptools' build_ext.parallel only parallelizes *across extensions*,
+        # and the package ships a single extension, so we parallelize the
+        # per-object compiles ourselves by overriding the compiler's compile
+        # loop. Only the unix-style compiler drives compilation through the
+        # _compile hook used above; MSVC has its own loop, so leave it serial.
+        jobs = resolve_build_jobs()
+        parallelize = jobs > 1 and getattr(compiler, "compiler_type", None) in {
+            "unix",
+            "cygwin",
+        }
+        original_compile_method = compiler.compile
+
+        def parallel_compile(
+            sources,
+            output_dir=None,
+            macros=None,
+            include_dirs=None,
+            debug=0,
+            extra_preargs=None,
+            extra_postargs=None,
+            depends=None,
+        ):
+            macros, objects, extra_postargs, pp_opts, build = compiler._setup_compile(
+                output_dir, macros, include_dirs, sources, depends, extra_postargs
+            )
+            cc_args = compiler._get_cc_args(pp_opts, debug, extra_preargs)
+
+            def compile_one(obj):
+                try:
+                    src, ext = build[obj]
+                except KeyError:
+                    return
+                compiler._compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
+
+            with ThreadPoolExecutor(max_workers=jobs) as executor:
+                # Iterate results so the first compile error propagates.
+                for _ in executor.map(compile_one, objects):
+                    pass
+            return objects
+
+        if parallelize:
+            compiler.compile = parallel_compile
         try:
             super().build_extensions()
         finally:
-            self.compiler._compile = original_compile
+            compiler._compile = original_compile
+            if parallelize:
+                compiler.compile = original_compile_method
 
 
 build_config = load_build_config()

--- a/setup.py
+++ b/setup.py
@@ -71,10 +71,19 @@ class BuildExt(build_ext):
         # loop. Only the unix-style compiler drives compilation through the
         # _compile hook used above; MSVC has its own loop, so leave it serial.
         jobs = resolve_build_jobs()
-        parallelize = jobs > 1 and getattr(compiler, "compiler_type", None) in {
-            "unix",
-            "cygwin",
-        }
+        # Parallelizing a single extension's sources means reimplementing the
+        # compiler's compile loop with distutils internals (_setup_compile /
+        # _get_cc_args / _compile). Guard on their presence so a future setuptools
+        # that renames or drops them simply falls back to the correct serial
+        # build instead of erroring.
+        parallelize = (
+            jobs > 1
+            and getattr(compiler, "compiler_type", None) in {"unix", "cygwin"}
+            and all(
+                hasattr(compiler, attr)
+                for attr in ("_setup_compile", "_get_cc_args", "_compile")
+            )
+        )
         original_compile_method = compiler.compile
 
         def parallel_compile(

--- a/test/python/test_build_config.py
+++ b/test/python/test_build_config.py
@@ -271,6 +271,22 @@ def test_make_export_escapes_dollar_signs():
     assert "$$ORIGIN" in build_config._make_export(config)
 
 
+def test_make_export_escapes_hash():
+    config = resolve_build_config(
+        platform_name="linux",
+        compiler="clang++",
+        openmp=False,
+        cxxflags="-DTAG=a#b",
+    )
+
+    raw = build_config._field_value(config, "compile_flags")
+    assert "a#b" in raw
+
+    # An unescaped `#` would start a Make comment on `include`, truncating the
+    # value, so it is backslash-escaped.
+    assert "a\\#b" in build_config._make_export(config)
+
+
 def test_setup_py_passes_features_env_to_build_config():
     setup_tree = ast.parse(SETUP_PY_PATH.read_text(encoding="utf-8"))
 

--- a/test/python/test_build_config.py
+++ b/test/python/test_build_config.py
@@ -1,5 +1,6 @@
 import ast
 import importlib.util
+import re
 from pathlib import Path
 
 
@@ -223,6 +224,51 @@ def test_python_make_build_env_passes_features():
     python_mk = PYTHON_MK_PATH.read_text(encoding="utf-8")
 
     assert 'FEATURES="$(FEATURES)"' in python_mk
+
+
+def test_python_make_build_env_passes_build_jobs():
+    python_mk = PYTHON_MK_PATH.read_text(encoding="utf-8")
+
+    assert 'INFOMAP_BUILD_JOBS="$(JOBS)"' in python_mk
+
+
+def test_make_export_matches_per_field_values():
+    config = resolve_build_config(
+        platform_name="linux",
+        compiler="clang++",
+        openmp=True,
+    )
+
+    lines = build_config._make_export(config).splitlines()
+
+    # One assignment per mapped field, each a parseable Make assignment.
+    assert len(lines) == len(build_config.MAKE_EXPORT_FIELDS)
+    rendered = {}
+    for line in lines:
+        name, sep, value = line.partition(" := ")
+        assert sep, f"not a Make assignment: {line!r}"
+        assert re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", name), name
+        rendered[name] = value
+
+    # Values must equal the prior per-field rendering (with `$` escaped).
+    for make_var, field in build_config.MAKE_EXPORT_FIELDS:
+        expected = build_config._field_value(config, field).replace("$", "$$")
+        assert rendered[make_var] == expected
+
+
+def test_make_export_escapes_dollar_signs():
+    config = resolve_build_config(
+        platform_name="linux",
+        compiler="clang++",
+        openmp=False,
+        cxxflags="-DPATH=$ORIGIN",
+    )
+
+    raw = build_config._field_value(config, "compile_flags")
+    assert "$ORIGIN" in raw and "$$" not in raw
+
+    # On `include`, an unescaped `$` would be expanded by Make, so it is doubled.
+    assert "$$ORIGIN" in build_config._make_export(config)
 
 
 def test_setup_py_passes_features_env_to_build_config():


### PR DESCRIPTION
## Context

The build system is already well-tuned (ccache auto-detected for native, auto `-jN`, opt-in LTO), so these are **specific, safe** speedups across the native, Python, R, and CI build loops. No compilation semantics change.

## Changes

### 1. Per-translation-unit header dependencies — biggest native dev-loop win
`mk/native.mk` made every object depend on *all* 38 headers, so editing one header rebuilt all 24 TUs. Now the compiler emits `.d` files (`-MMD -MP`, gated to clang/gnu) that Make `-include`s, so only the TUs that actually include a changed header recompile. MSVC keeps the conservative `$(HEADERS)` prerequisite.

### 2. Resolve build config in one call
`build_config.py` was invoked ~11x per `make` (each spawns Python + probes the compiler + brew). Added a `make-export` mode; `mk/common.mk` now generates and `include`s a single Make fragment. Skipped on clean-only goals; stderr is left attached so failures are debuggable.

### 3. Speed up the Python wheel build (two ways)
- **Source-level parallel compile.** setuptools' `build_ext.parallel` only parallelizes *across extensions*, and we ship a single extension — so the naive approach gives **zero** speedup. We now parallelize the per-object compiles directly (honors `INFOMAP_BUILD_JOBS` -> `$(JOBS)`; unix compilers only).
- **ccache for Python.** `PYTHON_BUILD_CXX` now uses the ccache launcher (skipped on Windows). Cache hits work through `python -m build` isolation.

### 4. Speed up the R package build (two ways)
- **Parallel compile** via `MAKE="make -j$(JOBS)"`. R drives the SHLIB build through `$(MAKE)`, so overriding it parallelizes the per-object compiles (`MAKEFLAGS=-j` is *not* honored by `R CMD INSTALL`).
- **ccache for R.** On non-macOS, a user Makevars prepends ccache to R's configured compiler. On macOS the package's `configure` pins Apple clang with `override` (which beats a user Makevars), so `configure` now prefixes the pinned compiler with an optional launcher from `INFOMAP_R_CXX_LAUNCHER` — unset (CRAN / r-universe default) leaves behavior identical.

### 5. Persist ccache in CI
`_native-build.yml` started every run with an empty ccache. Added `actions/cache` on a workspace-local `CCACHE_DIR` (skipped on Windows/MinGW), so each run warm-starts from the previous.

## Measured impact (12-core macOS)

| | Before | After |
|---|---|---|
| Native rebuild after a header edit | all 24 TUs | **4–5 TUs** |
| Native no-op build | ~11 Python spawns | **~0.22 s** |
| Python wheel — cold build | ~34 s (serial) | **~12 s** (2.8×, real parallelism) |
| Python wheel — repeat build | ~34 s (no cache) | **~2.8 s** (~12×, ccache hits) |
| R package — cold build | ~35 s (serial) | **~15.6 s** (2.3×, parallel) |
| R package — repeat build | ~35 s (no cache) | **~7.5 s** (4.7×, ccache hits) |

## Out of scope (safe-only)
Unity/PCH builds and mold/lld linker were intentionally excluded. ccache persistence in the Python/R CI workflows (cross-run) is a possible follow-up; the parallel speedups already apply there automatically.

## Verification
- `make doctor` flags identical before/after (`make-export` matches the old `field` path).
- Native: clean build + binary OK; `-MP` phony stanzas present; C++ suite **14/14**.
- Python: wheel built + installed via the parallel+ccache path; unit suite **221 passed, 2 skipped**; `_make_export` covered by new tests.
- R: module loads; `R CMD check --as-cran` reports "checking compilation flags in Makevars ... OK" with only the pre-existing WARNING/NOTE (missing checkbashisms/pandoc locally + CRAN-incoming network NOTE), identical to master.
