### PR TITLE
refactor: replace hand-rolled loops with std algorithms

### DIFF
--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -26,6 +26,7 @@
 #include "../utils/MemoryUsage.h"
 #include "../utils/PrettyOutput.h"
 #include "../utils/TimingRegistry.h"
+#include "../utils/convert.h"
 
 #include <stdexcept>
 #include <string>
@@ -55,13 +56,7 @@ namespace {
     if (compression.empty())
       return "0%";
 
-    std::string summary;
-    for (unsigned int i = 0; i < compression.size(); ++i) {
-      if (i > 0)
-        summary += ", ";
-      summary += compression[i];
-    }
-    return summary;
+    return io::stringify(compression, ", ");
   }
 
   void printPrettyStart(const Config& config, const Date& startDate, unsigned int numInitialModuleIds)

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -915,13 +915,8 @@ NodePaths InfomapBase::normalizeTreePaths(const TreePaths& tree, unsigned int& n
   normalized.reserve(tree.size());
 
   // Fast path: every row is a state-level leaf — pass through.
-  bool allState = true;
-  for (const auto& tp : tree) {
-    if (tp.idType != TreeLeafIdType::state) {
-      allState = false;
-      break;
-    }
-  }
+  bool allState = std::all_of(tree.begin(), tree.end(),
+      [](const auto& tp) { return tp.idType == TreeLeafIdType::state; });
   if (allState) {
     for (const auto& tp : tree)
       normalized.emplace_back(tp.nodeId, tp.path);
@@ -1164,12 +1159,8 @@ InfomapBase& InfomapBase::initPartition(const std::map<unsigned int, unsigned in
     ++moduleIndex;
   }
 
-  unsigned int numNodesWithoutClusterInfo = 0;
-  for (auto& count : selectedNodes) {
-    if (count == 0) {
-      ++numNodesWithoutClusterInfo;
-    }
-  }
+  unsigned int numNodesWithoutClusterInfo = static_cast<unsigned int>(
+      std::count_if(selectedNodes.begin(), selectedNodes.end(), [](unsigned int count) { return count == 0; }));
 
   if (numNodesWithoutClusterInfo == 0) {
     return initPartition(modules, hard);

--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -15,6 +15,8 @@
 #include "../utils/FileURI.h"
 #include "../utils/Log.h"
 #include "../utils/convert.h"
+#include <algorithm>
+#include <iterator>
 #include <vector>
 #include <stdexcept>
 #include <utility>
@@ -225,10 +227,11 @@ namespace {
 const std::vector<std::string>& flowModelNames()
 {
   static const std::vector<std::string> names = [] {
+    const auto& mappings = flowModelMappings();
     std::vector<std::string> values;
-    for (const auto& mapping : flowModelMappings()) {
-      values.push_back(mapping.first);
-    }
+    values.reserve(mappings.size());
+    std::transform(mappings.begin(), mappings.end(), std::back_inserter(values),
+        [](const auto& mapping) { return mapping.first; });
     return values;
   }();
   return names;

--- a/src/io/OutputFormats.cpp
+++ b/src/io/OutputFormats.cpp
@@ -10,6 +10,7 @@
 #include "OutputFormats.h"
 
 #include <algorithm>
+#include <iterator>
 #include <stdexcept>
 #include <sstream>
 #include <utility>
@@ -105,10 +106,11 @@ const std::vector<OutputFormat>& outputFormats()
 
 std::vector<std::string> outputFormatNames()
 {
+  const auto& formats = outputFormats();
   std::vector<std::string> names;
-  for (const auto& format : outputFormats()) {
-    names.push_back(format.optionName);
-  }
+  names.reserve(formats.size());
+  std::transform(formats.begin(), formats.end(), std::back_inserter(names),
+      [](const auto& format) { return format.optionName; });
   return names;
 }
 

--- a/src/io/OutputPlan.cpp
+++ b/src/io/OutputPlan.cpp
@@ -95,13 +95,7 @@ namespace {
         summaries.push_back(group.second.front().empty() ? group.first : io::Str() << group.first << "." << group.second.front());
         continue;
       }
-      io::Str suffixes;
-      for (unsigned int i = 0; i < group.second.size(); ++i) {
-        if (i > 0)
-          suffixes << ",";
-        suffixes << group.second[i];
-      }
-      summaries.push_back(io::Str() << group.first << ".{" << std::string(suffixes) << "}");
+      summaries.push_back(io::Str() << group.first << ".{" << io::stringify(group.second, ",") << "}");
     }
     return summaries;
   }

--- a/src/io/ProgramInterface.cpp
+++ b/src/io/ProgramInterface.cpp
@@ -10,6 +10,7 @@
 #include "ProgramInterface.h"
 #include "Features.h"
 #include "../utils/Log.h"
+#include "../utils/convert.h"
 
 #include <map>
 #include <utility>
@@ -165,13 +166,7 @@ namespace {
 
   std::string join(const std::vector<std::string>& values, const std::string& separator)
   {
-    std::ostringstream out;
-    for (unsigned int i = 0; i < values.size(); ++i) {
-      if (i > 0)
-        out << separator;
-      out << values[i];
-    }
-    return out.str();
+    return io::stringify(values, separator);
   }
 
   std::string bashWords(const std::vector<std::string>& values)

--- a/src/utils/Random.h
+++ b/src/utils/Random.h
@@ -11,6 +11,7 @@
 #define RANDOM_H_
 
 #include <cstdint>
+#include <numeric>
 #include <random>
 #include <utility>
 #include <vector>
@@ -70,8 +71,7 @@ public:
   void getRandomizedIndexVector(std::vector<unsigned int>& randomOrder)
   {
     unsigned int size = randomOrder.size();
-    for (unsigned int i = 0; i < size; ++i)
-      randomOrder[i] = i;
+    std::iota(randomOrder.begin(), randomOrder.end(), 0u);
     for (unsigned int i = 0; i < size; ++i)
       std::swap(randomOrder[i], randomOrder[i + randInt(0, size - i - 1)]);
   }


### PR DESCRIPTION
Replaces hand-rolled loops in `src/` with standard-library equivalents where the mapping is clean and unambiguous. Two themed commits.

## Commit 1 — std algorithms
All C++14 (no `std::ranges`), no behavior change:
- `Random::getRandomizedIndexVector`: index-init loop → `std::iota` (the Fisher–Yates shuffle below it is intentionally left as-is — it uses the project's deterministic `randInt`, not `std::shuffle`)
- `outputFormatNames` / `flowModelNames`: projection loops → `std::transform`
- `normalizeTreePaths` fast-path check → `std::all_of`
- `initPartition` zero-count → `std::count_if` (result cast back to `unsigned int` to preserve the type used in downstream arithmetic)

## Commit 2 — reuse `io::stringify` for delimiter joins
Four near-identical "append with separator" loops duplicated logic already provided by `io::stringify(container, delimiter)` in `utils/convert.h`:
- `InfomapBase::compressionSummary`
- `ProgramInterface::join`
- `OutputPlan` suffix join

`PrettyOutput`'s header/row rendering looks similar but wraps each field in `std::setw`, so it is not a plain join and was left untouched.

## Verification
- Compiles cleanly with the project toolchain (Homebrew clang, C++14)
- `make test-native` → **14/14 ctest suites pass** (config, output, partition, program-interface, flow, parser, CLI, …)

## Notes
- Background: these were surfaced by auditing for `<algorithm>` candidates. CLion/Nova's "An algorithm operating on ranges can be used" inspection returned 0 hits (it's conservative), so the candidates were found by a manual sweep and each verified by hand.
- A couple of lower-value optional candidates (an extra `transform`, a scalar `accumulate`) were deliberately skipped to keep the diff small and high-value.