### PR TITLE
feat: regularized memory (feature flagged)

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -124,8 +124,8 @@ Configure a feature-enabled Python wheel or editable local install through the
 same `FEATURES` variable:
 
 ```bash
-FEATURES=regularized-multilayer make build-python
-FEATURES=regularized-multilayer make dev-python-install
+FEATURES=regularized-higher-order make build-python
+FEATURES=regularized-higher-order make dev-python-install
 ```
 
 Feature names are defined in `scripts/build_config.py`. The existing SIMD log

--- a/scripts/build_config.py
+++ b/scripts/build_config.py
@@ -16,9 +16,9 @@ FEATURE_REGISTRY = {
         "requires": [],
         "conflicts": [],
     },
-    "regularized-multilayer": {
-        "define": "INFOMAP_FEATURE_REGULARIZED_MULTILAYER",
-        "description": "Enable experimental regularized flow for multilayer networks.",
+    "regularized-higher-order": {
+        "define": "INFOMAP_FEATURE_REGULARIZED_HIGHER_ORDER",
+        "description": "Enable experimental regularized flow for higher-order memory and multilayer networks.",
         "requires": [],
         "conflicts": [],
     },
@@ -181,9 +181,7 @@ def _normalize_features(features):
             continue
         if feature not in FEATURE_REGISTRY:
             known = ", ".join(sorted(FEATURE_REGISTRY))
-            raise ValueError(
-                f"Unknown feature '{feature}'. Known features: {known}."
-            )
+            raise ValueError(f"Unknown feature '{feature}'. Known features: {known}.")
         requested.add(feature)
     return [feature for feature in FEATURE_REGISTRY if feature in requested]
 
@@ -196,9 +194,7 @@ def _validate_features(features):
             dependency for dependency in spec["requires"] if dependency not in enabled
         ]
         if missing:
