### PR TITLE
build: CCACHE_NOHASHDIR=1 so R tarball/binary builds hit ccache

### DIFF
--- a/mk/r.mk
+++ b/mk/r.mk
@@ -25,6 +25,11 @@ R_FORMAT_TARGETS := \
 #   * ccache as a compiler launcher, so repeat builds hit the cache — same idea
 #     as the native/Python builds. ccache execs the compiler unchanged for link
 #     steps, so it is safe as the CXX used to both compile and link the .so.
+#   * CCACHE_NOHASHDIR=1 (when ccache is active): R CMD INSTALL --build, the
+#     r-universe build, and CI binary builds compile inside a fresh temp dir each
+#     run, so ccache's default directory hashing (on with -g) would miss every
+#     time. Dropping it lets tarball installs hit the cache too, and lets the
+#     stable staged-dir install (dev-r-install) share entries with them.
 CCACHE_LAUNCHER := $(if $(and $(filter 1,$(USE_CCACHE)),$(CCACHE_BIN)),$(CCACHE_BIN),)
 R_PARALLEL := MAKE="$(MAKE) -j$(JOBS)"
 R_MAKEVARS_FILE := $(CURDIR)/$(R_BUILD_DIR)/.Makevars.infomap
@@ -43,14 +48,14 @@ R_MAKEVARS_FILE := $(CURDIR)/$(R_BUILD_DIR)/.Makevars.infomap
 ifeq ($(UNAME_S),Darwin)
 _R_CC  := $(if $(CCACHE_LAUNCHER),$(CCACHE_LAUNCHER) ,)/usr/bin/clang
 _R_CXX := $(if $(CCACHE_LAUNCHER),$(CCACHE_LAUNCHER) ,)/usr/bin/clang++
-R_CMD_ENV := R_MAKEVARS_USER=$(R_MAKEVARS_FILE) $(R_PARALLEL) INFOMAP_R_CXX_LAUNCHER=$(CCACHE_LAUNCHER)
+R_CMD_ENV := R_MAKEVARS_USER=$(R_MAKEVARS_FILE) $(R_PARALLEL) CCACHE_NOHASHDIR=1 INFOMAP_R_CXX_LAUNCHER=$(CCACHE_LAUNCHER)
 _write_r_makevars = @mkdir -p $(R_BUILD_DIR) && \
 	printf 'CC = %s\nCXX = %s\nCXX17 = %s\n' '$(_R_CC)' '$(_R_CXX)' '$(_R_CXX)' \
 	> $(R_MAKEVARS_FILE)
 else ifneq ($(CCACHE_LAUNCHER),)
 # Other unix: no configure override, so route R's configured compiler through
 # ccache via a user Makevars.
-R_CMD_ENV := R_MAKEVARS_USER=$(R_MAKEVARS_FILE) $(R_PARALLEL)
+R_CMD_ENV := R_MAKEVARS_USER=$(R_MAKEVARS_FILE) $(R_PARALLEL) CCACHE_NOHASHDIR=1
 _write_r_makevars = @mkdir -p $(R_BUILD_DIR) && \
 	cc="$$($(R) CMD config CC)"; cxx="$$($(R) CMD config CXX)"; cxx17="$$($(R) CMD config CXX17)"; \
 	printf 'CC = %s %s\nCXX = %s %s\nCXX17 = %s %s\n' \

--- a/mk/r.mk
+++ b/mk/r.mk
@@ -32,6 +32,10 @@ R_FORMAT_TARGETS := \
 #     stable staged-dir install (dev-r-install) share entries with them.
 CCACHE_LAUNCHER := $(if $(and $(filter 1,$(USE_CCACHE)),$(CCACHE_BIN)),$(CCACHE_BIN),)
 R_PARALLEL := MAKE="$(MAKE) -j$(JOBS)"
