### PR TITLE
fix: guard entropy network properties

### DIFF
--- a/src/core/BiasedMapEquation.cpp
+++ b/src/core/BiasedMapEquation.cpp
@@ -15,6 +15,7 @@
 #include <vector>
 #include <utility>
 #include <cstdlib>
+#include <mutex>
 #include "StateNetwork.h"
 
 namespace infomap {
@@ -24,12 +25,17 @@ unsigned int BiasedMapEquation::s_numNodes = 0;
 
 void BiasedMapEquation::setNetworkProperties(const StateNetwork& network)
 {
-  s_totalDegree = network.sumWeightedDegree();
+  auto totalDegree = network.sumWeightedDegree();
   // Negative entropy bias is based on discrete counts, if average weight is below 1, use unweighted total degree
-  if (s_totalDegree < network.sumDegree()) {
-    s_totalDegree = network.sumDegree();
+  if (totalDegree < network.sumDegree()) {
+    totalDegree = network.sumDegree();
   }
-  s_numNodes = network.numNodes();
+  const auto numNodes = network.numNodes();
+
+  static std::mutex networkPropertiesMutex;
+  std::lock_guard<std::mutex> lock(networkPropertiesMutex);
+  s_totalDegree = totalDegree;
+  s_numNodes = numNodes;
 }
 
 double BiasedMapEquation::getIndexCodelength() const

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1064,7 +1064,8 @@ void InfomapBase::generateSubNetwork(Network& network)
   if (!this->regularized) {
     m_calculateEnterExitFlow = true;
   }
-  BiasedMapEquation::setNetworkProperties(network);
+  if (entropyBiasCorrection)
+    BiasedMapEquation::setNetworkProperties(network);
 
   if (std::abs(sumNodeFlow - 1.0) > 1e-10)
     Log() << "Warning, total flow on nodes differs from 1.0 by " << sumNodeFlow - 1.0 << ".\n";


### PR DESCRIPTION
## Summary
- compute biased map network property values before taking the lock
- guard the shared entropy-bias statics with a mutex when they are updated
- skip `BiasedMapEquation::setNetworkProperties()` unless `entropyBiasCorrection` is enabled

## Verification
- `make format-native`
- `make build-native OPENMP=1`
- `make test-native OPENMP=1`

## Notes
This keeps the synchronization on the only path that reads the shared entropy-bias network properties and avoids the work on default non-entropy runs.