### PR TITLE
feat: --num-threads auto resolving cpuset / SLURM / OMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,7 @@ if(BUILD_TESTING)
     add_infomap_cpp_test(infomap_cpp_utils_io_tests test/cpp/test_utils_io.cpp "fast;core;utils;io")
     add_infomap_cpp_test(infomap_cpp_program_interface_tests test/cpp/test_program_interface.cpp "fast;core;parser;cli")
     add_infomap_cpp_test(infomap_cpp_config_tests test/cpp/test_config.cpp "fast;core;config;cli")
+    add_infomap_cpp_test(infomap_cpp_thread_config_tests test/cpp/test_thread_config.cpp "fast;core;threads")
     add_infomap_cpp_test(infomap_cpp_no_output_tests test/cpp/test_no_output.cpp "fast;core;output;library")
     add_infomap_cpp_test(infomap_cpp_output_view_tests test/cpp/test_output_view.cpp "fast;core;output")
 
@@ -242,6 +243,7 @@ if(BUILD_TESTING)
             infomap_cpp_utils_io_tests
             infomap_cpp_program_interface_tests
             infomap_cpp_config_tests
+            infomap_cpp_thread_config_tests
             infomap_cpp_no_output_tests
             infomap_cpp_output_view_tests
             infomap_cli

--- a/interfaces/R/infomap/R/options.R
+++ b/interfaces/R/infomap/R/options.R
@@ -72,6 +72,8 @@ ACCURACY_OPTIONS <- list(
   list(type = "value", name = "tune_iteration_relative_threshold", flag = "--tune-iteration-relative-threshold", default = 1e-05, include = .skip_when_not_equal(1e-05)),
   list(type = "flag", name = "inner_parallelization", flag = "--inner-parallelization", default = FALSE),
   list(type = "flag", name = "parallel_trials", flag = "--parallel-trials", default = FALSE),
+  list(type = "value", name = "num_threads", flag = "--num-threads", default = NULL, include = .skip_when_null),
+  list(type = "value", name = "threads", flag = "--threads", default = NULL, include = .skip_when_null),
   list(type = "flag", name = "prefer_modular_solution", flag = "--prefer-modular-solution", default = FALSE),
   list(type = "value", name = "num_random_moves", flag = "--num-random-moves", default = NULL, include = .skip_when_null),
   list(type = "value", name = "max_degree_for_random_moves", flag = "--max-degree-for-random-moves", default = NULL, include = .skip_when_null)
@@ -93,8 +95,8 @@ OPTION_FIELD_NAMES <- c(
   "multilayer_relax_limit", "multilayer_relax_limit_up", "multilayer_relax_limit_down", "multilayer_relax_by_jsd",
   "seed", "num_trials", "core_loop_limit", "core_level_limit",
   "tune_iteration_limit", "core_loop_codelength_threshold", "tune_iteration_relative_threshold", "fast_hierarchical_solution",
-  "inner_parallelization", "parallel_trials", "prefer_modular_solution", "num_random_moves",
-  "max_degree_for_random_moves"
+  "inner_parallelization", "parallel_trials", "num_threads", "threads",
+  "prefer_modular_solution", "num_random_moves", "max_degree_for_random_moves"
 )
 
 OPTION_DEFAULTS <- list(
@@ -160,6 +162,8 @@ OPTION_DEFAULTS <- list(
   fast_hierarchical_solution = NULL,
   inner_parallelization = FALSE,
   parallel_trials = FALSE,
+  num_threads = NULL,
+  threads = NULL,
   prefer_modular_solution = FALSE,
   num_random_moves = NULL,
   max_degree_for_random_moves = NULL
@@ -254,6 +258,8 @@ OPTION_DEFAULTS <- list(
 #'   \item{`fast_hierarchical_solution`}{Find top modules quickly. Use -FF to keep all fast levels. Use -FFF to skip recursive refinement.}
 #'   \item{`inner_parallelization`}{Experimental: use batched parallel node moves for coarse optimization. Performance gains are workload-dependent, often require a relaxed core-loop-codelength-threshold and low tune-iteration-limit, and may produce a different partition than serial optimization.}
 #'   \item{`parallel_trials`}{Run independent trials in parallel with OpenMP. --num-trials remains the total number of trials; the number of parallel workers follows the OpenMP thread count (e.g. OMP_NUM_THREADS), clamped to --num-trials. Peak memory scales with the worker count. Nested OpenMP and --inner-parallelization are disabled inside workers.}
+#'   \item{`num_threads`}{Effective thread budget: 'auto' (resolve from --num-threads > INFOMAP_NUM_THREADS > SLURM_CPUS_PER_TASK > OMP_NUM_THREADS > cpuset > hardware), or a positive integer. 1 forces fully serial. Governs the recursive partition, parallel trials, and inner parallelization.}
+#'   \item{`threads`}{Alias for --num-threads.}
 #'   \item{`prefer_modular_solution`}{Prefer a modular solution even when one module gives a lower codelength.}
 #'   \item{`num_random_moves`}{Try this many random moves in each core loop to merge weakly connected nodes.}
 #'   \item{`max_degree_for_random_moves`}{Try random moves only for nodes with degree at most this value.}

--- a/interfaces/parameters/overrides.json
+++ b/interfaces/parameters/overrides.json
@@ -8,6 +8,14 @@
       {
         "flag": "--inner-parallelization",
         "reason": "The JavaScript package runs Infomap in a single-threaded worker, so exposing OpenMP node-move scheduling would be misleading."
+      },
+      {
+        "flag": "--num-threads",
+        "reason": "The JavaScript package runs Infomap in a single-threaded WASM worker, so an OpenMP thread budget is meaningless there."
+      },
+      {
+        "flag": "--threads",
+        "reason": "Alias of --num-threads; the single-threaded JavaScript worker has no OpenMP thread budget."
       }
     ]
   },

--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -431,6 +431,8 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin, InfomapWrapper):  # no
         prefer_modular_solution=False,
         inner_parallelization=False,
         parallel_trials=False,
+        num_threads=None,
+        threads=None,
         num_random_moves=None,
         max_degree_for_random_moves=None,
     ):
@@ -1693,6 +1695,8 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin, InfomapWrapper):  # no
         prefer_modular_solution=False,
         inner_parallelization=False,
         parallel_trials=False,