+# Only meaningful when ccache is active; empty otherwise so the no-ccache
+# environment is left byte-for-byte unchanged. Trailing space lets it abut the
+# next assignment cleanly.
+R_CCACHE_ENV := $(if $(CCACHE_LAUNCHER),CCACHE_NOHASHDIR=1 ,)
 R_MAKEVARS_FILE := $(CURDIR)/$(R_BUILD_DIR)/.Makevars.infomap
 
 # On macOS, Homebrew LLVM clang++ may be first in PATH but Homebrew R uses
@@ -48,14 +52,14 @@ R_MAKEVARS_FILE := $(CURDIR)/$(R_BUILD_DIR)/.Makevars.infomap
 ifeq ($(UNAME_S),Darwin)
 _R_CC  := $(if $(CCACHE_LAUNCHER),$(CCACHE_LAUNCHER) ,)/usr/bin/clang
 _R_CXX := $(if $(CCACHE_LAUNCHER),$(CCACHE_LAUNCHER) ,)/usr/bin/clang++
-R_CMD_ENV := R_MAKEVARS_USER=$(R_MAKEVARS_FILE) $(R_PARALLEL) CCACHE_NOHASHDIR=1 INFOMAP_R_CXX_LAUNCHER=$(CCACHE_LAUNCHER)
+R_CMD_ENV := R_MAKEVARS_USER=$(R_MAKEVARS_FILE) $(R_PARALLEL) $(R_CCACHE_ENV)INFOMAP_R_CXX_LAUNCHER=$(CCACHE_LAUNCHER)
 _write_r_makevars = @mkdir -p $(R_BUILD_DIR) && \
 	printf 'CC = %s\nCXX = %s\nCXX17 = %s\n' '$(_R_CC)' '$(_R_CXX)' '$(_R_CXX)' \
 	> $(R_MAKEVARS_FILE)
 else ifneq ($(CCACHE_LAUNCHER),)
 # Other unix: no configure override, so route R's configured compiler through
 # ccache via a user Makevars.
-R_CMD_ENV := R_MAKEVARS_USER=$(R_MAKEVARS_FILE) $(R_PARALLEL) CCACHE_NOHASHDIR=1
+R_CMD_ENV := R_MAKEVARS_USER=$(R_MAKEVARS_FILE) $(R_PARALLEL) $(R_CCACHE_ENV)
 _write_r_makevars = @mkdir -p $(R_BUILD_DIR) && \
 	cc="$$($(R) CMD config CC)"; cxx="$$($(R) CMD config CXX)"; cxx17="$$($(R) CMD config CXX17)"; \
 	printf 'CC = %s %s\nCXX = %s %s\nCXX17 = %s %s\n' \


### PR DESCRIPTION
## Context

Follow-up to #611. After that merged, `make build-r-binary` showed no ccache speedup locally even though `dev-r-install` did.

**Root cause:** `build-r-binary` (and the r-universe / CI binary builds) install from a tarball that `R CMD INSTALL --build` extracts to a **fresh temp directory each run**. ccache's default directory hashing (active because R compiles with `-g`) keys on that path, so every such build missed the cache and recompiled cold. `dev-r-install` installs from the stable `build/R/infomap` staged dir, so it hit 100%.

## Change

Set `CCACHE_NOHASHDIR=1` in the ccache-active `R_CMD_ENV` branches in `mk/r.mk`, dropping the working directory from the ccache hash.

## Measured (12-core macOS)

| `make build-r-binary` | ccache hits | time |
|---|---|---|
| before | 0/24 (0%) | ~14.6 s |
| after | **24/24 (100%)** | **~8.7 s** |

(The ~2 s over `dev-r-install`'s 6.9 s is tarball + binary `.tgz` packaging, inherent to the target.) As a bonus, the staged-dir and tarball installs now share cache entries — building via one warms the cache for the other.

## Safety

R compiles with **relative** source paths (`-c src/foo.cpp`), so the object is functionally identical regardless of the build directory; only the embedded `-g` path may come from the first cached build, which is immaterial for a release binary. This is exactly the documented use case for `CCACHE_NOHASHDIR` (same sources built in different directories). The non-ccache branch is unchanged.
