### PR TITLE
perf: flatten the physical-node module maps to sorted vectors

### DIFF
--- a/src/core/MapEquation.h
+++ b/src/core/MapEquation.h
@@ -20,16 +20,27 @@
 #include <vector>
 #include <map>
 #include <ostream>
+#include <algorithm>
 
 namespace infomap {
 
 class InfoNode;
 
-struct MemNodeSet {
-  MemNodeSet(unsigned int numMemNodes, double sumFlow) : numMemNodes(numMemNodes), sumFlow(sumFlow) {}
+// One module entry of a physical node's flat module map, kept sorted by
+// module id. The sort order is load-bearing: iteration order determines
+// floating-point summation order in the codelength terms.
+struct ModuleMemNodes {
+  ModuleMemNodes(unsigned int module, unsigned int numMemNodes, double sumFlow)
+      : module(module), numMemNodes(numMemNodes), sumFlow(sumFlow) {}
+  unsigned int module;
   unsigned int numMemNodes; // use counter to check for zero to avoid round-off errors in sumFlow
   double sumFlow;
 };
+
+inline std::vector<ModuleMemNodes>::iterator findModuleMemNodes(std::vector<ModuleMemNodes>& moduleToMemNodes, unsigned int module)
+{
+  return std::lower_bound(moduleToMemNodes.begin(), moduleToMemNodes.end(), module, [](const ModuleMemNodes& memNodes, unsigned int target) { return memNodes.module < target; });
+}
 
 template <typename FlowDataType = FlowData, typename DeltaFlowDataType = DeltaFlow>
 class MapEquation {

--- a/src/core/MemMapEquation.cpp
+++ b/src/core/MemMapEquation.cpp
@@ -210,9 +210,14 @@ void MemMapEquation::initPartitionOfPhysicalNodes(std::vector<InfoNode*>& nodes)
     unsigned int moduleIndex = node.index; // Assume unique module index for all nodes in this initiation phase
 
     for (PhysData& physData : node.physicalNodes) {
-      m_physToModuleToMemNodes[physData.physNodeIndex].insert(m_physToModuleToMemNodes[physData.physNodeIndex].end(),
-                                                              std::make_pair(moduleIndex, MemNodeSet(1, physData.sumFlowFromM2Node)));
+      m_physToModuleToMemNodes[physData.physNodeIndex].emplace_back(moduleIndex, 1, physData.sumFlowFromM2Node);
     }
+  }
+
+  // Keep each physical node's entries sorted by module id; the move and
+  // codelength code relies on this for lookups and summation order.
+  for (auto& moduleToMemNodes : m_physToModuleToMemNodes) {
+    std::sort(moduleToMemNodes.begin(), moduleToMemNodes.end(), [](const ModuleMemNodes& a, const ModuleMemNodes& b) { return a.module < b.module; });
   }
 
   m_memoryContributionsAdded = false;
@@ -236,8 +241,8 @@ void MemMapEquation::calculateNodeFlow_log_nodeFlow()
   nodeFlow_log_nodeFlow = 0.0;
   for (unsigned int i = 0; i < m_numPhysicalNodes; ++i) {
     const ModuleToMemNodes& moduleToMemNodes = m_physToModuleToMemNodes[i];
-    for (const auto& moduleToMemNode : moduleToMemNodes)
-      nodeFlow_log_nodeFlow += infomath::plogp(moduleToMemNode.second.sumFlow);
+    for (const auto& memNodes : moduleToMemNodes)
+      nodeFlow_log_nodeFlow += infomath::plogp(memNodes.sumFlow);
   }
 }
 
@@ -294,19 +299,18 @@ void MemMapEquation::addMemoryContributions(InfoNode& current,
   for (unsigned int i = 0; i < numPhysicalNodes; ++i) {
     PhysData& physData = physicalNodes[i];
     ModuleToMemNodes& moduleToMemNodes = m_physToModuleToMemNodes[physData.physNodeIndex];
-    for (const auto& moduleToMemNode : moduleToMemNodes) {
-      unsigned int moduleIndex = moduleToMemNode.first;
-      auto& memNodeSet = moduleToMemNode.second;
+    for (const auto& memNodes : moduleToMemNodes) {
+      unsigned int moduleIndex = memNodes.module;
       if (moduleIndex == current.index) // From where the multiple assigned node is moved
       {
-        double oldPhysFlow = memNodeSet.sumFlow;
-        double newPhysFlow = memNodeSet.sumFlow - physData.sumFlowFromM2Node;
+        double oldPhysFlow = memNodes.sumFlow;
+        double newPhysFlow = memNodes.sumFlow - physData.sumFlowFromM2Node;
         oldModuleDelta.sumDeltaPlogpPhysFlow += infomath::plogp(newPhysFlow) - infomath::plogp(oldPhysFlow);
         oldModuleDelta.sumPlogpPhysFlow += infomath::plogp(physData.sumFlowFromM2Node);
       } else // To where the multiple assigned node is moved
       {
-        double oldPhysFlow = memNodeSet.sumFlow;
-        double newPhysFlow = memNodeSet.sumFlow + physData.sumFlowFromM2Node;
+        double oldPhysFlow = memNodes.sumFlow;
+        double newPhysFlow = memNodes.sumFlow + physData.sumFlowFromM2Node;
 
         double sumDeltaPlogpPhysFlow = infomath::plogp(newPhysFlow) - infomath::plogp(oldPhysFlow);
         double sumPlogpPhysFlow = infomath::plogp(physData.sumFlowFromM2Node);
@@ -360,23 +364,21 @@ void MemMapEquation::updatePhysicalNodes(InfoNode& current, unsigned int oldModu
     ModuleToMemNodes& moduleToMemNodes = m_physToModuleToMemNodes[physData.physNodeIndex];
 
     // Remove contribution to old module
-    auto overlapIt = moduleToMemNodes.find(oldModuleIndex);
-    if (overlapIt == moduleToMemNodes.end())
+    auto overlapIt = findModuleMemNodes(moduleToMemNodes, oldModuleIndex);
+    if (overlapIt == moduleToMemNodes.end() || overlapIt->module != oldModuleIndex)
       throw std::length_error(io::Str() << "Couldn't find old module " << oldModuleIndex << " in physical node " << physData.physNodeIndex);
 
-    MemNodeSet& oldMemNodeSet = overlapIt->second;
-    oldMemNodeSet.sumFlow -= physData.sumFlowFromM2Node;
-    if (--oldMemNodeSet.numMemNodes == 0)
+    overlapIt->sumFlow -= physData.sumFlowFromM2Node;
+    if (--overlapIt->numMemNodes == 0)
       moduleToMemNodes.erase(overlapIt);
 
     // Add contribution to new module
-    overlapIt = moduleToMemNodes.find(bestModuleIndex);
-    if (overlapIt == moduleToMemNodes.end()) {
-      moduleToMemNodes.insert(std::make_pair(bestModuleIndex, MemNodeSet(1, physData.sumFlowFromM2Node)));
+    overlapIt = findModuleMemNodes(moduleToMemNodes, bestModuleIndex);
+    if (overlapIt == moduleToMemNodes.end() || overlapIt->module != bestModuleIndex) {
+      moduleToMemNodes.insert(overlapIt, ModuleMemNodes(bestModuleIndex, 1, physData.sumFlowFromM2Node));
     } else {
-      MemNodeSet& newMemNodeSet = overlapIt->second;
-      ++newMemNodeSet.numMemNodes;
-      newMemNodeSet.sumFlow += physData.sumFlowFromM2Node;
+      ++overlapIt->numMemNodes;
+      overlapIt->sumFlow += physData.sumFlowFromM2Node;
     }
   }
 }
@@ -391,50 +393,47 @@ void MemMapEquation::addMemoryContributionsAndUpdatePhysicalNodes(InfoNode& curr
     ModuleToMemNodes& moduleToMemNodes = m_physToModuleToMemNodes[physData.physNodeIndex];
 
     // Remove contribution to old module
-    auto overlapIt = moduleToMemNodes.find(oldModuleIndex);
-    if (overlapIt == moduleToMemNodes.end())
+    auto overlapIt = findModuleMemNodes(moduleToMemNodes, oldModuleIndex);
+    if (overlapIt == moduleToMemNodes.end() || overlapIt->module != oldModuleIndex)
       throw std::length_error("Couldn't find old module among physical node assignments.");
 
-    MemNodeSet& oldMemNodeSet = overlapIt->second;
-    double oldPhysFlow = oldMemNodeSet.sumFlow;
-    double newPhysFlow = oldMemNodeSet.sumFlow - physData.sumFlowFromM2Node;
+    double oldPhysFlow = overlapIt->sumFlow;
+    double newPhysFlow = overlapIt->sumFlow - physData.sumFlowFromM2Node;
     oldModuleDelta.sumDeltaPlogpPhysFlow += infomath::plogp(newPhysFlow) - infomath::plogp(oldPhysFlow);
     oldModuleDelta.sumPlogpPhysFlow += infomath::plogp(physData.sumFlowFromM2Node);
-    oldMemNodeSet.sumFlow -= physData.sumFlowFromM2Node;
-    if (--oldMemNodeSet.numMemNodes == 0)
+    overlapIt->sumFlow -= physData.sumFlowFromM2Node;
+    if (--overlapIt->numMemNodes == 0)
       moduleToMemNodes.erase(overlapIt);
 
     // Add contribution to new module
-    overlapIt = moduleToMemNodes.find(bestModuleIndex);
-    if (overlapIt == moduleToMemNodes.end()) {
-      moduleToMemNodes.insert(std::make_pair(bestModuleIndex, MemNodeSet(1, physData.sumFlowFromM2Node)));
+    overlapIt = findModuleMemNodes(moduleToMemNodes, bestModuleIndex);
+    if (overlapIt == moduleToMemNodes.end() || overlapIt->module != bestModuleIndex) {
+      moduleToMemNodes.insert(overlapIt, ModuleMemNodes(bestModuleIndex, 1, physData.sumFlowFromM2Node));
       oldPhysFlow = 0.0;
       newPhysFlow = physData.sumFlowFromM2Node;
       newModuleDelta.sumDeltaPlogpPhysFlow += infomath::plogp(newPhysFlow) - infomath::plogp(oldPhysFlow);
       newModuleDelta.sumPlogpPhysFlow += infomath::plogp(physData.sumFlowFromM2Node);
     } else {
-      MemNodeSet& newMemNodeSet = overlapIt->second;
-      oldPhysFlow = newMemNodeSet.sumFlow;
-      newPhysFlow = newMemNodeSet.sumFlow + physData.sumFlowFromM2Node;
+      oldPhysFlow = overlapIt->sumFlow;
+      newPhysFlow = overlapIt->sumFlow + physData.sumFlowFromM2Node;
       newModuleDelta.sumDeltaPlogpPhysFlow += infomath::plogp(newPhysFlow) - infomath::plogp(oldPhysFlow);
       newModuleDelta.sumPlogpPhysFlow += infomath::plogp(physData.sumFlowFromM2Node);
-      ++newMemNodeSet.numMemNodes;
-      newMemNodeSet.sumFlow += physData.sumFlowFromM2Node;
+      ++overlapIt->numMemNodes;
+      overlapIt->sumFlow += physData.sumFlowFromM2Node;
     }
   }
 }
 
 void MemMapEquation::consolidateModules(std::vector<InfoNode*>& modules)
 {
-  std::map<unsigned int, std::map<unsigned int, unsigned int>> validate;
-
   for (unsigned int i = 0; i < m_numPhysicalNodes; ++i) {
     ModuleToMemNodes& modToMemNodes = m_physToModuleToMemNodes[i];
-    for (const auto& modToMemNode : modToMemNodes) {
-      if (++validate[modToMemNode.first][i] > 1)
+    for (unsigned int j = 0; j < modToMemNodes.size(); ++j) {
+      // Sorted strictly increasing module ids guarantee no (module, phys) duplicates
+      if (j > 0 && modToMemNodes[j].module <= modToMemNodes[j - 1].module)
         throw std::domain_error("[InfomapGreedy::consolidateModules] Error updating physical nodes: duplication error");
 
-      modules[modToMemNode.first]->physicalNodes.emplace_back(i, modToMemNode.second.sumFlow);
+      modules[modToMemNodes[j].module]->physicalNodes.emplace_back(i, modToMemNodes[j].sumFlow);
     }
   }
 }

--- a/src/core/MemMapEquation.h
+++ b/src/core/MemMapEquation.h
@@ -21,7 +21,6 @@
 namespace infomap {
 
 class InfoNode;
-struct MemNodeSet;
 
 class MemMapEquation : private MapEquation<FlowData, MemDeltaFlow> {
   using Base = MapEquation<FlowData, MemDeltaFlow>;
@@ -156,9 +155,9 @@ private:
   using Base::exitNetworkFlow;
   using Base::exitNetworkFlow_log_exitNetworkFlow;
 
-  using ModuleToMemNodes = std::map<unsigned int, MemNodeSet>;
+  using ModuleToMemNodes = std::vector<ModuleMemNodes>; // sorted by module id
 
-  std::vector<ModuleToMemNodes> m_physToModuleToMemNodes; // vector[physicalNodeID] map<moduleID, {#memNodes, sumFlow}>
+  std::vector<ModuleToMemNodes> m_physToModuleToMemNodes; // vector[physicalNodeID] sorted vector of {moduleID, #memNodes, sumFlow}
   unsigned int m_numPhysicalNodes = 0;
   bool m_memoryContributionsAdded = false;
 };

--- a/src/core/RegularizedMultilayerMapEquation.cpp
+++ b/src/core/RegularizedMultilayerMapEquation.cpp
@@ -209,9 +209,14 @@ void RegularizedMultilayerMapEquation::initPartitionOfPhysicalNodes(std::vector<
     unsigned int moduleIndex = node.index; // Assume unique module index for all nodes in this initiation phase
 
     for (PhysData& physData : node.physicalNodes) {
-      m_physToModuleToMemNodes[physData.physNodeIndex].insert(m_physToModuleToMemNodes[physData.physNodeIndex].end(),
-                                                              std::make_pair(moduleIndex, MemNodeSet(1, physData.sumFlowFromM2Node)));
+      m_physToModuleToMemNodes[physData.physNodeIndex].emplace_back(moduleIndex, 1, physData.sumFlowFromM2Node);
     }
+  }
+
+  // Keep each physical node's entries sorted by module id; the move and
+  // codelength code relies on this for lookups and summation order.
+  for (auto& moduleToMemNodes : m_physToModuleToMemNodes) {
+    std::sort(moduleToMemNodes.begin(), moduleToMemNodes.end(), [](const ModuleMemNodes& a, const ModuleMemNodes& b) { return a.module < b.module; });
   }
 
   m_memoryContributionsAdded = false;
@@ -246,8 +251,8 @@ void RegularizedMultilayerMapEquation::calculateNodeFlow_log_nodeFlow()
   nodeFlow_log_nodeFlow = 0.0;
   for (unsigned int i = 0; i < m_numPhysicalNodes; ++i) {
     const ModuleToMemNodes& moduleToMemNodes = m_physToModuleToMemNodes[i];
-    for (const auto& moduleToMemNode : moduleToMemNodes)
-      nodeFlow_log_nodeFlow += infomath::plogp(moduleToMemNode.second.sumFlow);
+    for (const auto& memNodes : moduleToMemNodes)
+      nodeFlow_log_nodeFlow += infomath::plogp(memNodes.sumFlow);
   }
 }
 
@@ -304,19 +309,18 @@ void RegularizedMultilayerMapEquation::addMemoryContributions(InfoNode& current,
   for (unsigned int i = 0; i < numPhysicalNodes; ++i) {
     PhysData& physData = physicalNodes[i];
     ModuleToMemNodes& moduleToMemNodes = m_physToModuleToMemNodes[physData.physNodeIndex];
-    for (const auto& moduleToMemNode : moduleToMemNodes) {
-      unsigned int moduleIndex = moduleToMemNode.first;
-      auto& memNodeSet = moduleToMemNode.second;
+    for (const auto& memNodes : moduleToMemNodes) {
+      unsigned int moduleIndex = memNodes.module;
       if (moduleIndex == current.index) // From where the multiple assigned node is moved
       {
-        double oldPhysFlow = memNodeSet.sumFlow;
-        double newPhysFlow = memNodeSet.sumFlow - physData.sumFlowFromM2Node;
+        double oldPhysFlow = memNodes.sumFlow;
+        double newPhysFlow = memNodes.sumFlow - physData.sumFlowFromM2Node;
         oldModuleDelta.sumDeltaPlogpPhysFlow += infomath::plogp(newPhysFlow) - infomath::plogp(oldPhysFlow);
         oldModuleDelta.sumPlogpPhysFlow += infomath::plogp(physData.sumFlowFromM2Node);
       } else // To where the multiple assigned node is moved
       {
-        double oldPhysFlow = memNodeSet.sumFlow;
-        double newPhysFlow = memNodeSet.sumFlow + physData.sumFlowFromM2Node;
+        double oldPhysFlow = memNodes.sumFlow;
+        double newPhysFlow = memNodes.sumFlow + physData.sumFlowFromM2Node;
 
         double sumDeltaPlogpPhysFlow = infomath::plogp(newPhysFlow) - infomath::plogp(oldPhysFlow);
         double sumPlogpPhysFlow = infomath::plogp(physData.sumFlowFromM2Node);
@@ -468,23 +472,21 @@ void RegularizedMultilayerMapEquation::updatePhysicalNodes(InfoNode& current, un
     ModuleToMemNodes& moduleToMemNodes = m_physToModuleToMemNodes[physData.physNodeIndex];
 
     // Remove contribution to old module
-    auto overlapIt = moduleToMemNodes.find(oldModuleIndex);
-    if (overlapIt == moduleToMemNodes.end())
+    auto overlapIt = findModuleMemNodes(moduleToMemNodes, oldModuleIndex);
+    if (overlapIt == moduleToMemNodes.end() || overlapIt->module != oldModuleIndex)
       throw std::length_error(io::Str() << "Couldn't find old module " << oldModuleIndex << " in physical node " << physData.physNodeIndex);
 
-    MemNodeSet& oldMemNodeSet = overlapIt->second;
-    oldMemNodeSet.sumFlow -= physData.sumFlowFromM2Node;
-    if (--oldMemNodeSet.numMemNodes == 0)
+    overlapIt->sumFlow -= physData.sumFlowFromM2Node;
+    if (--overlapIt->numMemNodes == 0)
       moduleToMemNodes.erase(overlapIt);
 
     // Add contribution to new module
-    overlapIt = moduleToMemNodes.find(bestModuleIndex);
-    if (overlapIt == moduleToMemNodes.end()) {
-      moduleToMemNodes.insert(std::make_pair(bestModuleIndex, MemNodeSet(1, physData.sumFlowFromM2Node)));
+    overlapIt = findModuleMemNodes(moduleToMemNodes, bestModuleIndex);
+    if (overlapIt == moduleToMemNodes.end() || overlapIt->module != bestModuleIndex) {
+      moduleToMemNodes.insert(overlapIt, ModuleMemNodes(bestModuleIndex, 1, physData.sumFlowFromM2Node));
     } else {
-      MemNodeSet& newMemNodeSet = overlapIt->second;
-      ++newMemNodeSet.numMemNodes;
-      newMemNodeSet.sumFlow += physData.sumFlowFromM2Node;
+      ++overlapIt->numMemNodes;
+      overlapIt->sumFlow += physData.sumFlowFromM2Node;
     }
   }
 }
@@ -499,50 +501,47 @@ void RegularizedMultilayerMapEquation::addMemoryContributionsAndUpdatePhysicalNo
     ModuleToMemNodes& moduleToMemNodes = m_physToModuleToMemNodes[physData.physNodeIndex];
 
     // Remove contribution to old module
-    auto overlapIt = moduleToMemNodes.find(oldModuleIndex);
-    if (overlapIt == moduleToMemNodes.end())
+    auto overlapIt = findModuleMemNodes(moduleToMemNodes, oldModuleIndex);
+    if (overlapIt == moduleToMemNodes.end() || overlapIt->module != oldModuleIndex)
       throw std::length_error("Couldn't find old module among physical node assignments.");
 
-    MemNodeSet& oldMemNodeSet = overlapIt->second;
-    double oldPhysFlow = oldMemNodeSet.sumFlow;
-    double newPhysFlow = oldMemNodeSet.sumFlow - physData.sumFlowFromM2Node;
+    double oldPhysFlow = overlapIt->sumFlow;
+    double newPhysFlow = overlapIt->sumFlow - physData.sumFlowFromM2Node;
     oldModuleDelta.sumDeltaPlogpPhysFlow += infomath::plogp(newPhysFlow) - infomath::plogp(oldPhysFlow);
     oldModuleDelta.sumPlogpPhysFlow += infomath::plogp(physData.sumFlowFromM2Node);
-    oldMemNodeSet.sumFlow -= physData.sumFlowFromM2Node;
-    if (--oldMemNodeSet.numMemNodes == 0)
+    overlapIt->sumFlow -= physData.sumFlowFromM2Node;
+    if (--overlapIt->numMemNodes == 0)
       moduleToMemNodes.erase(overlapIt);
 
     // Add contribution to new module
-    overlapIt = moduleToMemNodes.find(bestModuleIndex);
-    if (overlapIt == moduleToMemNodes.end()) {
-      moduleToMemNodes.insert(std::make_pair(bestModuleIndex, MemNodeSet(1, physData.sumFlowFromM2Node)));
+    overlapIt = findModuleMemNodes(moduleToMemNodes, bestModuleIndex);
+    if (overlapIt == moduleToMemNodes.end() || overlapIt->module != bestModuleIndex) {
+      moduleToMemNodes.insert(overlapIt, ModuleMemNodes(bestModuleIndex, 1, physData.sumFlowFromM2Node));
       oldPhysFlow = 0.0;
       newPhysFlow = physData.sumFlowFromM2Node;
       newModuleDelta.sumDeltaPlogpPhysFlow += infomath::plogp(newPhysFlow) - infomath::plogp(oldPhysFlow);
       newModuleDelta.sumPlogpPhysFlow += infomath::plogp(physData.sumFlowFromM2Node);
     } else {
-      MemNodeSet& newMemNodeSet = overlapIt->second;
-      oldPhysFlow = newMemNodeSet.sumFlow;
-      newPhysFlow = newMemNodeSet.sumFlow + physData.sumFlowFromM2Node;
+      oldPhysFlow = overlapIt->sumFlow;
+      newPhysFlow = overlapIt->sumFlow + physData.sumFlowFromM2Node;
       newModuleDelta.sumDeltaPlogpPhysFlow += infomath::plogp(newPhysFlow) - infomath::plogp(oldPhysFlow);
       newModuleDelta.sumPlogpPhysFlow += infomath::plogp(physData.sumFlowFromM2Node);
-      ++newMemNodeSet.numMemNodes;
-      newMemNodeSet.sumFlow += physData.sumFlowFromM2Node;
+      ++overlapIt->numMemNodes;
+      overlapIt->sumFlow += physData.sumFlowFromM2Node;
     }
   }
 }
 
 void RegularizedMultilayerMapEquation::consolidateModules(std::vector<InfoNode*>& modules)
 {
-  std::map<unsigned int, std::map<unsigned int, unsigned int>> validate;
-
   for (unsigned int i = 0; i < m_numPhysicalNodes; ++i) {
     ModuleToMemNodes& modToMemNodes = m_physToModuleToMemNodes[i];
-    for (const auto& modToMemNode : modToMemNodes) {
-      if (++validate[modToMemNode.first][i] > 1)
+    for (unsigned int j = 0; j < modToMemNodes.size(); ++j) {
+      // Sorted strictly increasing module ids guarantee no (module, phys) duplicates
+      if (j > 0 && modToMemNodes[j].module <= modToMemNodes[j - 1].module)
         throw std::domain_error("[InfomapGreedy::consolidateModules] Error updating physical nodes: duplication error");
 
-      modules[modToMemNode.first]->physicalNodes.emplace_back(i, modToMemNode.second.sumFlow);
+      modules[modToMemNodes[j].module]->physicalNodes.emplace_back(i, modToMemNodes[j].sumFlow);
     }
   }
 

--- a/src/core/RegularizedMultilayerMapEquation.h
+++ b/src/core/RegularizedMultilayerMapEquation.h
@@ -160,10 +160,10 @@ private:
   using Base::exitNetworkFlow;
   using Base::exitNetworkFlow_log_exitNetworkFlow;
 
-  using ModuleToMemNodes = std::map<unsigned int, MemNodeSet>;
+  using ModuleToMemNodes = std::vector<ModuleMemNodes>; // sorted by module id
   using LayerTeleFlowMap = std::map<unsigned int, LayerTeleFlowData>;
 
-  std::vector<ModuleToMemNodes> m_physToModuleToMemNodes; // vector[physicalNodeID] map<moduleID, {#memNodes, sumFlow}>
+  std::vector<ModuleToMemNodes> m_physToModuleToMemNodes; // vector[physicalNodeID] sorted vector of {moduleID, #memNodes, sumFlow}
   std::vector<LayerTeleFlowMap> m_moduleLayerTeleFlowData; // vector[moduleID] map<layerID, layer teleport flow>
   unsigned int m_numPhysicalNodes = 0;
   bool m_memoryContributionsAdded = false;


### PR DESCRIPTION
## Summary

`MemMapEquation` and `RegularizedMultilayerMapEquation` kept one `std::map<unsigned int, MemNodeSet>` per physical node, traversed in full for every move candidate in `addMemoryContributions` and mutated on every accepted move. Each entry was a separately allocated ~64-byte tree node holding 16 bytes of payload, so the hot move path chased pointers across the heap and accepted moves churned the allocator.

This PR replaces the map with a `std::vector<ModuleMemNodes>` of `{module, numMemNodes, sumFlow}` entries kept sorted by module id. Lookups use `lower_bound`; inserts and erases shift the tail of a small contiguous array (entries per physical node are bounded by its number of state nodes and shrink as modules merge).

## Why results are unchanged

The module-id sort order is preserved everywhere because it is load-bearing: iteration order determines floating-point summation order in `nodeFlow_log_nodeFlow` and the order module deltas enter the `VectorMap` during move evaluation, which feeds the randomized search order. Output is bit-identical to master.

The duplicate-detection map in `consolidateModules` (a nested `std::map` rebuilt per consolidation) is replaced by a strictly-increasing check on the sorted entries, which guarantees the same (module, physical node) uniqueness without the allocation cost.

## Performance (Apple Silicon, 8 threads, release build)

| Benchmark | master | this PR |
|---|---|---|
| states 100k phys × 4 states (~1.6M links) | 23.1 s / 1.43 GB RSS | 21.5 s (−7%) / 1.30 GB RSS |

Ordinary networks are unaffected (memory contributions are a no-op there). Independent of #651 and #652; compounds with #652's serial-path buffer reuse on higher-order networks.

## Verification

- Output byte-identical against master on all example networks (ordinary, directed, states, multilayer, bipartite, fast-hierarchical, parallel-trials) and on the 100k×4 state network.
- 19/19 ctest suites pass; modified files clang-format clean.
- Note: the `RegularizedMultilayerMapEquation` changes mirror `MemMapEquation`'s exactly and compile in the default build, but no large benchmark here exercises the regularized flow beyond ctest coverage.