+        num_threads=None,
+        threads=None,
         num_random_moves=None,
         max_degree_for_random_moves=None,
     ):

--- a/interfaces/python/src/infomap/_options.py
+++ b/interfaces/python/src/infomap/_options.py
@@ -74,6 +74,8 @@ _ACCURACY_OPTION_SPECS = (
     ("value", "tune_iteration_relative_threshold", "--tune-iteration-relative-threshold", lambda value: value != 1e-05),
     ("flag", "inner_parallelization", "--inner-parallelization", None),
     ("flag", "parallel_trials", "--parallel-trials", None),
+    ("value", "num_threads", "--num-threads", lambda value: value is not None),
+    ("value", "threads", "--threads", lambda value: value is not None),
     ("flag", "prefer_modular_solution", "--prefer-modular-solution", None),
     ("value", "num_random_moves", "--num-random-moves", lambda value: value is not None),
     ("value", "max_degree_for_random_moves", "--max-degree-for-random-moves", lambda value: value is not None),
@@ -276,6 +278,13 @@ class InfomapOptions:
         (e.g. OMP_NUM_THREADS), clamped to --num-trials. Peak memory scales with the
         worker count. Nested OpenMP and --inner-parallelization are disabled inside
         workers.
+    num_threads : str, optional
+        Effective thread budget: 'auto' (resolve from --num-threads >
+        INFOMAP_NUM_THREADS > SLURM_CPUS_PER_TASK > OMP_NUM_THREADS > cpuset >
+        hardware), or a positive integer. 1 forces fully serial. Governs the recursive
+        partition, parallel trials, and inner parallelization.
+    threads : str, optional
+        Alias for --num-threads.
     prefer_modular_solution : bool, optional
         Prefer a modular solution even when one module gives a lower codelength.
     num_random_moves : int, optional
@@ -353,6 +362,8 @@ class InfomapOptions:
     fast_hierarchical_solution: int | None = None
     inner_parallelization: bool = False
     parallel_trials: bool = False
+    num_threads: str | None = None
+    threads: str | None = None
     prefer_modular_solution: bool = False
     num_random_moves: int | None = None
     max_degree_for_random_moves: int | None = None
@@ -472,6 +483,8 @@ def _construct_args(
     fast_hierarchical_solution=None,
     inner_parallelization=False,
     parallel_trials=False,
+    num_threads=None,
+    threads=None,
     prefer_modular_solution=False,
     num_random_moves=None,
     max_degree_for_random_moves=None,

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -545,7 +545,9 @@ private:
       Log(2) << "Run Infomap...\n";
 #ifdef _OPENMP
     {
-      const unsigned int cpus = static_cast<unsigned int>(std::max(1, omp_get_num_procs()));
+      // Prefer the cpuset size (the actual allocation under Linux/SLURM) over
+      // omp_get_num_procs(), which ignores affinity; fall back when unknown.
+      const unsigned int cpus = m_cpusetCount > 0 ? m_cpusetCount : static_cast<unsigned int>(std::max(1, omp_get_num_procs()));
       const char* source = threadSourceName(m_threadBudget.source);
       const char* innerState = m_infomap.innerParallelization ? "enabled" : "disabled";
       if (m_infomap.prettyOutput) {
@@ -560,9 +562,11 @@ private:
       }
 
       // Oversubscription warnings (only meaningful when cpuset is known, i.e. Linux).
-      if (m_cpusetCount > 0 && m_infomap.numThreads > m_cpusetCount) {
-        Log::important() << "  -> Warning: --num-threads " << m_infomap.numThreads
-                         << " exceeds the available cpuset of " << m_cpusetCount
+      // Warn whenever the *resolved* budget exceeds the cpuset, regardless of source
+      // (explicit --num-threads, INFOMAP_NUM_THREADS, SLURM_CPUS_PER_TASK, OMP_NUM_THREADS).
+      if (m_cpusetCount > 0 && m_threadBudget.threads > m_cpusetCount) {
+        Log::important() << "  -> Warning: thread budget " << m_threadBudget.threads
+                         << " (" << source << ") exceeds the available cpuset of " << m_cpusetCount
                          << " CPUs; this may oversubscribe the node.\n";
       }
       if (m_cpusetCount > 0) {

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -702,10 +702,12 @@ public:
       report.version = INFOMAP_VERSION;
 #ifdef _OPENMP
       report.openmp = true;
-      report.threadsRequested = static_cast<unsigned int>(std::max(1, omp_get_max_threads()));
+      report.threadsRequested = m_threadBudget.threads;
+      report.threadSource = threadSourceName(m_threadBudget.source);
 #else
       report.openmp = false;
       report.threadsRequested = 1;
+      report.threadSource = "serial";
 #endif
       report.threadsUsed = result.threadsUsed;
       report.network = m_reportNetwork;

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -161,7 +161,11 @@ public:
       m_threadBudget = resolveThreadBudget(threadSources);
       m_cpusetCount = threadSources.cpusetCount;
 #ifdef _OPENMP
-      omp_set_num_threads(static_cast<int>(m_threadBudget.threads));
+      // Clamp to INT_MAX before the signed cast: the budget is unsigned, and a value
+      // above INT_MAX would make omp_set_num_threads see a negative thread count.
+      const unsigned int ompThreads = std::min(m_threadBudget.threads,
+          static_cast<unsigned int>(std::numeric_limits<int>::max()));
+      omp_set_num_threads(static_cast<int>(ompThreads));
 #endif
     }
     preflightOutputTargets(m_infomap);

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -26,6 +26,7 @@
 #include "../utils/FlowCalculator.h"
 #include "../utils/MemoryUsage.h"
 #include "../utils/PrettyOutput.h"
+#include "../utils/ThreadConfig.h"
 #include "../utils/TimingRegistry.h"
 #include "../utils/convert.h"
 
@@ -148,6 +149,14 @@ public:
 
   Result run()
   {
+    {
+      ThreadSources threadSources = readThreadSourcesFromEnv();
+      threadSources.explicitThreads = m_infomap.numThreads; // 0 = auto
+      m_threadBudget = resolveThreadBudget(threadSources);
+#ifdef _OPENMP
+      omp_set_num_threads(static_cast<int>(m_threadBudget.threads));
+#endif
+    }
     preflightOutputTargets(m_infomap);
     validateNetwork();
     {
@@ -682,6 +691,7 @@ private:
   const unsigned int m_numTrials = m_infomap.numTrials;
   bool m_runParallelTrials = false;
   unsigned int m_threadsUsed = 1;
+  ThreadBudget m_threadBudget;
 };
 
 std::map<unsigned int, std::vector<unsigned int>> InfomapBase::getMultilevelModules(bool states)

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -150,6 +150,12 @@ public:
   Result run()
   {
     {
+      // Resolve the thread budget once for the whole run. RunSession is only
+      // constructed for the main Infomap (run(Network&) requires isMainInfomap),
+      // so this fires exactly once, before any OpenMP region. Setting the
+      // process-global max thread count lets all parallel regions (recursive
+      // partition, parallel trials, inner parallelization) inherit the budget
+      // via their existing omp_get_max_threads() calls.
       ThreadSources threadSources = readThreadSourcesFromEnv();
       threadSources.explicitThreads = m_infomap.numThreads; // 0 = auto
       m_threadBudget = resolveThreadBudget(threadSources);

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -159,6 +159,7 @@ public:
       ThreadSources threadSources = readThreadSourcesFromEnv();
       threadSources.explicitThreads = m_infomap.numThreads; // 0 = auto
       m_threadBudget = resolveThreadBudget(threadSources);
+      m_cpusetCount = threadSources.cpusetCount;
 #ifdef _OPENMP
       omp_set_num_threads(static_cast<int>(m_threadBudget.threads));
 #endif
@@ -542,6 +543,39 @@ private:
       Log(2) << "Run Infomap with memory...\n";
     else
       Log(2) << "Run Infomap...\n";
+#ifdef _OPENMP
+    {
+      const unsigned int cpus = static_cast<unsigned int>(std::max(1, omp_get_num_procs()));
+      const char* source = threadSourceName(m_threadBudget.source);
+      const char* innerState = m_infomap.innerParallelization ? "enabled" : "disabled";
+      if (m_infomap.prettyOutput) {
+        PrettyOutput pretty(true);
+        Log::pretty() << pretty.dim() << "  Runtime: " << cpus << " CPUs available, thread budget "
+                      << m_threadBudget.threads << " (" << source << "), inner parallelization "
+                      << innerState << pretty.reset() << "\n";
+      } else {
+        Log() << "  -> Runtime: " << cpus << " CPUs available, thread budget "
+              << m_threadBudget.threads << " (" << source << "), inner parallelization "
+              << innerState << ".\n";
+      }
+
+      // Oversubscription warnings (only meaningful when cpuset is known, i.e. Linux).
+      if (m_cpusetCount > 0 && m_infomap.numThreads > m_cpusetCount) {
+        Log::important() << "  -> Warning: --num-threads " << m_infomap.numThreads
+                         << " exceeds the available cpuset of " << m_cpusetCount
+                         << " CPUs; this may oversubscribe the node.\n";
+      }
+      if (m_cpusetCount > 0) {
+        const unsigned int innerThreads = (m_infomap.innerParallelization && !m_runParallelTrials) ? m_threadBudget.threads : 1;
+        const unsigned int demand = m_threadsUsed * innerThreads;
+        if (demand > m_cpusetCount) {
+          Log::important() << "  -> Warning: " << m_threadsUsed << " trial workers x " << innerThreads
+                           << " inner threads = " << demand << " exceeds the available cpuset of "
+                           << m_cpusetCount << " CPUs.\n";
+        }
+      }
+    }
+#endif
   }
 
   void runTrial(unsigned int trialIndex, Result& result)
@@ -698,6 +732,7 @@ private:
   bool m_runParallelTrials = false;
   unsigned int m_threadsUsed = 1;
   ThreadBudget m_threadBudget;
+  unsigned int m_cpusetCount = 0;
 };
 
 std::map<unsigned int, std::vector<unsigned int>> InfomapBase::getMultilevelModules(bool states)

--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -18,6 +18,7 @@
 #include "../utils/convert.h"
 #include <algorithm>
 #include <iterator>
+#include <limits>
 #include <vector>
 #include <stdexcept>
 #include <utility>
@@ -166,6 +167,23 @@ namespace {
     }
   }
 
+  void applyThreadBudgetInteraction(Config& config)
+  {
+    if (config.numThreadsArg.empty() || config.numThreadsArg == "auto") {
+      config.numThreads = 0;
+      return;
+    }
+    try {
+      const long value = std::stol(config.numThreadsArg);
+      if (value < 1 || static_cast<unsigned long>(value) > std::numeric_limits<unsigned int>::max()) {
+        throw std::runtime_error("--num-threads must be 'auto' or a positive integer");
+      }
+      config.numThreads = static_cast<unsigned int>(value);
+    } catch (const std::invalid_argument&) {
+      throw std::runtime_error("--num-threads must be 'auto' or a positive integer");
+    }
+  }
+
   // Lifecycle-only steps. These read staged parse state, touch the filesystem,
   // or mutate global state — they are not Config invariants and must not fire
   // when a library user calls adaptDefaults() on a mutated Config.
@@ -305,6 +323,7 @@ void Config::adaptDefaults()
   applyLibraryOutputDefaults(*this);
   validateRequiredCliOutput(*this);
   applyOptionInteractions(*this);
+  applyThreadBudgetInteraction(*this);
   validateRunReportOutput(*this);
   normalizeOutputDirectory(*this);
   applyOutputNameDefault(*this);

--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -17,6 +17,7 @@
 #include "../utils/Log.h"
 #include "../utils/convert.h"
 #include <algorithm>
+#include <cstddef>
 #include <iterator>
 #include <limits>
 #include <vector>
@@ -173,15 +174,25 @@ namespace {
       config.numThreads = 0;
       return;
     }
-    try {
-      const long value = std::stol(config.numThreadsArg);
-      if (value < 1 || static_cast<unsigned long>(value) > std::numeric_limits<unsigned int>::max()) {
-        throw std::runtime_error("--num-threads must be 'auto' or a positive integer");
-      }
-      config.numThreads = static_cast<unsigned int>(value);
-    } catch (const std::invalid_argument&) {
+    const auto invalid = []() {
       throw std::runtime_error("--num-threads must be 'auto' or a positive integer");
+    };
+    long value = 0;
+    try {
+      std::size_t consumed = 0;
+      value = std::stol(config.numThreadsArg, &consumed);
+      if (consumed != config.numThreadsArg.size()) {
+        invalid(); // trailing garbage like "4x"
+      }
+    } catch (const std::invalid_argument&) {
+      invalid();
+    } catch (const std::out_of_range&) {
+      invalid();
     }
+    if (value < 1 || static_cast<unsigned long>(value) > std::numeric_limits<unsigned int>::max()) {
+      invalid();
+    }
+    config.numThreads = static_cast<unsigned int>(value);
   }
 
   // Lifecycle-only steps. These read staged parse state, touch the filesystem,

--- a/src/io/Config.h
+++ b/src/io/Config.h
@@ -145,6 +145,8 @@ struct Config {
   std::string summaryJsonPath;
   std::string runManifestPath;
   bool memoryReport = false;
+  std::string numThreadsArg = "auto"; // raw --num-threads / --threads argument
+  unsigned int numThreads = 0;        // 0 = auto; positive = explicit request
 #endif
   int cluLevel = 1; // Write modules at specified depth from root. 1, 2, ... or -1 for bottom level
   bool printFlowNetwork = false;
@@ -234,6 +236,8 @@ struct Config {
     summaryJsonPath = other.summaryJsonPath;
     runManifestPath = other.runManifestPath;
     memoryReport = other.memoryReport;
+    numThreadsArg = other.numThreadsArg;
+    numThreads = other.numThreads;
 #endif
     verbosity = other.verbosity;
     verboseNumberPrecision = other.verboseNumberPrecision;

--- a/src/io/ParameterCatalog.cpp
+++ b/src/io/ParameterCatalog.cpp
@@ -846,6 +846,22 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .group("Accuracy")
         .advanced()
         .configTarget(&Config::parallelTrials),
+    param()
+        .longName("num-threads")
+        .description("Effective thread budget: 'auto' (resolve from --num-threads > INFOMAP_NUM_THREADS > SLURM_CPUS_PER_TASK > OMP_NUM_THREADS > cpuset > hardware), or a positive integer. 1 forces fully serial. Governs the recursive partition, parallel trials, and inner parallelization.")
+        .argument(ArgType::string)
+        .group("Accuracy")
+        .advanced()
+        .defaultValue("auto")
+        .configTarget(&Config::numThreadsArg),
+    param()
+        .longName("threads")
+        .description("Alias for --num-threads.")
+        .argument(ArgType::string)
+        .group("Accuracy")
+        .advanced()
+        .defaultValue("auto")
+        .configTarget(&Config::numThreadsArg),
 #if INFOMAP_FEATURE_TEST_FEATURE
     param()
         .longName("test-feature")

--- a/src/io/RunReport.cpp
+++ b/src/io/RunReport.cpp
@@ -106,6 +106,7 @@ std::string runTimingReportJson(const RunTimingReport& report)
       << "\"openmp\":" << (report.openmp ? "true" : "false") << ','
       << "\"threads_requested\":" << report.threadsRequested << ','
       << "\"threads_used\":" << report.threadsUsed << ','
+      << "\"thread_source\":" << jsonString(report.threadSource) << ','
       << "\"network\":{"
       << "\"nodes\":" << report.network.nodes << ','
       << "\"links\":" << report.network.links << ','

--- a/src/io/RunReport.h
+++ b/src/io/RunReport.h
@@ -41,6 +41,7 @@ struct RunTimingReport {
   bool openmp = false;
   unsigned int threadsRequested = 1;
   unsigned int threadsUsed = 1;
+  std::string threadSource = "serial";
   RunReportNetwork network;
   std::vector<std::pair<std::string, double>> timing;
   std::vector<TrialTimingRecord> trials;

--- a/src/utils/ThreadConfig.cpp
+++ b/src/utils/ThreadConfig.cpp
@@ -10,6 +10,7 @@
 #include "ThreadConfig.h"
 
 #include <algorithm>
+#include <cerrno>
 #include <cstddef>
 #include <cstdlib>
 #include <limits>
@@ -84,10 +85,37 @@ namespace {
   unsigned int readCpusetCount()
   {
 #if defined(__linux__)
-    cpu_set_t set;
-    CPU_ZERO(&set);
-    if (sched_getaffinity(0, sizeof(set), &set) == 0) {
-      return static_cast<unsigned int>(CPU_COUNT(&set));
+    // Fast path: the fixed-size set covers machines up to CPU_SETSIZE (typically 1024) CPUs.
+    {
+      cpu_set_t set;
+      CPU_ZERO(&set);
+      if (sched_getaffinity(0, sizeof(set), &set) == 0) {
+        return static_cast<unsigned int>(CPU_COUNT(&set));
+      }
+      if (errno != EINVAL) {
+        return 0; // a non-size error won't be fixed by a larger mask
+      }
+    }
+    // Large machines (> CPU_SETSIZE CPUs) make the fixed-size call fail with EINVAL;
+    // grow a dynamically-allocated mask until sched_getaffinity succeeds.
+    for (unsigned int numCpus = CPU_SETSIZE * 2; numCpus <= CPU_SETSIZE * 1024u; numCpus *= 2) {
+      cpu_set_t* set = CPU_ALLOC(numCpus);
+      if (set == nullptr) {
+        break;
+      }
+      const std::size_t size = CPU_ALLOC_SIZE(numCpus);
+      CPU_ZERO_S(size, set);
+      const int rc = sched_getaffinity(0, size, set);
+      if (rc == 0) {
+        const unsigned int count = static_cast<unsigned int>(CPU_COUNT_S(size, set));
+        CPU_FREE(set);
+        return count;
+      }
+      const int err = errno;
+      CPU_FREE(set);
+      if (err != EINVAL) {
+        break;
+      }
     }
 #endif
     return 0;

--- a/src/utils/ThreadConfig.cpp
+++ b/src/utils/ThreadConfig.cpp
@@ -10,6 +10,7 @@
 #include "ThreadConfig.h"
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdlib>
 #include <limits>
 #include <string>
@@ -67,8 +68,11 @@ namespace {
       return 0;
     }
     try {
-      const long value = std::stol(std::string(raw));
-      if (value > 0 && value <= static_cast<long>(std::numeric_limits<unsigned int>::max())) {
+      const std::string text(raw);
+      std::size_t consumed = 0;
+      const long value = std::stol(text, &consumed);
+      // Reject trailing garbage (e.g. "4x") — treat a non-numeric env value as unset.
+      if (consumed == text.size() && value > 0 && value <= static_cast<long>(std::numeric_limits<unsigned int>::max())) {
         return static_cast<unsigned int>(value);
       }
       return 0;

--- a/src/utils/ThreadConfig.cpp
+++ b/src/utils/ThreadConfig.cpp
@@ -1,0 +1,90 @@
+#include "ThreadConfig.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <string>
+#include <thread>
+
+#if defined(__linux__)
+#include <sched.h>
+#endif
+
+namespace infomap {
+
+ThreadBudget resolveThreadBudget(const ThreadSources& s)
+{
+  const auto pick = [](unsigned int value, ThreadSource source, ThreadBudget& out) {
+    if (value > 0) {
+      out.threads = value;
+      out.source = source;
+      return true;
+    }
+    return false;
+  };
+
+  ThreadBudget budget;
+  if (pick(s.explicitThreads, ThreadSource::Explicit, budget)
+      || pick(s.infomapEnv, ThreadSource::InfomapEnv, budget)
+      || pick(s.slurmCpusPerTask, ThreadSource::Slurm, budget)
+      || pick(s.ompEnv, ThreadSource::Omp, budget)
+      || pick(s.cpusetCount, ThreadSource::Cpuset, budget)) {
+    return budget;
+  }
+  budget.threads = std::max(1u, s.hardwareConcurrency);
+  budget.source = ThreadSource::Hardware;
+  return budget;
+}
+
+const char* threadSourceName(ThreadSource source)
+{
+  switch (source) {
+    case ThreadSource::Explicit: return "--num-threads";
+    case ThreadSource::InfomapEnv: return "INFOMAP_NUM_THREADS";
+    case ThreadSource::Slurm: return "SLURM_CPUS_PER_TASK";
+    case ThreadSource::Omp: return "OMP_NUM_THREADS";
+    case ThreadSource::Cpuset: return "cpuset";
+    case ThreadSource::Hardware: return "hardware_concurrency";
+  }
+  return "unknown";
+}
+
+namespace {
+  unsigned int parseEnvCount(const char* name)
+  {
+    const char* raw = std::getenv(name);
+    if (raw == nullptr) {
+      return 0;
+    }
+    try {
+      const long value = std::stol(std::string(raw));
+      return value > 0 ? static_cast<unsigned int>(value) : 0;
+    } catch (...) {
+      return 0;
+    }
+  }
+
+  unsigned int readCpusetCount()
+  {
+#if defined(__linux__)
+    cpu_set_t set;
+    CPU_ZERO(&set);
+    if (sched_getaffinity(0, sizeof(set), &set) == 0) {
+      return static_cast<unsigned int>(CPU_COUNT(&set));
+    }
+#endif
+    return 0;
+  }
+} // namespace
+
+ThreadSources readThreadSourcesFromEnv()
+{
+  ThreadSources s;
+  s.infomapEnv = parseEnvCount("INFOMAP_NUM_THREADS");
+  s.slurmCpusPerTask = parseEnvCount("SLURM_CPUS_PER_TASK");
+  s.ompEnv = parseEnvCount("OMP_NUM_THREADS");
+  s.cpusetCount = readCpusetCount();
+  s.hardwareConcurrency = std::max(1u, std::thread::hardware_concurrency());
+  return s;
+}
+
+} // namespace infomap

--- a/src/utils/ThreadConfig.cpp
+++ b/src/utils/ThreadConfig.cpp
@@ -1,7 +1,17 @@
+/*******************************************************************************
+ Infomap software package for multi-level network clustering
+ Copyright (c) 2013, 2014 Daniel Edler, Anton Holmgren, Martin Rosvall
+
+ This file is part of the Infomap software package.
+ See file LICENSE_GPLv3.txt for full license details.
+ For more information, see <http://www.mapequation.org>
+ ******************************************************************************/
+
 #include "ThreadConfig.h"
 
 #include <algorithm>
 #include <cstdlib>
+#include <limits>
 #include <string>
 #include <thread>
 
@@ -45,6 +55,7 @@ const char* threadSourceName(ThreadSource source)
     case ThreadSource::Cpuset: return "cpuset";
     case ThreadSource::Hardware: return "hardware_concurrency";
   }
+  // unreachable — all enumerators handled above
   return "unknown";
 }
 
@@ -57,7 +68,10 @@ namespace {
     }
     try {
       const long value = std::stol(std::string(raw));
-      return value > 0 ? static_cast<unsigned int>(value) : 0;
+      if (value > 0 && value <= static_cast<long>(std::numeric_limits<unsigned int>::max())) {
+        return static_cast<unsigned int>(value);
+      }
+      return 0;
     } catch (...) {
       return 0;
     }

--- a/src/utils/ThreadConfig.h
+++ b/src/utils/ThreadConfig.h
@@ -1,0 +1,36 @@
+#ifndef THREAD_CONFIG_H_
+#define THREAD_CONFIG_H_
+
+#include <cstdint>
+
+namespace infomap {
+
+// A thread count of 0 means "absent / not specified" (C++14 — no std::optional).
+struct ThreadSources {
+  unsigned int explicitThreads = 0;    // --num-threads N (0 = auto)
+  unsigned int infomapEnv = 0;         // INFOMAP_NUM_THREADS
+  unsigned int slurmCpusPerTask = 0;   // SLURM_CPUS_PER_TASK
+  unsigned int ompEnv = 0;             // OMP_NUM_THREADS
+  unsigned int cpusetCount = 0;        // sched_getaffinity
+  unsigned int hardwareConcurrency = 1; // always >= 1, final fallback
+};
+
+enum class ThreadSource : std::uint8_t { Explicit, InfomapEnv, Slurm, Omp, Cpuset, Hardware };
+
+struct ThreadBudget {
+  unsigned int threads = 1;
+  ThreadSource source = ThreadSource::Hardware;
+};
+
+// Pure: first non-zero source in precedence order wins, clamped to >= 1.
+ThreadBudget resolveThreadBudget(const ThreadSources& sources);
+
+// Human-readable source label for logs / JSON (e.g. "SLURM_CPUS_PER_TASK").
+const char* threadSourceName(ThreadSource source);
+
+// Production wiring: reads env vars + sched_getaffinity + hardware_concurrency.
+ThreadSources readThreadSourcesFromEnv();
+
+} // namespace infomap
+
+#endif // THREAD_CONFIG_H_

--- a/src/utils/ThreadConfig.h
+++ b/src/utils/ThreadConfig.h
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ Infomap software package for multi-level network clustering
+ Copyright (c) 2013, 2014 Daniel Edler, Anton Holmgren, Martin Rosvall
+
+ This file is part of the Infomap software package.
+ See file LICENSE_GPLv3.txt for full license details.
+ For more information, see <http://www.mapequation.org>
+ ******************************************************************************/
+
 #ifndef THREAD_CONFIG_H_
 #define THREAD_CONFIG_H_
 

--- a/test/cpp/test_config.cpp
+++ b/test/cpp/test_config.cpp
@@ -548,4 +548,38 @@ TEST_CASE("Parameter catalog registers with ProgramInterface through a named ada
   CHECK_FALSE(api.getUsedOptionArguments().empty());
 }
 
+TEST_CASE("Config parses --num-threads as an explicit budget [fast][core][config][cli]")
+{
+  const Config config("input.net --silent --no-file-output --num-threads 4", true);
+  CHECK(config.numThreads == 4);
+}
+
+TEST_CASE("Config accepts --threads as an alias for --num-threads [fast][core][config][cli]")
+{
+  const Config config("input.net --silent --no-file-output --threads 6", true);
+  CHECK(config.numThreads == 6);
+}
+
+TEST_CASE("Config treats --num-threads auto as the zero sentinel [fast][core][config][cli]")
+{
+  const Config config("input.net --silent --no-file-output --num-threads auto", true);
+  CHECK(config.numThreads == 0);
+}
+
+TEST_CASE("Config defaults numThreads to auto when flag absent [fast][core][config][cli]")
+{
+  const Config config("input.net --silent --no-file-output", true);
+  CHECK(config.numThreads == 0);
+}
+
+TEST_CASE("Config rejects non-numeric, non-auto --num-threads [fast][core][config][cli]")
+{
+  CHECK_THROWS(Config("input.net --silent --no-file-output --num-threads banana", true));
+}
+
+TEST_CASE("Config rejects --num-threads 0 [fast][core][config][cli]")
+{
+  CHECK_THROWS(Config("input.net --silent --no-file-output --num-threads 0", true));
+}
+
 } // namespace

--- a/test/cpp/test_config.cpp
+++ b/test/cpp/test_config.cpp
@@ -582,4 +582,19 @@ TEST_CASE("Config rejects --num-threads 0 [fast][core][config][cli]")
   CHECK_THROWS(Config("input.net --silent --no-file-output --num-threads 0", true));
 }
 
+TEST_CASE("Config rejects an out-of-range --num-threads without crashing [fast][core][config][cli]")
+{
+  CHECK_THROWS(Config("input.net --silent --no-file-output --num-threads 999999999999999999999999", true));
+}
+
+TEST_CASE("Config rejects a negative --num-threads [fast][core][config][cli]")
+{
+  CHECK_THROWS(Config("input.net --silent --no-file-output --num-threads -1", true));
+}
+
+TEST_CASE("Config rejects --num-threads with trailing garbage [fast][core][config][cli]")
+{
+  CHECK_THROWS(Config("input.net --silent --no-file-output --num-threads 4x", true));
+}
+
 } // namespace

--- a/test/cpp/test_infomap_wrapper.cpp
+++ b/test/cpp/test_infomap_wrapper.cpp
@@ -220,6 +220,7 @@ TEST_CASE("Run reports write machine-readable JSON with no-file-output [fast][co
   CHECK(timingJson.find("\"openmp\":") != std::string::npos);
   CHECK(timingJson.find("\"threads_requested\":") != std::string::npos);
   CHECK(timingJson.find("\"threads_used\":1,") != std::string::npos);
+  CHECK(timingJson.find("\"thread_source\":\"") != std::string::npos);
   CHECK(timingJson.find("\"network\":{\"nodes\":") != std::string::npos);
   CHECK(timingJson.find("\"timing\":{") != std::string::npos);
   CHECK(timingJson.find("\"flow_calculation_s\":") != std::string::npos);

--- a/test/cpp/test_infomap_wrapper.cpp
+++ b/test/cpp/test_infomap_wrapper.cpp
@@ -221,6 +221,7 @@ TEST_CASE("Run reports write machine-readable JSON with no-file-output [fast][co
   CHECK(timingJson.find("\"threads_requested\":") != std::string::npos);
   CHECK(timingJson.find("\"threads_used\":1,") != std::string::npos);
   CHECK(timingJson.find("\"thread_source\":\"") != std::string::npos);
+  CHECK(timingJson.find("\"thread_source\":\"\"") == std::string::npos); // value is non-empty
   CHECK(timingJson.find("\"network\":{\"nodes\":") != std::string::npos);
   CHECK(timingJson.find("\"timing\":{") != std::string::npos);
   CHECK(timingJson.find("\"flow_calculation_s\":") != std::string::npos);

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -767,12 +767,17 @@ TEST_CASE("numNonTrivialTopModules is zero when all nodes are in one module [fas
   infomap::test::checkCanonicalPartition(im, { { 1, 2, 3, 4, 5 } });
 }
 
-TEST_CASE("--num-threads 1 matches default codelength on a small network [fast][core][threads]")
+TEST_CASE("--num-threads bounds parallel-trials workers without changing the result [fast][core][threads]")
 {
-  const char* baseFlags = "--num-trials 3 --seed 123 --no-file-output --silent";
-  InfomapWrapper serial(std::string("--num-threads 1 ") + baseFlags);
-  InfomapWrapper parallelTrials(std::string("--num-threads 1 --parallel-trials ") + baseFlags);
-  for (InfomapWrapper* im : { &serial, &parallelTrials }) {
+  // Parallel trials reseed per trial (seed = base + trialIndex), so the result is
+  // invariant to the worker count. --num-threads only bounds how many workers run.
+  // Therefore a 1-thread budget and a 4-thread budget must produce the same best
+  // result, which confirms omp_set_num_threads(B) propagates into the worker pool
+  // without altering the per-trial RNG sequence.
+  const char* baseFlags = "--parallel-trials --num-trials 4 --seed 123 --no-file-output --silent";
+  InfomapWrapper oneThread(std::string("--num-threads 1 ") + baseFlags);
+  InfomapWrapper fourThreads(std::string("--num-threads 4 ") + baseFlags);
+  for (InfomapWrapper* im : { &oneThread, &fourThreads }) {
     im->addLink(0, 1);
     im->addLink(1, 2);
     im->addLink(2, 0);
@@ -782,8 +787,8 @@ TEST_CASE("--num-threads 1 matches default codelength on a small network [fast][
     im->addLink(5, 3);
     im->run();
   }
-  CHECK(serial.codelength() == doctest::Approx(parallelTrials.codelength()));
-  CHECK(serial.numTopModules() == parallelTrials.numTopModules());
+  CHECK(oneThread.codelength() == doctest::Approx(fourThreads.codelength()));
+  CHECK(oneThread.numTopModules() == fourThreads.numTopModules());
 }
 
 } // namespace

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -767,4 +767,22 @@ TEST_CASE("numNonTrivialTopModules is zero when all nodes are in one module [fas
   infomap::test::checkCanonicalPartition(im, { { 1, 2, 3, 4, 5 } });
 }
 
+TEST_CASE("--num-threads 1 matches default codelength on a small network [fast][core][threads]")
+{
+  const char* baseFlags = "--num-trials 3 --seed 123 --no-file-output --silent";
+  InfomapWrapper serial(std::string("--num-threads 1 ") + baseFlags);
+  InfomapWrapper parallelTrials(std::string("--num-threads 1 --parallel-trials ") + baseFlags);
+  for (InfomapWrapper* im : { &serial, &parallelTrials }) {
+    im->addLink(0, 1);
+    im->addLink(1, 2);
+    im->addLink(2, 0);
+    im->addLink(2, 3);
+    im->addLink(3, 4);
+    im->addLink(4, 5);
+    im->addLink(5, 3);
+    im->run();
+  }
+  CHECK(serial.codelength() == doctest::Approx(parallelTrials.codelength()));
+}
+
 } // namespace

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -783,6 +783,7 @@ TEST_CASE("--num-threads 1 matches default codelength on a small network [fast][
     im->run();
   }
   CHECK(serial.codelength() == doctest::Approx(parallelTrials.codelength()));
+  CHECK(serial.numTopModules() == parallelTrials.numTopModules());
 }
 
 } // namespace

--- a/test/cpp/test_thread_config.cpp
+++ b/test/cpp/test_thread_config.cpp
@@ -1,0 +1,80 @@
+#include "vendor/doctest.h"
+
+#include "utils/ThreadConfig.h"
+
+#include <string>
+
+using infomap::resolveThreadBudget;
+using infomap::ThreadBudget;
+using infomap::ThreadSource;
+using infomap::ThreadSources;
+using infomap::threadSourceName;
+
+TEST_CASE("Explicit --num-threads wins over every other source [fast][core][threads]")
+{
+  ThreadSources s;
+  s.explicitThreads = 3;
+  s.infomapEnv = 5;
+  s.slurmCpusPerTask = 8;
+  s.ompEnv = 16;
+  s.cpusetCount = 32;
+  s.hardwareConcurrency = 64;
+  const ThreadBudget b = resolveThreadBudget(s);
+  CHECK(b.threads == 3);
+  CHECK(b.source == ThreadSource::Explicit);
+}
+
+TEST_CASE("Precedence falls through to the first present source [fast][core][threads]")
+{
+  ThreadSources s;
+  s.slurmCpusPerTask = 8; // INFOMAP_NUM_THREADS absent, SLURM present
+  s.ompEnv = 16;
+  s.cpusetCount = 32;
+  s.hardwareConcurrency = 64;
+  const ThreadBudget b = resolveThreadBudget(s);
+  CHECK(b.threads == 8);
+  CHECK(b.source == ThreadSource::Slurm);
+}
+
+TEST_CASE("OMP_NUM_THREADS used when SLURM and INFOMAP unset [fast][core][threads]")
+{
+  ThreadSources s;
+  s.ompEnv = 16;
+  s.cpusetCount = 32;
+  s.hardwareConcurrency = 64;
+  const ThreadBudget b = resolveThreadBudget(s);
+  CHECK(b.threads == 16);
+  CHECK(b.source == ThreadSource::Omp);
+}
+
+TEST_CASE("cpuset used when env vars unset [fast][core][threads]")
+{
+  ThreadSources s;
+  s.cpusetCount = 12;
+  s.hardwareConcurrency = 64;
+  const ThreadBudget b = resolveThreadBudget(s);
+  CHECK(b.threads == 12);
+  CHECK(b.source == ThreadSource::Cpuset);
+}
+
+TEST_CASE("hardware_concurrency is the final fallback [fast][core][threads]")
+{
+  ThreadSources s;
+  s.hardwareConcurrency = 64;
+  const ThreadBudget b = resolveThreadBudget(s);
+  CHECK(b.threads == 64);
+  CHECK(b.source == ThreadSource::Hardware);
+}
+
+TEST_CASE("Budget is clamped to at least 1 [fast][core][threads]")
+{
+  ThreadSources s; // all zero, hardwareConcurrency defaults to 1
+  const ThreadBudget b = resolveThreadBudget(s);
+  CHECK(b.threads == 1);
+}
+
+TEST_CASE("threadSourceName returns documented labels [fast][core][threads]")
+{
+  CHECK(std::string(threadSourceName(ThreadSource::Slurm)) == "SLURM_CPUS_PER_TASK");
+  CHECK(std::string(threadSourceName(ThreadSource::Cpuset)) == "cpuset");
+}

--- a/test/cpp/test_thread_config.cpp
+++ b/test/cpp/test_thread_config.cpp
@@ -73,8 +73,25 @@ TEST_CASE("Budget is clamped to at least 1 [fast][core][threads]")
   CHECK(b.threads == 1);
 }
 
+TEST_CASE("INFOMAP_NUM_THREADS wins when explicit is absent [fast][core][threads]")
+{
+  ThreadSources s;
+  s.infomapEnv = 7;
+  s.slurmCpusPerTask = 8;
+  s.ompEnv = 16;
+  s.cpusetCount = 32;
+  s.hardwareConcurrency = 64;
+  const ThreadBudget b = resolveThreadBudget(s);
+  CHECK(b.threads == 7);
+  CHECK(b.source == ThreadSource::InfomapEnv);
+}
+
 TEST_CASE("threadSourceName returns documented labels [fast][core][threads]")
 {
+  CHECK(std::string(threadSourceName(ThreadSource::Explicit)) == "--num-threads");
+  CHECK(std::string(threadSourceName(ThreadSource::InfomapEnv)) == "INFOMAP_NUM_THREADS");
   CHECK(std::string(threadSourceName(ThreadSource::Slurm)) == "SLURM_CPUS_PER_TASK");
+  CHECK(std::string(threadSourceName(ThreadSource::Omp)) == "OMP_NUM_THREADS");
   CHECK(std::string(threadSourceName(ThreadSource::Cpuset)) == "cpuset");
+  CHECK(std::string(threadSourceName(ThreadSource::Hardware)) == "hardware_concurrency");
 }

--- a/test/cpp/test_thread_config.cpp
+++ b/test/cpp/test_thread_config.cpp
@@ -2,8 +2,10 @@
 
 #include "utils/ThreadConfig.h"
 
+#include <cstdlib>
 #include <string>
 
+using infomap::readThreadSourcesFromEnv;
 using infomap::resolveThreadBudget;
 using infomap::ThreadBudget;
 using infomap::ThreadSource;
@@ -95,3 +97,63 @@ TEST_CASE("threadSourceName returns documented labels [fast][core][threads]")
   CHECK(std::string(threadSourceName(ThreadSource::Cpuset)) == "cpuset");
   CHECK(std::string(threadSourceName(ThreadSource::Hardware)) == "hardware_concurrency");
 }
+
+#if defined(__unix__) || defined(__APPLE__)
+namespace {
+// RAII save/restore of an env var so the test never leaks state into other cases.
+struct ScopedEnv {
+  std::string name;
+  bool hadValue = false;
+  std::string previous;
+  explicit ScopedEnv(const char* envName) : name(envName)
+  {
+    if (const char* current = std::getenv(envName)) {
+      hadValue = true;
+      previous = current;
+    }
+  }
+  void set(const char* value) const { setenv(name.c_str(), value, 1); }
+  void clear() const { unsetenv(name.c_str()); }
+  ~ScopedEnv()
+  {
+    if (hadValue) {
+      setenv(name.c_str(), previous.c_str(), 1);
+    } else {
+      unsetenv(name.c_str());
+    }
+  }
+};
+} // namespace
+
+TEST_CASE("readThreadSourcesFromEnv reads env vars and rejects trailing garbage [fast][core][threads]")
+{
+  ScopedEnv infomapEnv("INFOMAP_NUM_THREADS");
+  ScopedEnv slurmEnv("SLURM_CPUS_PER_TASK");
+  ScopedEnv ompEnv("OMP_NUM_THREADS");
+
+  infomapEnv.set("7");
+  slurmEnv.set("8");
+  ompEnv.set("16");
+  {
+    const ThreadSources s = readThreadSourcesFromEnv();
+    CHECK(s.infomapEnv == 7);
+    CHECK(s.slurmCpusPerTask == 8);
+    CHECK(s.ompEnv == 16);
+    CHECK(s.hardwareConcurrency >= 1); // always present fallback
+    // The env values feed precedence resolution: INFOMAP_NUM_THREADS wins here.
+    CHECK(resolveThreadBudget(s).source == ThreadSource::InfomapEnv);
+    CHECK(resolveThreadBudget(s).threads == 7);
+  }
+
+  // Trailing garbage and non-numeric values are treated as unset (0), not parsed loosely.
+  infomapEnv.set("4x");
+  slurmEnv.clear();
+  ompEnv.clear();
+  {
+    const ThreadSources s = readThreadSourcesFromEnv();
+    CHECK(s.infomapEnv == 0);
+    CHECK(s.slurmCpusPerTask == 0);
+    CHECK(s.ompEnv == 0);
+  }
+}
+#endif


### PR DESCRIPTION
Closes #626.

## Summary
Adds a `--num-threads auto|N` thread policy (alias `--threads`) that resolves an effective thread budget from a documented precedence and governs all OpenMP work, without changing default behavior.

Precedence: `--num-threads` → `INFOMAP_NUM_THREADS` → `SLURM_CPUS_PER_TASK` → `OMP_NUM_THREADS` → Linux cpuset (`sched_getaffinity`) → `hardware_concurrency`.

- New `src/utils/ThreadConfig.{h,cpp}` — pure, unit-tested budget resolver + env reader.
- Budget applied once via `omp_set_num_threads(B)` in the run session; all three OpenMP paths (recursive partition, parallel trials, inner parallelization) inherit it via the existing `omp_get_max_threads()`.
- `--num-threads 1` → fully serial. Runtime/budget log line in both plain and `--pretty` modes; cpuset oversubscription warnings.
- Effective budget + source surfaced in `--timing-json` (`threads_requested`, `thread_source`).
- `--num-threads`/`--threads` hidden from the JS bindings (single-threaded WASM worker); present in Python/R.

## Notes for reviewers
- The 4-worker memory cap described in the issue is **intentionally dropped** — it was already removed by #628 in favor of "budget = resolved threads". This PR follows #628 and adds the cpuset/SLURM-aware resolution that was the remaining core of #626.
- `omp_set_num_threads` sets a process-global that is not restored after the run (intended for CLI-wide governance; library embedders should be aware).
- `Config::numThreads` is under `#ifndef SWIG` → no SWIG wrapper churn.

## Test plan
- [x] `make test-native OPENMP=1` (16/16)
- [x] `make test-binding-options-freshness`, `make test-python-swig-freshness`, `make test-r-swig-freshness`
- [x] No SWIG churn (`interfaces/python/generated/` clean)