-            raise ValueError(
-                f"Feature '{feature}' requires: {', '.join(missing)}."
-            )
+            raise ValueError(f"Feature '{feature}' requires: {', '.join(missing)}.")
         conflicts = [conflict for conflict in spec["conflicts"] if conflict in enabled]
         if conflicts:
             raise ValueError(

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -14,7 +14,7 @@
 #include "BiasedMapEquation.h"
 #include "MemMapEquation.h"
 #include "MetaMapEquation.h"
-#if INFOMAP_FEATURE_REGULARIZED_MULTILAYER
+#if INFOMAP_FEATURE_REGULARIZED_HIGHER_ORDER
 #include "RegularizedMultilayerMapEquation.h"
 #endif
 #include "InfomapOptimizer.h"
@@ -916,8 +916,7 @@ NodePaths InfomapBase::normalizeTreePaths(const TreePaths& tree, unsigned int& n
   normalized.reserve(tree.size());
 
   // Fast path: every row is a state-level leaf — pass through.
-  bool allState = std::all_of(tree.begin(), tree.end(),
-      [](const auto& tp) { return tp.idType == TreeLeafIdType::state; });
+  bool allState = std::all_of(tree.begin(), tree.end(), [](const auto& tp) { return tp.idType == TreeLeafIdType::state; });
   if (allState) {
     for (const auto& tp : tree)
       normalized.emplace_back(tp.nodeId, tp.path);
@@ -1339,7 +1338,7 @@ void InfomapBase::generateSubNetwork(Network& network)
     Log() << "  -> Rescale link flow with global Markov time " << markovTime << "\n";
   }
 
-  for (auto& linkIt : network.nodeLinkMap()) {
+  for (auto& linkIt : network.effectiveLinkMap()) {
     unsigned int linkSourceId = linkIt.first.id;
     unsigned int sourceIndex = nodeIndexMap[linkSourceId];
     const auto& subLinks = linkIt.second;
@@ -2739,7 +2738,7 @@ void InfomapBase::initOptimizer(bool forceNoMemory)
   if (haveMetaData()) {
     m_optimizer = std::make_unique<InfomapOptimizer<MetaMapEquation>>();
   } else if (haveMemory() && !forceNoMemory) {
-#if INFOMAP_FEATURE_REGULARIZED_MULTILAYER
+#if INFOMAP_FEATURE_REGULARIZED_HIGHER_ORDER
     if (isRegularizedMultilayerFlow()) {
       m_optimizer = std::make_unique<InfomapOptimizer<RegularizedMultilayerMapEquation>>();
     } else {

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -177,7 +177,7 @@ inline bool InfomapOptimizer<MemMapEquation>::shouldUseInnerParallelization() co
   return false;
 }
 
-#if INFOMAP_FEATURE_REGULARIZED_MULTILAYER
+#if INFOMAP_FEATURE_REGULARIZED_HIGHER_ORDER
 template <>
 inline bool InfomapOptimizer<RegularizedMultilayerMapEquation>::shouldUseInnerParallelization() const
 {

--- a/src/core/StateNetwork.cpp
+++ b/src/core/StateNetwork.cpp
@@ -228,12 +228,14 @@ bool StateNetwork::undirectedToDirected()
 void StateNetwork::clearLinks()
 {
   m_nodeLinkMap.clear();
+  clearEffectiveLinkMap();
 }
 
 void StateNetwork::clear()
 {
   m_nodes.clear();
   m_nodeLinkMap.clear();
+  clearEffectiveLinkMap();
   m_physNodes.clear();
   m_outWeights.clear();
   m_names.clear();

--- a/src/core/StateNetwork.h
+++ b/src/core/StateNetwork.h
@@ -16,7 +16,6 @@
 #include <utility>
 #include <vector>
 #include <set>
-#include <utility>
 
 namespace infomap {
 
@@ -95,6 +94,8 @@ protected:
   bool m_higherOrderInputMethodCalled = false;
   NodeMap m_nodes; // Nodes indexed by state id (equal physical id for first-order networks)
   NodeLinkMap m_nodeLinkMap;
+  NodeLinkMap m_effectiveLinkMap;
+  bool m_haveEffectiveLinkMap = false;
   unsigned int m_numStateNodesFound = 0;
   double m_sumNodeWeight = 0.0;
   unsigned int m_numLinks = 0;
@@ -175,6 +176,20 @@ public:
   double sumNodeWeight() const { return m_sumNodeWeight; }
   const NodeLinkMap& nodeLinkMap() const { return m_nodeLinkMap; }
   NodeLinkMap& nodeLinkMap() { return m_nodeLinkMap; }
+#ifndef SWIG
+  const NodeLinkMap& effectiveLinkMap() const { return m_haveEffectiveLinkMap ? m_effectiveLinkMap : m_nodeLinkMap; }
+  void setEffectiveLinkMap(NodeLinkMap effectiveLinkMap)
+  {
+    m_effectiveLinkMap = std::move(effectiveLinkMap);
+    m_haveEffectiveLinkMap = true;
+  }
+  void clearEffectiveLinkMap()
+  {
+    m_effectiveLinkMap.clear();
+    m_haveEffectiveLinkMap = false;
+  }
+  bool haveEffectiveLinkMap() const { return m_haveEffectiveLinkMap; }
+#endif
   unsigned int numLinks() const { return m_numLinks; }
   double sumLinkWeight() const { return m_sumLinkWeight; }
   unsigned int numSelfLinks() const { return m_numSelfLinks; }

--- a/src/io/Network.cpp
+++ b/src/io/Network.cpp
@@ -25,10 +25,10 @@ using std::make_pair;
 
 namespace {
 
-#if !INFOMAP_FEATURE_REGULARIZED_MULTILAYER
-  const char* regularizedMultilayerFeatureError()
+#if !INFOMAP_FEATURE_REGULARIZED_HIGHER_ORDER
+  const char* regularizedHigherOrderFeatureError()
   {
-    return "Regularized multilayer flow requires building with FEATURES=regularized-multilayer.";
+    return "Regularized higher-order flow requires building with FEATURES=regularized-higher-order.";
   }
 #endif
 
@@ -203,9 +203,9 @@ void Network::addMultilayerLinks(const std::vector<unsigned int>& sourceLayerIds
 
 void Network::generateStateNetworkFromMultilayer()
 {
-#if !INFOMAP_FEATURE_REGULARIZED_MULTILAYER
+#if !INFOMAP_FEATURE_REGULARIZED_HIGHER_ORDER
   if (m_config.regularized) {
-    throw std::runtime_error(regularizedMultilayerFeatureError());
+    throw std::runtime_error(regularizedHigherOrderFeatureError());
   }
 #endif
 

--- a/src/utils/FlowCalculator.cpp
+++ b/src/utils/FlowCalculator.cpp
@@ -8,6 +8,7 @@
  ******************************************************************************/
 
 #include "FlowCalculator.h"
+#include "RegularizedMemoryFlowBuilder.h"
 #include "../utils/Log.h"
 #include "../utils/PrettyOutput.h"
 #include "../utils/convert.h"
@@ -20,15 +21,16 @@
 #include <functional>
 #include <stdexcept>
 #include <unordered_map>
+#include <utility>
 
 namespace infomap {
 
 namespace {
 
-#if !INFOMAP_FEATURE_REGULARIZED_MULTILAYER
-  const char* regularizedMultilayerFeatureError()
+#if !INFOMAP_FEATURE_REGULARIZED_HIGHER_ORDER
+  const char* regularizedHigherOrderFeatureError()
   {
-    return "Regularized multilayer flow requires building with FEATURES=regularized-multilayer.";
+    return "Regularized higher-order flow requires building with FEATURES=regularized-higher-order.";
   }
 #endif
 
@@ -52,6 +54,7 @@ inline void normalize(std::vector<T>& v) noexcept
 FlowCalculator::FlowCalculator(StateNetwork& network, const Config& config)
     : numNodes(network.numNodes())
 {
+  network.clearEffectiveLinkMap();
   m_prettyOutput = config.prettyOutput;
   Log() << "Calculating global network flow using flow model '" << config.flowModel << "'... " << std::flush;
 
@@ -171,12 +174,19 @@ FlowCalculator::FlowCalculator(StateNetwork& network, const Config& config)
   case FlowModel::undirected:
     if (config.regularized) {
       if (config.isMultilayerNetwork()) {
-#if INFOMAP_FEATURE_REGULARIZED_MULTILAYER
+#if INFOMAP_FEATURE_REGULARIZED_HIGHER_ORDER
         calcUndirectedRegularizedMultilayerFlow(network, config);
 #else
-        throw std::runtime_error(regularizedMultilayerFeatureError());
+        throw std::runtime_error(regularizedHigherOrderFeatureError());
 #endif
       } else {
+        if (network.haveMemoryInput()) {
+#if !INFOMAP_FEATURE_REGULARIZED_HIGHER_ORDER
+          throw std::runtime_error(regularizedHigherOrderFeatureError());
+#else
+          throw std::runtime_error("Regularized undirected memory networks are not supported yet; use directed flow or run without --regularized.");
+#endif
+        }
         calcUndirectedRegularizedFlow(network, config);
       }
     } else {
@@ -184,15 +194,27 @@ FlowCalculator::FlowCalculator(StateNetwork& network, const Config& config)
     }
     break;
   case FlowModel::directed:
+    if (config.regularized && network.haveMemoryInput()) {
+#if !INFOMAP_FEATURE_REGULARIZED_HIGHER_ORDER
+      throw std::runtime_error(regularizedHigherOrderFeatureError());
+#endif
+      if (network.isBipartite()) {
+        throw std::runtime_error("Regularized bipartite memory networks are not supported.");
+      }
+    }
     if (network.isBipartite() && config.bipartiteTeleportation) {
       calcDirectedBipartiteFlow(network, config);
     } else {
       if (config.regularized) {
         if (config.isMultilayerNetwork()) {
-#if INFOMAP_FEATURE_REGULARIZED_MULTILAYER
+#if INFOMAP_FEATURE_REGULARIZED_HIGHER_ORDER
           calcDirectedRegularizedMultilayerFlow(network, config);
 #else
-          throw std::runtime_error(regularizedMultilayerFeatureError());
+          throw std::runtime_error(regularizedHigherOrderFeatureError());
+#endif
+        } else if (network.haveMemoryInput()) {
+#if INFOMAP_FEATURE_REGULARIZED_HIGHER_ORDER
+          calcDirectedRegularizedMemoryFlow(network, config);
 #endif
         } else {
           calcDirectedRegularizedFlow(network, config);
@@ -477,6 +499,40 @@ void FlowCalculator::calcDirectedFlow(const StateNetwork& network, const Config&
   }
 }
 
+void FlowCalculator::calcDirectedRegularizedMemoryFlow(StateNetwork& network, const Config& config)
+{
+  m_flowMethod = "directed regularized memory flow";
+  m_teleportation = "none, Eq. 18/24 memory prior on observed state support";
+  Log() << "\n  -> Using regularized memory flow with Eq. 18/24 priors on observed state support. " << std::flush;
+  if (config.regularizationStrength == 0.0) {
+    Log::important() << "\n  Warning: Regularized memory with zero prior strength has no global teleportation; "
+                     << "stationary flow can depend on initialization if the posterior chain is reducible or periodic.\n";
+  }
+
+  RegularizedMemoryFlowBuilder builder(network, config, nodeIndexMap, flowLinks);
+  auto result = builder.build();
+
+  nodeFlow = std::move(result.nodeFlow);
+  nodeTeleportWeights = std::move(result.nodeTeleportWeights);
+  nodeTeleportFlow = std::move(result.nodeTeleportFlow);
+  enterFlow = std::move(result.enterFlow);
+  exitFlow = std::move(result.exitFlow);
+
+  for (unsigned int i = 0; i < flowLinks.size(); ++i) {
+    flowLinks[i].flow = result.observedLinkFlow[i];
+  }
+  network.setEffectiveLinkMap(std::move(result.effectiveLinkMap));
+
+  recordPageRank(result.iterations, result.error, result.converged);
+  if (!result.converged) {
+    Log::important() << "\n  Warning: Regularized memory stationary flow did not converge after "
+                     << result.iterations << " iterations with error " << result.error << ".\n";
+  } else {
+    Log() << "\n  -> Regularized memory stationary flow done in " << result.iterations
+          << " iterations with error " << result.error << ".\n";
+  }
+}
+
 void FlowCalculator::calcDirectedRegularizedFlow(const StateNetwork& network, const Config& config) noexcept
 {
   m_flowMethod = "directed regularized flow";
@@ -633,7 +689,7 @@ void FlowCalculator::calcDirectedRegularizedFlow(const StateNetwork& network, co
   }
 }
 
-#if INFOMAP_FEATURE_REGULARIZED_MULTILAYER
+#if INFOMAP_FEATURE_REGULARIZED_HIGHER_ORDER
 void FlowCalculator::calcDirectedRegularizedMultilayerFlow(const StateNetwork& network, const Config& config) noexcept
 {
   Log() << "\n  -> Using regularized multilayer flow. " << std::flush;
@@ -918,7 +974,7 @@ void FlowCalculator::calcDirectedRegularizedMultilayerFlow(const StateNetwork& n
     enterFlow[i] += (layerTeleFlow[layerIndices[i]] - nodeTeleportFlow[i]) * nodeTeleportWeights[i];
   }
 }
-#endif // INFOMAP_FEATURE_REGULARIZED_MULTILAYER
+#endif // INFOMAP_FEATURE_REGULARIZED_HIGHER_ORDER
 
 void FlowCalculator::calcUndirectedRegularizedFlow(const StateNetwork& network, const Config& config) noexcept
 {
@@ -1017,14 +1073,14 @@ void FlowCalculator::calcUndirectedRegularizedFlow(const StateNetwork& network, 
   }
 }
 
-#if INFOMAP_FEATURE_REGULARIZED_MULTILAYER
+#if INFOMAP_FEATURE_REGULARIZED_HIGHER_ORDER
 void FlowCalculator::calcUndirectedRegularizedMultilayerFlow(const StateNetwork& network, const Config& config)
 {
   (void)network;
   (void)config;
   throw std::runtime_error("Undirected regularized multilayer flow is not implemented.");
 }
-#endif // INFOMAP_FEATURE_REGULARIZED_MULTILAYER
+#endif // INFOMAP_FEATURE_REGULARIZED_HIGHER_ORDER
 
 void FlowCalculator::calcDirectedBipartiteFlow(const StateNetwork& network, const Config& config) noexcept
 {

--- a/src/utils/FlowCalculator.h
+++ b/src/utils/FlowCalculator.h
@@ -10,6 +10,8 @@
 #ifndef FLOW_CALCULATOR_H_
 #define FLOW_CALCULATOR_H_
 
+#include "FlowLink.h"
+
 #include <unordered_map>
 #include <string>
 #include <vector>
@@ -18,14 +20,6 @@ namespace infomap {
 
 struct Config;
 class StateNetwork;
-
-namespace detail {
-  struct FlowLink {
-    unsigned int source;
-    unsigned int target;
-    double flow;
-  };
-} // namespace detail
 
 /**
  * Calculate flow on network based on different flow models
@@ -39,6 +33,7 @@ private:
   void calcDirectedFlow(const StateNetwork&, const Config&) noexcept;
   void calcUndirectedRegularizedFlow(const StateNetwork&, const Config&) noexcept;
   void calcUndirectedRegularizedMultilayerFlow(const StateNetwork&, const Config&);
+  void calcDirectedRegularizedMemoryFlow(StateNetwork&, const Config&);
   void calcDirectedRegularizedFlow(const StateNetwork&, const Config&) noexcept;
   void calcDirectedRegularizedMultilayerFlow(const StateNetwork&, const Config&) noexcept;
   void calcDirectedBipartiteFlow(const StateNetwork&, const Config&) noexcept;

--- a/src/utils/FlowLink.h
+++ b/src/utils/FlowLink.h
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ Infomap software package for multi-level network clustering
+ Copyright (c) 2013, 2014 Daniel Edler, Anton Holmgren, Martin Rosvall
+
+ This file is part of the Infomap software package.
+ See file LICENSE_GPLv3.txt for full license details.
+ For more information, see <http://www.mapequation.org>
+ ******************************************************************************/
+
+#ifndef FLOW_LINK_H_
+#define FLOW_LINK_H_
+
+namespace infomap {
+namespace detail {
+
+  struct FlowLink {
+    unsigned int source;
+    unsigned int target;
+    double flow;
+  };
+
+} // namespace detail
+} // namespace infomap
+
+#endif // FLOW_LINK_H_

--- a/src/utils/RegularizedMemoryFlowBuilder.cpp
+++ b/src/utils/RegularizedMemoryFlowBuilder.cpp
@@ -14,7 +14,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <limits>
 #include <map>
 #include <numeric>
 #include <set>
@@ -23,7 +22,6 @@
 namespace infomap {
 namespace {
 
-  using Transition = RegularizedMemoryFlowResult::Transition;
   using Key = std::pair<unsigned int, unsigned int>;
 
   constexpr double kConvergenceThreshold = 1.0e-15;

--- a/src/utils/RegularizedMemoryFlowBuilder.cpp
+++ b/src/utils/RegularizedMemoryFlowBuilder.cpp
@@ -1,0 +1,262 @@
+/*******************************************************************************
+ Infomap software package for multi-level network clustering
+ Copyright (c) 2013, 2014 Daniel Edler, Anton Holmgren, Martin Rosvall
+
+ This file is part of the Infomap software package.
+ See file LICENSE_GPLv3.txt for full license details.
+ For more information, see <http://www.mapequation.org>
+ ******************************************************************************/
+
+#include "RegularizedMemoryFlowBuilder.h"
+
+#include "../io/Config.h"
+#include "../utils/convert.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <map>
+#include <numeric>
+#include <set>
+#include <stdexcept>
+
+namespace infomap {
+namespace {
+
+  using Transition = RegularizedMemoryFlowResult::Transition;
+  using Key = std::pair<unsigned int, unsigned int>;
+
+  constexpr double kConvergenceThreshold = 1.0e-15;
+
+  std::string stateStructureError(const std::string& message)
+  {
+    return io::Str() << "Regularized memory networks require valid single-step second-order state structure: " << message;
+  }
+
+  void normalize(std::vector<double>& values)
+  {
+    double sum = std::accumulate(values.begin(), values.end(), 0.0);
+    if (sum == 0.0) {
+      throw std::runtime_error("Regularized memory stationary flow has zero total flow.");
+    }
+    for (auto& value : values) {
+      value /= sum;
+    }
+  }
+
+} // namespace
+
+RegularizedMemoryFlowBuilder::RegularizedMemoryFlowBuilder(const StateNetwork& network,
+                                                           const Config& config,
+                                                           const std::unordered_map<unsigned int, unsigned int>& nodeIndexMap,
+                                                           const std::vector<detail::FlowLink>& observedLinks)
+    : m_network(network),
+      m_config(config),
+      m_nodeIndexMap(nodeIndexMap),
+      m_observedLinks(observedLinks)
+{
+}
+
+RegularizedMemoryFlowResult RegularizedMemoryFlowBuilder::build() const
+{
+  RegularizedMemoryFlowResult result;
+
+  const unsigned int numStates = m_network.numNodes();
+  const unsigned int numPhysicalNodes = m_network.numPhysicalNodes();
+  if (numStates == 0 || numPhysicalNodes == 0) {
+    throw std::runtime_error("Regularized memory flow requires a non-empty state network.");
+  }
+
+  std::vector<unsigned int> stateIds(numStates, 0);
+  std::vector<unsigned int> physicalIds(numStates, 0);
+  std::map<unsigned int, unsigned int> physicalIdToIndex;
+
+  for (const auto& nodeIt : m_network.nodes()) {
+    const auto index = m_nodeIndexMap.at(nodeIt.second.id);
+    stateIds[index] = nodeIt.second.id;
+    physicalIds[index] = nodeIt.second.physicalId;
+    physicalIdToIndex.emplace(nodeIt.second.physicalId, physicalIdToIndex.size());
+  }
+
+  std::vector<unsigned int> context(numStates, 0);
+  std::vector<bool> hasContext(numStates, false);
+  for (const auto& link : m_observedLinks) {
+    const auto candidateContext = physicalIds[link.source];
+    if (hasContext[link.target] && context[link.target] != candidateContext) {
+      throw std::runtime_error(stateStructureError(io::Str()
+                                                   << "state node " << stateIds[link.target] << " receives contexts "
+                                                   << context[link.target] << " and " << candidateContext << "."));
+    }
+    context[link.target] = candidateContext;
+    hasContext[link.target] = true;
+  }
+
+  std::map<Key, unsigned int> targetByPhysicalContext;
+  for (unsigned int index = 0; index < numStates; ++index) {
+    if (!hasContext[index]) {
+      continue;
+    }
+    Key key { physicalIds[index], context[index] };
+    auto inserted = targetByPhysicalContext.emplace(key, index);
+    if (!inserted.second) {
+      throw std::runtime_error(stateStructureError(io::Str()
+                                                   << "multiple state nodes map to physical/context pair ("
+                                                   << key.first << ", " << key.second << ")."));
+    }
+  }
+
+  const unsigned int numObservedPhysicalNodes = physicalIdToIndex.size();
+  if (numObservedPhysicalNodes == 0 || numObservedPhysicalNodes > numPhysicalNodes) {
+    throw std::runtime_error("Regularized memory flow found inconsistent physical node indexing.");
+  }
+
+  std::vector<double> sigmaOut(numObservedPhysicalNodes, 0.0);
+  std::vector<double> sigmaIn(numObservedPhysicalNodes, 0.0);
+  std::vector<std::set<unsigned int>> distinctOut(numObservedPhysicalNodes);
+  std::vector<std::set<unsigned int>> distinctIn(numObservedPhysicalNodes);
+
+  for (const auto& link : m_observedLinks) {
+    const auto sourcePhysical = physicalIds[link.source];
+    const auto targetPhysical = physicalIds[link.target];
+    const auto sourcePhysicalIndex = physicalIdToIndex.at(sourcePhysical);
+    const auto targetPhysicalIndex = physicalIdToIndex.at(targetPhysical);
+    sigmaOut[sourcePhysicalIndex] += link.flow;
+    sigmaIn[targetPhysicalIndex] += link.flow;
+    distinctOut[sourcePhysicalIndex].insert(targetPhysical);
+    distinctIn[targetPhysicalIndex].insert(sourcePhysical);
+  }
+
+  double sumKappa = 0.0;
+  double sumSigma = 0.0;
+  for (unsigned int i = 0; i < numObservedPhysicalNodes; ++i) {
+    sumKappa += distinctIn[i].size() + distinctOut[i].size();
+    sumSigma += sigmaIn[i] + sigmaOut[i];
+  }
+  if (sumSigma == 0.0 || sumKappa == 0.0) {
+    throw std::runtime_error("Regularized memory flow requires observed physical transitions.");
+  }
+
+  const double lambda = m_config.regularizationStrength * std::log(static_cast<double>(numPhysicalNodes))
+      / (static_cast<double>(numPhysicalNodes) * static_cast<double>(numPhysicalNodes));
+  const double scale = sumKappa / sumSigma;
+
+  result.posterior.assign(numStates, {});
+  std::vector<std::map<unsigned int, double>> numerators(numStates);
+  std::vector<double> denominator(numStates, 0.0);
+
+  for (const auto& link : m_observedLinks) {
+    numerators[link.source][link.target] += link.flow;
+    denominator[link.source] += link.flow;
+  }
+
+  for (unsigned int source = 0; source < numStates; ++source) {
+    const auto sourcePhysical = physicalIds[source];
+    const auto sourcePhysicalIndex = physicalIdToIndex.at(sourcePhysical);
+    const auto kappaSourceOut = static_cast<double>(distinctOut[sourcePhysicalIndex].size());
+    const auto sigmaSourceOut = sigmaOut[sourcePhysicalIndex];
+    if (kappaSourceOut == 0.0 || sigmaSourceOut == 0.0 || lambda == 0.0) {
+      continue;
+    }
+
+    for (const auto& physicalTarget : physicalIdToIndex) {
+      const auto targetPhysical = physicalTarget.first;
+      const auto targetPhysicalIndex = physicalTarget.second;
+      if (m_config.noSelfLinks && sourcePhysical == targetPhysical) {
+        continue;
+      }
+      auto targetIt = targetByPhysicalContext.find(Key { targetPhysical, sourcePhysical });
+      if (targetIt == targetByPhysicalContext.end()) {
+        continue;
+      }
+
+      const auto kappaTargetIn = static_cast<double>(distinctIn[targetPhysicalIndex].size());
+      const auto sigmaTargetIn = sigmaIn[targetPhysicalIndex];
+      if (kappaTargetIn == 0.0 || sigmaTargetIn == 0.0) {
+        continue;
+      }
+
+      const double gamma = lambda * scale * sigmaSourceOut * sigmaTargetIn / (kappaSourceOut * kappaTargetIn);
+      if (gamma <= 0.0 || !std::isfinite(gamma)) {
+        continue;
+      }
+      numerators[source][targetIt->second] += gamma;
+      denominator[source] += gamma;
+    }
+  }
+
+  for (unsigned int source = 0; source < numStates; ++source) {
+    if (denominator[source] == 0.0) {
+      throw std::runtime_error(io::Str()
+                               << "Regularized memory source state " << stateIds[source]
+                               << " at physical node " << physicalIds[source]
+                               << " has no observed outgoing support and no valid second-order prior targets. "
+                               << "Remove the sink state or run without --regularized.");
+    }
+    for (const auto& targetNumerator : numerators[source]) {
+      result.posterior[source].push_back({ targetNumerator.first, targetNumerator.second / denominator[source] });
+    }
+  }
+
+  result.nodeFlow.assign(numStates, 1.0 / static_cast<double>(numStates));
+  std::vector<double> nextFlow(numStates, 0.0);
+  for (unsigned int iteration = 0; iteration < m_config.maxFlowIterations; ++iteration) {
+    std::fill(nextFlow.begin(), nextFlow.end(), 0.0);
+    for (unsigned int source = 0; source < numStates; ++source) {
+      for (const auto& transition : result.posterior[source]) {
+        nextFlow[transition.first] += result.nodeFlow[source] * transition.second;
+      }
+    }
+    normalize(nextFlow);
+
+    double error = 0.0;
+    for (unsigned int i = 0; i < numStates; ++i) {
+      error += std::abs(nextFlow[i] - result.nodeFlow[i]);
+    }
+    result.nodeFlow = nextFlow;
+    result.error = error;
+    result.iterations = iteration + 1;
+    if (iteration >= 50 && error <= kConvergenceThreshold) {
+      break;
+    }
+  }
+  result.converged = result.error <= kConvergenceThreshold || result.iterations < m_config.maxFlowIterations;
+
+  result.nodeTeleportWeights.assign(numStates, 0.0);
+  result.nodeTeleportFlow.assign(numStates, 0.0);
+  result.enterFlow.assign(numStates, 0.0);
+  result.exitFlow.assign(numStates, 0.0);
+  result.observedLinkFlow.assign(m_observedLinks.size(), 0.0);
+
+  for (unsigned int source = 0; source < numStates; ++source) {
+    StateNetwork::StateNode sourceNode(stateIds[source]);
+    auto& effectiveTargets = result.effectiveLinkMap[sourceNode];
+    for (const auto& transition : result.posterior[source]) {
+      const auto target = transition.first;
+      const double flow = result.nodeFlow[source] * transition.second;
+      StateNetwork::StateNode targetNode(stateIds[target]);
+      auto inserted = effectiveTargets.insert(std::make_pair(targetNode, StateNetwork::LinkData(transition.second)));
+      auto& data = inserted.first->second;
+      if (inserted.second) {
+        data.flow = flow;
+      } else {
+        data.weight += transition.second;
+        data.flow += flow;
+      }
+      if (source != target) {
+        result.exitFlow[source] += flow;
+        result.enterFlow[target] += flow;
+      }
+    }
+  }
+
+  for (unsigned int i = 0; i < m_observedLinks.size(); ++i) {
+    const auto& link = m_observedLinks[i];
+    result.observedLinkFlow[i] = denominator[link.source] > 0.0
+        ? result.nodeFlow[link.source] * link.flow / denominator[link.source]
+        : 0.0;
+  }
+
+  return result;
+}
+
+} // namespace infomap

--- a/src/utils/RegularizedMemoryFlowBuilder.h
+++ b/src/utils/RegularizedMemoryFlowBuilder.h
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ Infomap software package for multi-level network clustering
+ Copyright (c) 2013, 2014 Daniel Edler, Anton Holmgren, Martin Rosvall
+
+ This file is part of the Infomap software package.
+ See file LICENSE_GPLv3.txt for full license details.
+ For more information, see <http://www.mapequation.org>
+ ******************************************************************************/
+
+#ifndef REGULARIZED_MEMORY_FLOW_BUILDER_H_
+#define REGULARIZED_MEMORY_FLOW_BUILDER_H_
+
+#include "../core/StateNetwork.h"
+#include "FlowLink.h"
+
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace infomap {
+
+struct RegularizedMemoryFlowResult {
+  using Transition = std::pair<unsigned int, double>;
+
+  std::vector<std::vector<Transition>> posterior;
+  std::vector<double> nodeFlow;
+  std::vector<double> nodeTeleportWeights;
+  std::vector<double> nodeTeleportFlow;
+  std::vector<double> enterFlow;
+  std::vector<double> exitFlow;
+  std::vector<double> observedLinkFlow;
+  StateNetwork::NodeLinkMap effectiveLinkMap;
+  unsigned int iterations = 0;
+  double error = 0.0;
+  bool converged = true;
+};
+
+class RegularizedMemoryFlowBuilder {
+public:
+  RegularizedMemoryFlowBuilder(const StateNetwork& network,
+                               const Config& config,
+                               const std::unordered_map<unsigned int, unsigned int>& nodeIndexMap,
+                               const std::vector<detail::FlowLink>& observedLinks);
+
+  RegularizedMemoryFlowResult build() const;
+
+private:
+  const StateNetwork& m_network;
+  const Config& m_config;
+  const std::unordered_map<unsigned int, unsigned int>& m_nodeIndexMap;
+  const std::vector<detail::FlowLink>& m_observedLinks;
+};
+
+} // namespace infomap
+
+#endif // REGULARIZED_MEMORY_FLOW_BUILDER_H_

--- a/test/cpp/test_flow.cpp
+++ b/test/cpp/test_flow.cpp
@@ -358,9 +358,9 @@ MemoryBuilderInput makeMemoryBuilderInput(const infomap::Network& network)
     input.nodeIndexMap[node.second.id] = index++;
   }
   for (const auto& source : network.nodeLinkMap()) {
-    const auto sourceIndex = input.nodeIndexMap[source.first.id];
+    const auto sourceIndex = input.nodeIndexMap.at(source.first.id);
     for (const auto& target : source.second) {
-      input.observedLinks.push_back({ sourceIndex, input.nodeIndexMap[target.first.id], target.second.weight });
+      input.observedLinks.push_back({ sourceIndex, input.nodeIndexMap.at(target.first.id), target.second.weight });
     }
   }
   return input;

--- a/test/cpp/test_flow.cpp
+++ b/test/cpp/test_flow.cpp
@@ -3,14 +3,19 @@
 #include "Infomap.h"
 
 #include "TestUtils.h"
+#include "io/Network.h"
+#include "utils/FlowCalculator.h"
+#include "utils/RegularizedMemoryFlowBuilder.h"
 
 #include <array>
 #include <cmath>
 #include <cstdio>
 #include <fstream>
 #include <map>
+#include <numeric>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #ifdef _OPENMP
@@ -274,26 +279,26 @@ RegularizedMultilayerEgoFlow analyticRegularizedMultilayerEgoFlow()
   const double absentBaseFromZ = 1.0 - alphaInterAbsent / 2.0;
 
   const std::array<double, 3> layerTeleportFlowCoefficients = {
-      alpha,
-      2.0 * alpha * presentBaseFromY + 2.0 * absentBaseFromY,
-      2.0 * alpha * presentBaseFromZ + 2.0 * absentBaseFromZ,
+    alpha,
+    2.0 * alpha * presentBaseFromY + 2.0 * absentBaseFromY,
+    2.0 * alpha * presentBaseFromZ + 2.0 * absentBaseFromZ,
   };
   const std::array<double, 3> presentBaseCoefficients = { 0.0, presentBaseFromY, presentBaseFromZ };
 
-  std::array<std::array<double, 3>, 3> coefficients = {{
-      {{
+  std::array<std::array<double, 3>, 3> coefficients = { {
+      { {
           1.0 - layerTeleportFlowCoefficients[0] / numPhysicalNodes - beta * presentBaseCoefficients[0],
           -layerTeleportFlowCoefficients[1] / numPhysicalNodes - beta * presentBaseCoefficients[1],
           -layerTeleportFlowCoefficients[2] / numPhysicalNodes - beta * presentBaseCoefficients[2],
-      }},
-      {{
+      } },
+      { {
           -layerTeleportFlowCoefficients[0] / numPhysicalNodes - beta / 2.0,
           1.0 - layerTeleportFlowCoefficients[1] / numPhysicalNodes - beta * presentBaseCoefficients[1] / 2.0,
           -layerTeleportFlowCoefficients[2] / numPhysicalNodes - beta * presentBaseCoefficients[2] / 2.0,
-      }},
-      {{ 2.0, 4.0, 4.0 }},
-  }};
-  const auto solution = solve3x3(coefficients, {{ 0.0, 0.0, 1.0 }});
+      } },
+      { { 2.0, 4.0, 4.0 } },
+  } };
+  const auto solution = solve3x3(coefficients, { { 0.0, 0.0, 1.0 } });
 
   const double egoPhysicalFlow = 2.0 * solution[0];
   const double peripheralPhysicalFlow = solution[1] + solution[2];
@@ -312,11 +317,11 @@ FlowRunResult runDirectedFixture(const std::string& extraFlags)
   auto modules = im.getModules();
   infomap::test::checkRunSanity(im);
   return {
-      modules,
-      infomap::test::canonicalPartition(modules),
-      im.codelength(),
-      im.getIndexCodelength(),
-      im.numTopModules(),
+    modules,
+    infomap::test::canonicalPartition(modules),
+    im.codelength(),
+    im.getIndexCodelength(),
+    im.numTopModules(),
   };
 }
 
@@ -340,12 +345,379 @@ void checkInnerParallelPartitionCodelength(const std::string& extraFlags, const 
   infomap::test::checkApproxCodelength(check.getIndexCodelength(), result.indexCodelength, 1e-9);
 }
 
+struct MemoryBuilderInput {
+  std::unordered_map<unsigned int, unsigned int> nodeIndexMap;
+  std::vector<infomap::detail::FlowLink> observedLinks;
+};
+
+MemoryBuilderInput makeMemoryBuilderInput(const infomap::Network& network)
+{
+  MemoryBuilderInput input;
+  unsigned int index = 0;
+  for (const auto& node : network.nodes()) {
+    input.nodeIndexMap[node.second.id] = index++;
+  }
+  for (const auto& source : network.nodeLinkMap()) {
+    const auto sourceIndex = input.nodeIndexMap[source.first.id];
+    for (const auto& target : source.second) {
+      input.observedLinks.push_back({ sourceIndex, input.nodeIndexMap[target.first.id], target.second.weight });
+    }
+  }
+  return input;
+}
+
+infomap::RegularizedMemoryFlowResult buildRegularizedMemoryFlow(infomap::Network& network, const std::string& extraFlags = "")
+{
+  infomap::Config config(infomap::test::defaultFlags("--directed --regularized --no-infomap " + extraFlags));
+  network.setConfig(config);
+  auto input = makeMemoryBuilderInput(network);
+  return infomap::RegularizedMemoryFlowBuilder(network, config, input.nodeIndexMap, input.observedLinks).build();
+}
+
+double transitionProbability(const infomap::RegularizedMemoryFlowResult& result, unsigned int source, unsigned int target)
+{
+  for (const auto& transition : result.posterior.at(source)) {
+    if (transition.first == target) {
+      return transition.second;
+    }
+  }
+  return 0.0;
+}
+
+unsigned int stateIndex(const infomap::Network& network, unsigned int stateId)
+{
+  return makeMemoryBuilderInput(network).nodeIndexMap.at(stateId);
+}
+
+std::unordered_map<unsigned int, unsigned int> stateIndexById(const infomap::Network& network)
+{
+  return makeMemoryBuilderInput(network).nodeIndexMap;
+}
+
+template <typename NetworkLike>
+void addRegularizedMemoryPosteriorFixture(NetworkLike& network)
+{
+  network.addStateNode(12, 1); // s_1^2
+  network.addStateNode(21, 2); // s_2^1
+  network.addStateNode(31, 3); // s_3^1
+  network.addStateNode(13, 1); // s_1^3
+  network.addLink(12, 21, 2.0);
+  network.addLink(12, 31, 1.0);
+  network.addLink(21, 12, 3.0);
+  network.addLink(31, 13, 4.0);
+  network.addLink(13, 21, 1.0);
+}
+
+void checkSameRegularizedMemoryFlow(const infomap::RegularizedMemoryFlowResult& lhs, const infomap::RegularizedMemoryFlowResult& rhs)
+{
+  REQUIRE(lhs.posterior.size() == rhs.posterior.size());
+  REQUIRE(lhs.nodeFlow.size() == rhs.nodeFlow.size());
+  for (unsigned int i = 0; i < lhs.posterior.size(); ++i) {
+    REQUIRE(lhs.posterior[i].size() == rhs.posterior[i].size());
+    for (unsigned int j = 0; j < lhs.posterior[i].size(); ++j) {
+      CHECK(lhs.posterior[i][j].first == rhs.posterior[i][j].first);
+      CHECK(lhs.posterior[i][j].second == doctest::Approx(rhs.posterior[i][j].second).epsilon(1e-12));
+    }
+    CHECK(lhs.nodeFlow[i] == doctest::Approx(rhs.nodeFlow[i]).epsilon(1e-12));
+  }
+}
+
+#if INFOMAP_FEATURE_REGULARIZED_HIGHER_ORDER
+TEST_CASE("Regularized memory prior gamma matches two-node oracle [fast][core][flow]")
+{
+  infomap::Config config(infomap::test::defaultFlags("--directed --regularized --no-infomap"));
+  infomap::Network network(config);
+  network.addStateNode(12, 1);
+  network.addStateNode(21, 2);
+  network.addLink(12, 21, 2.0);
+  network.addLink(21, 12, 2.0);
+
+  const auto result = buildRegularizedMemoryFlow(network);
+
+  const double gamma = std::log(2.0) / 2.0;
+  const double expectedObservedFlow = 0.5 * 2.0 / (2.0 + gamma);
+  CHECK(result.observedLinkFlow[0] == doctest::Approx(expectedObservedFlow).epsilon(1e-12));
+  CHECK(result.observedLinkFlow[1] == doctest::Approx(expectedObservedFlow).epsilon(1e-12));
+}
+
+TEST_CASE("Regularized memory posterior normalizes observed and prior support [fast][core][flow]")
+{
+  infomap::Config config(infomap::test::defaultFlags("--directed --regularized --no-infomap"));
+  infomap::Network network(config);
+  addRegularizedMemoryPosteriorFixture(network);
+
+  const auto result = buildRegularizedMemoryFlow(network);
+
+  const double lambda = std::log(3.0) / 9.0;
+  const double scale = 4.0 / 11.0;
+  const double gammaTo2 = lambda * scale * 4.0 * 3.0 / 2.0;
+  const double gammaTo3 = lambda * scale * 4.0 * 1.0 / 2.0;
+  const double denominator = 3.0 + gammaTo2 + gammaTo3;
+
+  CHECK(transitionProbability(result, stateIndex(network, 12), stateIndex(network, 21)) == doctest::Approx((2.0 + gammaTo2) / denominator).epsilon(1e-12));
+  CHECK(transitionProbability(result, stateIndex(network, 12), stateIndex(network, 31)) == doctest::Approx((1.0 + gammaTo3) / denominator).epsilon(1e-12));
+}
+
+TEST_CASE("Regularized memory no-self-links controls physical self priors [fast][core][flow]")
+{
+  infomap::Config withSelf(infomap::test::defaultFlags("--directed --regularized --no-infomap"));
+  infomap::Network withSelfNetwork(withSelf);
+  withSelfNetwork.addStateNode(12, 1);
+  withSelfNetwork.addStateNode(11, 1);
+  withSelfNetwork.addStateNode(21, 2);
+  withSelfNetwork.addLink(12, 11, 1.0);
+  withSelfNetwork.addLink(12, 21, 1.0);
+  withSelfNetwork.addLink(11, 21, 1.0);
+  withSelfNetwork.addLink(21, 12, 1.0);
+  auto withSelfResult = buildRegularizedMemoryFlow(withSelfNetwork);
+
+  infomap::Config withoutSelf(infomap::test::defaultFlags("--directed --regularized --no-infomap --no-self-links"));
+  infomap::Network withoutSelfNetwork(withoutSelf);
+  withoutSelfNetwork.addStateNode(12, 1);
+  withoutSelfNetwork.addStateNode(11, 1);
+  withoutSelfNetwork.addStateNode(21, 2);
+  withoutSelfNetwork.addLink(12, 11, 1.0);
+  withoutSelfNetwork.addLink(12, 21, 1.0);
+  withoutSelfNetwork.addLink(11, 21, 1.0);
+  withoutSelfNetwork.addLink(21, 12, 1.0);
+  auto withoutSelfResult = buildRegularizedMemoryFlow(withoutSelfNetwork, "--no-self-links");
+
+  CHECK(transitionProbability(withSelfResult, stateIndex(withSelfNetwork, 12), stateIndex(withSelfNetwork, 11))
+        > transitionProbability(withoutSelfResult, stateIndex(withoutSelfNetwork, 12), stateIndex(withoutSelfNetwork, 11)));
+}
+
+TEST_CASE("Regularized memory rejects dangling rows without valid second-order support [fast][core][flow]")
+{
+  infomap::Config config(infomap::test::defaultFlags("--directed --regularized --no-infomap"));
+  infomap::Network network(config);
+  network.addStateNode(12, 1);
+  network.addStateNode(21, 2);
+  network.addStateNode(31, 3);
+  network.addLink(12, 21, 1.0);
+  network.addLink(21, 12, 1.0);
+
+  CHECK_THROWS_WITH_AS(
+      buildRegularizedMemoryFlow(network),
+      "Regularized memory source state 31 at physical node 3 has no observed outgoing support and no valid second-order prior targets. Remove the sink state or run without --regularized.",
+      std::runtime_error);
+}
+
+TEST_CASE("Regularized memory rejects conflicting inferred contexts [fast][core][flow]")
+{
+  infomap::Config config(infomap::test::defaultFlags("--directed --regularized --no-infomap"));
+  infomap::Network network(config);
+  network.addStateNode(12, 1);
+  network.addStateNode(21, 2);
+  network.addStateNode(31, 3);
+  network.addLink(12, 31, 1.0);
+  network.addLink(21, 31, 1.0);
+
+  CHECK_THROWS_WITH_AS(
+      buildRegularizedMemoryFlow(network),
+      "Regularized memory networks require valid single-step second-order state structure: state node 31 receives contexts 1 and 2.",
+      std::runtime_error);
+}
+
+TEST_CASE("Regularized memory rejects duplicate physical-context targets [fast][core][flow]")
+{
+  infomap::Config config(infomap::test::defaultFlags("--directed --regularized --no-infomap"));
+  infomap::Network network(config);
+  network.addStateNode(12, 1);
+  network.addStateNode(13, 1);
+  network.addStateNode(21, 2);
+  network.addStateNode(201, 2);
+  network.addLink(12, 21, 1.0);
+  network.addLink(13, 201, 1.0);
+
+  CHECK_THROWS_WITH_AS(
+      buildRegularizedMemoryFlow(network),
+      "Regularized memory networks require valid single-step second-order state structure: multiple state nodes map to physical/context pair (2, 1).",
+      std::runtime_error);
+}
+
+TEST_CASE("Regularized memory accepts source states without inferred context [fast][core][flow]")
+{
+  infomap::Config config(infomap::test::defaultFlags("--directed --regularized --no-infomap"));
+  infomap::Network network(config);
+  network.addStateNode(41, 4);
+  network.addStateNode(14, 1);
+  network.addStateNode(21, 2);
+  network.addStateNode(32, 3);
+  network.addStateNode(13, 1);
+  network.addLink(41, 14, 1.0);
+  network.addLink(14, 21, 1.0);
+  network.addLink(21, 32, 1.0);
+  network.addLink(32, 13, 1.0);
+  network.addLink(13, 21, 1.0);
+
+  CHECK_NOTHROW(buildRegularizedMemoryFlow(network));
+}
+
+TEST_CASE("Regularized memory ignores directed teleportation options [fast][core][flow]")
+{
+  infomap::Config baseConfig(infomap::test::defaultFlags("--directed --regularized --no-infomap"));
+  infomap::Network baseNetwork(baseConfig);
+  addRegularizedMemoryPosteriorFixture(baseNetwork);
+  const auto baseResult = buildRegularizedMemoryFlow(baseNetwork);
+
+  infomap::Config teleportConfig(infomap::test::defaultFlags("--directed --regularized --no-infomap --recorded-teleportation --to-nodes"));
+  infomap::Network teleportNetwork(teleportConfig);
+  addRegularizedMemoryPosteriorFixture(teleportNetwork);
+  const auto teleportResult = buildRegularizedMemoryFlow(teleportNetwork, "--recorded-teleportation --to-nodes");
+
+  checkSameRegularizedMemoryFlow(baseResult, teleportResult);
+}
+
+TEST_CASE("Regularized memory strength zero uses observed MLE on connected support [fast][core][flow]")
+{
+  infomap::Config config(infomap::test::defaultFlags("--directed --regularized --no-infomap --regularization-strength 0"));
+  infomap::Network network(config);
+  addRegularizedMemoryPosteriorFixture(network);
+
+  const auto result = buildRegularizedMemoryFlow(network, "--regularization-strength 0");
+
+  CHECK(transitionProbability(result, stateIndex(network, 12), stateIndex(network, 21)) == doctest::Approx(2.0 / 3.0).epsilon(1e-12));
+  CHECK(transitionProbability(result, stateIndex(network, 12), stateIndex(network, 31)) == doctest::Approx(1.0 / 3.0).epsilon(1e-12));
+}
+
+TEST_CASE("Regularized memory supports non-contiguous physical ids [fast][core][flow]")
+{
+  infomap::Config config(infomap::test::defaultFlags("--directed --regularized --no-infomap"));
+  infomap::Network network(config);
+  network.addStateNode(1020, 10);
+  network.addStateNode(2010, 20);
+  network.addStateNode(3010, 30);
+  network.addStateNode(1030, 10);
+  network.addLink(1020, 2010, 2.0);
+  network.addLink(1020, 3010, 1.0);
+  network.addLink(2010, 1020, 3.0);
+  network.addLink(3010, 1030, 4.0);
+  network.addLink(1030, 2010, 1.0);
+
+  const auto result = buildRegularizedMemoryFlow(network);
+
+  CHECK(transitionProbability(result, stateIndex(network, 1020), stateIndex(network, 2010)) > 0.0);
+  CHECK(transitionProbability(result, stateIndex(network, 1020), stateIndex(network, 3010)) > 0.0);
+}
+
+TEST_CASE("Regularized memory tiny prior strength approaches observed MLE [fast][core][flow]")
+{
+  infomap::Config config(infomap::test::defaultFlags("--directed --regularized --no-infomap --regularization-strength 1e-12"));
+  infomap::Network network(config);
+  addRegularizedMemoryPosteriorFixture(network);
+
+  const auto result = buildRegularizedMemoryFlow(network, "--regularization-strength 1e-12");
+
+  CHECK(transitionProbability(result, stateIndex(network, 12), stateIndex(network, 21)) == doctest::Approx(2.0 / 3.0).epsilon(1e-10));
+  CHECK(transitionProbability(result, stateIndex(network, 12), stateIndex(network, 31)) == doctest::Approx(1.0 / 3.0).epsilon(1e-10));
+}
+
+TEST_CASE("Regularized memory handles zero-degree physical nodes without NaN [fast][core][flow]")
+{
+  infomap::Config config(infomap::test::defaultFlags("--directed --regularized --no-infomap"));
+  infomap::Network network(config);
+  addRegularizedMemoryPosteriorFixture(network);
+  network.addPhysicalNode(99);
+
+  const auto result = buildRegularizedMemoryFlow(network);
+
+  for (const auto flow : result.nodeFlow) {
+    CHECK(std::isfinite(flow));
+  }
+  for (const auto& transitions : result.posterior) {
+    for (const auto& transition : transitions) {
+      CHECK(std::isfinite(transition.second));
+    }
+  }
+}
+
+TEST_CASE("Regularized memory physical flow is the sum of state flows [fast][core][flow]")
+{
+  infomap::Config config(infomap::test::defaultFlags("--directed --regularized --no-infomap"));
+  infomap::Network network(config);
+  addRegularizedMemoryPosteriorFixture(network);
+
+  const auto result = buildRegularizedMemoryFlow(network);
+  const auto indices = stateIndexById(network);
+
+  std::map<unsigned int, double> physicalFlow;
+  for (const auto& node : network.nodes()) {
+    physicalFlow[node.second.physicalId] += result.nodeFlow[indices.at(node.second.id)];
+  }
+
+  const double totalPhysicalFlow = std::accumulate(
+      physicalFlow.begin(),
+      physicalFlow.end(),
+      0.0,
+      [](double sum, const auto& flow) { return sum + flow.second; });
+
+  CHECK(totalPhysicalFlow == doctest::Approx(1.0).epsilon(1e-12));
+  for (const auto& flow : physicalFlow) {
+    CHECK(flow.second > 0.0);
+  }
+}
+
+TEST_CASE("Regularized memory dispatch rejects unsupported memory variants [fast][core][flow]")
+{
+  InfomapWrapper undirected(infomap::test::defaultFlags("--flow-model undirected --regularized --no-infomap"));
+  undirected.addStateNode(12, 1);
+  undirected.addStateNode(21, 2);
+  undirected.addLink(12, 21, 1.0);
+  undirected.addLink(21, 12, 1.0);
+  CHECK_THROWS_WITH_AS(
+      undirected.run(),
+      "Regularized undirected memory networks are not supported yet; use directed flow or run without --regularized.",
+      std::runtime_error);
+
+  InfomapWrapper bipartite(infomap::test::defaultFlags("--directed --regularized --no-infomap"));
+  bipartite.addStateNode(12, 1);
+  bipartite.addStateNode(21, 2);
+  bipartite.addLink(12, 21, 1.0);
+  bipartite.addLink(21, 12, 1.0);
+  bipartite.setBipartiteStartId(21);
+  CHECK_THROWS_WITH_AS(
+      bipartite.run(),
+      "Regularized bipartite memory networks are not supported.",
+      std::runtime_error);
+}
+
+TEST_CASE("Regularized memory keeps prior links hidden from output links [fast][core][flow]")
+{
+  InfomapWrapper im(infomap::test::defaultFlags("--directed --regularized --no-infomap --two-level"));
+  addRegularizedMemoryPosteriorFixture(im);
+
+  im.run();
+
+  CHECK(im.network().haveEffectiveLinkMap());
+  CHECK(im.getLinks(false).count({ 13, 31 }) == 0);
+
+  const auto sourceIt = im.network().effectiveLinkMap().find(infomap::StateNetwork::StateNode(13));
+  REQUIRE(sourceIt != im.network().effectiveLinkMap().end());
+
+  const auto targetIt = sourceIt->second.find(infomap::StateNetwork::StateNode(31));
+  REQUIRE(targetIt != sourceIt->second.end());
+  CHECK(targetIt->second.weight > 0.0);
+  CHECK(targetIt->second.flow > 0.0);
+}
+#else
+TEST_CASE("Regularized memory flow requires compile-time feature [fast][core][flow]")
+{
+  InfomapWrapper im(infomap::test::defaultFlags("--directed --regularized --no-infomap --two-level"));
+  addRegularizedMemoryPosteriorFixture(im);
+
+  CHECK_THROWS_WITH_AS(
+      im.run(),
+      "Regularized higher-order flow requires building with FEATURES=regularized-higher-order.",
+      std::runtime_error);
+}
+#endif
+
 TEST_CASE("Recorded teleportation stays stable across trial counts for the directed fixture [fast][core][flow]")
 {
   const auto oneTrial = runDirectedFixture("--recorded-teleportation --num-trials 1");
   const auto twoTrials = runDirectedFixture("--recorded-teleportation --num-trials 2");
 
-  CHECK(oneTrial.partition == std::vector<std::vector<unsigned int>>{{1, 2, 3}, {4, 5, 6}});
+  CHECK(oneTrial.partition == std::vector<std::vector<unsigned int>> { { 1, 2, 3 }, { 4, 5, 6 } });
   CHECK(oneTrial.partition == twoTrials.partition);
   CHECK(oneTrial.codelength == doctest::Approx(twoTrials.codelength));
   CHECK(oneTrial.indexCodelength == doctest::Approx(twoTrials.indexCodelength));
@@ -356,7 +728,7 @@ TEST_CASE("Directed to-nodes teleportation keeps the expected coarse partition [
   const auto result = runDirectedFixture("--to-nodes");
 
   CHECK(result.numTopModules == 2);
-  CHECK(result.partition == std::vector<std::vector<unsigned int>>{{1, 2, 3}, {4, 5, 6}});
+  CHECK(result.partition == std::vector<std::vector<unsigned int>> { { 1, 2, 3 }, { 4, 5, 6 } });
 }
 
 TEST_CASE("Directed regularization remains numerically sane on the teleportation fixture [fast][core][flow]")
@@ -364,7 +736,7 @@ TEST_CASE("Directed regularization remains numerically sane on the teleportation
   const auto result = runDirectedFixture("--regularized");
 
   CHECK(result.numTopModules == 1);
-  CHECK(result.partition == std::vector<std::vector<unsigned int>>{{1, 2, 3, 4, 5, 6}});
+  CHECK(result.partition == std::vector<std::vector<unsigned int>> { { 1, 2, 3, 4, 5, 6 } });
   CHECK(result.codelength > result.indexCodelength);
   infomap::test::checkApproxCodelength(result.codelength, 2.575842872);
 }
@@ -378,7 +750,7 @@ TEST_CASE("Undirected regularization remains stable on the two-triangles fixture
 
   infomap::test::checkRunSanity(im);
   CHECK(im.numTopModules() == 1);
-  infomap::test::checkCanonicalPartition(im, {{1, 2, 3, 4, 5, 6}});
+  infomap::test::checkCanonicalPartition(im, { { 1, 2, 3, 4, 5, 6 } });
   infomap::test::checkApproxCodelength(im.codelength(), 2.575767408, 1e-9);
 }
 
@@ -401,7 +773,7 @@ TEST_CASE("Directed regularized codelength matches analytic multi-level tree [fa
   infomap::test::checkApproxCodelength(im.codelength(), 4.051270346886);
 }
 
-#if INFOMAP_FEATURE_REGULARIZED_MULTILAYER
+#if INFOMAP_FEATURE_REGULARIZED_HIGHER_ORDER
 TEST_CASE("Regularized multilayer flow supports non-dense matchable state ids [fast][core][flow]")
 {
   InfomapWrapper im(infomap::test::defaultFlags(
@@ -453,13 +825,13 @@ TEST_CASE("Regularized multilayer ego flow matches analytic prior-strength sampl
 TEST_CASE("Regularized multilayer asymmetric flow matches analytic prior-strength sample [fast][core][flow]")
 {
   const std::vector<MultilayerIntraLink> intraLinks = {
-      { 1, 1, 2, 2.0 },
-      { 1, 2, 1, 1.0 },
-      { 1, 1, 3, 1.0 },
-      { 1, 3, 1, 1.0 },
-      { 2, 1, 2, 1.0 },
-      { 2, 2, 3, 3.0 },
-      { 2, 3, 1, 1.0 },
+    { 1, 1, 2, 2.0 },
+    { 1, 2, 1, 1.0 },
+    { 1, 1, 3, 1.0 },
+    { 1, 3, 1, 1.0 },
+    { 2, 1, 2, 1.0 },
+    { 2, 2, 3, 3.0 },
+    { 2, 3, 1, 1.0 },
   };
 
   InfomapWrapper im(infomap::test::defaultFlags("--directed --regularized --no-infomap --two-level"));
@@ -473,10 +845,10 @@ TEST_CASE("Regularized multilayer asymmetric flow matches analytic prior-strengt
 TEST_CASE("Regularized multilayer matchable state-id flow matches analytic prior-strength sample [fast][core][flow]")
 {
   const std::vector<MultilayerIntraLink> intraLinks = {
-      { 1, 10, 20, 1.0 },
-      { 1, 20, 10, 2.0 },
-      { 2, 10, 30, 3.0 },
-      { 2, 30, 10, 1.0 },
+    { 1, 10, 20, 1.0 },
+    { 1, 20, 10, 2.0 },
+    { 2, 10, 30, 3.0 },
+    { 2, 30, 10, 1.0 },
   };
 
   InfomapWrapper im(infomap::test::defaultFlags(
@@ -496,13 +868,13 @@ TEST_CASE("Inner parallelization with regularized multilayer input falls back to
 #endif
 
   const std::vector<MultilayerIntraLink> intraLinks = {
-      { 1, 1, 2, 2.0 },
-      { 1, 2, 1, 1.0 },
-      { 1, 1, 3, 1.0 },
-      { 1, 3, 1, 1.0 },
-      { 2, 1, 2, 1.0 },
-      { 2, 2, 3, 3.0 },
-      { 2, 3, 1, 1.0 },
+    { 1, 1, 2, 2.0 },
+    { 1, 2, 1, 1.0 },
+    { 1, 1, 3, 1.0 },
+    { 1, 3, 1, 1.0 },
+    { 2, 1, 2, 1.0 },
+    { 2, 2, 3, 3.0 },
+    { 2, 3, 1, 1.0 },
   };
 
   auto runRegularizedMultilayer = [&intraLinks](const std::string& extraFlags) {
@@ -531,7 +903,7 @@ TEST_CASE("Inner parallelization with regularized multilayer input falls back to
   infomap::test::checkApproxCodelength(requestedInner.indexCodelength, serial.indexCodelength, 1e-12);
 }
 #else
-TEST_CASE("Regularized multilayer flow requires compile-time feature [fast][core][flow]")
+TEST_CASE("Regularized higher-order multilayer flow requires compile-time feature [fast][core][flow]")
 {
   InfomapWrapper im(infomap::test::defaultFlags("--directed --regularized --no-infomap --two-level"));
   im.addMultilayerIntraLink(1, 1, 2, 1.0);
@@ -539,7 +911,7 @@ TEST_CASE("Regularized multilayer flow requires compile-time feature [fast][core
 
   CHECK_THROWS_WITH_AS(
       im.run(),
-      "Regularized multilayer flow requires building with FEATURES=regularized-multilayer.",
+      "Regularized higher-order flow requires building with FEATURES=regularized-higher-order.",
       std::runtime_error);
 }
 #endif
@@ -681,7 +1053,7 @@ TEST_CASE("Precomputed flow fixture remains runnable in C++ tests [fast][core][f
   CHECK(im.numTopModules() == 2);
   CHECK(im.numLevels() == 2);
   infomap::test::checkApproxCodelength(im.codelength(), 1.889659695224);
-  infomap::test::checkCanonicalPartition(im, {{1, 2, 3}, {4, 5, 6}});
+  infomap::test::checkCanonicalPartition(im, { { 1, 2, 3 }, { 4, 5, 6 } });
 }
 
 } // namespace

--- a/test/python/test_build_config.py
+++ b/test/python/test_build_config.py
@@ -106,7 +106,7 @@ def test_features_are_disabled_by_default():
     assert config["enabled_features"] == []
     assert config["enabled_feature_defines"] == []
     assert "-DINFOMAP_USE_SIMD_LOG=1" not in config["compile_flags"]
-    assert "-DINFOMAP_FEATURE_REGULARIZED_MULTILAYER=1" not in config["compile_flags"]
+    assert "-DINFOMAP_FEATURE_REGULARIZED_HIGHER_ORDER=1" not in config["compile_flags"]
     assert "-DINFOMAP_FEATURE_TEST_FEATURE=1" not in config["compile_flags"]
     assert "INFOMAP_ENABLED_FEATURES" not in " ".join(config["compile_flags"])
 
@@ -149,23 +149,23 @@ def test_simd_log_is_feature():
     assert '-DINFOMAP_ENABLED_FEATURES=\\"simd-log\\"' in config["compile_flags"]
 
 
-def test_regularized_multilayer_is_feature():
+def test_regularized_higher_order_is_feature():
     config = resolve_build_config(
         platform_name="linux",
         compiler="clang++",
         mode="release",
         openmp=False,
-        features=["regularized-multilayer"],
+        features=["regularized-higher-order"],
     )
 
-    assert config["enabled_features"] == ["regularized-multilayer"]
+    assert config["enabled_features"] == ["regularized-higher-order"]
     assert config["enabled_feature_defines"] == [
-        "INFOMAP_FEATURE_REGULARIZED_MULTILAYER=1",
-        'INFOMAP_ENABLED_FEATURES="regularized-multilayer"',
+        "INFOMAP_FEATURE_REGULARIZED_HIGHER_ORDER=1",
+        'INFOMAP_ENABLED_FEATURES="regularized-higher-order"',
     ]
-    assert "-DINFOMAP_FEATURE_REGULARIZED_MULTILAYER=1" in config["compile_flags"]
+    assert "-DINFOMAP_FEATURE_REGULARIZED_HIGHER_ORDER=1" in config["compile_flags"]
     assert (
-        '-DINFOMAP_ENABLED_FEATURES=\\"regularized-multilayer\\"'
+        '-DINFOMAP_ENABLED_FEATURES=\\"regularized-higher-order\\"'
         in config["compile_flags"]
     )
 
@@ -176,16 +176,16 @@ def test_features_use_registry_order():
         compiler="clang++",
         mode="release",
         openmp=False,
-        features="test-feature,regularized-multilayer,simd-log",
+        features="test-feature,regularized-higher-order,simd-log",
     )
 
     assert config["enabled_features"] == [
         "simd-log",
-        "regularized-multilayer",
+        "regularized-higher-order",
         "test-feature",
     ]
     assert config["enabled_feature_defines"][-1] == (
-        'INFOMAP_ENABLED_FEATURES="simd-log,regularized-multilayer,test-feature"'
+        'INFOMAP_ENABLED_FEATURES="simd-log,regularized-higher-order,test-feature"'
     )
 
 


### PR DESCRIPTION
## Summary
- add directed regularized memory flow using Eq. 18/24 priors on observed second-order state support
- gate regularized memory and regularized multilayer behind the shared `FEATURES=regularized-higher-order` build feature
- keep prior links internal through an effective link map while preserving observed output links
- reject unsupported regularized undirected and bipartite memory inputs with explicit errors
- add C++ coverage for posterior normalization, context validation, hidden prior links, zero-strength behavior, non-contiguous ids, dispatch, and feature gating

## Verification
- `rtk make test-native`
- `FEATURES=regularized-higher-order rtk make test-native`
- `rtk make test-python-unit PYTEST_ARGS='test/python/test_build_config.py'`
- Python regularized memory smoke
- build/benchmarks state-network smoke: existing benchmark state files reject as invalid single-step second-order input, while non-regularized memory still runs
