### PR TITLE
build(R): fix R package URL and add cran-comments

### DIFF
--- a/interfaces/R/infomap/DESCRIPTION
+++ b/interfaces/R/infomap/DESCRIPTION
@@ -18,7 +18,7 @@ Description: R bindings for the Infomap network clustering algorithm. Infomap
     R helpers for inspecting the modular hierarchy, exporting to data
     frames, and integrating with the 'igraph' package.
 License: GPL-3
-URL: https://www.mapequation.org/infomap/, https://mapequation.r-universe.dev/infomap
+URL: https://mapequation.org/infomap/, https://mapequation.r-universe.dev/infomap
 BugReports: https://github.com/mapequation/infomap/issues
 Encoding: UTF-8
 SystemRequirements: C++17

--- a/interfaces/R/infomap/README.md
+++ b/interfaces/R/infomap/README.md
@@ -1,6 +1,6 @@
 # infomap
 
-R bindings for the [Infomap](https://www.mapequation.org/infomap/) network
+R bindings for the [Infomap](https://mapequation.org/infomap/) network
 clustering algorithm. Infomap decomposes a network into modules by
 optimally compressing a description of information flows on the network
 using the Map Equation.

--- a/interfaces/R/infomap/cran-comments.md
+++ b/interfaces/R/infomap/cran-comments.md
@@ -1,0 +1,32 @@
+## Submission
+
+This is a new submission of the `infomap` package: R bindings for the Infomap
+network clustering algorithm (the Map Equation), built as an R6 facade over
+SWIG-generated bindings to the bundled C++ sources.
+
+## R CMD check results
+
+0 errors | 0 warnings | 1 note
+
+The note is the standard new-submission note:
+
+* checking CRAN incoming feasibility ... NOTE
+  Maintainer: 'Daniel Edler <daniel.edler@umu.se>'
+  New submission
+
+Two informational items may also appear and are expected:
+
+* Installed size is ~6 MB, dominated by the compiled shared library and the
+  generated SWIG wrapper. The package vendors the Infomap C++ sources, so the
+  compiled object is inherently sizeable; we have kept the shipped sources
+  minimal (build artifacts are excluded via `.Rbuildignore`).
+* The package requires a C++17 compiler (declared in `SystemRequirements`).
+
+## Test environments
+
+- local: macOS, R 4.6.0
+- (fill in win-builder / R-hub / GitHub Actions results before submitting)
+
+## Reverse dependencies
+
+None (new package).

--- a/interfaces/R/infomap/cran-comments.md
+++ b/interfaces/R/infomap/cran-comments.md
@@ -24,8 +24,16 @@ Two informational items may also appear and are expected:
 
 ## Test environments
 
-- local: macOS, R 4.6.0
-- (fill in win-builder / R-hub / GitHub Actions results before submitting)
+`R CMD check --as-cran` (via rcmdcheck) is run on GitHub Actions across a
+six-way matrix:
+
+- ubuntu-24.04, R release and R oldrel
+- macos-15, R release and R oldrel
+- windows-2025 (VS 2026), R release and R oldrel
+
+Also checked locally on macOS, R 4.6.0: 0 errors, 0 warnings, and the single
+expected "New submission" NOTE. The GitHub Actions matrix is the authoritative
+multi-platform result; confirm it is green before submitting.
 
 ## Reverse dependencies
 

--- a/interfaces/R/infomap/man/infomap-package.Rd
+++ b/interfaces/R/infomap/man/infomap-package.Rd
@@ -24,7 +24,7 @@ SWIG-generated bindings.
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://www.mapequation.org/infomap/}
+  \item \url{https://mapequation.org/infomap/}
   \item \url{https://mapequation.r-universe.dev/infomap}
   \item Report bugs at \url{https://github.com/mapequation/infomap/issues}
 }


### PR DESCRIPTION
Toward #662 (CRAN submission).

## What

`R CMD check --as-cran` on the R package flagged the package URL as a permanent redirect:
`https://www.mapequation.org/infomap/` → `https://mapequation.org/infomap/` (HTTP 301). CRAN rejects redirecting URLs.

- Update the URL to the final target in `DESCRIPTION`, `README.md`, and the generated `man/infomap-package.Rd`.
- Add `cran-comments.md` (already `.Rbuildignore`'d), documenting the submission and the test-environment matrix.

## Result

`make test-r` (`R CMD check --as-cran`, R 4.6.0, macOS) now reports **0 errors, 0 warnings, 1 NOTE** — and the only NOTE is the expected first-submission one:

```
* checking CRAN incoming feasibility ... NOTE
  Maintainer: 'Daniel Edler <daniel.edler@umu.se>'
  New submission
```

The previous invalid-URL NOTE is gone. (Informational: installed size ~6 MB from the compiled C++/SWIG library; C++17 required — both noted in cran-comments.)

The same `--as-cran` check runs on GitHub Actions across **{ubuntu-24.04, macos-15, windows-2025-vs2026} × {release, oldrel}** (6 environments) — that matrix is the multi-platform CRAN check (no win-builder/R-hub needed).

## Remaining before submission (tracked in #662, not in this PR)

- Confirm the 6-environment GA R matrix is green on this change.
- Submit to CRAN.