### PR TITLE
perf(core): materialize-and-free sub-Infomap working sets (−60% peak RSS)

### DIFF
--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -2393,8 +2393,21 @@ void InfomapBase::resetFlowOnModules()
 
 unsigned int InfomapBase::removeModules()
 {
+  // Flatten until every child of root is a leaf. numLevels() only follows the
+  // firstChild chain (it assumes a uniform-depth tree, see its TODO), so it
+  // under-counts a ragged multilevel tree and would stop early, leaving deeper
+  // module subtrees behind. Loop on "any non-leaf child" instead so ragged trees
+  // (e.g. from materialize-and-free) flatten completely. For the uniform trees
+  // produced elsewhere this does the same number of passes as before.
+  auto rootHasModuleChild = [this]() {
+    for (auto& child : m_root)
+      if (!child.isLeaf())
+        return true;
+    return false;
+  };
+
   unsigned int numLevelsDeleted = 0;
-  while (numLevels() > 1) {
+  while (rootHasModuleChild()) {
     m_root.replaceChildrenWithGrandChildren();
     ++numLevelsDeleted;
   }
@@ -2681,15 +2694,60 @@ void InfomapBase::partitionModuleRecursively(InfoNode& module, unsigned int leve
   // Sized once before spawning so child records have stable addresses
   record.children.resize(numSubModulesQueued);
 
-  // Spawn the largest sub-modules first so the dominant subtrees start immediately
+  // Materialize this sub-partition into real children of `module`, then dispose
+  // the sub-Infomap so its working set (cloned active network + pools + maps) is
+  // freed immediately instead of being held live until the whole recursion ends.
+  // Top-down: `module`'s children are original main-tree leaves, so the new
+  // sub-module nodes reparent originals (never clones-of-clones) and output stays
+  // byte-identical. New module nodes use raw `new` (NOT the instance pool): the
+  // task graph runs this function concurrently and ObjectPool is per-instance,
+  // not thread-safe; malloc is. They are few, and InfoNode teardown deletes
+  // non-pool nodes via `delete`.
+  std::vector<InfoNode*> materializedSubModules(numSubModulesQueued, nullptr);
+  {
+    std::map<const InfoNode*, InfoNode*> cloneToMaterialized;
+    for (unsigned int k = 0; k < numSubModulesQueued; ++k) {
+      const InfoNode* cloneSubModule = subQueue[k];
+      auto* newSubModule = new InfoNode(cloneSubModule->data);
+      newSubModule->codelength = cloneSubModule->codelength;
+      cloneToMaterialized[cloneSubModule] = newSubModule;
+      materializedSubModules[k] = newSubModule;
+    }
+
+    std::vector<InfoNode*> originalLeaves;
+    originalLeaves.reserve(module.childDegree());
+    for (auto& child : module)
+      originalLeaves.push_back(&child);
+
+    module.releaseChildren();
+
+    auto cloneLeafIt = subInfomap.leafNodes().begin();
+    for (InfoNode* originalLeaf : originalLeaves) {
+      const InfoNode* cloneSubModule = (*cloneLeafIt)->parent;
+      cloneToMaterialized.at(cloneSubModule)->addChild(originalLeaf);
+      ++cloneLeafIt;
+    }
+
+    for (InfoNode* newSubModule : materializedSubModules)
+      module.addChild(newSubModule);
+
+    // module now plays the role the sub-Infomap root did under getInfomapRoot():
+    // its index codelength is the sub-partition's index codelength.
+    module.codelength = subInfomap.root().codelength;
+    module.disposeInfomap();
+  }
+
+  // Spawn the largest sub-modules first so the dominant subtrees start immediately.
+  // Children recurse into the materialized real nodes (disjoint subtrees, no shared
+  // sub-Infomap), so the task graph is unchanged and no taskwait is needed.
   std::vector<PartitionQueue::size_t> spawnOrder(numSubModulesQueued);
   std::iota(spawnOrder.begin(), spawnOrder.end(), PartitionQueue::size_t { 0 });
-  std::sort(spawnOrder.begin(), spawnOrder.end(), [&subQueue](PartitionQueue::size_t a, PartitionQueue::size_t b) {
-    return subQueue[a]->data.flow > subQueue[b]->data.flow;
+  std::sort(spawnOrder.begin(), spawnOrder.end(), [&materializedSubModules](PartitionQueue::size_t a, PartitionQueue::size_t b) {
+    return materializedSubModules[a]->data.flow > materializedSubModules[b]->data.flow;
   });
 
   for (auto subModuleIndex : spawnOrder) {
-    InfoNode* subModule = subQueue[subModuleIndex];
+    InfoNode* subModule = materializedSubModules[subModuleIndex];
     detail::PartitionTaskRecord* childRecord = &record.children[subModuleIndex];
     // Small subtrees run inline: spawning them as tasks costs more in task
     // scheduling and idle-thread stealing than their work is worth.

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -2742,11 +2742,17 @@ void InfomapBase::partitionModuleRecursively(InfoNode& module, unsigned int leve
 
     module.releaseChildren();
 
-    auto cloneLeafIt = subInfomap.leafNodes().begin();
-    for (InfoNode* originalLeaf : originalLeaves) {
-      const InfoNode* cloneSubModule = (*cloneLeafIt)->parent;
-      cloneToMaterialized.at(cloneSubModule)->addChild(originalLeaf);
-      ++cloneLeafIt;
+    // The sub-Infomap clones `module`'s leaves 1:1 in the same order, so clone
+    // leaf i corresponds to original leaf i. Assert that invariant explicitly:
+    // an indexed loop with a size check fails fast with a clear error if future
+    // subnetwork-generation changes ever break it, instead of walking the clone
+    // iterator past end() (UB / SIGSEGV).
+    const auto& cloneLeaves = subInfomap.leafNodes();
+    if (cloneLeaves.size() != originalLeaves.size())
+      throw std::logic_error("InfomapBase::partitionModuleRecursively(): sub-Infomap leaf count does not match the module's original leaves");
+    for (std::size_t i = 0; i < originalLeaves.size(); ++i) {
+      const InfoNode* cloneSubModule = cloneLeaves[i]->parent;
+      cloneToMaterialized.at(cloneSubModule)->addChild(originalLeaves[i]);
     }
 
     for (InfoNode* newSubModule : materializedSubModules)

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -2705,11 +2705,28 @@ void InfomapBase::partitionModuleRecursively(InfoNode& module, unsigned int leve
   // non-pool nodes via `delete`.
   std::vector<InfoNode*> materializedSubModules(numSubModulesQueued, nullptr);
   {
-    std::map<const InfoNode*, InfoNode*> cloneToMaterialized;
+    std::unordered_map<const InfoNode*, InfoNode*> cloneToMaterialized;
+    cloneToMaterialized.reserve(numSubModulesQueued);
     for (unsigned int k = 0; k < numSubModulesQueued; ++k) {
       const InfoNode* cloneSubModule = subQueue[k];
       auto* newSubModule = new InfoNode(cloneSubModule->data);
       newSubModule->codelength = cloneSubModule->codelength;
+      // Copy the objective-specific module aggregates the lazy sub-Infomap module
+      // node carried, so the materialized node is equivalent: calcCodelength and
+      // the deeper recursion read these on module nodes (e.g. MemMapEquation reads
+      // parent.physicalNodes). Without them, feature/higher-order builds compute
+      // wrong codelengths.
+      newSubModule->physicalNodes = cloneSubModule->physicalNodes;
+      newSubModule->stateNodes = cloneSubModule->stateNodes;
+#ifndef SWIG
+      newSubModule->layerTeleFlowData = cloneSubModule->layerTeleFlowData;
+      if (cloneSubModule->hasMetaCollection())
+        newSubModule->ensureMetaCollection() = *cloneSubModule->metaCollection;
+#endif
+#if INFOMAP_FEATURE_LOSSY_MAP_EQUATION
+      newSubModule->lossyEntropy = cloneSubModule->lossyEntropy;
+      newSubModule->lossyFlowLogFlow = cloneSubModule->lossyFlowLogFlow;
+#endif
       cloneToMaterialized[cloneSubModule] = newSubModule;
       materializedSubModules[k] = newSubModule;
     }

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -2698,8 +2698,12 @@ void InfomapBase::partitionModuleRecursively(InfoNode& module, unsigned int leve
   // the sub-Infomap so its working set (cloned active network + pools + maps) is
   // freed immediately instead of being held live until the whole recursion ends.
   // Top-down: `module`'s children are original main-tree leaves, so the new
-  // sub-module nodes reparent originals (never clones-of-clones) and output stays
-  // byte-identical. New module nodes use raw `new` (NOT the instance pool): the
+  // sub-module nodes reparent originals (never clones-of-clones). NOTE: this does
+  // NOT guarantee byte-identical output — recursing on original leaves sees a
+  // different edge order than the lazy clone path, so the order-sensitive greedy
+  // optimizer can settle on a different (quality-equivalent) optimum on deep
+  // networks; output is byte-identical only where recursion stays shallow.
+  // New module nodes use raw `new` (NOT the instance pool): the
   // task graph runs this function concurrently and ObjectPool is per-instance,
   // not thread-safe; malloc is. They are few, and InfoNode teardown deletes
   // non-pool nodes via `delete`.


### PR DESCRIPTION
## Summary

Replaces the **lazy nested-sub-Infomap** result model in the recursive partition with **materialize-then-recurse**: after a module's sub-partition is accepted, build real sub-module nodes directly under the module (reparenting the original leaves by assignment), **dispose the sub-Infomap** so its working set (cloned active network + pools + maps) is freed immediately, then recurse into the materialized children.

Today every accepted sub-Infomap stays live until the whole hierarchical partition finishes (heap attribution showed ~4800 concurrent on a 500k-state net, dominating peak RSS). Freeing each as its level consolidates collapses that.

## The win: peak RSS becomes ~depth-independent

The saving is **not** a fixed percentage — it grows with recursion depth, because the old model holds the whole accepted recursion tree's sub-Infomaps live (≈ `N · depth`), while this PR keeps only the active recursion path's working set live (≈ `N`).

Balanced hierarchical clique-networks, comparable size, peak RSS at 1 thread, OLD master vs NEW — **ordinary** (N≈156–328k nodes) and **higher-order/state** (≈156–200k state nodes) track almost identically at matched depth:

| achieved levels | OLD ord (GB) | NEW ord (GB) | saving ord | OLD state (GB) | NEW state (GB) | saving state |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 3 (flat) | 0.68 | 0.41 | +39 % | 0.58 | 0.36 | +38 % |
| 6 | 1.64 | 0.55 | +67 % | 1.11 | 0.38 | +66 % |
| 7 | — | — | — | 1.53 | 0.47 | +69 % |
| 8 | 1.71 | 0.46 | +73 % | 1.33 | 0.41 | +69 % |
| 9 | 1.68 | 0.45 | +73 % | 1.41 | 0.41 | +71 % |
| 10 | 1.71 | 0.44 | +74 % | — | — | — |
| 12 | 2.56 | 0.54 | +79 % | — | — | — |

- **NEW is ~flat** (≈ +0.01 GB/level; bounded by the active-path working set + a fixed ~0.4 GB parse/base floor).
- **OLD grows ~linearly** (ordinary +0.21 GB/level, ~15× faster; the whole accepted tree stays resident).

So the saving follows roughly `1 − 1/depth` (damped by the fixed floor): the deeper / more hierarchical the network, the larger the win — and this is **the same for ordinary and higher-order**. Higher-order is not intrinsically less compressible; at matched depth it saves the same.

## Concrete numbers at the typical workload (8 threads, `-N 10`)

| Network | peak RSS | wall |
| --- | --- | --- |
| sparse_1M (ordinary, ~10 levels) | **7.53 → 2.74 GB (−60 %)** | 139.5 → 134.3 s (−4 %) |
| sb_500k (higher-order) | **7.11 → 6.06 GB (−10 %)** | 520.4 → 499.9 s (−4 %) |

The −60 % on sparse_1M is just the ~10-level point on the curve above. sb_500k wins less here for two net-specific reasons, **not** because it is higher-order (the depth table shows state nets save the same at matched depth): it recurses shallower, and a larger share of its peak is fixed non-working-set that this PR doesn't free (state parse storage, `physicalNodes` on result nodes, MemMapEquation maps). A deep hierarchical state net still saves ~70 %. Wall time is **faster** everywhere measured (less allocation/teardown, smaller working set) — no regression. `--parallel-trials` is neutral (concurrent trials overlap their peaks), which is fine as it isn't the common workload. Per-trial check: sparse_1M 8t `-N20` = 2.73 GB (flat vs `-N10`, no unbounded leak).

## ⚠️ Output change on large/deep networks (accepted baseline change)

The greedy optimizer is order-sensitive. The old model recurses on **clones** (whose edge order is permuted by repeated cloning); this PR recurses on the **original** leaves (original edge order). Same edges/flow, different order → a **different but equally-valid local optimum**, but only once recursion goes deeper than 2 levels.

**Byte-identical** wherever recursion stays ≤2 levels — which is structural, since this PR only touches the multi-level recursion path:

- the entire test suite + example networks (all shallow) → `ctest` stays green with **no baseline edits**;
- any run with `-2` / `--two-level` (verified identical on sparse_1M);
- `--lossy` (implies `--two-level`);
- **regularized-multilayer** at 3 levels — byte-identical across 5 seeds (exercises the `layerTeleFlowData` materialize-copy);
- **biased** (`--preferred-number-of-modules`) at 3 levels — byte-identical.

**Quality-neutral divergence** on deep multi-level partitions (ordinary, higher-order, multilayer-memory, meta). Paired codelength OLD vs NEW, single-trial per seed (the conservative view):

- ordinary sparse_1M (10 lvl): NEW better 3/3 (−0.002…−0.004 %); science2007 NEW −0.002 %; block_sparse +0.026 %; ring_of_cliques ≈ tie.
- higher-order state_500k: mixed ±0.001 %.
- multilayer-memory (deep): NEW better 3/3 (−0.005…−0.010 %).
- meta (8 lvl): mixed (worst single seed +0.084 %, others NEW-better).

Mean Δ ≈ 0 %, every cell within ±0.03 % except one meta seed, and NEW wins more cells than it loses — statistically equivalent, not a regression. **Release-notes call-out:** results on large/deep networks may differ (equivalently) from prior versions; bit-for-bit reproducibility against older releases is no longer guaranteed there.

## Implementation notes

- Materialized module nodes copy the cloned sub-module's objective aggregates (`physicalNodes`, `stateNodes`, `layerTeleFlowData`, `metaCollection`, lossy terms) so `calcCodelength` on module nodes stays correct in feature/higher-order builds; they use raw `new` (not the per-instance `ObjectPool`, which isn't thread-safe under the task graph) and are freed via `delete` in teardown.
- Fixed `removeModules()` to flatten **ragged** trees: it looped on `numLevels()`, which only follows the `firstChild` chain (assumes uniform depth — see its TODO). Materialize-and-free produces ragged multilevel real trees, so the old loop stopped early and left stale module nodes that corrupted later trials (multi-trial SIGSEGV). Now loops on "any non-leaf child of root".

## Test plan

- [x] `ctest` 21/21 in default and `regularized-multilayer lossy-map-equation` feature builds (venv python).
- [x] Byte-identical OLD vs NEW on small/shallow nets and all ≤2-level paths (`-2`, lossy, deep regularized-multilayer, deep biased) via `/usr/bin/diff` + md5.
- [x] Multi-trial / parallel-trials / inner-parallelization no longer crash (ASan clean, `-N 5` etc.).
- [x] Cross-model paired codelength study (ordinary, higher-order, multilayer, regularized-multilayer, meta, biased, lossy) — statistically equivalent / byte-identical.
- [x] RSS-vs-depth scaling for **both ordinary and higher-order/state** nets (matched-depth saving is equal) + RSS/wall A/B across 1-thread, 8-thread, `-N 10`/`-N 20`, `--parallel-trials`.