### PR TITLE
perf: cut multi-trial peak memory ~40% and shrink hot-path value types

### DIFF
--- a/interfaces/R/generated/infomap.R
+++ b/interfaces/R/generated/infomap.R
@@ -285,9 +285,9 @@ setClass('_p_infomap__DeltaFlow', contains = 'C++Reference')
 setClass("infomap::DeltaFlow",
     representation(
         module = "integer",
+        count = "integer",
         deltaExit = "numeric",
-        deltaEnter = "numeric",
-        count = "integer"),
+        deltaEnter = "numeric"),
         contains = "RSWIGStruct")
 
 
@@ -4081,6 +4081,38 @@ attr(`DeltaFlow_module_get`, 'returnType') = 'integer'
 attr(`DeltaFlow_module_get`, "inputTypes") = c('_p_infomap__DeltaFlow')
 class(`DeltaFlow_module_get`) = c("SWIGFunction", class('DeltaFlow_module_get'))
 
+# Start of DeltaFlow_count_set
+
+`DeltaFlow_count_set` = function(self, s_count)
+{
+  if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
+  s_count = as.integer(s_count);
+  
+  if(length(s_count) > 1) {
+    warning("using only the first element of s_count");
+  };
+  
+  ;.Call('R_swig_DeltaFlow_count_set', self, s_count, PACKAGE='infomap');
+  
+}
+
+attr(`DeltaFlow_count_set`, 'returnType') = 'void'
+attr(`DeltaFlow_count_set`, "inputTypes") = c('_p_infomap__DeltaFlow', 'integer')
+class(`DeltaFlow_count_set`) = c("SWIGFunction", class('DeltaFlow_count_set'))
+
+# Start of DeltaFlow_count_get
+
+`DeltaFlow_count_get` = function(self, .copy = FALSE)
+{
+  if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
+  ;.Call('R_swig_DeltaFlow_count_get', self, as.logical(.copy), PACKAGE='infomap');
+  
+}
+
+attr(`DeltaFlow_count_get`, 'returnType') = 'integer'
+attr(`DeltaFlow_count_get`, "inputTypes") = c('_p_infomap__DeltaFlow')
+class(`DeltaFlow_count_get`) = c("SWIGFunction", class('DeltaFlow_count_get'))
+
 # Start of DeltaFlow_deltaExit_set
 
 `DeltaFlow_deltaExit_set` = function(self, s_deltaExit)
@@ -4134,38 +4166,6 @@ class(`DeltaFlow_deltaEnter_set`) = c("SWIGFunction", class('DeltaFlow_deltaEnte
 attr(`DeltaFlow_deltaEnter_get`, 'returnType') = 'numeric'
 attr(`DeltaFlow_deltaEnter_get`, "inputTypes") = c('_p_infomap__DeltaFlow')
 class(`DeltaFlow_deltaEnter_get`) = c("SWIGFunction", class('DeltaFlow_deltaEnter_get'))
-
-# Start of DeltaFlow_count_set
-
-`DeltaFlow_count_set` = function(self, s_count)
-{
-  if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
-  s_count = as.integer(s_count);
-  
-  if(length(s_count) > 1) {
-    warning("using only the first element of s_count");
-  };
-  
-  ;.Call('R_swig_DeltaFlow_count_set', self, s_count, PACKAGE='infomap');
-  
-}
-
-attr(`DeltaFlow_count_set`, 'returnType') = 'void'
-attr(`DeltaFlow_count_set`, "inputTypes") = c('_p_infomap__DeltaFlow', 'integer')
-class(`DeltaFlow_count_set`) = c("SWIGFunction", class('DeltaFlow_count_set'))
-
-# Start of DeltaFlow_count_get
-
-`DeltaFlow_count_get` = function(self, .copy = FALSE)
-{
-  if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
-  ;.Call('R_swig_DeltaFlow_count_get', self, as.logical(.copy), PACKAGE='infomap');
-  
-}
-
-attr(`DeltaFlow_count_get`, 'returnType') = 'integer'
-attr(`DeltaFlow_count_get`, "inputTypes") = c('_p_infomap__DeltaFlow')
-class(`DeltaFlow_count_get`) = c("SWIGFunction", class('DeltaFlow_count_get'))
 
 # Start of new_DeltaFlow
 
@@ -4390,8 +4390,8 @@ class(`swap__SWIG_0`) = c("SWIGFunction", class('swap__SWIG_0'))
 setMethod('$', '_p_infomap__DeltaFlow', function(x, name)
 
 {
-  accessorFuns = list('module' = DeltaFlow_module_get, 'deltaExit' = DeltaFlow_deltaExit_get, 'deltaEnter' = DeltaFlow_deltaEnter_get, 'count' = DeltaFlow_count_get, 'Equal' = DeltaFlow_Equal, 'PlusEqual' = DeltaFlow_PlusEqual, 'reset' = DeltaFlow_reset);
-  vaccessors = c('module', 'deltaExit', 'deltaEnter', 'count');
+  accessorFuns = list('module' = DeltaFlow_module_get, 'count' = DeltaFlow_count_get, 'deltaExit' = DeltaFlow_deltaExit_get, 'deltaEnter' = DeltaFlow_deltaEnter_get, 'Equal' = DeltaFlow_Equal, 'PlusEqual' = DeltaFlow_PlusEqual, 'reset' = DeltaFlow_reset);
+  vaccessors = c('module', 'count', 'deltaExit', 'deltaEnter');
   ;        idx = pmatch(name, names(accessorFuns));
   if(is.na(idx)) 
   return(callNextMethod(x, name));
@@ -4408,7 +4408,7 @@ setMethod('$', '_p_infomap__DeltaFlow', function(x, name)
 setMethod('$<-', '_p_infomap__DeltaFlow', function(x, name, value)
 
 {
-  accessorFuns = list('module' = DeltaFlow_module_set, 'deltaExit' = DeltaFlow_deltaExit_set, 'deltaEnter' = DeltaFlow_deltaEnter_set, 'count' = DeltaFlow_count_set);
+  accessorFuns = list('module' = DeltaFlow_module_set, 'count' = DeltaFlow_count_set, 'deltaExit' = DeltaFlow_deltaExit_set, 'deltaEnter' = DeltaFlow_deltaEnter_set);
   ;        idx = pmatch(name, names(accessorFuns));
   if(is.na(idx)) 
   return(callNextMethod(x, name, value));
@@ -4423,7 +4423,7 @@ setMethod('[[<-', c('_p_infomap__DeltaFlow', 'character'),function(x, i, j, ...,
 
 {
   name = i;
-  accessorFuns = list('module' = DeltaFlow_module_set, 'deltaExit' = DeltaFlow_deltaExit_set, 'deltaEnter' = DeltaFlow_deltaEnter_set, 'count' = DeltaFlow_count_set);
+  accessorFuns = list('module' = DeltaFlow_module_set, 'count' = DeltaFlow_count_set, 'deltaExit' = DeltaFlow_deltaExit_set, 'deltaEnter' = DeltaFlow_deltaEnter_set);
   ;        idx = pmatch(name, names(accessorFuns));
   if(is.na(idx)) 
   return(callNextMethod(x, name, value));
@@ -4440,9 +4440,9 @@ setMethod('delete', '_p_infomap__DeltaFlow', function(obj) {delete_infomap__Delt
 CopyToR_infomap__DeltaFlow = function(value, obj = new("infomap::DeltaFlow"))
 {
   obj@module = value$module;
+  obj@count = value$count;
   obj@deltaExit = value$deltaExit;
   obj@deltaEnter = value$deltaEnter;
-  obj@count = value$count;
   obj;
 }
 
@@ -4451,9 +4451,9 @@ CopyToR_infomap__DeltaFlow = function(value, obj = new("infomap::DeltaFlow"))
 CopyToC_infomap__DeltaFlow = function(value, obj)
 {
   obj$module = value@module;
+  obj$count = value@count;
   obj$deltaExit = value@deltaExit;
   obj$deltaEnter = value@deltaEnter;
-  obj$count = value@count;
   obj
 }
 
@@ -6462,37 +6462,6 @@ attr(`InfoNode_physicalNodes_get`, 'returnType') = '_p_std__vectorT_infomap__Phy
 attr(`InfoNode_physicalNodes_get`, "inputTypes") = c('_p_infomap__InfoNode')
 class(`InfoNode_physicalNodes_get`) = c("SWIGFunction", class('InfoNode_physicalNodes_get'))
 
-# Start of InfoNode_metaCollection_set
-
-`InfoNode_metaCollection_set` = function(self, s_metaCollection)
-{
-  if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
-  if (inherits(s_metaCollection, "ExternalReference")) s_metaCollection = slot(s_metaCollection,"ref"); 
-  ;.Call('R_swig_InfoNode_metaCollection_set', self, s_metaCollection, PACKAGE='infomap');
-  
-}
-
-attr(`InfoNode_metaCollection_set`, 'returnType') = 'void'
-attr(`InfoNode_metaCollection_set`, "inputTypes") = c('_p_infomap__InfoNode', '_p_MetaCollection')
-class(`InfoNode_metaCollection_set`) = c("SWIGFunction", class('InfoNode_metaCollection_set'))
-
-# Start of InfoNode_metaCollection_get
-
-`InfoNode_metaCollection_get` = function(self, .copy = FALSE)
-{
-  if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
-  ;ans = .Call('R_swig_InfoNode_metaCollection_get', self, as.logical(.copy), PACKAGE='infomap');
-  ans <- if (is.null(ans)) ans
-  else new("_p_MetaCollection", ref=ans);
-  
-  ans
-  
-}
-
-attr(`InfoNode_metaCollection_get`, 'returnType') = '_p_MetaCollection'
-attr(`InfoNode_metaCollection_get`, "inputTypes") = c('_p_infomap__InfoNode')
-class(`InfoNode_metaCollection_get`) = c("SWIGFunction", class('InfoNode_metaCollection_get'))
-
 # Start of InfoNode_stateNodes_set
 
 `InfoNode_stateNodes_set` = function(self, s_stateNodes)
@@ -8245,8 +8214,8 @@ class(`InfoNode_addOutEdge__SWIG_1`) = c("SWIGFunction", class('InfoNode_addOutE
 setMethod('$', '_p_infomap__InfoNode', function(x, name)
 
 {
-  accessorFuns = list('data' = InfoNode_data_get, 'index' = InfoNode_index_get, 'stateId' = InfoNode_stateId_get, 'physicalId' = InfoNode_physicalId_get, 'layerId' = InfoNode_layerId_get, 'metaData' = InfoNode_metaData_get, 'owner' = InfoNode_owner_get, 'parent' = InfoNode_parent_get, 'previous' = InfoNode_previous_get, '_next' = InfoNode__next_get, 'firstChild' = InfoNode_firstChild_get, 'lastChild' = InfoNode_lastChild_get, 'collapsedFirstChild' = InfoNode_collapsedFirstChild_get, 'collapsedLastChild' = InfoNode_collapsedLastChild_get, 'codelength' = InfoNode_codelength_get, 'dirty' = InfoNode_dirty_get, 'physicalNodes' = InfoNode_physicalNodes_get, 'metaCollection' = InfoNode_metaCollection_get, 'stateNodes' = InfoNode_stateNodes_get, 'Equal' = InfoNode_Equal, 'getMetaData' = InfoNode_getMetaData, 'getInfomap' = InfoNode_getInfomap, 'setInfomap' = InfoNode_setInfomap, 'getInfomapRoot' = InfoNode_getInfomapRoot, 'disposeInfomap' = InfoNode_disposeInfomap, 'numPhysicalNodes' = InfoNode_numPhysicalNodes, 'begin' = InfoNode_begin, 'end' = InfoNode_end, 'begin_child' = InfoNode_begin_child, 'end_child' = InfoNode_end_child, 'children' = InfoNode_children, 'infomap_children' = InfoNode_infomap_children, 'begin_post_depth_first' = InfoNode_begin_post_depth_first, 'begin_leaf_nodes' = InfoNode_begin_leaf_nodes, 'begin_leaf_modules' = InfoNode_begin_leaf_modules, 'begin_tree' = InfoNode_begin_tree, 'end_tree' = InfoNode_end_tree, 'infomapTree' = InfoNode_infomapTree, 'begin_outEdge' = InfoNode_begin_outEdge, 'end_outEdge' = InfoNode_end_outEdge, 'begin_inEdge' = InfoNode_begin_inEdge, 'end_inEdge' = InfoNode_end_inEdge, 'outEdges' = InfoNode_outEdges, 'inEdges' = InfoNode_inEdges, 'childDegree' = InfoNode_childDegree, 'isLeaf' = InfoNode_isLeaf, 'isLeafModule' = InfoNode_isLeafModule, 'isRoot' = InfoNode_isRoot, 'depth' = InfoNode_depth, 'firstDepthBelow' = InfoNode_firstDepthBelow, 'numLeafMembers' = InfoNode_numLeafMembers, 'isDangling' = InfoNode_isDangling, 'outDegree' = InfoNode_outDegree, 'inDegree' = InfoNode_inDegree, 'degree' = InfoNode_degree, 'isFirst' = InfoNode_isFirst, 'isLast' = InfoNode_isLast, 'childIndex' = InfoNode_childIndex, 'calculatePath' = InfoNode_calculatePath, 'infomapChildDegree' = InfoNode_infomapChildDegree, 'id' = InfoNode_id, 'EqualEqual' = InfoNode_EqualEqual, 'NotEqual' = InfoNode_NotEqual, 'initClean' = InfoNode_initClean, 'sortChildrenOnFlow' = InfoNode_sortChildrenOnFlow, 'collapseChildren' = InfoNode_collapseChildren, 'expandChildren' = InfoNode_expandChildren, 'setChildDegree' = InfoNode_setChildDegree, 'setNumLeafNodes' = InfoNode_setNumLeafNodes, 'addChild' = InfoNode_addChild, 'releaseChildren' = InfoNode_releaseChildren, 'replaceChildrenWithOneNode' = InfoNode_replaceChildrenWithOneNode, 'replaceWithChildren' = InfoNode_replaceWithChildren, 'replaceWithChildrenDebug' = InfoNode_replaceWithChildrenDebug, 'replaceChildrenWithGrandChildren' = InfoNode_replaceChildrenWithGrandChildren, 'replaceChildrenWithGrandChildrenDebug' = InfoNode_replaceChildrenWithGrandChildrenDebug, 'remove' = InfoNode_remove, 'deleteChildren' = InfoNode_deleteChildren, 'addOutEdge' = InfoNode_addOutEdge);
-  vaccessors = c('data', 'index', 'stateId', 'physicalId', 'layerId', 'metaData', 'owner', 'parent', 'previous', '_next', 'firstChild', 'lastChild', 'collapsedFirstChild', 'collapsedLastChild', 'codelength', 'dirty', 'physicalNodes', 'metaCollection', 'stateNodes');
+  accessorFuns = list('data' = InfoNode_data_get, 'index' = InfoNode_index_get, 'stateId' = InfoNode_stateId_get, 'physicalId' = InfoNode_physicalId_get, 'layerId' = InfoNode_layerId_get, 'metaData' = InfoNode_metaData_get, 'owner' = InfoNode_owner_get, 'parent' = InfoNode_parent_get, 'previous' = InfoNode_previous_get, '_next' = InfoNode__next_get, 'firstChild' = InfoNode_firstChild_get, 'lastChild' = InfoNode_lastChild_get, 'collapsedFirstChild' = InfoNode_collapsedFirstChild_get, 'collapsedLastChild' = InfoNode_collapsedLastChild_get, 'codelength' = InfoNode_codelength_get, 'dirty' = InfoNode_dirty_get, 'physicalNodes' = InfoNode_physicalNodes_get, 'stateNodes' = InfoNode_stateNodes_get, 'Equal' = InfoNode_Equal, 'getMetaData' = InfoNode_getMetaData, 'getInfomap' = InfoNode_getInfomap, 'setInfomap' = InfoNode_setInfomap, 'getInfomapRoot' = InfoNode_getInfomapRoot, 'disposeInfomap' = InfoNode_disposeInfomap, 'numPhysicalNodes' = InfoNode_numPhysicalNodes, 'begin' = InfoNode_begin, 'end' = InfoNode_end, 'begin_child' = InfoNode_begin_child, 'end_child' = InfoNode_end_child, 'children' = InfoNode_children, 'infomap_children' = InfoNode_infomap_children, 'begin_post_depth_first' = InfoNode_begin_post_depth_first, 'begin_leaf_nodes' = InfoNode_begin_leaf_nodes, 'begin_leaf_modules' = InfoNode_begin_leaf_modules, 'begin_tree' = InfoNode_begin_tree, 'end_tree' = InfoNode_end_tree, 'infomapTree' = InfoNode_infomapTree, 'begin_outEdge' = InfoNode_begin_outEdge, 'end_outEdge' = InfoNode_end_outEdge, 'begin_inEdge' = InfoNode_begin_inEdge, 'end_inEdge' = InfoNode_end_inEdge, 'outEdges' = InfoNode_outEdges, 'inEdges' = InfoNode_inEdges, 'childDegree' = InfoNode_childDegree, 'isLeaf' = InfoNode_isLeaf, 'isLeafModule' = InfoNode_isLeafModule, 'isRoot' = InfoNode_isRoot, 'depth' = InfoNode_depth, 'firstDepthBelow' = InfoNode_firstDepthBelow, 'numLeafMembers' = InfoNode_numLeafMembers, 'isDangling' = InfoNode_isDangling, 'outDegree' = InfoNode_outDegree, 'inDegree' = InfoNode_inDegree, 'degree' = InfoNode_degree, 'isFirst' = InfoNode_isFirst, 'isLast' = InfoNode_isLast, 'childIndex' = InfoNode_childIndex, 'calculatePath' = InfoNode_calculatePath, 'infomapChildDegree' = InfoNode_infomapChildDegree, 'id' = InfoNode_id, 'EqualEqual' = InfoNode_EqualEqual, 'NotEqual' = InfoNode_NotEqual, 'initClean' = InfoNode_initClean, 'sortChildrenOnFlow' = InfoNode_sortChildrenOnFlow, 'collapseChildren' = InfoNode_collapseChildren, 'expandChildren' = InfoNode_expandChildren, 'setChildDegree' = InfoNode_setChildDegree, 'setNumLeafNodes' = InfoNode_setNumLeafNodes, 'addChild' = InfoNode_addChild, 'releaseChildren' = InfoNode_releaseChildren, 'replaceChildrenWithOneNode' = InfoNode_replaceChildrenWithOneNode, 'replaceWithChildren' = InfoNode_replaceWithChildren, 'replaceWithChildrenDebug' = InfoNode_replaceWithChildrenDebug, 'replaceChildrenWithGrandChildren' = InfoNode_replaceChildrenWithGrandChildren, 'replaceChildrenWithGrandChildrenDebug' = InfoNode_replaceChildrenWithGrandChildrenDebug, 'remove' = InfoNode_remove, 'deleteChildren' = InfoNode_deleteChildren, 'addOutEdge' = InfoNode_addOutEdge);
+  vaccessors = c('data', 'index', 'stateId', 'physicalId', 'layerId', 'metaData', 'owner', 'parent', 'previous', '_next', 'firstChild', 'lastChild', 'collapsedFirstChild', 'collapsedLastChild', 'codelength', 'dirty', 'physicalNodes', 'stateNodes');
   ;        idx = pmatch(name, names(accessorFuns));
   if(is.na(idx)) 
   return(callNextMethod(x, name));
@@ -8263,7 +8232,7 @@ setMethod('$', '_p_infomap__InfoNode', function(x, name)
 setMethod('$<-', '_p_infomap__InfoNode', function(x, name, value)
 
 {
-  accessorFuns = list('data' = InfoNode_data_set, 'index' = InfoNode_index_set, 'stateId' = InfoNode_stateId_set, 'physicalId' = InfoNode_physicalId_set, 'layerId' = InfoNode_layerId_set, 'metaData' = InfoNode_metaData_set, 'owner' = InfoNode_owner_set, 'parent' = InfoNode_parent_set, 'previous' = InfoNode_previous_set, '_next' = InfoNode__next_set, 'firstChild' = InfoNode_firstChild_set, 'lastChild' = InfoNode_lastChild_set, 'collapsedFirstChild' = InfoNode_collapsedFirstChild_set, 'collapsedLastChild' = InfoNode_collapsedLastChild_set, 'codelength' = InfoNode_codelength_set, 'dirty' = InfoNode_dirty_set, 'physicalNodes' = InfoNode_physicalNodes_set, 'metaCollection' = InfoNode_metaCollection_set, 'stateNodes' = InfoNode_stateNodes_set);
+  accessorFuns = list('data' = InfoNode_data_set, 'index' = InfoNode_index_set, 'stateId' = InfoNode_stateId_set, 'physicalId' = InfoNode_physicalId_set, 'layerId' = InfoNode_layerId_set, 'metaData' = InfoNode_metaData_set, 'owner' = InfoNode_owner_set, 'parent' = InfoNode_parent_set, 'previous' = InfoNode_previous_set, '_next' = InfoNode__next_set, 'firstChild' = InfoNode_firstChild_set, 'lastChild' = InfoNode_lastChild_set, 'collapsedFirstChild' = InfoNode_collapsedFirstChild_set, 'collapsedLastChild' = InfoNode_collapsedLastChild_set, 'codelength' = InfoNode_codelength_set, 'dirty' = InfoNode_dirty_set, 'physicalNodes' = InfoNode_physicalNodes_set, 'stateNodes' = InfoNode_stateNodes_set);
   ;        idx = pmatch(name, names(accessorFuns));
   if(is.na(idx)) 
   return(callNextMethod(x, name, value));
@@ -8278,7 +8247,7 @@ setMethod('[[<-', c('_p_infomap__InfoNode', 'character'),function(x, i, j, ..., 
 
 {
   name = i;
-  accessorFuns = list('data' = InfoNode_data_set, 'index' = InfoNode_index_set, 'stateId' = InfoNode_stateId_set, 'physicalId' = InfoNode_physicalId_set, 'layerId' = InfoNode_layerId_set, 'metaData' = InfoNode_metaData_set, 'owner' = InfoNode_owner_set, 'parent' = InfoNode_parent_set, 'previous' = InfoNode_previous_set, '_next' = InfoNode__next_set, 'firstChild' = InfoNode_firstChild_set, 'lastChild' = InfoNode_lastChild_set, 'collapsedFirstChild' = InfoNode_collapsedFirstChild_set, 'collapsedLastChild' = InfoNode_collapsedLastChild_set, 'codelength' = InfoNode_codelength_set, 'dirty' = InfoNode_dirty_set, 'physicalNodes' = InfoNode_physicalNodes_set, 'metaCollection' = InfoNode_metaCollection_set, 'stateNodes' = InfoNode_stateNodes_set);
+  accessorFuns = list('data' = InfoNode_data_set, 'index' = InfoNode_index_set, 'stateId' = InfoNode_stateId_set, 'physicalId' = InfoNode_physicalId_set, 'layerId' = InfoNode_layerId_set, 'metaData' = InfoNode_metaData_set, 'owner' = InfoNode_owner_set, 'parent' = InfoNode_parent_set, 'previous' = InfoNode_previous_set, '_next' = InfoNode__next_set, 'firstChild' = InfoNode_firstChild_set, 'lastChild' = InfoNode_lastChild_set, 'collapsedFirstChild' = InfoNode_collapsedFirstChild_set, 'collapsedLastChild' = InfoNode_collapsedLastChild_set, 'codelength' = InfoNode_codelength_set, 'dirty' = InfoNode_dirty_set, 'physicalNodes' = InfoNode_physicalNodes_set, 'stateNodes' = InfoNode_stateNodes_set);
   ;        idx = pmatch(name, names(accessorFuns));
   if(is.na(idx)) 
   return(callNextMethod(x, name, value));
@@ -9735,37 +9704,6 @@ class(`InfomapIterator_physicalNodes_set`) = c("SWIGFunction", class('InfomapIte
 attr(`InfomapIterator_physicalNodes_get`, 'returnType') = '_p_std__vectorT_infomap__PhysData_std__allocatorT_infomap__PhysData_t_t'
 attr(`InfomapIterator_physicalNodes_get`, "inputTypes") = c('_p_infomap__InfomapIterator')
 class(`InfomapIterator_physicalNodes_get`) = c("SWIGFunction", class('InfomapIterator_physicalNodes_get'))
-
-# Start of InfomapIterator_metaCollection_set
-
-`InfomapIterator_metaCollection_set` = function(self, s_metaCollection)
-{
-  if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
-  if (inherits(s_metaCollection, "ExternalReference")) s_metaCollection = slot(s_metaCollection,"ref"); 
-  ;.Call('R_swig_InfomapIterator_metaCollection_set', self, s_metaCollection, PACKAGE='infomap');
-  
-}
-
-attr(`InfomapIterator_metaCollection_set`, 'returnType') = 'void'
-attr(`InfomapIterator_metaCollection_set`, "inputTypes") = c('_p_infomap__InfomapIterator', '_p_MetaCollection')
-class(`InfomapIterator_metaCollection_set`) = c("SWIGFunction", class('InfomapIterator_metaCollection_set'))
-
-# Start of InfomapIterator_metaCollection_get
-
-`InfomapIterator_metaCollection_get` = function(self, .copy = FALSE)
-{
-  if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
-  ;ans = .Call('R_swig_InfomapIterator_metaCollection_get', self, as.logical(.copy), PACKAGE='infomap');
-  ans <- if (is.null(ans)) ans
-  else new("_p_MetaCollection", ref=ans);
-  
-  ans
-  
-}
-
-attr(`InfomapIterator_metaCollection_get`, 'returnType') = '_p_MetaCollection'
-attr(`InfomapIterator_metaCollection_get`, "inputTypes") = c('_p_infomap__InfomapIterator')
-class(`InfomapIterator_metaCollection_get`) = c("SWIGFunction", class('InfomapIterator_metaCollection_get'))
 
 # Start of InfomapIterator_stateNodes_set
 
@@ -11257,8 +11195,8 @@ class(`InfomapIterator_addOutEdge__SWIG_1`) = c("SWIGFunction", class('InfomapIt
 setMethod('$', '_p_infomap__InfomapIterator', function(x, name)
 
 {
-  accessorFuns = list('Equal' = InfomapIterator_Equal, 'current' = InfomapIterator_current, '__ref__' = InfomapIterator___ref__, '__deref__' = InfomapIterator___deref__, 'EqualEqual' = InfomapIterator_EqualEqual, 'NotEqual' = InfomapIterator_NotEqual, 'PlusPlusPrefix' = InfomapIterator_PlusPlusPrefix, 'PlusPlusPostfix' = InfomapIterator_PlusPlusPostfix, 'stepForward' = InfomapIterator_stepForward, 'path' = InfomapIterator_path, 'moduleIndex' = InfomapIterator_moduleIndex, 'moduleId' = InfomapIterator_moduleId, 'childIndex' = InfomapIterator_childIndex, 'depth' = InfomapIterator_depth, 'modularCentrality' = InfomapIterator_modularCentrality, 'isEnd' = InfomapIterator_isEnd, 'copy' = InfomapIterator_copy, 'data' = InfomapIterator_data_get, 'index' = InfomapIterator_index_get, 'stateId' = InfomapIterator_stateId_get, 'physicalId' = InfomapIterator_physicalId_get, 'layerId' = InfomapIterator_layerId_get, 'metaData' = InfomapIterator_metaData_get, 'owner' = InfomapIterator_owner_get, 'parent' = InfomapIterator_parent_get, 'previous' = InfomapIterator_previous_get, '_next' = InfomapIterator__next_get, 'firstChild' = InfomapIterator_firstChild_get, 'lastChild' = InfomapIterator_lastChild_get, 'collapsedFirstChild' = InfomapIterator_collapsedFirstChild_get, 'collapsedLastChild' = InfomapIterator_collapsedLastChild_get, 'codelength' = InfomapIterator_codelength_get, 'dirty' = InfomapIterator_dirty_get, 'physicalNodes' = InfomapIterator_physicalNodes_get, 'metaCollection' = InfomapIterator_metaCollection_get, 'stateNodes' = InfomapIterator_stateNodes_get, 'getMetaData' = InfomapIterator_getMetaData, 'getInfomap' = InfomapIterator_getInfomap, 'setInfomap' = InfomapIterator_setInfomap, 'getInfomapRoot' = InfomapIterator_getInfomapRoot, 'disposeInfomap' = InfomapIterator_disposeInfomap, 'numPhysicalNodes' = InfomapIterator_numPhysicalNodes, 'begin' = InfomapIterator_begin, 'end' = InfomapIterator_end, 'begin_child' = InfomapIterator_begin_child, 'end_child' = InfomapIterator_end_child, 'children' = InfomapIterator_children, 'infomap_children' = InfomapIterator_infomap_children, 'begin_post_depth_first' = InfomapIterator_begin_post_depth_first, 'begin_leaf_nodes' = InfomapIterator_begin_leaf_nodes, 'begin_leaf_modules' = InfomapIterator_begin_leaf_modules, 'begin_tree' = InfomapIterator_begin_tree, 'end_tree' = InfomapIterator_end_tree, 'infomapTree' = InfomapIterator_infomapTree, 'begin_outEdge' = InfomapIterator_begin_outEdge, 'end_outEdge' = InfomapIterator_end_outEdge, 'begin_inEdge' = InfomapIterator_begin_inEdge, 'end_inEdge' = InfomapIterator_end_inEdge, 'outEdges' = InfomapIterator_outEdges, 'inEdges' = InfomapIterator_inEdges, 'childDegree' = InfomapIterator_childDegree, 'isLeaf' = InfomapIterator_isLeaf, 'isLeafModule' = InfomapIterator_isLeafModule, 'isRoot' = InfomapIterator_isRoot, 'firstDepthBelow' = InfomapIterator_firstDepthBelow, 'numLeafMembers' = InfomapIterator_numLeafMembers, 'isDangling' = InfomapIterator_isDangling, 'outDegree' = InfomapIterator_outDegree, 'inDegree' = InfomapIterator_inDegree, 'degree' = InfomapIterator_degree, 'isFirst' = InfomapIterator_isFirst, 'isLast' = InfomapIterator_isLast, 'calculatePath' = InfomapIterator_calculatePath, 'infomapChildDegree' = InfomapIterator_infomapChildDegree, 'id' = InfomapIterator_id, 'initClean' = InfomapIterator_initClean, 'sortChildrenOnFlow' = InfomapIterator_sortChildrenOnFlow, 'collapseChildren' = InfomapIterator_collapseChildren, 'expandChildren' = InfomapIterator_expandChildren, 'setChildDegree' = InfomapIterator_setChildDegree, 'setNumLeafNodes' = InfomapIterator_setNumLeafNodes, 'addChild' = InfomapIterator_addChild, 'releaseChildren' = InfomapIterator_releaseChildren, 'replaceChildrenWithOneNode' = InfomapIterator_replaceChildrenWithOneNode, 'replaceWithChildren' = InfomapIterator_replaceWithChildren, 'replaceWithChildrenDebug' = InfomapIterator_replaceWithChildrenDebug, 'replaceChildrenWithGrandChildren' = InfomapIterator_replaceChildrenWithGrandChildren, 'replaceChildrenWithGrandChildrenDebug' = InfomapIterator_replaceChildrenWithGrandChildrenDebug, 'remove' = InfomapIterator_remove, 'deleteChildren' = InfomapIterator_deleteChildren, 'addOutEdge' = InfomapIterator_addOutEdge);
-  vaccessors = c('data', 'index', 'stateId', 'physicalId', 'layerId', 'metaData', 'owner', 'parent', 'previous', '_next', 'firstChild', 'lastChild', 'collapsedFirstChild', 'collapsedLastChild', 'codelength', 'dirty', 'physicalNodes', 'metaCollection', 'stateNodes');
+  accessorFuns = list('Equal' = InfomapIterator_Equal, 'current' = InfomapIterator_current, '__ref__' = InfomapIterator___ref__, '__deref__' = InfomapIterator___deref__, 'EqualEqual' = InfomapIterator_EqualEqual, 'NotEqual' = InfomapIterator_NotEqual, 'PlusPlusPrefix' = InfomapIterator_PlusPlusPrefix, 'PlusPlusPostfix' = InfomapIterator_PlusPlusPostfix, 'stepForward' = InfomapIterator_stepForward, 'path' = InfomapIterator_path, 'moduleIndex' = InfomapIterator_moduleIndex, 'moduleId' = InfomapIterator_moduleId, 'childIndex' = InfomapIterator_childIndex, 'depth' = InfomapIterator_depth, 'modularCentrality' = InfomapIterator_modularCentrality, 'isEnd' = InfomapIterator_isEnd, 'copy' = InfomapIterator_copy, 'data' = InfomapIterator_data_get, 'index' = InfomapIterator_index_get, 'stateId' = InfomapIterator_stateId_get, 'physicalId' = InfomapIterator_physicalId_get, 'layerId' = InfomapIterator_layerId_get, 'metaData' = InfomapIterator_metaData_get, 'owner' = InfomapIterator_owner_get, 'parent' = InfomapIterator_parent_get, 'previous' = InfomapIterator_previous_get, '_next' = InfomapIterator__next_get, 'firstChild' = InfomapIterator_firstChild_get, 'lastChild' = InfomapIterator_lastChild_get, 'collapsedFirstChild' = InfomapIterator_collapsedFirstChild_get, 'collapsedLastChild' = InfomapIterator_collapsedLastChild_get, 'codelength' = InfomapIterator_codelength_get, 'dirty' = InfomapIterator_dirty_get, 'physicalNodes' = InfomapIterator_physicalNodes_get, 'stateNodes' = InfomapIterator_stateNodes_get, 'getMetaData' = InfomapIterator_getMetaData, 'getInfomap' = InfomapIterator_getInfomap, 'setInfomap' = InfomapIterator_setInfomap, 'getInfomapRoot' = InfomapIterator_getInfomapRoot, 'disposeInfomap' = InfomapIterator_disposeInfomap, 'numPhysicalNodes' = InfomapIterator_numPhysicalNodes, 'begin' = InfomapIterator_begin, 'end' = InfomapIterator_end, 'begin_child' = InfomapIterator_begin_child, 'end_child' = InfomapIterator_end_child, 'children' = InfomapIterator_children, 'infomap_children' = InfomapIterator_infomap_children, 'begin_post_depth_first' = InfomapIterator_begin_post_depth_first, 'begin_leaf_nodes' = InfomapIterator_begin_leaf_nodes, 'begin_leaf_modules' = InfomapIterator_begin_leaf_modules, 'begin_tree' = InfomapIterator_begin_tree, 'end_tree' = InfomapIterator_end_tree, 'infomapTree' = InfomapIterator_infomapTree, 'begin_outEdge' = InfomapIterator_begin_outEdge, 'end_outEdge' = InfomapIterator_end_outEdge, 'begin_inEdge' = InfomapIterator_begin_inEdge, 'end_inEdge' = InfomapIterator_end_inEdge, 'outEdges' = InfomapIterator_outEdges, 'inEdges' = InfomapIterator_inEdges, 'childDegree' = InfomapIterator_childDegree, 'isLeaf' = InfomapIterator_isLeaf, 'isLeafModule' = InfomapIterator_isLeafModule, 'isRoot' = InfomapIterator_isRoot, 'firstDepthBelow' = InfomapIterator_firstDepthBelow, 'numLeafMembers' = InfomapIterator_numLeafMembers, 'isDangling' = InfomapIterator_isDangling, 'outDegree' = InfomapIterator_outDegree, 'inDegree' = InfomapIterator_inDegree, 'degree' = InfomapIterator_degree, 'isFirst' = InfomapIterator_isFirst, 'isLast' = InfomapIterator_isLast, 'calculatePath' = InfomapIterator_calculatePath, 'infomapChildDegree' = InfomapIterator_infomapChildDegree, 'id' = InfomapIterator_id, 'initClean' = InfomapIterator_initClean, 'sortChildrenOnFlow' = InfomapIterator_sortChildrenOnFlow, 'collapseChildren' = InfomapIterator_collapseChildren, 'expandChildren' = InfomapIterator_expandChildren, 'setChildDegree' = InfomapIterator_setChildDegree, 'setNumLeafNodes' = InfomapIterator_setNumLeafNodes, 'addChild' = InfomapIterator_addChild, 'releaseChildren' = InfomapIterator_releaseChildren, 'replaceChildrenWithOneNode' = InfomapIterator_replaceChildrenWithOneNode, 'replaceWithChildren' = InfomapIterator_replaceWithChildren, 'replaceWithChildrenDebug' = InfomapIterator_replaceWithChildrenDebug, 'replaceChildrenWithGrandChildren' = InfomapIterator_replaceChildrenWithGrandChildren, 'replaceChildrenWithGrandChildrenDebug' = InfomapIterator_replaceChildrenWithGrandChildrenDebug, 'remove' = InfomapIterator_remove, 'deleteChildren' = InfomapIterator_deleteChildren, 'addOutEdge' = InfomapIterator_addOutEdge);
+  vaccessors = c('data', 'index', 'stateId', 'physicalId', 'layerId', 'metaData', 'owner', 'parent', 'previous', '_next', 'firstChild', 'lastChild', 'collapsedFirstChild', 'collapsedLastChild', 'codelength', 'dirty', 'physicalNodes', 'stateNodes');
   ;        idx = pmatch(name, names(accessorFuns));
   if(is.na(idx)) 
   return(callNextMethod(x, name));
@@ -11275,7 +11213,7 @@ setMethod('$', '_p_infomap__InfomapIterator', function(x, name)
 setMethod('$<-', '_p_infomap__InfomapIterator', function(x, name, value)
 
 {
-  accessorFuns = list('data' = InfomapIterator_data_set, 'index' = InfomapIterator_index_set, 'stateId' = InfomapIterator_stateId_set, 'physicalId' = InfomapIterator_physicalId_set, 'layerId' = InfomapIterator_layerId_set, 'metaData' = InfomapIterator_metaData_set, 'owner' = InfomapIterator_owner_set, 'parent' = InfomapIterator_parent_set, 'previous' = InfomapIterator_previous_set, '_next' = InfomapIterator__next_set, 'firstChild' = InfomapIterator_firstChild_set, 'lastChild' = InfomapIterator_lastChild_set, 'collapsedFirstChild' = InfomapIterator_collapsedFirstChild_set, 'collapsedLastChild' = InfomapIterator_collapsedLastChild_set, 'codelength' = InfomapIterator_codelength_set, 'dirty' = InfomapIterator_dirty_set, 'physicalNodes' = InfomapIterator_physicalNodes_set, 'metaCollection' = InfomapIterator_metaCollection_set, 'stateNodes' = InfomapIterator_stateNodes_set);
+  accessorFuns = list('data' = InfomapIterator_data_set, 'index' = InfomapIterator_index_set, 'stateId' = InfomapIterator_stateId_set, 'physicalId' = InfomapIterator_physicalId_set, 'layerId' = InfomapIterator_layerId_set, 'metaData' = InfomapIterator_metaData_set, 'owner' = InfomapIterator_owner_set, 'parent' = InfomapIterator_parent_set, 'previous' = InfomapIterator_previous_set, '_next' = InfomapIterator__next_set, 'firstChild' = InfomapIterator_firstChild_set, 'lastChild' = InfomapIterator_lastChild_set, 'collapsedFirstChild' = InfomapIterator_collapsedFirstChild_set, 'collapsedLastChild' = InfomapIterator_collapsedLastChild_set, 'codelength' = InfomapIterator_codelength_set, 'dirty' = InfomapIterator_dirty_set, 'physicalNodes' = InfomapIterator_physicalNodes_set, 'stateNodes' = InfomapIterator_stateNodes_set);
   ;        idx = pmatch(name, names(accessorFuns));
   if(is.na(idx)) 
   return(callNextMethod(x, name, value));
@@ -11290,7 +11228,7 @@ setMethod('[[<-', c('_p_infomap__InfomapIterator', 'character'),function(x, i, j
 
 {
   name = i;
-  accessorFuns = list('data' = InfomapIterator_data_set, 'index' = InfomapIterator_index_set, 'stateId' = InfomapIterator_stateId_set, 'physicalId' = InfomapIterator_physicalId_set, 'layerId' = InfomapIterator_layerId_set, 'metaData' = InfomapIterator_metaData_set, 'owner' = InfomapIterator_owner_set, 'parent' = InfomapIterator_parent_set, 'previous' = InfomapIterator_previous_set, '_next' = InfomapIterator__next_set, 'firstChild' = InfomapIterator_firstChild_set, 'lastChild' = InfomapIterator_lastChild_set, 'collapsedFirstChild' = InfomapIterator_collapsedFirstChild_set, 'collapsedLastChild' = InfomapIterator_collapsedLastChild_set, 'codelength' = InfomapIterator_codelength_set, 'dirty' = InfomapIterator_dirty_set, 'physicalNodes' = InfomapIterator_physicalNodes_set, 'metaCollection' = InfomapIterator_metaCollection_set, 'stateNodes' = InfomapIterator_stateNodes_set);
+  accessorFuns = list('data' = InfomapIterator_data_set, 'index' = InfomapIterator_index_set, 'stateId' = InfomapIterator_stateId_set, 'physicalId' = InfomapIterator_physicalId_set, 'layerId' = InfomapIterator_layerId_set, 'metaData' = InfomapIterator_metaData_set, 'owner' = InfomapIterator_owner_set, 'parent' = InfomapIterator_parent_set, 'previous' = InfomapIterator_previous_set, '_next' = InfomapIterator__next_set, 'firstChild' = InfomapIterator_firstChild_set, 'lastChild' = InfomapIterator_lastChild_set, 'collapsedFirstChild' = InfomapIterator_collapsedFirstChild_set, 'collapsedLastChild' = InfomapIterator_collapsedLastChild_set, 'codelength' = InfomapIterator_codelength_set, 'dirty' = InfomapIterator_dirty_set, 'physicalNodes' = InfomapIterator_physicalNodes_set, 'stateNodes' = InfomapIterator_stateNodes_set);
   ;        idx = pmatch(name, names(accessorFuns));
   if(is.na(idx)) 
   return(callNextMethod(x, name, value));
@@ -14304,37 +14242,6 @@ attr(`InfomapParentIterator_physicalNodes_get`, 'returnType') = '_p_std__vectorT
 attr(`InfomapParentIterator_physicalNodes_get`, "inputTypes") = c('_p_infomap__InfomapParentIterator')
 class(`InfomapParentIterator_physicalNodes_get`) = c("SWIGFunction", class('InfomapParentIterator_physicalNodes_get'))
 
-# Start of InfomapParentIterator_metaCollection_set
-
-`InfomapParentIterator_metaCollection_set` = function(self, s_metaCollection)
-{
-  if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
-  if (inherits(s_metaCollection, "ExternalReference")) s_metaCollection = slot(s_metaCollection,"ref"); 
-  ;.Call('R_swig_InfomapParentIterator_metaCollection_set', self, s_metaCollection, PACKAGE='infomap');
-  
-}
-
-attr(`InfomapParentIterator_metaCollection_set`, 'returnType') = 'void'
-attr(`InfomapParentIterator_metaCollection_set`, "inputTypes") = c('_p_infomap__InfomapParentIterator', '_p_MetaCollection')
-class(`InfomapParentIterator_metaCollection_set`) = c("SWIGFunction", class('InfomapParentIterator_metaCollection_set'))
-
-# Start of InfomapParentIterator_metaCollection_get
-
-`InfomapParentIterator_metaCollection_get` = function(self, .copy = FALSE)
-{
-  if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
-  ;ans = .Call('R_swig_InfomapParentIterator_metaCollection_get', self, as.logical(.copy), PACKAGE='infomap');
-  ans <- if (is.null(ans)) ans
-  else new("_p_MetaCollection", ref=ans);
-  
-  ans
-  
-}
-
-attr(`InfomapParentIterator_metaCollection_get`, 'returnType') = '_p_MetaCollection'
-attr(`InfomapParentIterator_metaCollection_get`, "inputTypes") = c('_p_infomap__InfomapParentIterator')
-class(`InfomapParentIterator_metaCollection_get`) = c("SWIGFunction", class('InfomapParentIterator_metaCollection_get'))
-
 # Start of InfomapParentIterator_stateNodes_set
 
 `InfomapParentIterator_stateNodes_set` = function(self, s_stateNodes)
@@ -15851,8 +15758,8 @@ class(`InfomapParentIterator_addOutEdge__SWIG_1`) = c("SWIGFunction", class('Inf
 setMethod('$', '_p_infomap__InfomapParentIterator', function(x, name)
 
 {
-  accessorFuns = list('Equal' = InfomapParentIterator_Equal, 'current' = InfomapParentIterator_current, '__ref__' = InfomapParentIterator___ref__, '__deref__' = InfomapParentIterator___deref__, 'EqualEqual' = InfomapParentIterator_EqualEqual, 'NotEqual' = InfomapParentIterator_NotEqual, 'PlusPlusPrefix' = InfomapParentIterator_PlusPlusPrefix, 'PlusPlusPostfix' = InfomapParentIterator_PlusPlusPostfix, 'stepForward' = InfomapParentIterator_stepForward, 'isEnd' = InfomapParentIterator_isEnd, 'data' = InfomapParentIterator_data_get, 'index' = InfomapParentIterator_index_get, 'stateId' = InfomapParentIterator_stateId_get, 'physicalId' = InfomapParentIterator_physicalId_get, 'layerId' = InfomapParentIterator_layerId_get, 'metaData' = InfomapParentIterator_metaData_get, 'owner' = InfomapParentIterator_owner_get, 'parent' = InfomapParentIterator_parent_get, 'previous' = InfomapParentIterator_previous_get, '_next' = InfomapParentIterator__next_get, 'firstChild' = InfomapParentIterator_firstChild_get, 'lastChild' = InfomapParentIterator_lastChild_get, 'collapsedFirstChild' = InfomapParentIterator_collapsedFirstChild_get, 'collapsedLastChild' = InfomapParentIterator_collapsedLastChild_get, 'codelength' = InfomapParentIterator_codelength_get, 'dirty' = InfomapParentIterator_dirty_get, 'physicalNodes' = InfomapParentIterator_physicalNodes_get, 'metaCollection' = InfomapParentIterator_metaCollection_get, 'stateNodes' = InfomapParentIterator_stateNodes_get, 'getMetaData' = InfomapParentIterator_getMetaData, 'getInfomap' = InfomapParentIterator_getInfomap, 'setInfomap' = InfomapParentIterator_setInfomap, 'getInfomapRoot' = InfomapParentIterator_getInfomapRoot, 'disposeInfomap' = InfomapParentIterator_disposeInfomap, 'numPhysicalNodes' = InfomapParentIterator_numPhysicalNodes, 'begin' = InfomapParentIterator_begin, 'end' = InfomapParentIterator_end, 'begin_child' = InfomapParentIterator_begin_child, 'end_child' = InfomapParentIterator_end_child, 'children' = InfomapParentIterator_children, 'infomap_children' = InfomapParentIterator_infomap_children, 'begin_post_depth_first' = InfomapParentIterator_begin_post_depth_first, 'begin_leaf_nodes' = InfomapParentIterator_begin_leaf_nodes, 'begin_leaf_modules' = InfomapParentIterator_begin_leaf_modules, 'begin_tree' = InfomapParentIterator_begin_tree, 'end_tree' = InfomapParentIterator_end_tree, 'infomapTree' = InfomapParentIterator_infomapTree, 'begin_outEdge' = InfomapParentIterator_begin_outEdge, 'end_outEdge' = InfomapParentIterator_end_outEdge, 'begin_inEdge' = InfomapParentIterator_begin_inEdge, 'end_inEdge' = InfomapParentIterator_end_inEdge, 'outEdges' = InfomapParentIterator_outEdges, 'inEdges' = InfomapParentIterator_inEdges, 'childDegree' = InfomapParentIterator_childDegree, 'isLeaf' = InfomapParentIterator_isLeaf, 'isLeafModule' = InfomapParentIterator_isLeafModule, 'isRoot' = InfomapParentIterator_isRoot, 'depth' = InfomapParentIterator_depth, 'firstDepthBelow' = InfomapParentIterator_firstDepthBelow, 'numLeafMembers' = InfomapParentIterator_numLeafMembers, 'isDangling' = InfomapParentIterator_isDangling, 'outDegree' = InfomapParentIterator_outDegree, 'inDegree' = InfomapParentIterator_inDegree, 'degree' = InfomapParentIterator_degree, 'isFirst' = InfomapParentIterator_isFirst, 'isLast' = InfomapParentIterator_isLast, 'childIndex' = InfomapParentIterator_childIndex, 'calculatePath' = InfomapParentIterator_calculatePath, 'infomapChildDegree' = InfomapParentIterator_infomapChildDegree, 'id' = InfomapParentIterator_id, 'initClean' = InfomapParentIterator_initClean, 'sortChildrenOnFlow' = InfomapParentIterator_sortChildrenOnFlow, 'collapseChildren' = InfomapParentIterator_collapseChildren, 'expandChildren' = InfomapParentIterator_expandChildren, 'setChildDegree' = InfomapParentIterator_setChildDegree, 'setNumLeafNodes' = InfomapParentIterator_setNumLeafNodes, 'addChild' = InfomapParentIterator_addChild, 'releaseChildren' = InfomapParentIterator_releaseChildren, 'replaceChildrenWithOneNode' = InfomapParentIterator_replaceChildrenWithOneNode, 'replaceWithChildren' = InfomapParentIterator_replaceWithChildren, 'replaceWithChildrenDebug' = InfomapParentIterator_replaceWithChildrenDebug, 'replaceChildrenWithGrandChildren' = InfomapParentIterator_replaceChildrenWithGrandChildren, 'replaceChildrenWithGrandChildrenDebug' = InfomapParentIterator_replaceChildrenWithGrandChildrenDebug, 'remove' = InfomapParentIterator_remove, 'deleteChildren' = InfomapParentIterator_deleteChildren, 'addOutEdge' = InfomapParentIterator_addOutEdge);
-  vaccessors = c('data', 'index', 'stateId', 'physicalId', 'layerId', 'metaData', 'owner', 'parent', 'previous', '_next', 'firstChild', 'lastChild', 'collapsedFirstChild', 'collapsedLastChild', 'codelength', 'dirty', 'physicalNodes', 'metaCollection', 'stateNodes');
+  accessorFuns = list('Equal' = InfomapParentIterator_Equal, 'current' = InfomapParentIterator_current, '__ref__' = InfomapParentIterator___ref__, '__deref__' = InfomapParentIterator___deref__, 'EqualEqual' = InfomapParentIterator_EqualEqual, 'NotEqual' = InfomapParentIterator_NotEqual, 'PlusPlusPrefix' = InfomapParentIterator_PlusPlusPrefix, 'PlusPlusPostfix' = InfomapParentIterator_PlusPlusPostfix, 'stepForward' = InfomapParentIterator_stepForward, 'isEnd' = InfomapParentIterator_isEnd, 'data' = InfomapParentIterator_data_get, 'index' = InfomapParentIterator_index_get, 'stateId' = InfomapParentIterator_stateId_get, 'physicalId' = InfomapParentIterator_physicalId_get, 'layerId' = InfomapParentIterator_layerId_get, 'metaData' = InfomapParentIterator_metaData_get, 'owner' = InfomapParentIterator_owner_get, 'parent' = InfomapParentIterator_parent_get, 'previous' = InfomapParentIterator_previous_get, '_next' = InfomapParentIterator__next_get, 'firstChild' = InfomapParentIterator_firstChild_get, 'lastChild' = InfomapParentIterator_lastChild_get, 'collapsedFirstChild' = InfomapParentIterator_collapsedFirstChild_get, 'collapsedLastChild' = InfomapParentIterator_collapsedLastChild_get, 'codelength' = InfomapParentIterator_codelength_get, 'dirty' = InfomapParentIterator_dirty_get, 'physicalNodes' = InfomapParentIterator_physicalNodes_get, 'stateNodes' = InfomapParentIterator_stateNodes_get, 'getMetaData' = InfomapParentIterator_getMetaData, 'getInfomap' = InfomapParentIterator_getInfomap, 'setInfomap' = InfomapParentIterator_setInfomap, 'getInfomapRoot' = InfomapParentIterator_getInfomapRoot, 'disposeInfomap' = InfomapParentIterator_disposeInfomap, 'numPhysicalNodes' = InfomapParentIterator_numPhysicalNodes, 'begin' = InfomapParentIterator_begin, 'end' = InfomapParentIterator_end, 'begin_child' = InfomapParentIterator_begin_child, 'end_child' = InfomapParentIterator_end_child, 'children' = InfomapParentIterator_children, 'infomap_children' = InfomapParentIterator_infomap_children, 'begin_post_depth_first' = InfomapParentIterator_begin_post_depth_first, 'begin_leaf_nodes' = InfomapParentIterator_begin_leaf_nodes, 'begin_leaf_modules' = InfomapParentIterator_begin_leaf_modules, 'begin_tree' = InfomapParentIterator_begin_tree, 'end_tree' = InfomapParentIterator_end_tree, 'infomapTree' = InfomapParentIterator_infomapTree, 'begin_outEdge' = InfomapParentIterator_begin_outEdge, 'end_outEdge' = InfomapParentIterator_end_outEdge, 'begin_inEdge' = InfomapParentIterator_begin_inEdge, 'end_inEdge' = InfomapParentIterator_end_inEdge, 'outEdges' = InfomapParentIterator_outEdges, 'inEdges' = InfomapParentIterator_inEdges, 'childDegree' = InfomapParentIterator_childDegree, 'isLeaf' = InfomapParentIterator_isLeaf, 'isLeafModule' = InfomapParentIterator_isLeafModule, 'isRoot' = InfomapParentIterator_isRoot, 'depth' = InfomapParentIterator_depth, 'firstDepthBelow' = InfomapParentIterator_firstDepthBelow, 'numLeafMembers' = InfomapParentIterator_numLeafMembers, 'isDangling' = InfomapParentIterator_isDangling, 'outDegree' = InfomapParentIterator_outDegree, 'inDegree' = InfomapParentIterator_inDegree, 'degree' = InfomapParentIterator_degree, 'isFirst' = InfomapParentIterator_isFirst, 'isLast' = InfomapParentIterator_isLast, 'childIndex' = InfomapParentIterator_childIndex, 'calculatePath' = InfomapParentIterator_calculatePath, 'infomapChildDegree' = InfomapParentIterator_infomapChildDegree, 'id' = InfomapParentIterator_id, 'initClean' = InfomapParentIterator_initClean, 'sortChildrenOnFlow' = InfomapParentIterator_sortChildrenOnFlow, 'collapseChildren' = InfomapParentIterator_collapseChildren, 'expandChildren' = InfomapParentIterator_expandChildren, 'setChildDegree' = InfomapParentIterator_setChildDegree, 'setNumLeafNodes' = InfomapParentIterator_setNumLeafNodes, 'addChild' = InfomapParentIterator_addChild, 'releaseChildren' = InfomapParentIterator_releaseChildren, 'replaceChildrenWithOneNode' = InfomapParentIterator_replaceChildrenWithOneNode, 'replaceWithChildren' = InfomapParentIterator_replaceWithChildren, 'replaceWithChildrenDebug' = InfomapParentIterator_replaceWithChildrenDebug, 'replaceChildrenWithGrandChildren' = InfomapParentIterator_replaceChildrenWithGrandChildren, 'replaceChildrenWithGrandChildrenDebug' = InfomapParentIterator_replaceChildrenWithGrandChildrenDebug, 'remove' = InfomapParentIterator_remove, 'deleteChildren' = InfomapParentIterator_deleteChildren, 'addOutEdge' = InfomapParentIterator_addOutEdge);
+  vaccessors = c('data', 'index', 'stateId', 'physicalId', 'layerId', 'metaData', 'owner', 'parent', 'previous', '_next', 'firstChild', 'lastChild', 'collapsedFirstChild', 'collapsedLastChild', 'codelength', 'dirty', 'physicalNodes', 'stateNodes');
   ;        idx = pmatch(name, names(accessorFuns));
   if(is.na(idx)) 
   return(callNextMethod(x, name));
@@ -15869,7 +15776,7 @@ setMethod('$', '_p_infomap__InfomapParentIterator', function(x, name)
 setMethod('$<-', '_p_infomap__InfomapParentIterator', function(x, name, value)
 
 {
-  accessorFuns = list('data' = InfomapParentIterator_data_set, 'index' = InfomapParentIterator_index_set, 'stateId' = InfomapParentIterator_stateId_set, 'physicalId' = InfomapParentIterator_physicalId_set, 'layerId' = InfomapParentIterator_layerId_set, 'metaData' = InfomapParentIterator_metaData_set, 'owner' = InfomapParentIterator_owner_set, 'parent' = InfomapParentIterator_parent_set, 'previous' = InfomapParentIterator_previous_set, '_next' = InfomapParentIterator__next_set, 'firstChild' = InfomapParentIterator_firstChild_set, 'lastChild' = InfomapParentIterator_lastChild_set, 'collapsedFirstChild' = InfomapParentIterator_collapsedFirstChild_set, 'collapsedLastChild' = InfomapParentIterator_collapsedLastChild_set, 'codelength' = InfomapParentIterator_codelength_set, 'dirty' = InfomapParentIterator_dirty_set, 'physicalNodes' = InfomapParentIterator_physicalNodes_set, 'metaCollection' = InfomapParentIterator_metaCollection_set, 'stateNodes' = InfomapParentIterator_stateNodes_set);
+  accessorFuns = list('data' = InfomapParentIterator_data_set, 'index' = InfomapParentIterator_index_set, 'stateId' = InfomapParentIterator_stateId_set, 'physicalId' = InfomapParentIterator_physicalId_set, 'layerId' = InfomapParentIterator_layerId_set, 'metaData' = InfomapParentIterator_metaData_set, 'owner' = InfomapParentIterator_owner_set, 'parent' = InfomapParentIterator_parent_set, 'previous' = InfomapParentIterator_previous_set, '_next' = InfomapParentIterator__next_set, 'firstChild' = InfomapParentIterator_firstChild_set, 'lastChild' = InfomapParentIterator_lastChild_set, 'collapsedFirstChild' = InfomapParentIterator_collapsedFirstChild_set, 'collapsedLastChild' = InfomapParentIterator_collapsedLastChild_set, 'codelength' = InfomapParentIterator_codelength_set, 'dirty' = InfomapParentIterator_dirty_set, 'physicalNodes' = InfomapParentIterator_physicalNodes_set, 'stateNodes' = InfomapParentIterator_stateNodes_set);
   ;        idx = pmatch(name, names(accessorFuns));
   if(is.na(idx)) 
   return(callNextMethod(x, name, value));
@@ -15884,7 +15791,7 @@ setMethod('[[<-', c('_p_infomap__InfomapParentIterator', 'character'),function(x
 
 {
   name = i;
-  accessorFuns = list('data' = InfomapParentIterator_data_set, 'index' = InfomapParentIterator_index_set, 'stateId' = InfomapParentIterator_stateId_set, 'physicalId' = InfomapParentIterator_physicalId_set, 'layerId' = InfomapParentIterator_layerId_set, 'metaData' = InfomapParentIterator_metaData_set, 'owner' = InfomapParentIterator_owner_set, 'parent' = InfomapParentIterator_parent_set, 'previous' = InfomapParentIterator_previous_set, '_next' = InfomapParentIterator__next_set, 'firstChild' = InfomapParentIterator_firstChild_set, 'lastChild' = InfomapParentIterator_lastChild_set, 'collapsedFirstChild' = InfomapParentIterator_collapsedFirstChild_set, 'collapsedLastChild' = InfomapParentIterator_collapsedLastChild_set, 'codelength' = InfomapParentIterator_codelength_set, 'dirty' = InfomapParentIterator_dirty_set, 'physicalNodes' = InfomapParentIterator_physicalNodes_set, 'metaCollection' = InfomapParentIterator_metaCollection_set, 'stateNodes' = InfomapParentIterator_stateNodes_set);
+  accessorFuns = list('data' = InfomapParentIterator_data_set, 'index' = InfomapParentIterator_index_set, 'stateId' = InfomapParentIterator_stateId_set, 'physicalId' = InfomapParentIterator_physicalId_set, 'layerId' = InfomapParentIterator_layerId_set, 'metaData' = InfomapParentIterator_metaData_set, 'owner' = InfomapParentIterator_owner_set, 'parent' = InfomapParentIterator_parent_set, 'previous' = InfomapParentIterator_previous_set, '_next' = InfomapParentIterator__next_set, 'firstChild' = InfomapParentIterator_firstChild_set, 'lastChild' = InfomapParentIterator_lastChild_set, 'collapsedFirstChild' = InfomapParentIterator_collapsedFirstChild_set, 'collapsedLastChild' = InfomapParentIterator_collapsedLastChild_set, 'codelength' = InfomapParentIterator_codelength_set, 'dirty' = InfomapParentIterator_dirty_set, 'physicalNodes' = InfomapParentIterator_physicalNodes_set, 'stateNodes' = InfomapParentIterator_stateNodes_set);
   ;        idx = pmatch(name, names(accessorFuns));
   if(is.na(idx)) 
   return(callNextMethod(x, name, value));

--- a/interfaces/R/generated/infomap.R
+++ b/interfaces/R/generated/infomap.R
@@ -332,6 +332,7 @@ setClass("infomap::InfomapIterator",
     representation(
         m_moduleIndexLevel = "integer",
         m_moduleIndex = "integer",
+        m_path = "integer",
         m_depth = "integer"),
         contains = "RSWIGStruct")
 
@@ -9079,15 +9080,11 @@ class(`InfomapIterator_stepForward`) = c("SWIGFunction", class('InfomapIterator_
 `InfomapIterator_path` = function(self, .copy = FALSE)
 {
   if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
-  ;ans = .Call('R_swig_InfomapIterator_path', self, as.logical(.copy), PACKAGE='infomap');
-  ans <- if (is.null(ans)) ans
-  else new("_p_std__dequeT_unsigned_int_t", ref=ans);
-  
-  ans
+  ;.Call('R_swig_InfomapIterator_path', self, as.logical(.copy), PACKAGE='infomap');
   
 }
 
-attr(`InfomapIterator_path`, 'returnType') = '_p_std__dequeT_unsigned_int_t'
+attr(`InfomapIterator_path`, 'returnType') = 'integer'
 attr(`InfomapIterator_path`, "inputTypes") = c('_p_infomap__InfomapIterator')
 class(`InfomapIterator_path`) = c("SWIGFunction", class('InfomapIterator_path'))
 
@@ -11246,6 +11243,7 @@ CopyToR_infomap__InfomapIterator = function(value, obj = new("infomap::InfomapIt
 {
   obj@m_moduleIndexLevel = value$m_moduleIndexLevel;
   obj@m_moduleIndex = value$m_moduleIndex;
+  obj@m_path = value$m_path;
   obj@m_depth = value$m_depth;
   obj;
 }
@@ -11256,6 +11254,7 @@ CopyToC_infomap__InfomapIterator = function(value, obj)
 {
   obj$m_moduleIndexLevel = value@m_moduleIndexLevel;
   obj$m_moduleIndex = value@m_moduleIndex;
+  obj$m_path = value@m_path;
   obj$m_depth = value@m_depth;
   obj
 }
@@ -11618,15 +11617,11 @@ class(`InfomapModuleIterator_modularCentrality`) = c("SWIGFunction", class('Info
 `InfomapModuleIterator_path` = function(self, .copy = FALSE)
 {
   if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
-  ;ans = .Call('R_swig_InfomapModuleIterator_path', self, as.logical(.copy), PACKAGE='infomap');
-  ans <- if (is.null(ans)) ans
-  else new("_p_std__dequeT_unsigned_int_t", ref=ans);
-  
-  ans
+  ;.Call('R_swig_InfomapModuleIterator_path', self, as.logical(.copy), PACKAGE='infomap');
   
 }
 
-attr(`InfomapModuleIterator_path`, 'returnType') = '_p_std__dequeT_unsigned_int_t'
+attr(`InfomapModuleIterator_path`, 'returnType') = 'integer'
 attr(`InfomapModuleIterator_path`, "inputTypes") = c('_p_infomap__InfomapModuleIterator')
 class(`InfomapModuleIterator_path`) = c("SWIGFunction", class('InfomapModuleIterator_path'))
 
@@ -12032,15 +12027,11 @@ class(`InfomapLeafModuleIterator_modularCentrality`) = c("SWIGFunction", class('
 `InfomapLeafModuleIterator_path` = function(self, .copy = FALSE)
 {
   if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
-  ;ans = .Call('R_swig_InfomapLeafModuleIterator_path', self, as.logical(.copy), PACKAGE='infomap');
-  ans <- if (is.null(ans)) ans
-  else new("_p_std__dequeT_unsigned_int_t", ref=ans);
-  
-  ans
+  ;.Call('R_swig_InfomapLeafModuleIterator_path', self, as.logical(.copy), PACKAGE='infomap');
   
 }
 
-attr(`InfomapLeafModuleIterator_path`, 'returnType') = '_p_std__dequeT_unsigned_int_t'
+attr(`InfomapLeafModuleIterator_path`, 'returnType') = 'integer'
 attr(`InfomapLeafModuleIterator_path`, "inputTypes") = c('_p_infomap__InfomapLeafModuleIterator')
 class(`InfomapLeafModuleIterator_path`) = c("SWIGFunction", class('InfomapLeafModuleIterator_path'))
 
@@ -12446,15 +12437,11 @@ class(`InfomapLeafIterator_modularCentrality`) = c("SWIGFunction", class('Infoma
 `InfomapLeafIterator_path` = function(self, .copy = FALSE)
 {
   if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
-  ;ans = .Call('R_swig_InfomapLeafIterator_path', self, as.logical(.copy), PACKAGE='infomap');
-  ans <- if (is.null(ans)) ans
-  else new("_p_std__dequeT_unsigned_int_t", ref=ans);
-  
-  ans
+  ;.Call('R_swig_InfomapLeafIterator_path', self, as.logical(.copy), PACKAGE='infomap');
   
 }
 
-attr(`InfomapLeafIterator_path`, 'returnType') = '_p_std__dequeT_unsigned_int_t'
+attr(`InfomapLeafIterator_path`, 'returnType') = 'integer'
 attr(`InfomapLeafIterator_path`, "inputTypes") = c('_p_infomap__InfomapLeafIterator')
 class(`InfomapLeafIterator_path`) = c("SWIGFunction", class('InfomapLeafIterator_path'))
 
@@ -12868,15 +12855,11 @@ class(`InfomapIteratorPhysical_modularCentrality`) = c("SWIGFunction", class('In
 `InfomapIteratorPhysical_path` = function(self, .copy = FALSE)
 {
   if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
-  ;ans = .Call('R_swig_InfomapIteratorPhysical_path', self, as.logical(.copy), PACKAGE='infomap');
-  ans <- if (is.null(ans)) ans
-  else new("_p_std__dequeT_unsigned_int_t", ref=ans);
-  
-  ans
+  ;.Call('R_swig_InfomapIteratorPhysical_path', self, as.logical(.copy), PACKAGE='infomap');
   
 }
 
-attr(`InfomapIteratorPhysical_path`, 'returnType') = '_p_std__dequeT_unsigned_int_t'
+attr(`InfomapIteratorPhysical_path`, 'returnType') = 'integer'
 attr(`InfomapIteratorPhysical_path`, "inputTypes") = c('_p_infomap__InfomapIteratorPhysical')
 class(`InfomapIteratorPhysical_path`) = c("SWIGFunction", class('InfomapIteratorPhysical_path'))
 
@@ -13243,15 +13226,11 @@ class(`InfomapLeafIteratorPhysical_modularCentrality`) = c("SWIGFunction", class
 `InfomapLeafIteratorPhysical_path` = function(self, .copy = FALSE)
 {
   if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
-  ;ans = .Call('R_swig_InfomapLeafIteratorPhysical_path', self, as.logical(.copy), PACKAGE='infomap');
-  ans <- if (is.null(ans)) ans
-  else new("_p_std__dequeT_unsigned_int_t", ref=ans);
-  
-  ans
+  ;.Call('R_swig_InfomapLeafIteratorPhysical_path', self, as.logical(.copy), PACKAGE='infomap');
   
 }
 
-attr(`InfomapLeafIteratorPhysical_path`, 'returnType') = '_p_std__dequeT_unsigned_int_t'
+attr(`InfomapLeafIteratorPhysical_path`, 'returnType') = 'integer'
 attr(`InfomapLeafIteratorPhysical_path`, "inputTypes") = c('_p_infomap__InfomapLeafIteratorPhysical')
 class(`InfomapLeafIteratorPhysical_path`) = c("SWIGFunction", class('InfomapLeafIteratorPhysical_path'))
 

--- a/interfaces/R/generated/infomap_wrap.cpp
+++ b/interfaces/R/generated/infomap_wrap.cpp
@@ -1327,111 +1327,110 @@ SWIGINTERN void SWIG_R_Raise(SEXP obj, const char *msg) {
 #define SWIGTYPE_p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t swig_types[11]
 #define SWIGTYPE_p_LeafModuleIteratorT_infomap__InfoNode_p_t swig_types[12]
 #define SWIGTYPE_p_LeafNodeIteratorT_infomap__InfoNode_p_t swig_types[13]
-#define SWIGTYPE_p_MetaCollection swig_types[14]
-#define SWIGTYPE_p_NodeLinkMap swig_types[15]
-#define SWIGTYPE_p_NodeMap swig_types[16]
-#define SWIGTYPE_p_OutLinkMap swig_types[17]
-#define SWIGTYPE_p_PartitionQueue swig_types[18]
-#define SWIGTYPE_p_Stopwatch swig_types[19]
-#define SWIGTYPE_p_TreeIteratorT_infomap__InfoNode_const_p_t swig_types[20]
-#define SWIGTYPE_p_TreeIteratorT_infomap__InfoNode_p_t swig_types[21]
-#define SWIGTYPE_p_allocator_type swig_types[22]
-#define SWIGTYPE_p_char swig_types[23]
-#define SWIGTYPE_p_child_iterator swig_types[24]
-#define SWIGTYPE_p_child_iterator_wrapper swig_types[25]
-#define SWIGTYPE_p_const_child_iterator swig_types[26]
-#define SWIGTYPE_p_const_child_iterator_wrapper swig_types[27]
-#define SWIGTYPE_p_const_edge_iterator swig_types[28]
-#define SWIGTYPE_p_const_edge_iterator_wrapper swig_types[29]
-#define SWIGTYPE_p_const_infomap_child_iterator swig_types[30]
-#define SWIGTYPE_p_const_infomap_child_iterator_wrapper swig_types[31]
-#define SWIGTYPE_p_const_infomap_iterator_wrapper swig_types[32]
-#define SWIGTYPE_p_const_leaf_module_iterator swig_types[33]
-#define SWIGTYPE_p_const_leaf_node_iterator swig_types[34]
-#define SWIGTYPE_p_const_post_depth_first_iterator swig_types[35]
-#define SWIGTYPE_p_const_tree_iterator swig_types[36]
-#define SWIGTYPE_p_difference_type swig_types[37]
-#define SWIGTYPE_p_edge_iterator swig_types[38]
-#define SWIGTYPE_p_edge_iterator_wrapper swig_types[39]
-#define SWIGTYPE_p_first_type swig_types[40]
-#define SWIGTYPE_p_infomap__Config swig_types[41]
-#define SWIGTYPE_p_infomap__DeltaFlow swig_types[42]
-#define SWIGTYPE_p_infomap__EdgeData swig_types[43]
-#define SWIGTYPE_p_infomap__FlowData swig_types[44]
-#define SWIGTYPE_p_infomap__FlowModel swig_types[45]
-#define SWIGTYPE_p_infomap__InfoEdge swig_types[46]
-#define SWIGTYPE_p_infomap__InfoNode swig_types[47]
-#define SWIGTYPE_p_infomap__InfomapBase swig_types[48]
-#define SWIGTYPE_p_infomap__InfomapConfigT_infomap__InfomapBase_t swig_types[49]
-#define SWIGTYPE_p_infomap__InfomapIterator swig_types[50]
-#define SWIGTYPE_p_infomap__InfomapIteratorPhysical swig_types[51]
-#define SWIGTYPE_p_infomap__InfomapLeafIterator swig_types[52]
-#define SWIGTYPE_p_infomap__InfomapLeafIteratorPhysical swig_types[53]
-#define SWIGTYPE_p_infomap__InfomapLeafModuleIterator swig_types[54]
-#define SWIGTYPE_p_infomap__InfomapModuleIterator swig_types[55]
-#define SWIGTYPE_p_infomap__InfomapParentIterator swig_types[56]
-#define SWIGTYPE_p_infomap__InfomapWrapper swig_types[57]
-#define SWIGTYPE_p_infomap__LayerNode swig_types[58]
-#define SWIGTYPE_p_infomap__LinkResult swig_types[59]
-#define SWIGTYPE_p_infomap__MemDeltaFlow swig_types[60]
-#define SWIGTYPE_p_infomap__Network swig_types[61]
-#define SWIGTYPE_p_infomap__PhysData swig_types[62]
-#define SWIGTYPE_p_infomap__StateNetwork swig_types[63]
-#define SWIGTYPE_p_infomap__StateNetwork__PhysNode swig_types[64]
-#define SWIGTYPE_p_infomap__StateNetwork__StateNode swig_types[65]
-#define SWIGTYPE_p_infomap__detail__PartitionQueue swig_types[66]
-#define SWIGTYPE_p_infomap__detail__PerLevelStat swig_types[67]
-#define SWIGTYPE_p_infomap_child_iterator swig_types[68]
-#define SWIGTYPE_p_infomap_child_iterator_wrapper swig_types[69]
-#define SWIGTYPE_p_infomap_iterator_wrapper swig_types[70]
-#define SWIGTYPE_p_key_type swig_types[71]
-#define SWIGTYPE_p_leaf_module_iterator swig_types[72]
-#define SWIGTYPE_p_leaf_node_iterator swig_types[73]
-#define SWIGTYPE_p_mapped_type swig_types[74]
-#define SWIGTYPE_p_post_depth_first_iterator swig_types[75]
-#define SWIGTYPE_p_second_type swig_types[76]
-#define SWIGTYPE_p_size_t swig_types[77]
-#define SWIGTYPE_p_size_type swig_types[78]
-#define SWIGTYPE_p_std__allocatorT_double_t swig_types[79]
-#define SWIGTYPE_p_std__allocatorT_infomap__LinkResult_t swig_types[80]
-#define SWIGTYPE_p_std__allocatorT_std__pairT_std__pairT_unsigned_int_unsigned_int_t_const_double_t_t swig_types[81]
-#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_std__string_t_t swig_types[82]
-#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_std__vectorT_unsigned_int_t_t_t swig_types[83]
-#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t swig_types[84]
-#define SWIGTYPE_p_std__allocatorT_unsigned_int_t swig_types[85]
-#define SWIGTYPE_p_std__dequeT_infomap__InfoNode_p_std__allocatorT_infomap__InfoNode_p_t_t__size_type swig_types[86]
-#define SWIGTYPE_p_std__dequeT_unsigned_int_t swig_types[87]
-#define SWIGTYPE_p_std__invalid_argument swig_types[88]
-#define SWIGTYPE_p_std__lessT_std__pairT_unsigned_int_unsigned_int_t_t swig_types[89]
-#define SWIGTYPE_p_std__lessT_unsigned_int_t swig_types[90]
-#define SWIGTYPE_p_std__mapT_infomap__StateNetwork__StateNode_std__mapT_infomap__StateNetwork__StateNode_infomap__StateNetwork__LinkData_std__lessT_infomap__StateNetwork__StateNode_t_std__allocatorT_std__pairT_infomap__StateNetwork__StateNode_const_infomap__StateNetwork__LinkData_t_t_t_std__lessT_infomap__StateNetwork__StateNode_t_std__allocatorT_std__pairT_infomap__StateNetwork__StateNode_const_std__mapT_infomap__StateNetwork__StateNode_infomap__StateNetwork__LinkData_std__lessT_infomap__StateNetwork__StateNode_t_std__allocatorT_std__pairT_infomap__StateNetwork__StateNode_const_infomap__StateNetwork__LinkData_t_t_t_t_t_t swig_types[91]
-#define SWIGTYPE_p_std__mapT_std__pairT_unsigned_int_unsigned_int_t_double_t swig_types[92]
-#define SWIGTYPE_p_std__mapT_unsigned_int_double_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_double_t_t_t swig_types[93]
-#define SWIGTYPE_p_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t swig_types[94]
-#define SWIGTYPE_p_std__mapT_unsigned_int_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t_t_t_t swig_types[95]
-#define SWIGTYPE_p_std__mapT_unsigned_int_std__string_t swig_types[96]
-#define SWIGTYPE_p_std__mapT_unsigned_int_std__vectorT_int_std__allocatorT_int_t_t_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_std__vectorT_int_std__allocatorT_int_t_t_t_t_t swig_types[97]
-#define SWIGTYPE_p_std__mapT_unsigned_int_std__vectorT_unsigned_int_t_t swig_types[98]
-#define SWIGTYPE_p_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t swig_types[99]
-#define SWIGTYPE_p_std__ostream swig_types[100]
-#define SWIGTYPE_p_std__out_of_range swig_types[101]
-#define SWIGTYPE_p_std__pairT_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t__iterator_bool_t swig_types[102]
-#define SWIGTYPE_p_std__pairT_std__mapT_unsigned_int_std__string_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_std__string_t_t_t__iterator_bool_t swig_types[103]
-#define SWIGTYPE_p_std__pairT_unsigned_int_unsigned_int_t swig_types[104]
-#define SWIGTYPE_p_std__vectorT_ParsedOption_std__allocatorT_ParsedOption_t_t swig_types[105]
-#define SWIGTYPE_p_std__vectorT_double_t swig_types[106]
-#define SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator swig_types[107]
-#define SWIGTYPE_p_std__vectorT_infomap__InfoNode_p_std__allocatorT_infomap__InfoNode_p_t_t swig_types[108]
-#define SWIGTYPE_p_std__vectorT_infomap__LinkResult_t swig_types[109]
-#define SWIGTYPE_p_std__vectorT_infomap__PhysData_std__allocatorT_infomap__PhysData_t_t swig_types[110]
-#define SWIGTYPE_p_std__vectorT_infomap__detail__PerLevelStat_std__allocatorT_infomap__detail__PerLevelStat_t_t swig_types[111]
-#define SWIGTYPE_p_std__vectorT_int_std__allocatorT_int_t_t swig_types[112]
-#define SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t swig_types[113]
-#define SWIGTYPE_p_std__vectorT_unsigned_int_t swig_types[114]
-#define SWIGTYPE_p_tree_iterator swig_types[115]
-#define SWIGTYPE_p_value_type swig_types[116]
-static swig_type_info *swig_types[118];
-static swig_module_info swig_module = {swig_types, 117, 0, 0, 0, 0};
+#define SWIGTYPE_p_NodeLinkMap swig_types[14]
+#define SWIGTYPE_p_NodeMap swig_types[15]
+#define SWIGTYPE_p_OutLinkMap swig_types[16]
+#define SWIGTYPE_p_PartitionQueue swig_types[17]
+#define SWIGTYPE_p_Stopwatch swig_types[18]
+#define SWIGTYPE_p_TreeIteratorT_infomap__InfoNode_const_p_t swig_types[19]
+#define SWIGTYPE_p_TreeIteratorT_infomap__InfoNode_p_t swig_types[20]
+#define SWIGTYPE_p_allocator_type swig_types[21]
+#define SWIGTYPE_p_char swig_types[22]
+#define SWIGTYPE_p_child_iterator swig_types[23]
+#define SWIGTYPE_p_child_iterator_wrapper swig_types[24]
+#define SWIGTYPE_p_const_child_iterator swig_types[25]
+#define SWIGTYPE_p_const_child_iterator_wrapper swig_types[26]
+#define SWIGTYPE_p_const_edge_iterator swig_types[27]
+#define SWIGTYPE_p_const_edge_iterator_wrapper swig_types[28]
+#define SWIGTYPE_p_const_infomap_child_iterator swig_types[29]
+#define SWIGTYPE_p_const_infomap_child_iterator_wrapper swig_types[30]
+#define SWIGTYPE_p_const_infomap_iterator_wrapper swig_types[31]
+#define SWIGTYPE_p_const_leaf_module_iterator swig_types[32]
+#define SWIGTYPE_p_const_leaf_node_iterator swig_types[33]
+#define SWIGTYPE_p_const_post_depth_first_iterator swig_types[34]
+#define SWIGTYPE_p_const_tree_iterator swig_types[35]
+#define SWIGTYPE_p_difference_type swig_types[36]
+#define SWIGTYPE_p_edge_iterator swig_types[37]
+#define SWIGTYPE_p_edge_iterator_wrapper swig_types[38]
+#define SWIGTYPE_p_first_type swig_types[39]
+#define SWIGTYPE_p_infomap__Config swig_types[40]
+#define SWIGTYPE_p_infomap__DeltaFlow swig_types[41]
+#define SWIGTYPE_p_infomap__EdgeData swig_types[42]
+#define SWIGTYPE_p_infomap__FlowData swig_types[43]
+#define SWIGTYPE_p_infomap__FlowModel swig_types[44]
+#define SWIGTYPE_p_infomap__InfoEdge swig_types[45]
+#define SWIGTYPE_p_infomap__InfoNode swig_types[46]
+#define SWIGTYPE_p_infomap__InfomapBase swig_types[47]
+#define SWIGTYPE_p_infomap__InfomapConfigT_infomap__InfomapBase_t swig_types[48]
+#define SWIGTYPE_p_infomap__InfomapIterator swig_types[49]
+#define SWIGTYPE_p_infomap__InfomapIteratorPhysical swig_types[50]
+#define SWIGTYPE_p_infomap__InfomapLeafIterator swig_types[51]
+#define SWIGTYPE_p_infomap__InfomapLeafIteratorPhysical swig_types[52]
+#define SWIGTYPE_p_infomap__InfomapLeafModuleIterator swig_types[53]
+#define SWIGTYPE_p_infomap__InfomapModuleIterator swig_types[54]
+#define SWIGTYPE_p_infomap__InfomapParentIterator swig_types[55]
+#define SWIGTYPE_p_infomap__InfomapWrapper swig_types[56]
+#define SWIGTYPE_p_infomap__LayerNode swig_types[57]
+#define SWIGTYPE_p_infomap__LinkResult swig_types[58]
+#define SWIGTYPE_p_infomap__MemDeltaFlow swig_types[59]
+#define SWIGTYPE_p_infomap__Network swig_types[60]
+#define SWIGTYPE_p_infomap__PhysData swig_types[61]
+#define SWIGTYPE_p_infomap__StateNetwork swig_types[62]
+#define SWIGTYPE_p_infomap__StateNetwork__PhysNode swig_types[63]
+#define SWIGTYPE_p_infomap__StateNetwork__StateNode swig_types[64]
+#define SWIGTYPE_p_infomap__detail__PartitionQueue swig_types[65]
+#define SWIGTYPE_p_infomap__detail__PerLevelStat swig_types[66]
+#define SWIGTYPE_p_infomap_child_iterator swig_types[67]
+#define SWIGTYPE_p_infomap_child_iterator_wrapper swig_types[68]
+#define SWIGTYPE_p_infomap_iterator_wrapper swig_types[69]
+#define SWIGTYPE_p_key_type swig_types[70]
+#define SWIGTYPE_p_leaf_module_iterator swig_types[71]
+#define SWIGTYPE_p_leaf_node_iterator swig_types[72]
+#define SWIGTYPE_p_mapped_type swig_types[73]
+#define SWIGTYPE_p_post_depth_first_iterator swig_types[74]
+#define SWIGTYPE_p_second_type swig_types[75]
+#define SWIGTYPE_p_size_t swig_types[76]
+#define SWIGTYPE_p_size_type swig_types[77]
+#define SWIGTYPE_p_std__allocatorT_double_t swig_types[78]
+#define SWIGTYPE_p_std__allocatorT_infomap__LinkResult_t swig_types[79]
+#define SWIGTYPE_p_std__allocatorT_std__pairT_std__pairT_unsigned_int_unsigned_int_t_const_double_t_t swig_types[80]
+#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_std__string_t_t swig_types[81]
+#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_std__vectorT_unsigned_int_t_t_t swig_types[82]
+#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t swig_types[83]
+#define SWIGTYPE_p_std__allocatorT_unsigned_int_t swig_types[84]
+#define SWIGTYPE_p_std__dequeT_infomap__InfoNode_p_std__allocatorT_infomap__InfoNode_p_t_t__size_type swig_types[85]
+#define SWIGTYPE_p_std__dequeT_unsigned_int_t swig_types[86]
+#define SWIGTYPE_p_std__invalid_argument swig_types[87]
+#define SWIGTYPE_p_std__lessT_std__pairT_unsigned_int_unsigned_int_t_t swig_types[88]
+#define SWIGTYPE_p_std__lessT_unsigned_int_t swig_types[89]
+#define SWIGTYPE_p_std__mapT_infomap__StateNetwork__StateNode_std__mapT_infomap__StateNetwork__StateNode_infomap__StateNetwork__LinkData_std__lessT_infomap__StateNetwork__StateNode_t_std__allocatorT_std__pairT_infomap__StateNetwork__StateNode_const_infomap__StateNetwork__LinkData_t_t_t_std__lessT_infomap__StateNetwork__StateNode_t_std__allocatorT_std__pairT_infomap__StateNetwork__StateNode_const_std__mapT_infomap__StateNetwork__StateNode_infomap__StateNetwork__LinkData_std__lessT_infomap__StateNetwork__StateNode_t_std__allocatorT_std__pairT_infomap__StateNetwork__StateNode_const_infomap__StateNetwork__LinkData_t_t_t_t_t_t swig_types[90]
+#define SWIGTYPE_p_std__mapT_std__pairT_unsigned_int_unsigned_int_t_double_t swig_types[91]
+#define SWIGTYPE_p_std__mapT_unsigned_int_double_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_double_t_t_t swig_types[92]
+#define SWIGTYPE_p_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t swig_types[93]
+#define SWIGTYPE_p_std__mapT_unsigned_int_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t_t_t_t swig_types[94]
+#define SWIGTYPE_p_std__mapT_unsigned_int_std__string_t swig_types[95]
+#define SWIGTYPE_p_std__mapT_unsigned_int_std__vectorT_int_std__allocatorT_int_t_t_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_std__vectorT_int_std__allocatorT_int_t_t_t_t_t swig_types[96]
+#define SWIGTYPE_p_std__mapT_unsigned_int_std__vectorT_unsigned_int_t_t swig_types[97]
+#define SWIGTYPE_p_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t swig_types[98]
+#define SWIGTYPE_p_std__ostream swig_types[99]
+#define SWIGTYPE_p_std__out_of_range swig_types[100]
+#define SWIGTYPE_p_std__pairT_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t__iterator_bool_t swig_types[101]
+#define SWIGTYPE_p_std__pairT_std__mapT_unsigned_int_std__string_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_std__string_t_t_t__iterator_bool_t swig_types[102]
+#define SWIGTYPE_p_std__pairT_unsigned_int_unsigned_int_t swig_types[103]
+#define SWIGTYPE_p_std__vectorT_ParsedOption_std__allocatorT_ParsedOption_t_t swig_types[104]
+#define SWIGTYPE_p_std__vectorT_double_t swig_types[105]
+#define SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator swig_types[106]
+#define SWIGTYPE_p_std__vectorT_infomap__InfoNode_p_std__allocatorT_infomap__InfoNode_p_t_t swig_types[107]
+#define SWIGTYPE_p_std__vectorT_infomap__LinkResult_t swig_types[108]
+#define SWIGTYPE_p_std__vectorT_infomap__PhysData_std__allocatorT_infomap__PhysData_t_t swig_types[109]
+#define SWIGTYPE_p_std__vectorT_infomap__detail__PerLevelStat_std__allocatorT_infomap__detail__PerLevelStat_t_t swig_types[110]
+#define SWIGTYPE_p_std__vectorT_int_std__allocatorT_int_t_t swig_types[111]
+#define SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t swig_types[112]
+#define SWIGTYPE_p_std__vectorT_unsigned_int_t swig_types[113]
+#define SWIGTYPE_p_tree_iterator swig_types[114]
+#define SWIGTYPE_p_value_type swig_types[115]
+static swig_type_info *swig_types[117];
+static swig_module_info swig_module = {swig_types, 116, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -10936,6 +10935,73 @@ R_swig_DeltaFlow_module_get ( SEXP self, SEXP s_swig_copy)
 
 
 SWIGEXPORT SEXP
+R_swig_DeltaFlow_count_set ( SEXP self, SEXP s_count)
+{
+  {
+    infomap::DeltaFlow *arg1 = 0 ;
+    unsigned int arg2 ;
+    void *argp1 = 0 ;
+    int res1 = 0 ;
+    int val2 ;
+    int ecode2 = 0 ;
+    unsigned int r_nprotect = 0;
+    SEXP r_ans = R_NilValue ;
+    VMAXTYPE r_vmax = vmaxget() ;
+    
+    res1 = SWIG_R_ConvertPtr(self, &argp1, SWIGTYPE_p_infomap__DeltaFlow, 0 |  0 );
+    if (!SWIG_IsOK(res1)) {
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "DeltaFlow_count_set" "', argument " "1"" of type '" "infomap::DeltaFlow *""'"); 
+    }
+    arg1 = reinterpret_cast< infomap::DeltaFlow * >(argp1);
+    ecode2 = SWIG_AsVal_int(s_count, &val2);
+    if (!SWIG_IsOK(ecode2)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "DeltaFlow_count_set" "', argument " "2"" of type '" "unsigned int""'");
+    } 
+    arg2 = static_cast< unsigned int >(val2);
+    if (arg1) (arg1)->count = arg2;
+    r_ans = R_NilValue;
+    vmaxset(r_vmax);
+    if(r_nprotect)  Rf_unprotect(r_nprotect);
+    
+    return r_ans;
+    fail: SWIGUNUSED;
+  }
+  Rf_error("%s %s", SWIG_ErrorType(SWIG_lasterror_code), SWIG_lasterror_msg);
+  return R_NilValue;
+}
+
+
+SWIGEXPORT SEXP
+R_swig_DeltaFlow_count_get ( SEXP self, SEXP s_swig_copy)
+{
+  {
+    unsigned int result;
+    infomap::DeltaFlow *arg1 = 0 ;
+    void *argp1 = 0 ;
+    int res1 = 0 ;
+    unsigned int r_nprotect = 0;
+    SEXP r_ans = R_NilValue ;
+    VMAXTYPE r_vmax = vmaxget() ;
+    
+    res1 = SWIG_R_ConvertPtr(self, &argp1, SWIGTYPE_p_infomap__DeltaFlow, 0 |  0 );
+    if (!SWIG_IsOK(res1)) {
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "DeltaFlow_count_get" "', argument " "1"" of type '" "infomap::DeltaFlow *""'"); 
+    }
+    arg1 = reinterpret_cast< infomap::DeltaFlow * >(argp1);
+    result = (unsigned int) ((arg1)->count);
+    r_ans = SWIG_From_int(static_cast< int >(result));
+    vmaxset(r_vmax);
+    if(r_nprotect)  Rf_unprotect(r_nprotect);
+    
+    return r_ans;
+    fail: SWIGUNUSED;
+  }
+  Rf_error("%s %s", SWIG_ErrorType(SWIG_lasterror_code), SWIG_lasterror_msg);
+  return R_NilValue;
+}
+
+
+SWIGEXPORT SEXP
 R_swig_DeltaFlow_deltaExit_set ( SEXP self, SEXP s_deltaExit)
 {
   {
@@ -11046,73 +11112,6 @@ R_swig_DeltaFlow_deltaEnter_get ( SEXP self, SEXP s_swig_copy)
     arg1 = reinterpret_cast< infomap::DeltaFlow * >(argp1);
     result = (double) ((arg1)->deltaEnter);
     r_ans = SWIG_From_double(static_cast< double >(result));
-    vmaxset(r_vmax);
-    if(r_nprotect)  Rf_unprotect(r_nprotect);
-    
-    return r_ans;
-    fail: SWIGUNUSED;
-  }
-  Rf_error("%s %s", SWIG_ErrorType(SWIG_lasterror_code), SWIG_lasterror_msg);
-  return R_NilValue;
-}
-
-
-SWIGEXPORT SEXP
-R_swig_DeltaFlow_count_set ( SEXP self, SEXP s_count)
-{
-  {
-    infomap::DeltaFlow *arg1 = 0 ;
-    unsigned int arg2 ;
-    void *argp1 = 0 ;
-    int res1 = 0 ;
-    int val2 ;
-    int ecode2 = 0 ;
-    unsigned int r_nprotect = 0;
-    SEXP r_ans = R_NilValue ;
-    VMAXTYPE r_vmax = vmaxget() ;
-    
-    res1 = SWIG_R_ConvertPtr(self, &argp1, SWIGTYPE_p_infomap__DeltaFlow, 0 |  0 );
-    if (!SWIG_IsOK(res1)) {
-      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "DeltaFlow_count_set" "', argument " "1"" of type '" "infomap::DeltaFlow *""'"); 
-    }
-    arg1 = reinterpret_cast< infomap::DeltaFlow * >(argp1);
-    ecode2 = SWIG_AsVal_int(s_count, &val2);
-    if (!SWIG_IsOK(ecode2)) {
-      SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "DeltaFlow_count_set" "', argument " "2"" of type '" "unsigned int""'");
-    } 
-    arg2 = static_cast< unsigned int >(val2);
-    if (arg1) (arg1)->count = arg2;
-    r_ans = R_NilValue;
-    vmaxset(r_vmax);
-    if(r_nprotect)  Rf_unprotect(r_nprotect);
-    
-    return r_ans;
-    fail: SWIGUNUSED;
-  }
-  Rf_error("%s %s", SWIG_ErrorType(SWIG_lasterror_code), SWIG_lasterror_msg);
-  return R_NilValue;
-}
-
-
-SWIGEXPORT SEXP
-R_swig_DeltaFlow_count_get ( SEXP self, SEXP s_swig_copy)
-{
-  {
-    unsigned int result;
-    infomap::DeltaFlow *arg1 = 0 ;
-    void *argp1 = 0 ;
-    int res1 = 0 ;
-    unsigned int r_nprotect = 0;
-    SEXP r_ans = R_NilValue ;
-    VMAXTYPE r_vmax = vmaxget() ;
-    
-    res1 = SWIG_R_ConvertPtr(self, &argp1, SWIGTYPE_p_infomap__DeltaFlow, 0 |  0 );
-    if (!SWIG_IsOK(res1)) {
-      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "DeltaFlow_count_get" "', argument " "1"" of type '" "infomap::DeltaFlow *""'"); 
-    }
-    arg1 = reinterpret_cast< infomap::DeltaFlow * >(argp1);
-    result = (unsigned int) ((arg1)->count);
-    r_ans = SWIG_From_int(static_cast< int >(result));
     vmaxset(r_vmax);
     if(r_nprotect)  Rf_unprotect(r_nprotect);
     
@@ -15148,79 +15147,6 @@ R_swig_InfoNode_physicalNodes_get ( SEXP self)
     arg1 = reinterpret_cast< infomap::InfoNode * >(argp1);
     result = (std::vector< infomap::PhysData,std::allocator< infomap::PhysData > > *)& ((arg1)->physicalNodes);
     r_ans = SWIG_R_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__vectorT_infomap__PhysData_std__allocatorT_infomap__PhysData_t_t, 0 |  0 );
-    vmaxset(r_vmax);
-    if(r_nprotect)  Rf_unprotect(r_nprotect);
-    
-    return r_ans;
-    fail: SWIGUNUSED;
-  }
-  Rf_error("%s %s", SWIG_ErrorType(SWIG_lasterror_code), SWIG_lasterror_msg);
-  return R_NilValue;
-}
-
-
-SWIGEXPORT SEXP
-R_swig_InfoNode_metaCollection_set ( SEXP self, SEXP s_metaCollection)
-{
-  {
-    infomap::InfoNode *arg1 = 0 ;
-    MetaCollection arg2 ;
-    void *argp1 = 0 ;
-    int res1 = 0 ;
-    void *argp2 ;
-    int res2 = 0 ;
-    unsigned int r_nprotect = 0;
-    SEXP r_ans = R_NilValue ;
-    VMAXTYPE r_vmax = vmaxget() ;
-    
-    res1 = SWIG_R_ConvertPtr(self, &argp1, SWIGTYPE_p_infomap__InfoNode, 0 |  0 );
-    if (!SWIG_IsOK(res1)) {
-      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfoNode_metaCollection_set" "', argument " "1"" of type '" "infomap::InfoNode *""'"); 
-    }
-    arg1 = reinterpret_cast< infomap::InfoNode * >(argp1);
-    {
-      res2 = SWIG_R_ConvertPtr(s_metaCollection, &argp2, SWIGTYPE_p_MetaCollection,  0 );
-      if (!SWIG_IsOK(res2)) {
-        SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "InfoNode_metaCollection_set" "', argument " "2"" of type '" "MetaCollection""'"); 
-      }  
-      if (!argp2) {
-        SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "InfoNode_metaCollection_set" "', argument " "2"" of type '" "MetaCollection""'");
-      } else {
-        arg2 = *(reinterpret_cast< MetaCollection * >(argp2));
-      }
-    }
-    if (arg1) (arg1)->metaCollection = arg2;
-    r_ans = R_NilValue;
-    vmaxset(r_vmax);
-    if(r_nprotect)  Rf_unprotect(r_nprotect);
-    
-    return r_ans;
-    fail: SWIGUNUSED;
-  }
-  Rf_error("%s %s", SWIG_ErrorType(SWIG_lasterror_code), SWIG_lasterror_msg);
-  return R_NilValue;
-}
-
-
-SWIGEXPORT SEXP
-R_swig_InfoNode_metaCollection_get ( SEXP self, SEXP s_swig_copy)
-{
-  {
-    MetaCollection result;
-    infomap::InfoNode *arg1 = 0 ;
-    void *argp1 = 0 ;
-    int res1 = 0 ;
-    unsigned int r_nprotect = 0;
-    SEXP r_ans = R_NilValue ;
-    VMAXTYPE r_vmax = vmaxget() ;
-    
-    res1 = SWIG_R_ConvertPtr(self, &argp1, SWIGTYPE_p_infomap__InfoNode, 0 |  0 );
-    if (!SWIG_IsOK(res1)) {
-      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfoNode_metaCollection_get" "', argument " "1"" of type '" "infomap::InfoNode *""'"); 
-    }
-    arg1 = reinterpret_cast< infomap::InfoNode * >(argp1);
-    result =  ((arg1)->metaCollection);
-    r_ans = SWIG_R_NewPointerObj((new MetaCollection(result)), SWIGTYPE_p_MetaCollection, SWIG_POINTER_OWN |  0 );
     vmaxset(r_vmax);
     if(r_nprotect)  Rf_unprotect(r_nprotect);
     
@@ -21443,79 +21369,6 @@ R_swig_InfomapIterator_physicalNodes_get ( SEXP self)
     arg1 = reinterpret_cast< infomap::InfomapIterator * >(argp1);
     result = (std::vector< infomap::PhysData,std::allocator< infomap::PhysData > > *)& ((*(infomap::InfomapIterator const *)arg1)->physicalNodes);
     r_ans = SWIG_R_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__vectorT_infomap__PhysData_std__allocatorT_infomap__PhysData_t_t, 0 |  0 );
-    vmaxset(r_vmax);
-    if(r_nprotect)  Rf_unprotect(r_nprotect);
-    
-    return r_ans;
-    fail: SWIGUNUSED;
-  }
-  Rf_error("%s %s", SWIG_ErrorType(SWIG_lasterror_code), SWIG_lasterror_msg);
-  return R_NilValue;
-}
-
-
-SWIGEXPORT SEXP
-R_swig_InfomapIterator_metaCollection_set ( SEXP self, SEXP s_metaCollection)
-{
-  {
-    infomap::InfomapIterator *arg1 = 0 ;
-    MetaCollection arg2 ;
-    void *argp1 = 0 ;
-    int res1 = 0 ;
-    void *argp2 ;
-    int res2 = 0 ;
-    unsigned int r_nprotect = 0;
-    SEXP r_ans = R_NilValue ;
-    VMAXTYPE r_vmax = vmaxget() ;
-    
-    res1 = SWIG_R_ConvertPtr(self, &argp1, SWIGTYPE_p_infomap__InfomapIterator, 0 |  0 );
-    if (!SWIG_IsOK(res1)) {
-      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapIterator_metaCollection_set" "', argument " "1"" of type '" "infomap::InfomapIterator *""'"); 
-    }
-    arg1 = reinterpret_cast< infomap::InfomapIterator * >(argp1);
-    {
-      res2 = SWIG_R_ConvertPtr(s_metaCollection, &argp2, SWIGTYPE_p_MetaCollection,  0 );
-      if (!SWIG_IsOK(res2)) {
-        SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "InfomapIterator_metaCollection_set" "', argument " "2"" of type '" "MetaCollection""'"); 
-      }  
-      if (!argp2) {
-        SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "InfomapIterator_metaCollection_set" "', argument " "2"" of type '" "MetaCollection""'");
-      } else {
-        arg2 = *(reinterpret_cast< MetaCollection * >(argp2));
-      }
-    }
-    if (arg1) (*arg1)->metaCollection = arg2;
-    r_ans = R_NilValue;
-    vmaxset(r_vmax);
-    if(r_nprotect)  Rf_unprotect(r_nprotect);
-    
-    return r_ans;
-    fail: SWIGUNUSED;
-  }
-  Rf_error("%s %s", SWIG_ErrorType(SWIG_lasterror_code), SWIG_lasterror_msg);
-  return R_NilValue;
-}
-
-
-SWIGEXPORT SEXP
-R_swig_InfomapIterator_metaCollection_get ( SEXP self, SEXP s_swig_copy)
-{
-  {
-    MetaCollection result;
-    infomap::InfomapIterator *arg1 = 0 ;
-    void *argp1 = 0 ;
-    int res1 = 0 ;
-    unsigned int r_nprotect = 0;
-    SEXP r_ans = R_NilValue ;
-    VMAXTYPE r_vmax = vmaxget() ;
-    
-    res1 = SWIG_R_ConvertPtr(self, &argp1, SWIGTYPE_p_infomap__InfomapIterator, 0 |  0 );
-    if (!SWIG_IsOK(res1)) {
-      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapIterator_metaCollection_get" "', argument " "1"" of type '" "infomap::InfomapIterator *""'"); 
-    }
-    arg1 = reinterpret_cast< infomap::InfomapIterator * >(argp1);
-    result =  ((*(infomap::InfomapIterator const *)arg1)->metaCollection);
-    r_ans = SWIG_R_NewPointerObj((new MetaCollection(result)), SWIGTYPE_p_MetaCollection, SWIG_POINTER_OWN |  0 );
     vmaxset(r_vmax);
     if(r_nprotect)  Rf_unprotect(r_nprotect);
     
@@ -29494,79 +29347,6 @@ R_swig_InfomapParentIterator_physicalNodes_get ( SEXP self)
     arg1 = reinterpret_cast< infomap::InfomapParentIterator * >(argp1);
     result = (std::vector< infomap::PhysData,std::allocator< infomap::PhysData > > *)& ((*(infomap::InfomapParentIterator const *)arg1)->physicalNodes);
     r_ans = SWIG_R_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__vectorT_infomap__PhysData_std__allocatorT_infomap__PhysData_t_t, 0 |  0 );
-    vmaxset(r_vmax);
-    if(r_nprotect)  Rf_unprotect(r_nprotect);
-    
-    return r_ans;
-    fail: SWIGUNUSED;
-  }
-  Rf_error("%s %s", SWIG_ErrorType(SWIG_lasterror_code), SWIG_lasterror_msg);
-  return R_NilValue;
-}
-
-
-SWIGEXPORT SEXP
-R_swig_InfomapParentIterator_metaCollection_set ( SEXP self, SEXP s_metaCollection)
-{
-  {
-    infomap::InfomapParentIterator *arg1 = 0 ;
-    MetaCollection arg2 ;
-    void *argp1 = 0 ;
-    int res1 = 0 ;
-    void *argp2 ;
-    int res2 = 0 ;
-    unsigned int r_nprotect = 0;
-    SEXP r_ans = R_NilValue ;
-    VMAXTYPE r_vmax = vmaxget() ;
-    
-    res1 = SWIG_R_ConvertPtr(self, &argp1, SWIGTYPE_p_infomap__InfomapParentIterator, 0 |  0 );
-    if (!SWIG_IsOK(res1)) {
-      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapParentIterator_metaCollection_set" "', argument " "1"" of type '" "infomap::InfomapParentIterator *""'"); 
-    }
-    arg1 = reinterpret_cast< infomap::InfomapParentIterator * >(argp1);
-    {
-      res2 = SWIG_R_ConvertPtr(s_metaCollection, &argp2, SWIGTYPE_p_MetaCollection,  0 );
-      if (!SWIG_IsOK(res2)) {
-        SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "InfomapParentIterator_metaCollection_set" "', argument " "2"" of type '" "MetaCollection""'"); 
-      }  
-      if (!argp2) {
-        SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "InfomapParentIterator_metaCollection_set" "', argument " "2"" of type '" "MetaCollection""'");
-      } else {
-        arg2 = *(reinterpret_cast< MetaCollection * >(argp2));
-      }
-    }
-    if (arg1) (*arg1)->metaCollection = arg2;
-    r_ans = R_NilValue;
-    vmaxset(r_vmax);
-    if(r_nprotect)  Rf_unprotect(r_nprotect);
-    
-    return r_ans;
-    fail: SWIGUNUSED;
-  }
-  Rf_error("%s %s", SWIG_ErrorType(SWIG_lasterror_code), SWIG_lasterror_msg);
-  return R_NilValue;
-}
-
-
-SWIGEXPORT SEXP
-R_swig_InfomapParentIterator_metaCollection_get ( SEXP self, SEXP s_swig_copy)
-{
-  {
-    MetaCollection result;
-    infomap::InfomapParentIterator *arg1 = 0 ;
-    void *argp1 = 0 ;
-    int res1 = 0 ;
-    unsigned int r_nprotect = 0;
-    SEXP r_ans = R_NilValue ;
-    VMAXTYPE r_vmax = vmaxget() ;
-    
-    res1 = SWIG_R_ConvertPtr(self, &argp1, SWIGTYPE_p_infomap__InfomapParentIterator, 0 |  0 );
-    if (!SWIG_IsOK(res1)) {
-      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapParentIterator_metaCollection_get" "', argument " "1"" of type '" "infomap::InfomapParentIterator *""'"); 
-    }
-    arg1 = reinterpret_cast< infomap::InfomapParentIterator * >(argp1);
-    result =  ((*(infomap::InfomapParentIterator const *)arg1)->metaCollection);
-    r_ans = SWIG_R_NewPointerObj((new MetaCollection(result)), SWIGTYPE_p_MetaCollection, SWIG_POINTER_OWN |  0 );
     vmaxset(r_vmax);
     if(r_nprotect)  Rf_unprotect(r_nprotect);
     
@@ -49065,7 +48845,6 @@ static swig_type_info _swigt__p_IterWrapperT_TreeIteratorT_infomap__InfoNode_p_t
 static swig_type_info _swigt__p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t = {"_p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t", "infomap::InfoNode::edge_iterator_wrapper *|IterWrapper< std::vector< infomap::InfoEdge *,std::allocator< infomap::InfoEdge * > >::iterator > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_LeafModuleIteratorT_infomap__InfoNode_p_t = {"_p_LeafModuleIteratorT_infomap__InfoNode_p_t", "infomap::InfoNode::leaf_module_iterator *|LeafModuleIterator< infomap::InfoNode * > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_LeafNodeIteratorT_infomap__InfoNode_p_t = {"_p_LeafNodeIteratorT_infomap__InfoNode_p_t", "infomap::InfoNode::leaf_node_iterator *|LeafNodeIterator< infomap::InfoNode * > *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_MetaCollection = {"_p_MetaCollection", "MetaCollection *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_NodeLinkMap = {"_p_NodeLinkMap", "NodeLinkMap *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_NodeMap = {"_p_NodeMap", "NodeMap *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_OutLinkMap = {"_p_OutLinkMap", "OutLinkMap *", 0, 0, (void*)0, 0};
@@ -49184,7 +48963,6 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t,
   &_swigt__p_LeafModuleIteratorT_infomap__InfoNode_p_t,
   &_swigt__p_LeafNodeIteratorT_infomap__InfoNode_p_t,
-  &_swigt__p_MetaCollection,
   &_swigt__p_NodeLinkMap,
   &_swigt__p_NodeMap,
   &_swigt__p_OutLinkMap,
@@ -49303,7 +49081,6 @@ static swig_cast_info _swigc__p_IterWrapperT_TreeIteratorT_infomap__InfoNode_p_t
 static swig_cast_info _swigc__p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t[] = {  {&_swigt__p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_LeafModuleIteratorT_infomap__InfoNode_p_t[] = {  {&_swigt__p_LeafModuleIteratorT_infomap__InfoNode_p_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_LeafNodeIteratorT_infomap__InfoNode_p_t[] = {  {&_swigt__p_LeafNodeIteratorT_infomap__InfoNode_p_t, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_MetaCollection[] = {  {&_swigt__p_MetaCollection, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_NodeLinkMap[] = {  {&_swigt__p_NodeLinkMap, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_NodeMap[] = {  {&_swigt__p_NodeMap, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_OutLinkMap[] = {  {&_swigt__p_OutLinkMap, 0, 0, 0},{0, 0, 0, 0}};
@@ -49422,7 +49199,6 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t,
   _swigc__p_LeafModuleIteratorT_infomap__InfoNode_p_t,
   _swigc__p_LeafNodeIteratorT_infomap__InfoNode_p_t,
-  _swigc__p_MetaCollection,
   _swigc__p_NodeLinkMap,
   _swigc__p_NodeMap,
   _swigc__p_OutLinkMap,
@@ -50204,8 +49980,8 @@ SWIGINTERN R_CallMethodDef CallEntries[] = {
    {"R_swig_Config_minimumSingleNodeCodelengthImprovement_set", (DL_FUNC) &R_swig_Config_minimumSingleNodeCodelengthImprovement_set, 2},
    {"R_swig_StateNetwork_names__SWIG_0", (DL_FUNC) &R_swig_StateNetwork_names__SWIG_0, 2},
    {"R_swig_vector_uint_pop", (DL_FUNC) &R_swig_vector_uint_pop, 2},
-   {"R_swig_Config_clusterDataFile_get", (DL_FUNC) &R_swig_Config_clusterDataFile_get, 2},
    {"R_swig_InfomapLeafIteratorPhysical_current__SWIG_0", (DL_FUNC) &R_swig_InfomapLeafIteratorPhysical_current__SWIG_0, 1},
+   {"R_swig_Config_clusterDataFile_get", (DL_FUNC) &R_swig_Config_clusterDataFile_get, 2},
    {"R_swig_StateNetwork_names__SWIG_1", (DL_FUNC) &R_swig_StateNetwork_names__SWIG_1, 2},
    {"R_swig_InfoNode_begin_inEdge", (DL_FUNC) &R_swig_InfoNode_begin_inEdge, 2},
    {"R_swig_InfomapLeafIteratorPhysical_current__SWIG_1", (DL_FUNC) &R_swig_InfomapLeafIteratorPhysical_current__SWIG_1, 1},
@@ -50219,7 +49995,6 @@ SWIGINTERN R_CallMethodDef CallEntries[] = {
    {"R_swig_InfomapParentIterator_inDegree", (DL_FUNC) &R_swig_InfomapParentIterator_inDegree, 2},
    {"R_swig_InfomapBase_getEntropyRate", (DL_FUNC) &R_swig_InfomapBase_getEntropyRate, 2},
    {"R_swig_DeltaFlow_module_set", (DL_FUNC) &R_swig_DeltaFlow_module_set, 2},
-   {"R_swig_InfomapParentIterator_metaCollection_get", (DL_FUNC) &R_swig_InfomapParentIterator_metaCollection_get, 2},
    {"R_swig_vector_link_result_empty", (DL_FUNC) &R_swig_vector_link_result_empty, 2},
    {"R_swig_InfoNode_end_tree__SWIG_0", (DL_FUNC) &R_swig_InfoNode_end_tree__SWIG_0, 2},
    {"R_swig_InfoNode_end_tree__SWIG_1", (DL_FUNC) &R_swig_InfoNode_end_tree__SWIG_1, 2},
@@ -50590,12 +50365,10 @@ SWIGINTERN R_CallMethodDef CallEntries[] = {
    {"R_swig_new_LinkResult__SWIG_0", (DL_FUNC) &R_swig_new_LinkResult__SWIG_0, 0},
    {"R_swig_new_LinkResult__SWIG_1", (DL_FUNC) &R_swig_new_LinkResult__SWIG_1, 4},
    {"R_swig_InfomapIterator_collapsedLastChild_get", (DL_FUNC) &R_swig_InfomapIterator_collapsedLastChild_get, 1},
-   {"R_swig_InfoNode_metaCollection_get", (DL_FUNC) &R_swig_InfoNode_metaCollection_get, 2},
    {"R_swig_Config_verbosity_get", (DL_FUNC) &R_swig_Config_verbosity_get, 2},
    {"R_swig_Network_addMultilayerLinks", (DL_FUNC) &R_swig_Network_addMultilayerLinks, 6},
    {"R_swig_InfomapWrapper_getLinkResults", (DL_FUNC) &R_swig_InfomapWrapper_getLinkResults, 2},
    {"R_swig_InfomapParentIterator_firstDepthBelow", (DL_FUNC) &R_swig_InfomapParentIterator_firstDepthBelow, 2},
-   {"R_swig_InfomapIterator_metaCollection_get", (DL_FUNC) &R_swig_InfomapIterator_metaCollection_get, 2},
    {"R_swig_InfoNode_parent_set", (DL_FUNC) &R_swig_InfoNode_parent_set, 2},
    {"R_swig_InfomapBase_numTopModules", (DL_FUNC) &R_swig_InfomapBase_numTopModules, 2},
    {"R_swig_PartitionQueue_numNonTrivialModules_get", (DL_FUNC) &R_swig_PartitionQueue_numNonTrivialModules_get, 2},
@@ -50680,7 +50453,6 @@ SWIGINTERN R_CallMethodDef CallEntries[] = {
    {"R_swig_InfomapBase_haveModules", (DL_FUNC) &R_swig_InfomapBase_haveModules, 2},
    {"R_swig_FlowModel_Equal", (DL_FUNC) &R_swig_FlowModel_Equal, 3},
    {"R_swig_InfomapIterator_isFirst", (DL_FUNC) &R_swig_InfomapIterator_isFirst, 2},
-   {"R_swig_InfomapParentIterator_metaCollection_set", (DL_FUNC) &R_swig_InfomapParentIterator_metaCollection_set, 2},
    {"R_swig_Config_bipartiteTeleportation_get", (DL_FUNC) &R_swig_Config_bipartiteTeleportation_get, 2},
    {"R_swig_InfoNode_childDegree", (DL_FUNC) &R_swig_InfoNode_childDegree, 2},
    {"R_swig_InfomapConfigInfomapBase_setTuneIterationLimit", (DL_FUNC) &R_swig_InfomapConfigInfomapBase_setTuneIterationLimit, 3},
@@ -50770,10 +50542,10 @@ SWIGINTERN R_CallMethodDef CallEntries[] = {
    {"R_swig_vector_double___len__", (DL_FUNC) &R_swig_vector_double___len__, 2},
    {"R_swig_InfomapIterator_disposeInfomap", (DL_FUNC) &R_swig_InfomapIterator_disposeInfomap, 2},
    {"R_swig_InfomapIterator_getInfomapRoot__SWIG_0", (DL_FUNC) &R_swig_InfomapIterator_getInfomapRoot__SWIG_0, 1},
+   {"R_swig_InfomapLeafIteratorPhysical_copy", (DL_FUNC) &R_swig_InfomapLeafIteratorPhysical_copy, 2},
    {"R_swig_Config_multilayerRelaxLimitDown_get", (DL_FUNC) &R_swig_Config_multilayerRelaxLimitDown_get, 2},
    {"R_swig_InfomapIterator_getInfomapRoot__SWIG_1", (DL_FUNC) &R_swig_InfomapIterator_getInfomapRoot__SWIG_1, 1},
    {"R_swig_InfomapIterator_numPhysicalNodes", (DL_FUNC) &R_swig_InfomapIterator_numPhysicalNodes, 2},
-   {"R_swig_InfomapLeafIteratorPhysical_copy", (DL_FUNC) &R_swig_InfomapLeafIteratorPhysical_copy, 2},
    {"R_swig_vector_double___setitem__", (DL_FUNC) &R_swig_vector_double___setitem__, 3},
    {"R_swig_InfoNode_collapsedFirstChild_set", (DL_FUNC) &R_swig_InfoNode_collapsedFirstChild_set, 2},
    {"R_swig_new_pair_uint_uint__SWIG_0", (DL_FUNC) &R_swig_new_pair_uint_uint__SWIG_0, 0},
@@ -51090,13 +50862,11 @@ SWIGINTERN R_CallMethodDef CallEntries[] = {
    {"R_swig_Config_haveMemory", (DL_FUNC) &R_swig_Config_haveMemory, 2},
    {"R_swig_InfomapWrapper_addMultilayerLink__SWIG_1", (DL_FUNC) &R_swig_InfomapWrapper_addMultilayerLink__SWIG_1, 5},
    {"R_swig_Config_preferModularSolution_get", (DL_FUNC) &R_swig_Config_preferModularSolution_get, 2},
-   {"R_swig_InfoNode_metaCollection_set", (DL_FUNC) &R_swig_InfoNode_metaCollection_set, 2},
    {"R_swig_Config_verbosity_set", (DL_FUNC) &R_swig_Config_verbosity_set, 2},
    {"R_swig_InfomapIterator_collapsedLastChild_set", (DL_FUNC) &R_swig_InfomapIterator_collapsedLastChild_set, 2},
    {"R_swig_EdgeData_flow_get", (DL_FUNC) &R_swig_EdgeData_flow_get, 2},
    {"R_swig_InfoNode_EqualEqual", (DL_FUNC) &R_swig_InfoNode_EqualEqual, 3},
    {"R_swig_delete_vector_link_result", (DL_FUNC) &R_swig_delete_vector_link_result, 1},
-   {"R_swig_InfomapIterator_metaCollection_set", (DL_FUNC) &R_swig_InfomapIterator_metaCollection_set, 2},
    {"R_swig_PartitionQueue_numNonTrivialModules_set", (DL_FUNC) &R_swig_PartitionQueue_numNonTrivialModules_set, 2},
    {"R_swig_PerLevelStat_numModules_get", (DL_FUNC) &R_swig_PerLevelStat_numModules_get, 2},
    {"R_swig_InfomapBase_numActiveModules", (DL_FUNC) &R_swig_InfomapBase_numActiveModules, 2},

--- a/interfaces/R/generated/infomap_wrap.cpp
+++ b/interfaces/R/generated/infomap_wrap.cpp
@@ -19969,7 +19969,7 @@ SWIGEXPORT SEXP
 R_swig_InfomapIterator_path ( SEXP self, SEXP s_swig_copy)
 {
   {
-    std::deque< unsigned int,std::allocator< unsigned int > > *result = 0 ;
+    std::vector< unsigned int,std::allocator< unsigned int > > *result = 0 ;
     infomap::InfomapIterator *arg1 = 0 ;
     void *argp1 = 0 ;
     int res1 = 0 ;
@@ -19984,12 +19984,12 @@ R_swig_InfomapIterator_path ( SEXP self, SEXP s_swig_copy)
     arg1 = reinterpret_cast< infomap::InfomapIterator * >(argp1);
     {
       try {
-        result = (std::deque< unsigned int,std::allocator< unsigned int > > *) &((infomap::InfomapIterator const *)arg1)->path();
+        result = (std::vector< unsigned int,std::allocator< unsigned int > > *) &((infomap::InfomapIterator const *)arg1)->path();
       } catch (const std::exception& e) {
         SWIG_exception(SWIG_RuntimeError, e.what());
       }
     }
-    r_ans = swig::from(static_cast< std::deque< unsigned int,std::allocator< unsigned int > > >(*result));
+    r_ans = swig::from(static_cast< std::vector< unsigned int,std::allocator< unsigned int > > >(*result));
     vmaxset(r_vmax);
     if(r_nprotect)  Rf_unprotect(r_nprotect);
     
@@ -24782,7 +24782,7 @@ SWIGEXPORT SEXP
 R_swig_InfomapModuleIterator_path ( SEXP self, SEXP s_swig_copy)
 {
   {
-    std::deque< unsigned int,std::allocator< unsigned int > > *result = 0 ;
+    std::vector< unsigned int,std::allocator< unsigned int > > *result = 0 ;
     infomap::InfomapModuleIterator *arg1 = 0 ;
     void *argp1 = 0 ;
     int res1 = 0 ;
@@ -24797,12 +24797,12 @@ R_swig_InfomapModuleIterator_path ( SEXP self, SEXP s_swig_copy)
     arg1 = reinterpret_cast< infomap::InfomapModuleIterator * >(argp1);
     {
       try {
-        result = (std::deque< unsigned int,std::allocator< unsigned int > > *) &((infomap::InfomapModuleIterator const *)arg1)->path();
+        result = (std::vector< unsigned int,std::allocator< unsigned int > > *) &((infomap::InfomapModuleIterator const *)arg1)->path();
       } catch (const std::exception& e) {
         SWIG_exception(SWIG_RuntimeError, e.what());
       }
     }
-    r_ans = swig::from(static_cast< std::deque< unsigned int,std::allocator< unsigned int > > >(*result));
+    r_ans = swig::from(static_cast< std::vector< unsigned int,std::allocator< unsigned int > > >(*result));
     vmaxset(r_vmax);
     if(r_nprotect)  Rf_unprotect(r_nprotect);
     
@@ -25465,7 +25465,7 @@ SWIGEXPORT SEXP
 R_swig_InfomapLeafModuleIterator_path ( SEXP self, SEXP s_swig_copy)
 {
   {
-    std::deque< unsigned int,std::allocator< unsigned int > > *result = 0 ;
+    std::vector< unsigned int,std::allocator< unsigned int > > *result = 0 ;
     infomap::InfomapLeafModuleIterator *arg1 = 0 ;
     void *argp1 = 0 ;
     int res1 = 0 ;
@@ -25480,12 +25480,12 @@ R_swig_InfomapLeafModuleIterator_path ( SEXP self, SEXP s_swig_copy)
     arg1 = reinterpret_cast< infomap::InfomapLeafModuleIterator * >(argp1);
     {
       try {
-        result = (std::deque< unsigned int,std::allocator< unsigned int > > *) &((infomap::InfomapLeafModuleIterator const *)arg1)->path();
+        result = (std::vector< unsigned int,std::allocator< unsigned int > > *) &((infomap::InfomapLeafModuleIterator const *)arg1)->path();
       } catch (const std::exception& e) {
         SWIG_exception(SWIG_RuntimeError, e.what());
       }
     }
-    r_ans = swig::from(static_cast< std::deque< unsigned int,std::allocator< unsigned int > > >(*result));
+    r_ans = swig::from(static_cast< std::vector< unsigned int,std::allocator< unsigned int > > >(*result));
     vmaxset(r_vmax);
     if(r_nprotect)  Rf_unprotect(r_nprotect);
     
@@ -26148,7 +26148,7 @@ SWIGEXPORT SEXP
 R_swig_InfomapLeafIterator_path ( SEXP self, SEXP s_swig_copy)
 {
   {
-    std::deque< unsigned int,std::allocator< unsigned int > > *result = 0 ;
+    std::vector< unsigned int,std::allocator< unsigned int > > *result = 0 ;
     infomap::InfomapLeafIterator *arg1 = 0 ;
     void *argp1 = 0 ;
     int res1 = 0 ;
@@ -26163,12 +26163,12 @@ R_swig_InfomapLeafIterator_path ( SEXP self, SEXP s_swig_copy)
     arg1 = reinterpret_cast< infomap::InfomapLeafIterator * >(argp1);
     {
       try {
-        result = (std::deque< unsigned int,std::allocator< unsigned int > > *) &((infomap::InfomapLeafIterator const *)arg1)->path();
+        result = (std::vector< unsigned int,std::allocator< unsigned int > > *) &((infomap::InfomapLeafIterator const *)arg1)->path();
       } catch (const std::exception& e) {
         SWIG_exception(SWIG_RuntimeError, e.what());
       }
     }
-    r_ans = swig::from(static_cast< std::deque< unsigned int,std::allocator< unsigned int > > >(*result));
+    r_ans = swig::from(static_cast< std::vector< unsigned int,std::allocator< unsigned int > > >(*result));
     vmaxset(r_vmax);
     if(r_nprotect)  Rf_unprotect(r_nprotect);
     
@@ -26829,7 +26829,7 @@ SWIGEXPORT SEXP
 R_swig_InfomapIteratorPhysical_path ( SEXP self, SEXP s_swig_copy)
 {
   {
-    std::deque< unsigned int,std::allocator< unsigned int > > *result = 0 ;
+    std::vector< unsigned int,std::allocator< unsigned int > > *result = 0 ;
     infomap::InfomapIteratorPhysical *arg1 = 0 ;
     void *argp1 = 0 ;
     int res1 = 0 ;
@@ -26844,12 +26844,12 @@ R_swig_InfomapIteratorPhysical_path ( SEXP self, SEXP s_swig_copy)
     arg1 = reinterpret_cast< infomap::InfomapIteratorPhysical * >(argp1);
     {
       try {
-        result = (std::deque< unsigned int,std::allocator< unsigned int > > *) &((infomap::InfomapIteratorPhysical const *)arg1)->path();
+        result = (std::vector< unsigned int,std::allocator< unsigned int > > *) &((infomap::InfomapIteratorPhysical const *)arg1)->path();
       } catch (const std::exception& e) {
         SWIG_exception(SWIG_RuntimeError, e.what());
       }
     }
-    r_ans = swig::from(static_cast< std::deque< unsigned int,std::allocator< unsigned int > > >(*result));
+    r_ans = swig::from(static_cast< std::vector< unsigned int,std::allocator< unsigned int > > >(*result));
     vmaxset(r_vmax);
     if(r_nprotect)  Rf_unprotect(r_nprotect);
     
@@ -27459,7 +27459,7 @@ SWIGEXPORT SEXP
 R_swig_InfomapLeafIteratorPhysical_path ( SEXP self, SEXP s_swig_copy)
 {
   {
-    std::deque< unsigned int,std::allocator< unsigned int > > *result = 0 ;
+    std::vector< unsigned int,std::allocator< unsigned int > > *result = 0 ;
     infomap::InfomapLeafIteratorPhysical *arg1 = 0 ;
     void *argp1 = 0 ;
     int res1 = 0 ;
@@ -27474,12 +27474,12 @@ R_swig_InfomapLeafIteratorPhysical_path ( SEXP self, SEXP s_swig_copy)
     arg1 = reinterpret_cast< infomap::InfomapLeafIteratorPhysical * >(argp1);
     {
       try {
-        result = (std::deque< unsigned int,std::allocator< unsigned int > > *) &((infomap::InfomapLeafIteratorPhysical const *)arg1)->path();
+        result = (std::vector< unsigned int,std::allocator< unsigned int > > *) &((infomap::InfomapLeafIteratorPhysical const *)arg1)->path();
       } catch (const std::exception& e) {
         SWIG_exception(SWIG_RuntimeError, e.what());
       }
     }
-    r_ans = swig::from(static_cast< std::deque< unsigned int,std::allocator< unsigned int > > >(*result));
+    r_ans = swig::from(static_cast< std::vector< unsigned int,std::allocator< unsigned int > > >(*result));
     vmaxset(r_vmax);
     if(r_nprotect)  Rf_unprotect(r_nprotect);
     

--- a/interfaces/python/generated/infomap_wrap.cpp
+++ b/interfaces/python/generated/infomap_wrap.cpp
@@ -25806,7 +25806,7 @@ SWIGINTERN PyObject *_wrap_InfomapIterator_path(PyObject *self, PyObject *args) 
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject *swig_obj[1] ;
-  std::deque< unsigned int,std::allocator< unsigned int > > *result = 0 ;
+  std::vector< unsigned int,std::allocator< unsigned int > > *result = 0 ;
   
   (void)self;
   if (!args) SWIG_fail;
@@ -25818,12 +25818,12 @@ SWIGINTERN PyObject *_wrap_InfomapIterator_path(PyObject *self, PyObject *args) 
   arg1 = reinterpret_cast< infomap::InfomapIterator * >(argp1);
   {
     try {
-      result = (std::deque< unsigned int,std::allocator< unsigned int > > *) &((infomap::InfomapIterator const *)arg1)->path();
+      result = (std::vector< unsigned int,std::allocator< unsigned int > > *) &((infomap::InfomapIterator const *)arg1)->path();
     } catch (const std::exception& e) {
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  resultobj = swig::from(static_cast< std::deque< unsigned int,std::allocator< unsigned int > > >(*result));
+  resultobj = swig::from(static_cast< std::vector< unsigned int,std::allocator< unsigned int > > >(*result));
   return resultobj;
 fail:
   return NULL;
@@ -30337,7 +30337,7 @@ SWIGINTERN PyObject *_wrap_InfomapModuleIterator_path(PyObject *self, PyObject *
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject *swig_obj[1] ;
-  std::deque< unsigned int,std::allocator< unsigned int > > *result = 0 ;
+  std::vector< unsigned int,std::allocator< unsigned int > > *result = 0 ;
   
   (void)self;
   if (!args) SWIG_fail;
@@ -30349,12 +30349,12 @@ SWIGINTERN PyObject *_wrap_InfomapModuleIterator_path(PyObject *self, PyObject *
   arg1 = reinterpret_cast< infomap::InfomapModuleIterator * >(argp1);
   {
     try {
-      result = (std::deque< unsigned int,std::allocator< unsigned int > > *) &((infomap::InfomapModuleIterator const *)arg1)->path();
+      result = (std::vector< unsigned int,std::allocator< unsigned int > > *) &((infomap::InfomapModuleIterator const *)arg1)->path();
     } catch (const std::exception& e) {
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  resultobj = swig::from(static_cast< std::deque< unsigned int,std::allocator< unsigned int > > >(*result));
+  resultobj = swig::from(static_cast< std::vector< unsigned int,std::allocator< unsigned int > > >(*result));
   return resultobj;
 fail:
   return NULL;
@@ -30865,7 +30865,7 @@ SWIGINTERN PyObject *_wrap_InfomapLeafModuleIterator_path(PyObject *self, PyObje
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject *swig_obj[1] ;
-  std::deque< unsigned int,std::allocator< unsigned int > > *result = 0 ;
+  std::vector< unsigned int,std::allocator< unsigned int > > *result = 0 ;
   
   (void)self;
   if (!args) SWIG_fail;
@@ -30877,12 +30877,12 @@ SWIGINTERN PyObject *_wrap_InfomapLeafModuleIterator_path(PyObject *self, PyObje
   arg1 = reinterpret_cast< infomap::InfomapLeafModuleIterator * >(argp1);
   {
     try {
-      result = (std::deque< unsigned int,std::allocator< unsigned int > > *) &((infomap::InfomapLeafModuleIterator const *)arg1)->path();
+      result = (std::vector< unsigned int,std::allocator< unsigned int > > *) &((infomap::InfomapLeafModuleIterator const *)arg1)->path();
     } catch (const std::exception& e) {
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  resultobj = swig::from(static_cast< std::deque< unsigned int,std::allocator< unsigned int > > >(*result));
+  resultobj = swig::from(static_cast< std::vector< unsigned int,std::allocator< unsigned int > > >(*result));
   return resultobj;
 fail:
   return NULL;
@@ -31393,7 +31393,7 @@ SWIGINTERN PyObject *_wrap_InfomapLeafIterator_path(PyObject *self, PyObject *ar
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject *swig_obj[1] ;
-  std::deque< unsigned int,std::allocator< unsigned int > > *result = 0 ;
+  std::vector< unsigned int,std::allocator< unsigned int > > *result = 0 ;
   
   (void)self;
   if (!args) SWIG_fail;
@@ -31405,12 +31405,12 @@ SWIGINTERN PyObject *_wrap_InfomapLeafIterator_path(PyObject *self, PyObject *ar
   arg1 = reinterpret_cast< infomap::InfomapLeafIterator * >(argp1);
   {
     try {
-      result = (std::deque< unsigned int,std::allocator< unsigned int > > *) &((infomap::InfomapLeafIterator const *)arg1)->path();
+      result = (std::vector< unsigned int,std::allocator< unsigned int > > *) &((infomap::InfomapLeafIterator const *)arg1)->path();
     } catch (const std::exception& e) {
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  resultobj = swig::from(static_cast< std::deque< unsigned int,std::allocator< unsigned int > > >(*result));
+  resultobj = swig::from(static_cast< std::vector< unsigned int,std::allocator< unsigned int > > >(*result));
   return resultobj;
 fail:
   return NULL;
@@ -31932,7 +31932,7 @@ SWIGINTERN PyObject *_wrap_InfomapIteratorPhysical_path(PyObject *self, PyObject
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject *swig_obj[1] ;
-  std::deque< unsigned int,std::allocator< unsigned int > > *result = 0 ;
+  std::vector< unsigned int,std::allocator< unsigned int > > *result = 0 ;
   
   (void)self;
   if (!args) SWIG_fail;
@@ -31944,12 +31944,12 @@ SWIGINTERN PyObject *_wrap_InfomapIteratorPhysical_path(PyObject *self, PyObject
   arg1 = reinterpret_cast< infomap::InfomapIteratorPhysical * >(argp1);
   {
     try {
-      result = (std::deque< unsigned int,std::allocator< unsigned int > > *) &((infomap::InfomapIteratorPhysical const *)arg1)->path();
+      result = (std::vector< unsigned int,std::allocator< unsigned int > > *) &((infomap::InfomapIteratorPhysical const *)arg1)->path();
     } catch (const std::exception& e) {
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  resultobj = swig::from(static_cast< std::deque< unsigned int,std::allocator< unsigned int > > >(*result));
+  resultobj = swig::from(static_cast< std::vector< unsigned int,std::allocator< unsigned int > > >(*result));
   return resultobj;
 fail:
   return NULL;
@@ -32460,7 +32460,7 @@ SWIGINTERN PyObject *_wrap_InfomapLeafIteratorPhysical_path(PyObject *self, PyOb
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject *swig_obj[1] ;
-  std::deque< unsigned int,std::allocator< unsigned int > > *result = 0 ;
+  std::vector< unsigned int,std::allocator< unsigned int > > *result = 0 ;
   
   (void)self;
   if (!args) SWIG_fail;
@@ -32472,12 +32472,12 @@ SWIGINTERN PyObject *_wrap_InfomapLeafIteratorPhysical_path(PyObject *self, PyOb
   arg1 = reinterpret_cast< infomap::InfomapLeafIteratorPhysical * >(argp1);
   {
     try {
-      result = (std::deque< unsigned int,std::allocator< unsigned int > > *) &((infomap::InfomapLeafIteratorPhysical const *)arg1)->path();
+      result = (std::vector< unsigned int,std::allocator< unsigned int > > *) &((infomap::InfomapLeafIteratorPhysical const *)arg1)->path();
     } catch (const std::exception& e) {
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  resultobj = swig::from(static_cast< std::deque< unsigned int,std::allocator< unsigned int > > >(*result));
+  resultobj = swig::from(static_cast< std::vector< unsigned int,std::allocator< unsigned int > > >(*result));
   return resultobj;
 fail:
   return NULL;

--- a/interfaces/python/generated/infomap_wrap.cpp
+++ b/interfaces/python/generated/infomap_wrap.cpp
@@ -3457,109 +3457,108 @@ SWIG_Python_NonDynamicSetAttr(PyObject *obj, PyObject *name, PyObject *value) {
 #define SWIGTYPE_p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t swig_types[11]
 #define SWIGTYPE_p_LeafModuleIteratorT_infomap__InfoNode_p_t swig_types[12]
 #define SWIGTYPE_p_LeafNodeIteratorT_infomap__InfoNode_p_t swig_types[13]
-#define SWIGTYPE_p_MetaCollection swig_types[14]
-#define SWIGTYPE_p_NodeLinkMap swig_types[15]
-#define SWIGTYPE_p_NodeMap swig_types[16]
-#define SWIGTYPE_p_OutLinkMap swig_types[17]
-#define SWIGTYPE_p_PartitionQueue swig_types[18]
-#define SWIGTYPE_p_Stopwatch swig_types[19]
-#define SWIGTYPE_p_TreeIteratorT_infomap__InfoNode_const_p_t swig_types[20]
-#define SWIGTYPE_p_TreeIteratorT_infomap__InfoNode_p_t swig_types[21]
-#define SWIGTYPE_p_allocator_type swig_types[22]
-#define SWIGTYPE_p_char swig_types[23]
-#define SWIGTYPE_p_child_iterator swig_types[24]
-#define SWIGTYPE_p_child_iterator_wrapper swig_types[25]
-#define SWIGTYPE_p_const_child_iterator swig_types[26]
-#define SWIGTYPE_p_const_child_iterator_wrapper swig_types[27]
-#define SWIGTYPE_p_const_edge_iterator swig_types[28]
-#define SWIGTYPE_p_const_edge_iterator_wrapper swig_types[29]
-#define SWIGTYPE_p_const_infomap_child_iterator swig_types[30]
-#define SWIGTYPE_p_const_infomap_child_iterator_wrapper swig_types[31]
-#define SWIGTYPE_p_const_infomap_iterator_wrapper swig_types[32]
-#define SWIGTYPE_p_const_leaf_module_iterator swig_types[33]
-#define SWIGTYPE_p_const_leaf_node_iterator swig_types[34]
-#define SWIGTYPE_p_const_post_depth_first_iterator swig_types[35]
-#define SWIGTYPE_p_const_tree_iterator swig_types[36]
-#define SWIGTYPE_p_difference_type swig_types[37]
-#define SWIGTYPE_p_edge_iterator swig_types[38]
-#define SWIGTYPE_p_edge_iterator_wrapper swig_types[39]
-#define SWIGTYPE_p_first_type swig_types[40]
-#define SWIGTYPE_p_infomap__Config swig_types[41]
-#define SWIGTYPE_p_infomap__DeltaFlow swig_types[42]
-#define SWIGTYPE_p_infomap__EdgeData swig_types[43]
-#define SWIGTYPE_p_infomap__FlowData swig_types[44]
-#define SWIGTYPE_p_infomap__FlowModel swig_types[45]
-#define SWIGTYPE_p_infomap__InfoEdge swig_types[46]
-#define SWIGTYPE_p_infomap__InfoNode swig_types[47]
-#define SWIGTYPE_p_infomap__InfomapBase swig_types[48]
-#define SWIGTYPE_p_infomap__InfomapConfigT_infomap__InfomapBase_t swig_types[49]
-#define SWIGTYPE_p_infomap__InfomapIterator swig_types[50]
-#define SWIGTYPE_p_infomap__InfomapIteratorPhysical swig_types[51]
-#define SWIGTYPE_p_infomap__InfomapLeafIterator swig_types[52]
-#define SWIGTYPE_p_infomap__InfomapLeafIteratorPhysical swig_types[53]
-#define SWIGTYPE_p_infomap__InfomapLeafModuleIterator swig_types[54]
-#define SWIGTYPE_p_infomap__InfomapModuleIterator swig_types[55]
-#define SWIGTYPE_p_infomap__InfomapParentIterator swig_types[56]
-#define SWIGTYPE_p_infomap__InfomapWrapper swig_types[57]
-#define SWIGTYPE_p_infomap__LayerNode swig_types[58]
-#define SWIGTYPE_p_infomap__MemDeltaFlow swig_types[59]
-#define SWIGTYPE_p_infomap__Network swig_types[60]
-#define SWIGTYPE_p_infomap__PhysData swig_types[61]
-#define SWIGTYPE_p_infomap__StateNetwork swig_types[62]
-#define SWIGTYPE_p_infomap__StateNetwork__PhysNode swig_types[63]
-#define SWIGTYPE_p_infomap__StateNetwork__StateNode swig_types[64]
-#define SWIGTYPE_p_infomap__detail__PartitionQueue swig_types[65]
-#define SWIGTYPE_p_infomap__detail__PerLevelStat swig_types[66]
-#define SWIGTYPE_p_infomap_child_iterator swig_types[67]
-#define SWIGTYPE_p_infomap_child_iterator_wrapper swig_types[68]
-#define SWIGTYPE_p_infomap_iterator_wrapper swig_types[69]
-#define SWIGTYPE_p_key_type swig_types[70]
-#define SWIGTYPE_p_leaf_module_iterator swig_types[71]
-#define SWIGTYPE_p_leaf_node_iterator swig_types[72]
-#define SWIGTYPE_p_mapped_type swig_types[73]
-#define SWIGTYPE_p_p_PyObject swig_types[74]
-#define SWIGTYPE_p_post_depth_first_iterator swig_types[75]
-#define SWIGTYPE_p_second_type swig_types[76]
-#define SWIGTYPE_p_size_t swig_types[77]
-#define SWIGTYPE_p_size_type swig_types[78]
-#define SWIGTYPE_p_std__allocatorT_double_t swig_types[79]
-#define SWIGTYPE_p_std__allocatorT_std__pairT_std__pairT_unsigned_int_unsigned_int_t_const_double_t_t swig_types[80]
-#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_std__string_t_t swig_types[81]
-#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_std__vectorT_unsigned_int_t_t_t swig_types[82]
-#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t swig_types[83]
-#define SWIGTYPE_p_std__allocatorT_unsigned_int_t swig_types[84]
-#define SWIGTYPE_p_std__dequeT_infomap__InfoNode_p_std__allocatorT_infomap__InfoNode_p_t_t__size_type swig_types[85]
-#define SWIGTYPE_p_std__dequeT_unsigned_int_t swig_types[86]
-#define SWIGTYPE_p_std__invalid_argument swig_types[87]
-#define SWIGTYPE_p_std__lessT_std__pairT_unsigned_int_unsigned_int_t_t swig_types[88]
-#define SWIGTYPE_p_std__lessT_unsigned_int_t swig_types[89]
-#define SWIGTYPE_p_std__mapT_infomap__StateNetwork__StateNode_std__mapT_infomap__StateNetwork__StateNode_infomap__StateNetwork__LinkData_std__lessT_infomap__StateNetwork__StateNode_t_std__allocatorT_std__pairT_infomap__StateNetwork__StateNode_const_infomap__StateNetwork__LinkData_t_t_t_std__lessT_infomap__StateNetwork__StateNode_t_std__allocatorT_std__pairT_infomap__StateNetwork__StateNode_const_std__mapT_infomap__StateNetwork__StateNode_infomap__StateNetwork__LinkData_std__lessT_infomap__StateNetwork__StateNode_t_std__allocatorT_std__pairT_infomap__StateNetwork__StateNode_const_infomap__StateNetwork__LinkData_t_t_t_t_t_t swig_types[90]
-#define SWIGTYPE_p_std__mapT_std__pairT_unsigned_int_unsigned_int_t_double_t swig_types[91]
-#define SWIGTYPE_p_std__mapT_unsigned_int_double_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_double_t_t_t swig_types[92]
-#define SWIGTYPE_p_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t swig_types[93]
-#define SWIGTYPE_p_std__mapT_unsigned_int_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t_t_t_t swig_types[94]
-#define SWIGTYPE_p_std__mapT_unsigned_int_std__string_t swig_types[95]
-#define SWIGTYPE_p_std__mapT_unsigned_int_std__vectorT_int_std__allocatorT_int_t_t_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_std__vectorT_int_std__allocatorT_int_t_t_t_t_t swig_types[96]
-#define SWIGTYPE_p_std__mapT_unsigned_int_std__vectorT_unsigned_int_t_t swig_types[97]
-#define SWIGTYPE_p_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t swig_types[98]
-#define SWIGTYPE_p_std__ostream swig_types[99]
-#define SWIGTYPE_p_std__pairT_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t__iterator_bool_t swig_types[100]
-#define SWIGTYPE_p_std__pairT_std__mapT_unsigned_int_std__string_t__iterator_bool_t swig_types[101]
-#define SWIGTYPE_p_std__pairT_unsigned_int_unsigned_int_t swig_types[102]
-#define SWIGTYPE_p_std__vectorT_ParsedOption_std__allocatorT_ParsedOption_t_t swig_types[103]
-#define SWIGTYPE_p_std__vectorT_double_t swig_types[104]
-#define SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator swig_types[105]
-#define SWIGTYPE_p_std__vectorT_infomap__InfoNode_p_std__allocatorT_infomap__InfoNode_p_t_t swig_types[106]
-#define SWIGTYPE_p_std__vectorT_infomap__PhysData_std__allocatorT_infomap__PhysData_t_t swig_types[107]
-#define SWIGTYPE_p_std__vectorT_infomap__detail__PerLevelStat_std__allocatorT_infomap__detail__PerLevelStat_t_t swig_types[108]
-#define SWIGTYPE_p_std__vectorT_int_std__allocatorT_int_t_t swig_types[109]
-#define SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t swig_types[110]
-#define SWIGTYPE_p_std__vectorT_unsigned_int_t swig_types[111]
-#define SWIGTYPE_p_swig__SwigPyIterator swig_types[112]
-#define SWIGTYPE_p_tree_iterator swig_types[113]
-#define SWIGTYPE_p_value_type swig_types[114]
-static swig_type_info *swig_types[116];
-static swig_module_info swig_module = {swig_types, 115, 0, 0, 0, 0};
+#define SWIGTYPE_p_NodeLinkMap swig_types[14]
+#define SWIGTYPE_p_NodeMap swig_types[15]
+#define SWIGTYPE_p_OutLinkMap swig_types[16]
+#define SWIGTYPE_p_PartitionQueue swig_types[17]
+#define SWIGTYPE_p_Stopwatch swig_types[18]
+#define SWIGTYPE_p_TreeIteratorT_infomap__InfoNode_const_p_t swig_types[19]
+#define SWIGTYPE_p_TreeIteratorT_infomap__InfoNode_p_t swig_types[20]
+#define SWIGTYPE_p_allocator_type swig_types[21]
+#define SWIGTYPE_p_char swig_types[22]
+#define SWIGTYPE_p_child_iterator swig_types[23]
+#define SWIGTYPE_p_child_iterator_wrapper swig_types[24]
+#define SWIGTYPE_p_const_child_iterator swig_types[25]
+#define SWIGTYPE_p_const_child_iterator_wrapper swig_types[26]
+#define SWIGTYPE_p_const_edge_iterator swig_types[27]
+#define SWIGTYPE_p_const_edge_iterator_wrapper swig_types[28]
+#define SWIGTYPE_p_const_infomap_child_iterator swig_types[29]
+#define SWIGTYPE_p_const_infomap_child_iterator_wrapper swig_types[30]
+#define SWIGTYPE_p_const_infomap_iterator_wrapper swig_types[31]
+#define SWIGTYPE_p_const_leaf_module_iterator swig_types[32]
+#define SWIGTYPE_p_const_leaf_node_iterator swig_types[33]
+#define SWIGTYPE_p_const_post_depth_first_iterator swig_types[34]
+#define SWIGTYPE_p_const_tree_iterator swig_types[35]
+#define SWIGTYPE_p_difference_type swig_types[36]
+#define SWIGTYPE_p_edge_iterator swig_types[37]
+#define SWIGTYPE_p_edge_iterator_wrapper swig_types[38]
+#define SWIGTYPE_p_first_type swig_types[39]
+#define SWIGTYPE_p_infomap__Config swig_types[40]
+#define SWIGTYPE_p_infomap__DeltaFlow swig_types[41]
+#define SWIGTYPE_p_infomap__EdgeData swig_types[42]
+#define SWIGTYPE_p_infomap__FlowData swig_types[43]
+#define SWIGTYPE_p_infomap__FlowModel swig_types[44]
+#define SWIGTYPE_p_infomap__InfoEdge swig_types[45]
+#define SWIGTYPE_p_infomap__InfoNode swig_types[46]
+#define SWIGTYPE_p_infomap__InfomapBase swig_types[47]
+#define SWIGTYPE_p_infomap__InfomapConfigT_infomap__InfomapBase_t swig_types[48]
+#define SWIGTYPE_p_infomap__InfomapIterator swig_types[49]
+#define SWIGTYPE_p_infomap__InfomapIteratorPhysical swig_types[50]
+#define SWIGTYPE_p_infomap__InfomapLeafIterator swig_types[51]
+#define SWIGTYPE_p_infomap__InfomapLeafIteratorPhysical swig_types[52]
+#define SWIGTYPE_p_infomap__InfomapLeafModuleIterator swig_types[53]
+#define SWIGTYPE_p_infomap__InfomapModuleIterator swig_types[54]
+#define SWIGTYPE_p_infomap__InfomapParentIterator swig_types[55]
+#define SWIGTYPE_p_infomap__InfomapWrapper swig_types[56]
+#define SWIGTYPE_p_infomap__LayerNode swig_types[57]
+#define SWIGTYPE_p_infomap__MemDeltaFlow swig_types[58]
+#define SWIGTYPE_p_infomap__Network swig_types[59]
+#define SWIGTYPE_p_infomap__PhysData swig_types[60]
+#define SWIGTYPE_p_infomap__StateNetwork swig_types[61]
+#define SWIGTYPE_p_infomap__StateNetwork__PhysNode swig_types[62]
+#define SWIGTYPE_p_infomap__StateNetwork__StateNode swig_types[63]
+#define SWIGTYPE_p_infomap__detail__PartitionQueue swig_types[64]
+#define SWIGTYPE_p_infomap__detail__PerLevelStat swig_types[65]
+#define SWIGTYPE_p_infomap_child_iterator swig_types[66]
+#define SWIGTYPE_p_infomap_child_iterator_wrapper swig_types[67]
+#define SWIGTYPE_p_infomap_iterator_wrapper swig_types[68]
+#define SWIGTYPE_p_key_type swig_types[69]
+#define SWIGTYPE_p_leaf_module_iterator swig_types[70]
+#define SWIGTYPE_p_leaf_node_iterator swig_types[71]
+#define SWIGTYPE_p_mapped_type swig_types[72]
+#define SWIGTYPE_p_p_PyObject swig_types[73]
+#define SWIGTYPE_p_post_depth_first_iterator swig_types[74]
+#define SWIGTYPE_p_second_type swig_types[75]
+#define SWIGTYPE_p_size_t swig_types[76]
+#define SWIGTYPE_p_size_type swig_types[77]
+#define SWIGTYPE_p_std__allocatorT_double_t swig_types[78]
+#define SWIGTYPE_p_std__allocatorT_std__pairT_std__pairT_unsigned_int_unsigned_int_t_const_double_t_t swig_types[79]
+#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_std__string_t_t swig_types[80]
+#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_std__vectorT_unsigned_int_t_t_t swig_types[81]
+#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t swig_types[82]
+#define SWIGTYPE_p_std__allocatorT_unsigned_int_t swig_types[83]
+#define SWIGTYPE_p_std__dequeT_infomap__InfoNode_p_std__allocatorT_infomap__InfoNode_p_t_t__size_type swig_types[84]
+#define SWIGTYPE_p_std__dequeT_unsigned_int_t swig_types[85]
+#define SWIGTYPE_p_std__invalid_argument swig_types[86]
+#define SWIGTYPE_p_std__lessT_std__pairT_unsigned_int_unsigned_int_t_t swig_types[87]
+#define SWIGTYPE_p_std__lessT_unsigned_int_t swig_types[88]
+#define SWIGTYPE_p_std__mapT_infomap__StateNetwork__StateNode_std__mapT_infomap__StateNetwork__StateNode_infomap__StateNetwork__LinkData_std__lessT_infomap__StateNetwork__StateNode_t_std__allocatorT_std__pairT_infomap__StateNetwork__StateNode_const_infomap__StateNetwork__LinkData_t_t_t_std__lessT_infomap__StateNetwork__StateNode_t_std__allocatorT_std__pairT_infomap__StateNetwork__StateNode_const_std__mapT_infomap__StateNetwork__StateNode_infomap__StateNetwork__LinkData_std__lessT_infomap__StateNetwork__StateNode_t_std__allocatorT_std__pairT_infomap__StateNetwork__StateNode_const_infomap__StateNetwork__LinkData_t_t_t_t_t_t swig_types[89]
+#define SWIGTYPE_p_std__mapT_std__pairT_unsigned_int_unsigned_int_t_double_t swig_types[90]
+#define SWIGTYPE_p_std__mapT_unsigned_int_double_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_double_t_t_t swig_types[91]
+#define SWIGTYPE_p_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t swig_types[92]
+#define SWIGTYPE_p_std__mapT_unsigned_int_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t_t_t_t swig_types[93]
+#define SWIGTYPE_p_std__mapT_unsigned_int_std__string_t swig_types[94]
+#define SWIGTYPE_p_std__mapT_unsigned_int_std__vectorT_int_std__allocatorT_int_t_t_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_std__vectorT_int_std__allocatorT_int_t_t_t_t_t swig_types[95]
+#define SWIGTYPE_p_std__mapT_unsigned_int_std__vectorT_unsigned_int_t_t swig_types[96]
+#define SWIGTYPE_p_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t swig_types[97]
+#define SWIGTYPE_p_std__ostream swig_types[98]
+#define SWIGTYPE_p_std__pairT_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t__iterator_bool_t swig_types[99]
+#define SWIGTYPE_p_std__pairT_std__mapT_unsigned_int_std__string_t__iterator_bool_t swig_types[100]
+#define SWIGTYPE_p_std__pairT_unsigned_int_unsigned_int_t swig_types[101]
+#define SWIGTYPE_p_std__vectorT_ParsedOption_std__allocatorT_ParsedOption_t_t swig_types[102]
+#define SWIGTYPE_p_std__vectorT_double_t swig_types[103]
+#define SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator swig_types[104]
+#define SWIGTYPE_p_std__vectorT_infomap__InfoNode_p_std__allocatorT_infomap__InfoNode_p_t_t swig_types[105]
+#define SWIGTYPE_p_std__vectorT_infomap__PhysData_std__allocatorT_infomap__PhysData_t_t swig_types[106]
+#define SWIGTYPE_p_std__vectorT_infomap__detail__PerLevelStat_std__allocatorT_infomap__detail__PerLevelStat_t_t swig_types[107]
+#define SWIGTYPE_p_std__vectorT_int_std__allocatorT_int_t_t swig_types[108]
+#define SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t swig_types[109]
+#define SWIGTYPE_p_std__vectorT_unsigned_int_t swig_types[110]
+#define SWIGTYPE_p_swig__SwigPyIterator swig_types[111]
+#define SWIGTYPE_p_tree_iterator swig_types[112]
+#define SWIGTYPE_p_value_type swig_types[113]
+static swig_type_info *swig_types[115];
+static swig_module_info swig_module = {swig_types, 114, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -13432,6 +13431,60 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_DeltaFlow_count_set(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  infomap::DeltaFlow *arg1 = 0 ;
+  unsigned int arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned int val2 ;
+  int ecode2 = 0 ;
+  PyObject *swig_obj[2] ;
+  
+  (void)self;
+  if (!SWIG_Python_UnpackTuple(args, "DeltaFlow_count_set", 2, 2, swig_obj)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__DeltaFlow, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "DeltaFlow_count_set" "', argument " "1"" of type '" "infomap::DeltaFlow *""'"); 
+  }
+  arg1 = reinterpret_cast< infomap::DeltaFlow * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_int(swig_obj[1], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "DeltaFlow_count_set" "', argument " "2"" of type '" "unsigned int""'");
+  } 
+  arg2 = static_cast< unsigned int >(val2);
+  if (arg1) (arg1)->count = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_DeltaFlow_count_get(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  infomap::DeltaFlow *arg1 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  unsigned int result;
+  
+  (void)self;
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__DeltaFlow, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "DeltaFlow_count_get" "', argument " "1"" of type '" "infomap::DeltaFlow *""'"); 
+  }
+  arg1 = reinterpret_cast< infomap::DeltaFlow * >(argp1);
+  result = (unsigned int) ((arg1)->count);
+  resultobj = SWIG_From_unsigned_SS_int(static_cast< unsigned int >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_DeltaFlow_deltaExit_set(PyObject *self, PyObject *args) {
   PyObject *resultobj = 0;
   infomap::DeltaFlow *arg1 = 0 ;
@@ -13534,60 +13587,6 @@ SWIGINTERN PyObject *_wrap_DeltaFlow_deltaEnter_get(PyObject *self, PyObject *ar
   arg1 = reinterpret_cast< infomap::DeltaFlow * >(argp1);
   result = (double) ((arg1)->deltaEnter);
   resultobj = SWIG_From_double(static_cast< double >(result));
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_DeltaFlow_count_set(PyObject *self, PyObject *args) {
-  PyObject *resultobj = 0;
-  infomap::DeltaFlow *arg1 = 0 ;
-  unsigned int arg2 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  unsigned int val2 ;
-  int ecode2 = 0 ;
-  PyObject *swig_obj[2] ;
-  
-  (void)self;
-  if (!SWIG_Python_UnpackTuple(args, "DeltaFlow_count_set", 2, 2, swig_obj)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__DeltaFlow, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "DeltaFlow_count_set" "', argument " "1"" of type '" "infomap::DeltaFlow *""'"); 
-  }
-  arg1 = reinterpret_cast< infomap::DeltaFlow * >(argp1);
-  ecode2 = SWIG_AsVal_unsigned_SS_int(swig_obj[1], &val2);
-  if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "DeltaFlow_count_set" "', argument " "2"" of type '" "unsigned int""'");
-  } 
-  arg2 = static_cast< unsigned int >(val2);
-  if (arg1) (arg1)->count = arg2;
-  resultobj = SWIG_Py_Void();
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_DeltaFlow_count_get(PyObject *self, PyObject *args) {
-  PyObject *resultobj = 0;
-  infomap::DeltaFlow *arg1 = 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  PyObject *swig_obj[1] ;
-  unsigned int result;
-  
-  (void)self;
-  if (!args) SWIG_fail;
-  swig_obj[0] = args;
-  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__DeltaFlow, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "DeltaFlow_count_get" "', argument " "1"" of type '" "infomap::DeltaFlow *""'"); 
-  }
-  arg1 = reinterpret_cast< infomap::DeltaFlow * >(argp1);
-  result = (unsigned int) ((arg1)->count);
-  resultobj = SWIG_From_unsigned_SS_int(static_cast< unsigned int >(result));
   return resultobj;
 fail:
   return NULL;
@@ -19435,68 +19434,6 @@ SWIGINTERN PyObject *_wrap_InfoNode_physicalNodes_get(PyObject *self, PyObject *
   arg1 = reinterpret_cast< infomap::InfoNode * >(argp1);
   result = (std::vector< infomap::PhysData,std::allocator< infomap::PhysData > > *)& ((arg1)->physicalNodes);
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__vectorT_infomap__PhysData_std__allocatorT_infomap__PhysData_t_t, 0 |  0 );
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_InfoNode_metaCollection_set(PyObject *self, PyObject *args) {
-  PyObject *resultobj = 0;
-  infomap::InfoNode *arg1 = 0 ;
-  MetaCollection arg2 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  void *argp2 ;
-  int res2 = 0 ;
-  PyObject *swig_obj[2] ;
-  
-  (void)self;
-  if (!SWIG_Python_UnpackTuple(args, "InfoNode_metaCollection_set", 2, 2, swig_obj)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__InfoNode, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfoNode_metaCollection_set" "', argument " "1"" of type '" "infomap::InfoNode *""'"); 
-  }
-  arg1 = reinterpret_cast< infomap::InfoNode * >(argp1);
-  {
-    res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_MetaCollection,  0  | 0);
-    if (!SWIG_IsOK(res2)) {
-      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "InfoNode_metaCollection_set" "', argument " "2"" of type '" "MetaCollection""'"); 
-    }  
-    if (!argp2) {
-      SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "InfoNode_metaCollection_set" "', argument " "2"" of type '" "MetaCollection""'");
-    } else {
-      MetaCollection * temp = reinterpret_cast< MetaCollection * >(argp2);
-      arg2 = *temp;
-      if (SWIG_IsNewObj(res2)) delete temp;
-    }
-  }
-  if (arg1) (arg1)->metaCollection = arg2;
-  resultobj = SWIG_Py_Void();
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_InfoNode_metaCollection_get(PyObject *self, PyObject *args) {
-  PyObject *resultobj = 0;
-  infomap::InfoNode *arg1 = 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  PyObject *swig_obj[1] ;
-  MetaCollection result;
-  
-  (void)self;
-  if (!args) SWIG_fail;
-  swig_obj[0] = args;
-  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__InfoNode, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfoNode_metaCollection_get" "', argument " "1"" of type '" "infomap::InfoNode *""'"); 
-  }
-  arg1 = reinterpret_cast< infomap::InfoNode * >(argp1);
-  result =  ((arg1)->metaCollection);
-  resultobj = SWIG_NewPointerObj((new MetaCollection(result)), SWIGTYPE_p_MetaCollection, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -27021,68 +26958,6 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_InfomapIterator_metaCollection_set(PyObject *self, PyObject *args) {
-  PyObject *resultobj = 0;
-  infomap::InfomapIterator *arg1 = 0 ;
-  MetaCollection arg2 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  void *argp2 ;
-  int res2 = 0 ;
-  PyObject *swig_obj[2] ;
-  
-  (void)self;
-  if (!SWIG_Python_UnpackTuple(args, "InfomapIterator_metaCollection_set", 2, 2, swig_obj)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__InfomapIterator, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapIterator_metaCollection_set" "', argument " "1"" of type '" "infomap::InfomapIterator *""'"); 
-  }
-  arg1 = reinterpret_cast< infomap::InfomapIterator * >(argp1);
-  {
-    res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_MetaCollection,  0  | 0);
-    if (!SWIG_IsOK(res2)) {
-      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "InfomapIterator_metaCollection_set" "', argument " "2"" of type '" "MetaCollection""'"); 
-    }  
-    if (!argp2) {
-      SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "InfomapIterator_metaCollection_set" "', argument " "2"" of type '" "MetaCollection""'");
-    } else {
-      MetaCollection * temp = reinterpret_cast< MetaCollection * >(argp2);
-      arg2 = *temp;
-      if (SWIG_IsNewObj(res2)) delete temp;
-    }
-  }
-  if (arg1) (*arg1)->metaCollection = arg2;
-  resultobj = SWIG_Py_Void();
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_InfomapIterator_metaCollection_get(PyObject *self, PyObject *args) {
-  PyObject *resultobj = 0;
-  infomap::InfomapIterator *arg1 = 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  PyObject *swig_obj[1] ;
-  MetaCollection result;
-  
-  (void)self;
-  if (!args) SWIG_fail;
-  swig_obj[0] = args;
-  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__InfomapIterator, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapIterator_metaCollection_get" "', argument " "1"" of type '" "infomap::InfomapIterator *""'"); 
-  }
-  arg1 = reinterpret_cast< infomap::InfomapIterator * >(argp1);
-  result =  ((*(infomap::InfomapIterator const *)arg1)->metaCollection);
-  resultobj = SWIG_NewPointerObj((new MetaCollection(result)), SWIGTYPE_p_MetaCollection, SWIG_POINTER_OWN |  0 );
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
 SWIGINTERN PyObject *_wrap_InfomapIterator_stateNodes_set(PyObject *self, PyObject *args) {
   PyObject *resultobj = 0;
   infomap::InfomapIterator *arg1 = 0 ;
@@ -34159,68 +34034,6 @@ SWIGINTERN PyObject *_wrap_InfomapParentIterator_physicalNodes_get(PyObject *sel
   arg1 = reinterpret_cast< infomap::InfomapParentIterator * >(argp1);
   result = (std::vector< infomap::PhysData,std::allocator< infomap::PhysData > > *)& ((*(infomap::InfomapParentIterator const *)arg1)->physicalNodes);
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__vectorT_infomap__PhysData_std__allocatorT_infomap__PhysData_t_t, 0 |  0 );
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_InfomapParentIterator_metaCollection_set(PyObject *self, PyObject *args) {
-  PyObject *resultobj = 0;
-  infomap::InfomapParentIterator *arg1 = 0 ;
-  MetaCollection arg2 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  void *argp2 ;
-  int res2 = 0 ;
-  PyObject *swig_obj[2] ;
-  
-  (void)self;
-  if (!SWIG_Python_UnpackTuple(args, "InfomapParentIterator_metaCollection_set", 2, 2, swig_obj)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__InfomapParentIterator, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapParentIterator_metaCollection_set" "', argument " "1"" of type '" "infomap::InfomapParentIterator *""'"); 
-  }
-  arg1 = reinterpret_cast< infomap::InfomapParentIterator * >(argp1);
-  {
-    res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_MetaCollection,  0  | 0);
-    if (!SWIG_IsOK(res2)) {
-      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "InfomapParentIterator_metaCollection_set" "', argument " "2"" of type '" "MetaCollection""'"); 
-    }  
-    if (!argp2) {
-      SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "InfomapParentIterator_metaCollection_set" "', argument " "2"" of type '" "MetaCollection""'");
-    } else {
-      MetaCollection * temp = reinterpret_cast< MetaCollection * >(argp2);
-      arg2 = *temp;
-      if (SWIG_IsNewObj(res2)) delete temp;
-    }
-  }
-  if (arg1) (*arg1)->metaCollection = arg2;
-  resultobj = SWIG_Py_Void();
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_InfomapParentIterator_metaCollection_get(PyObject *self, PyObject *args) {
-  PyObject *resultobj = 0;
-  infomap::InfomapParentIterator *arg1 = 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  PyObject *swig_obj[1] ;
-  MetaCollection result;
-  
-  (void)self;
-  if (!args) SWIG_fail;
-  swig_obj[0] = args;
-  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__InfomapParentIterator, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapParentIterator_metaCollection_get" "', argument " "1"" of type '" "infomap::InfomapParentIterator *""'"); 
-  }
-  arg1 = reinterpret_cast< infomap::InfomapParentIterator * >(argp1);
-  result =  ((*(infomap::InfomapParentIterator const *)arg1)->metaCollection);
-  resultobj = SWIG_NewPointerObj((new MetaCollection(result)), SWIGTYPE_p_MetaCollection, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -58746,12 +58559,12 @@ static PyMethodDef SwigMethods[] = {
 	 { "FlowData_swiginit", FlowData_swiginit, METH_VARARGS, NULL},
 	 { "DeltaFlow_module_set", _wrap_DeltaFlow_module_set, METH_VARARGS, NULL},
 	 { "DeltaFlow_module_get", _wrap_DeltaFlow_module_get, METH_O, NULL},
+	 { "DeltaFlow_count_set", _wrap_DeltaFlow_count_set, METH_VARARGS, NULL},
+	 { "DeltaFlow_count_get", _wrap_DeltaFlow_count_get, METH_O, NULL},
 	 { "DeltaFlow_deltaExit_set", _wrap_DeltaFlow_deltaExit_set, METH_VARARGS, NULL},
 	 { "DeltaFlow_deltaExit_get", _wrap_DeltaFlow_deltaExit_get, METH_O, NULL},
 	 { "DeltaFlow_deltaEnter_set", _wrap_DeltaFlow_deltaEnter_set, METH_VARARGS, NULL},
 	 { "DeltaFlow_deltaEnter_get", _wrap_DeltaFlow_deltaEnter_get, METH_O, NULL},
-	 { "DeltaFlow_count_set", _wrap_DeltaFlow_count_set, METH_VARARGS, NULL},
-	 { "DeltaFlow_count_get", _wrap_DeltaFlow_count_get, METH_O, NULL},
 	 { "new_DeltaFlow", _wrap_new_DeltaFlow, METH_VARARGS, NULL},
 	 { "delete_DeltaFlow", _wrap_delete_DeltaFlow, METH_O, NULL},
 	 { "DeltaFlow___iadd__", _wrap_DeltaFlow___iadd__, METH_VARARGS, NULL},
@@ -58883,8 +58696,6 @@ static PyMethodDef SwigMethods[] = {
 	 { "InfoNode_dirty_get", _wrap_InfoNode_dirty_get, METH_O, NULL},
 	 { "InfoNode_physicalNodes_set", _wrap_InfoNode_physicalNodes_set, METH_VARARGS, NULL},
 	 { "InfoNode_physicalNodes_get", _wrap_InfoNode_physicalNodes_get, METH_O, NULL},
-	 { "InfoNode_metaCollection_set", _wrap_InfoNode_metaCollection_set, METH_VARARGS, NULL},
-	 { "InfoNode_metaCollection_get", _wrap_InfoNode_metaCollection_get, METH_O, NULL},
 	 { "InfoNode_stateNodes_set", _wrap_InfoNode_stateNodes_set, METH_VARARGS, NULL},
 	 { "InfoNode_stateNodes_get", _wrap_InfoNode_stateNodes_get, METH_O, NULL},
 	 { "new_InfoNode", _wrap_new_InfoNode, METH_VARARGS, NULL},
@@ -59036,8 +58847,6 @@ static PyMethodDef SwigMethods[] = {
 	 { "InfomapIterator_dirty_get", _wrap_InfomapIterator_dirty_get, METH_O, NULL},
 	 { "InfomapIterator_physicalNodes_set", _wrap_InfomapIterator_physicalNodes_set, METH_VARARGS, NULL},
 	 { "InfomapIterator_physicalNodes_get", _wrap_InfomapIterator_physicalNodes_get, METH_O, NULL},
-	 { "InfomapIterator_metaCollection_set", _wrap_InfomapIterator_metaCollection_set, METH_VARARGS, NULL},
-	 { "InfomapIterator_metaCollection_get", _wrap_InfomapIterator_metaCollection_get, METH_O, NULL},
 	 { "InfomapIterator_stateNodes_set", _wrap_InfomapIterator_stateNodes_set, METH_VARARGS, NULL},
 	 { "InfomapIterator_stateNodes_get", _wrap_InfomapIterator_stateNodes_get, METH_O, NULL},
 	 { "InfomapIterator_getMetaData", _wrap_InfomapIterator_getMetaData, METH_VARARGS, NULL},
@@ -59193,8 +59002,6 @@ static PyMethodDef SwigMethods[] = {
 	 { "InfomapParentIterator_dirty_get", _wrap_InfomapParentIterator_dirty_get, METH_O, NULL},
 	 { "InfomapParentIterator_physicalNodes_set", _wrap_InfomapParentIterator_physicalNodes_set, METH_VARARGS, NULL},
 	 { "InfomapParentIterator_physicalNodes_get", _wrap_InfomapParentIterator_physicalNodes_get, METH_O, NULL},
-	 { "InfomapParentIterator_metaCollection_set", _wrap_InfomapParentIterator_metaCollection_set, METH_VARARGS, NULL},
-	 { "InfomapParentIterator_metaCollection_get", _wrap_InfomapParentIterator_metaCollection_get, METH_O, NULL},
 	 { "InfomapParentIterator_stateNodes_set", _wrap_InfomapParentIterator_stateNodes_set, METH_VARARGS, NULL},
 	 { "InfomapParentIterator_stateNodes_get", _wrap_InfomapParentIterator_stateNodes_get, METH_O, NULL},
 	 { "InfomapParentIterator_getMetaData", _wrap_InfomapParentIterator_getMetaData, METH_VARARGS, NULL},
@@ -59706,7 +59513,6 @@ static swig_type_info _swigt__p_IterWrapperT_TreeIteratorT_infomap__InfoNode_p_t
 static swig_type_info _swigt__p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t = {"_p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t", "infomap::InfoNode::edge_iterator_wrapper *|IterWrapper< std::vector< infomap::InfoEdge *,std::allocator< infomap::InfoEdge * > >::iterator > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_LeafModuleIteratorT_infomap__InfoNode_p_t = {"_p_LeafModuleIteratorT_infomap__InfoNode_p_t", "infomap::InfoNode::leaf_module_iterator *|LeafModuleIterator< infomap::InfoNode * > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_LeafNodeIteratorT_infomap__InfoNode_p_t = {"_p_LeafNodeIteratorT_infomap__InfoNode_p_t", "infomap::InfoNode::leaf_node_iterator *|LeafNodeIterator< infomap::InfoNode * > *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_MetaCollection = {"_p_MetaCollection", "MetaCollection *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_NodeLinkMap = {"_p_NodeLinkMap", "NodeLinkMap *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_NodeMap = {"_p_NodeMap", "NodeMap *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_OutLinkMap = {"_p_OutLinkMap", "OutLinkMap *", 0, 0, (void*)0, 0};
@@ -59823,7 +59629,6 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t,
   &_swigt__p_LeafModuleIteratorT_infomap__InfoNode_p_t,
   &_swigt__p_LeafNodeIteratorT_infomap__InfoNode_p_t,
-  &_swigt__p_MetaCollection,
   &_swigt__p_NodeLinkMap,
   &_swigt__p_NodeMap,
   &_swigt__p_OutLinkMap,
@@ -59940,7 +59745,6 @@ static swig_cast_info _swigc__p_IterWrapperT_TreeIteratorT_infomap__InfoNode_p_t
 static swig_cast_info _swigc__p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t[] = {  {&_swigt__p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_LeafModuleIteratorT_infomap__InfoNode_p_t[] = {  {&_swigt__p_LeafModuleIteratorT_infomap__InfoNode_p_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_LeafNodeIteratorT_infomap__InfoNode_p_t[] = {  {&_swigt__p_LeafNodeIteratorT_infomap__InfoNode_p_t, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_MetaCollection[] = {  {&_swigt__p_MetaCollection, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_NodeLinkMap[] = {  {&_swigt__p_NodeLinkMap, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_NodeMap[] = {  {&_swigt__p_NodeMap, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_OutLinkMap[] = {  {&_swigt__p_OutLinkMap, 0, 0, 0},{0, 0, 0, 0}};
@@ -60057,7 +59861,6 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_IterWrapperT_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator_t,
   _swigc__p_LeafModuleIteratorT_infomap__InfoNode_p_t,
   _swigc__p_LeafNodeIteratorT_infomap__InfoNode_p_t,
-  _swigc__p_MetaCollection,
   _swigc__p_NodeLinkMap,
   _swigc__p_NodeMap,
   _swigc__p_OutLinkMap,

--- a/interfaces/python/src/infomap/_swig.py
+++ b/interfaces/python/src/infomap/_swig.py
@@ -263,9 +263,9 @@ class DeltaFlow(object):
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
     __repr__ = _swig_repr
     module = property(_infomap.DeltaFlow_module_get, _infomap.DeltaFlow_module_set)
+    count = property(_infomap.DeltaFlow_count_get, _infomap.DeltaFlow_count_set)
     deltaExit = property(_infomap.DeltaFlow_deltaExit_get, _infomap.DeltaFlow_deltaExit_set)
     deltaEnter = property(_infomap.DeltaFlow_deltaEnter_get, _infomap.DeltaFlow_deltaEnter_set)
-    count = property(_infomap.DeltaFlow_count_get, _infomap.DeltaFlow_count_set)
 
     def __init__(self, *args):
         _infomap.DeltaFlow_swiginit(self, _infomap.new_DeltaFlow(*args))
@@ -526,7 +526,6 @@ class InfoNode(object):
     codelength = property(_infomap.InfoNode_codelength_get, _infomap.InfoNode_codelength_set)
     dirty = property(_infomap.InfoNode_dirty_get, _infomap.InfoNode_dirty_set)
     physicalNodes = property(_infomap.InfoNode_physicalNodes_get, _infomap.InfoNode_physicalNodes_set)
-    metaCollection = property(_infomap.InfoNode_metaCollection_get, _infomap.InfoNode_metaCollection_set)
     stateNodes = property(_infomap.InfoNode_stateNodes_get, _infomap.InfoNode_stateNodes_set)
 
     def __init__(self, *args):
@@ -1082,7 +1081,6 @@ class InfomapIterator(object):
     codelength = property(_infomap.InfomapIterator_codelength_get, _infomap.InfomapIterator_codelength_set)
     dirty = property(_infomap.InfomapIterator_dirty_get, _infomap.InfomapIterator_dirty_set)
     physicalNodes = property(_infomap.InfomapIterator_physicalNodes_get, _infomap.InfomapIterator_physicalNodes_set)
-    metaCollection = property(_infomap.InfomapIterator_metaCollection_get, _infomap.InfomapIterator_metaCollection_set)
     stateNodes = property(_infomap.InfomapIterator_stateNodes_get, _infomap.InfomapIterator_stateNodes_set)
 
     def getMetaData(self, dimension=0):
@@ -1761,7 +1759,6 @@ class InfomapParentIterator(object):
     codelength = property(_infomap.InfomapParentIterator_codelength_get, _infomap.InfomapParentIterator_codelength_set)
     dirty = property(_infomap.InfomapParentIterator_dirty_get, _infomap.InfomapParentIterator_dirty_set)
     physicalNodes = property(_infomap.InfomapParentIterator_physicalNodes_get, _infomap.InfomapParentIterator_physicalNodes_set)
-    metaCollection = property(_infomap.InfomapParentIterator_metaCollection_get, _infomap.InfomapParentIterator_metaCollection_set)
     stateNodes = property(_infomap.InfomapParentIterator_stateNodes_get, _infomap.InfomapParentIterator_stateNodes_set)
 
     def getMetaData(self, dimension=0):

--- a/src/core/FlowData.h
+++ b/src/core/FlowData.h
@@ -60,10 +60,11 @@ struct FlowData {
 };
 
 struct DeltaFlow {
+  // module and count grouped so the two 4-byte fields pack into one 8-byte slot
   unsigned int module = 0;
+  unsigned int count = 0;
   double deltaExit = 0.0;
   double deltaEnter = 0.0;
-  unsigned int count = 0;
 
   explicit DeltaFlow(unsigned int module, double deltaExit, double deltaEnter)
       : module(module),
@@ -75,7 +76,7 @@ struct DeltaFlow {
   DeltaFlow(DeltaFlow&&) = default;
   DeltaFlow& operator=(const DeltaFlow&) = default;
   DeltaFlow& operator=(DeltaFlow&&) = default;
-  virtual ~DeltaFlow() = default;
+  ~DeltaFlow() = default;
 
   DeltaFlow& operator+=(const DeltaFlow& other)
   {
@@ -86,7 +87,7 @@ struct DeltaFlow {
     return *this;
   }
 
-  virtual void reset()
+  void reset()
   {
     module = 0;
     deltaExit = 0.0;
@@ -127,7 +128,7 @@ struct MemDeltaFlow : DeltaFlow {
     return *this;
   }
 
-  void reset() override
+  void reset()
   {
     DeltaFlow::reset();
     sumDeltaPlogpPhysFlow = 0.0;

--- a/src/core/InfoNode.h
+++ b/src/core/InfoNode.h
@@ -92,8 +92,8 @@ public:
   std::vector<PhysData> physicalNodes;
 #ifndef SWIG
   std::vector<LayerTeleFlowData> layerTeleFlowData; // For regularized multilayer flow
+  std::unique_ptr<MetaCollection> metaCollection; // For modules; lazily allocated, only set when meta data is used
 #endif
-  MetaCollection metaCollection; // For modules
   std::vector<unsigned int> stateNodes; // For physically aggregated nodes
 
 private:
@@ -140,7 +140,7 @@ public:
         dirty(other.dirty),
         physicalNodes(other.physicalNodes),
         layerTeleFlowData(other.layerTeleFlowData),
-        metaCollection(other.metaCollection),
+        metaCollection(other.metaCollection ? std::make_unique<MetaCollection>(*other.metaCollection) : nullptr),
         m_childDegree(other.m_childDegree),
         m_childrenChanged(other.m_childrenChanged),
         m_numLeafMembers(other.m_numLeafMembers) {}
@@ -149,6 +149,8 @@ public:
 
   InfoNode& operator=(const InfoNode& other)
   {
+    if (this == &other)
+      return *this;
     data = other.data;
     index = other.index;
     stateId = other.stateId;
@@ -164,7 +166,7 @@ public:
     collapsedLastChild = other.collapsedLastChild;
     codelength = other.codelength;
     dirty = other.dirty;
-    metaCollection = other.metaCollection;
+    metaCollection = other.metaCollection ? std::make_unique<MetaCollection>(*other.metaCollection) : nullptr;
     m_childDegree = other.m_childDegree;
     m_childrenChanged = other.m_childrenChanged;
     m_numLeafMembers = other.m_numLeafMembers;
@@ -181,6 +183,21 @@ public:
     auto meta = metaData[dimension];
     return meta < 0 ? 0 : static_cast<unsigned int>(meta);
   }
+
+#ifndef SWIG
+  // ---------------------------- Meta collection ----------------------------
+  // The collection is only allocated for nodes that carry meta data, so a node
+  // in a run without meta data costs just the null pointer. Kept out of the
+  // SWIG bindings since it is an internal aggregation structure.
+  bool hasMetaCollection() const noexcept { return metaCollection != nullptr; }
+
+  MetaCollection& ensureMetaCollection()
+  {
+    if (!metaCollection)
+      metaCollection = std::make_unique<MetaCollection>();
+    return *metaCollection;
+  }
+#endif
 
   // ---------------------------- Infomap ----------------------------
   InfomapBase& getInfomap();

--- a/src/core/MetaMapEquation.cpp
+++ b/src/core/MetaMapEquation.cpp
@@ -12,6 +12,7 @@
 #include "InfoNode.h"
 #include "../utils/Log.h"
 
+#include <memory>
 #include <vector>
 #include <utility>
 
@@ -75,7 +76,7 @@ void MetaMapEquation::initPartition(std::vector<InfoNode*>& nodes)
 
 void MetaMapEquation::initMetaNodes(InfoNode& root)
 {
-  bool notInitiated = root.firstChild->metaCollection.empty();
+  bool notInitiated = !root.firstChild->hasMetaCollection() || root.firstChild->metaCollection->empty();
   if (notInitiated) {
     Log(3) << "MetaMapEquation::initMetaNodes()...\n";
 
@@ -88,12 +89,12 @@ void MetaMapEquation::initMetaNodes(InfoNode& root)
         if (!node.metaData.empty()) {
           // TODO: Use flow here and move weightByFlow choice to metaCollection, using flowCount?
           double flow = weightByFlow ? node.data.flow : m_unweightedNodeFlow;
-          node.parent->metaCollection.add(node.metaData[0], flow);
+          node.parent->ensureMetaCollection().add(node.metaData[0], flow);
         } else {
           throw std::length_error("A node is missing meta data using MetaMapEquation");
         }
-      } else {
-        node.parent->metaCollection.add(node.metaCollection);
+      } else if (node.hasMetaCollection()) {
+        node.parent->ensureMetaCollection().add(*node.metaCollection);
       }
     }
   }
@@ -107,14 +108,14 @@ void MetaMapEquation::initPartitionOfMetaNodes(std::vector<InfoNode*>& nodes)
   for (auto& n : nodes) {
     InfoNode& node = *n;
     unsigned int moduleIndex = node.index; // Assume unique module index for all nodes in this initiation phase
-    if (node.metaCollection.empty()) {
+    if (!node.hasMetaCollection() || node.metaCollection->empty()) {
       if (!node.metaData.empty()) {
         double flow = weightByFlow ? node.data.flow : m_unweightedNodeFlow;
-        node.metaCollection.add(node.metaData[0], flow);
+        node.ensureMetaCollection().add(node.metaData[0], flow);
       } else
         throw std::length_error("A node is missing meta data using MetaMapEquation");
     }
-    m_moduleToMetaCollection[moduleIndex] = node.metaCollection;
+    m_moduleToMetaCollection[moduleIndex] = *node.metaCollection;
   }
 }
 
@@ -133,7 +134,8 @@ void MetaMapEquation::calculateCodelength(std::vector<InfoNode*>& nodes)
   // Treat each node as a single module
   for (InfoNode* n : nodes) {
     InfoNode& node = *n;
-    metaCodelength += node.metaCollection.calculateEntropy();
+    if (node.hasMetaCollection())
+      metaCodelength += node.metaCollection->calculateEntropy();
   }
 }
 
@@ -149,8 +151,8 @@ double MetaMapEquation::calcCodelengthOnModuleOfLeafNodes(const InfoNode& parent
   // Meta addition
   MetaCollection metaCollection;
   for (const InfoNode& node : parent) {
-    if (!node.metaCollection.empty())
-      metaCollection.add(node.metaCollection);
+    if (node.hasMetaCollection() && !node.metaCollection->empty())
+      metaCollection.add(*node.metaCollection);
     else
       metaCollection.add(node.metaData[0], weightByFlow ? node.data.flow : m_unweightedNodeFlow); // TODO: Initiate to collection and use all dimensions
   }
@@ -187,21 +189,22 @@ INFOMAP_HOT double MetaMapEquation::getDeltaCodelengthOnMovingNode(InfoNode& cur
 double MetaMapEquation::getCurrentModuleMetaCodelength(unsigned int module, InfoNode& current, int addRemoveOrNothing)
 {
   auto& currentMetaCollection = m_moduleToMetaCollection[module];
+  const MetaCollection* nodeMeta = current.metaCollection.get();
 
   double moduleMetaCodelength = 0.0;
 
-  if (addRemoveOrNothing == 0) {
+  if (addRemoveOrNothing == 0 || nodeMeta == nullptr) {
     moduleMetaCodelength = currentMetaCollection.calculateEntropy();
   }
   // If add or remove, do the change, calculate new codelength and then undo the change
   else if (addRemoveOrNothing == 1) {
-    currentMetaCollection.add(current.metaCollection);
+    currentMetaCollection.add(*nodeMeta);
     moduleMetaCodelength = currentMetaCollection.calculateEntropy();
-    currentMetaCollection.remove(current.metaCollection);
+    currentMetaCollection.remove(*nodeMeta);
   } else {
-    currentMetaCollection.remove(current.metaCollection);
+    currentMetaCollection.remove(*nodeMeta);
     moduleMetaCodelength = currentMetaCollection.calculateEntropy();
-    currentMetaCollection.add(current.metaCollection);
+    currentMetaCollection.add(*nodeMeta);
   }
 
   return moduleMetaCodelength;
@@ -240,13 +243,15 @@ void MetaMapEquation::updateCodelengthOnMovingNode(InfoNode& current,
 
 void MetaMapEquation::updateMetaData(InfoNode& current, unsigned int oldModuleIndex, unsigned int bestModuleIndex)
 {
+  const MetaCollection* nodeMeta = current.metaCollection.get();
+  if (nodeMeta == nullptr)
+    return;
+
   // Remove meta id from old module (can be a set of meta ids when moving submodules in coarse tune)
-  auto& oldMetaCollection = m_moduleToMetaCollection[oldModuleIndex];
-  oldMetaCollection.remove(current.metaCollection);
+  m_moduleToMetaCollection[oldModuleIndex].remove(*nodeMeta);
 
   // Add meta id to new module
-  auto& newMetaCollection = m_moduleToMetaCollection[bestModuleIndex];
-  newMetaCollection.add(current.metaCollection);
+  m_moduleToMetaCollection[bestModuleIndex].add(*nodeMeta);
 }
 
 void MetaMapEquation::consolidateModules(std::vector<InfoNode*>& modules)
@@ -254,7 +259,7 @@ void MetaMapEquation::consolidateModules(std::vector<InfoNode*>& modules)
   for (auto& module : modules) {
     if (module == nullptr)
       continue;
-    module->metaCollection = m_moduleToMetaCollection[module->index];
+    module->metaCollection = std::make_unique<MetaCollection>(m_moduleToMetaCollection[module->index]);
   }
 }
 

--- a/src/core/iterators/InfomapIterator.h
+++ b/src/core/iterators/InfomapIterator.h
@@ -10,7 +10,7 @@
 #ifndef INFOMAP_ITERATOR_H_
 #define INFOMAP_ITERATOR_H_
 
-#include <deque>
+#include <vector>
 #include <map>
 #include <cmath>
 
@@ -29,7 +29,7 @@ protected:
   InfoNode* m_current = nullptr;
   int m_moduleIndexLevel = -1; // TODO: Not used.
   unsigned int m_moduleIndex = 0;
-  std::deque<unsigned int> m_path; // The tree path to current node (indexing starting from one!)
+  std::vector<unsigned int> m_path; // The tree path to current node (indexing starting from one!)
   unsigned int m_depth = 0;
 
 public:
@@ -75,7 +75,7 @@ public:
     return *this;
   }
 
-  const std::deque<unsigned int>& path() const noexcept { return m_path; }
+  const std::vector<unsigned int>& path() const noexcept { return m_path; }
 
   unsigned int moduleIndex() const noexcept { return m_moduleIndex; }
 

--- a/src/core/iterators/infomapIterators.h
+++ b/src/core/iterators/infomapIterators.h
@@ -11,7 +11,7 @@
 #define INFOMAP_ITERATORS_H_
 
 #include "treeIterators.h"
-#include <deque>
+#include <vector>
 #include <limits>
 
 namespace infomap {
@@ -233,7 +233,7 @@ class InfomapDepthFirstIterator : public DepthFirstIteratorBase<NodePointerType>
 protected:
   using Base = DepthFirstIteratorBase<NodePointerType>;
 
-  std::deque<unsigned int> m_path; // The child index path to current node
+  std::vector<unsigned int> m_path; // The child index path to current node
   unsigned int m_moduleIndex = 0;
   int m_moduleIndexLevel = -1;
 
@@ -353,7 +353,7 @@ public:
     return *this;
   }
 
-  const std::deque<unsigned int>& path() const
+  const std::vector<unsigned int>& path() const
   {
     return m_path;
   }

--- a/src/core/iterators/treeIterators.h
+++ b/src/core/iterators/treeIterators.h
@@ -12,7 +12,7 @@
 
 #include <cstddef>
 #include <iterator>
-#include <deque>
+#include <vector>
 
 namespace infomap {
 
@@ -115,7 +115,7 @@ protected:
   NodePointerType m_current = nullptr;
   int m_moduleIndexLevel = -1;
   unsigned int m_moduleIndex = 0;
-  std::deque<unsigned int> m_path; // The child index path to current node
+  std::vector<unsigned int> m_path; // The child index path to current node
   unsigned int m_depth = 0;
 
 public:
@@ -157,7 +157,7 @@ public:
 
   bool operator!=(const TreeIterator& rhs) const { return !(m_current == rhs.m_current); }
 
-  const std::deque<unsigned int>& path() const { return m_path; }
+  const std::vector<unsigned int>& path() const { return m_path; }
 
   unsigned int moduleIndex() const { return m_moduleIndex; }
 

--- a/src/io/ClusterMap.h
+++ b/src/io/ClusterMap.h
@@ -14,11 +14,10 @@
 #include <string>
 #include <map>
 #include <vector>
-#include <deque>
 
 namespace infomap {
 
-using Path = std::deque<unsigned int>; // 1-based indexing
+using Path = std::vector<unsigned int>; // 1-based indexing
 
 using NodePath = std::pair<unsigned int, Path>;
 

--- a/src/io/OutputView.cpp
+++ b/src/io/OutputView.cpp
@@ -192,7 +192,7 @@ bool OutputView::shouldIncludeLeaf(const InfoNode& node, OutputLeafPolicy filter
 }
 
 OutputLeafRow OutputView::leafRow(const InfoNode& node,
-                                  const std::deque<unsigned int>& path,
+                                  const std::vector<unsigned int>& path,
                                   unsigned int moduleId,
                                   double modularCentrality) const
 {

--- a/src/io/OutputView.h
+++ b/src/io/OutputView.h
@@ -11,7 +11,7 @@
 #define OUTPUT_VIEW_H_
 
 #include <cstdint>
-#include <deque>
+#include <vector>
 #include <functional>
 #include <map>
 #include <string>
@@ -30,7 +30,7 @@ enum class OutputLeafPolicy : std::uint8_t {
 
 struct OutputLeafRow {
   const InfoNode& node;
-  std::deque<unsigned int> path;
+  std::vector<unsigned int> path;
   unsigned int moduleId = 0;
   double modularCentrality = 0.0;
   unsigned int stateId = 0;
@@ -96,7 +96,7 @@ public:
 private:
   bool shouldIncludeLeaf(const InfoNode& node, OutputLeafPolicy filter) const;
   OutputLeafRow leafRow(const InfoNode& node,
-                        const std::deque<unsigned int>& path,
+                        const std::vector<unsigned int>& path,
                         unsigned int moduleId,
                         double modularCentrality) const;
   OutputTreeRow treeRow(const InfoNode& node, unsigned int depth) const;


### PR DESCRIPTION
## Summary

Memory and hot-path cleanups, in increasing order of impact. The headline is a **~40% peak-RSS reduction on multi-trial runs** from replacing a `std::deque` with a `std::vector` for tree paths; the rest shrink the most heavily-allocated value types.

### 1. Tree paths: `std::deque` → `std::vector` (the big one)
The tree iterators stored the node path in a `std::deque<unsigned int>`, and `RunSession::updateBestResult` copies that path into `bestTree` **once per leaf node** when `-N > 1`. libc++'s deque allocates a fixed **4096-byte block** on first `push_back`, so every short path (2–3 levels) costs a full 4 KB → a 100k-node run holds 100k deques ≈ **400 MB**, dwarfing everything else. The path is only ever grown at the back, so `std::vector` is a drop-in.

This is a long-standing latent cost (the deque-path design predates the 2022 file reorganizations; later refactors only moved it). It only bites with `-N > 1` **and** large networks, is peak-RSS only (no correctness/test impact), and is ~8× worse on libc++ (4 KB blocks) than libstdc++ (512 B) — so it stayed invisible in CI.

### 2–3. Value-type shrink
| Type | Before | After | Saving |
|---|---|---|---|
| `InfoNode` (per node) | 360 B | **328 B** | −32 B |
| `DeltaFlow` (hot path) | 40 B | **24 B** | −16 B |
| `MemDeltaFlow` | 56 B | **40 B** | −16 B |

- `InfoNode::metaCollection` embedded a `MetaCollection` (40 B) in every node even when meta data is unused → now a lazily-allocated `unique_ptr`, only allocated for nodes that carry meta data. Memory-safe (lifetime tied to the node), kept behind `#ifndef SWIG`.
- `DeltaFlow`/`MemDeltaFlow` had a virtual dtor + `reset()` but are never used polymorphically (`MapEquation` is templated per delta type) → vtable removed, `module`+`count` packed.

### Commits
1. `perf(core): allocate InfoNode meta collection lazily`
2. `perf(core): drop the vtable from DeltaFlow/MemDeltaFlow`
3. `chore(bindings): regenerate Python and R SWIG outputs`
4. `perf(core): use std::vector instead of std::deque for tree paths`
5. `chore(bindings): regenerate after tree-path type change`

## ⚠️ Binding API note
Commit 1 removes the previously-exposed `node.metaCollection` get/set **property** from the Python/R bindings (an internal aggregation structure). Commit 4 changes `it.path()` to return `std::vector<unsigned int>` instead of `std::deque<unsigned int>`.

## Benchmarks (empirical, 100k-node networks, `-N 2`, single-thread)

`before` = master, `PR` = struct cleanups only, `dequefix` = full branch.

| Network | codelength | RSS before | RSS PR | RSS dequefix | Δ vs master |
|---|---|---|---|---|---|
| **A — plain** | `14.46302464` ✓ | 641 MB | 623 MB | **342 MB** | **−47%** |
| **B — meta data** | `15.73227279` ✓ | 665 MB | 646 MB | **390 MB** | **−41%** |
| **C — multilayer** | `11.6237715` ✓ | 663 MB | 632 MB | **385 MB** | **−42%** |

- **Codelength is bit-identical** across all binaries and code paths (first-order, meta data, multilayer/state).
- The deque→vector change dominates: ~250–300 MB removed. The struct changes contribute the remaining ~1–3% (and a reproducible **−15% wall time** on the first-order path from the `DeltaFlow` de-virtualization, measured separately at `-N 1`).
- Single-trial (`-N 1`) runs are unaffected by the deque change (`bestTree` is only built when `-N > 1`) — no regression.

## Verification
- Native: **14/14** tests pass (incl. memory/state and metadata golden-codelength).
- Python: **167 passed, 28 skipped** against the rebuilt extension.
- R: `R CMD check` **0 errors** (1 warning + 1 note are pre-existing URL-redirect / new-submission notes in `DESCRIPTION`/`.Rd`).
- SWIG freshness (Python + R): fresh. Build clean under `-Wall -Wextra -pedantic -Wnon-virtual-dtor`.
