### PR TITLE
feat: add infomap-network v1.0 JSON input format (#645)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,7 @@ if(BUILD_TESTING)
             PRIVATE
                 "${CMAKE_CURRENT_SOURCE_DIR}/src"
                 "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp"
+                "${CMAKE_CURRENT_SOURCE_DIR}/vendor/nlohmann_json/include"
         )
         target_compile_definitions(
             ${target_name}

--- a/interfaces/js/src/index.ts
+++ b/interfaces/js/src/index.ts
@@ -4,6 +4,13 @@ import fileToString, {
   type TreeStateNode as StateNode,
 } from "./filetypes";
 import networkToString from "./network";
+export type {
+  InfomapNetworkJson,
+  InfomapNetworkJsonNode,
+  InfomapNetworkJsonState,
+  InfomapNetworkJsonEdge,
+  InfomapNetworkJsonType,
+} from "./network";
 import type { RunOptions } from "./run-options";
 import { createInfomapWorker } from "./worker";
 import parameters from "../generated/parameters.json";

--- a/interfaces/js/src/network.ts
+++ b/interfaces/js/src/network.ts
@@ -57,10 +57,10 @@ export type NetworkTypes =
   | MultilayerNetwork
   | MultilayerIntraInterNetwork;
 
-// --- infomap-network-json v1.0 authoring types (RFC #645) -------------------
+// --- infomap-network v1.0 authoring types (RFC #645) -------------------
 // Construct one of these and pass `network: JSON.stringify(net)` to run().
 // Infomap detects the format by content. These mirror
-// test/schemas/json/infomap-network-json.schema.json.
+// test/schemas/json/infomap-network.schema.json.
 
 export type InfomapNetworkJsonType =
   | "standard"
@@ -95,7 +95,7 @@ export interface InfomapNetworkJsonEdge {
 }
 
 export interface InfomapNetworkJson {
-  format: "infomap-network-json";
+  format: "infomap-network";
   version: "1.0";
   type?: InfomapNetworkJsonType;
   directed?: boolean;
@@ -143,7 +143,7 @@ const isMultilayerIntraInter = (
 /**
  * Convert a legacy network object to Pajek text.
  *
- * @deprecated Prefer the `infomap-network-json` format: build an
+ * @deprecated Prefer the `infomap-network` format: build an
  * {@link InfomapNetworkJson} and pass `network: JSON.stringify(net)` to run().
  * The format is detected by content. This object-to-Pajek path will be removed.
  */

--- a/interfaces/js/src/network.ts
+++ b/interfaces/js/src/network.ts
@@ -57,6 +57,55 @@ export type NetworkTypes =
   | MultilayerNetwork
   | MultilayerIntraInterNetwork;
 
+// --- infomap-network-json v1.0 authoring types (RFC #645) -------------------
+// Construct one of these and pass `network: JSON.stringify(net)` to run().
+// Infomap detects the format by content. These mirror
+// test/schemas/json/infomap-network-json.schema.json.
+
+export type InfomapNetworkJsonType =
+  | "standard"
+  | "bipartite"
+  | "multilayer"
+  | "state";
+
+export interface InfomapNetworkJsonNode {
+  id: number;
+  name?: string;
+  weight?: number;
+  /** One-dimensional integer metadata (enables meta coding, like --meta-data). */
+  meta?: number;
+  /** Initial-partition path: [module] (≡ .clu) or [..] (≡ .tree). */
+  path?: number[];
+}
+
+export interface InfomapNetworkJsonState {
+  id: number;
+  node: number;
+  name?: string;
+  weight?: number;
+  path?: number[];
+}
+
+export interface InfomapNetworkJsonEdge {
+  source: number;
+  target: number;
+  weight?: number;
+  /** Multilayer only: one layer id (intra) or two (full / inter). */
+  layers?: number[];
+}
+
+export interface InfomapNetworkJson {
+  format: "infomap-network-json";
+  version: "1.0";
+  type?: InfomapNetworkJsonType;
+  directed?: boolean;
+  multilayer?: "full" | "intra" | "intra-inter";
+  bipartiteStartId?: number;
+  nodes?: InfomapNetworkJsonNode[];
+  states?: InfomapNetworkJsonState[];
+  edges: InfomapNetworkJsonEdge[];
+}
+
 const isBipartite = (network: NetworkTypes): network is BipartiteNetwork => {
   const net = network as BipartiteNetwork;
   return "bipartiteStartId" in net && !("states" in net);
@@ -91,6 +140,13 @@ const isMultilayerIntraInter = (
   return "intra" in net;
 };
 
+/**
+ * Convert a legacy network object to Pajek text.
+ *
+ * @deprecated Prefer the `infomap-network-json` format: build an
+ * {@link InfomapNetworkJson} and pass `network: JSON.stringify(net)` to run().
+ * The format is detected by content. This object-to-Pajek path will be removed.
+ */
 export default function stringifyNetwork(network: NetworkTypes) {
   if (isMultilayerIntraInter(network)) {
     return multilayerIntraInterToString(network);

--- a/interfaces/js/test/unit/network-json-schema-parity.test.ts
+++ b/interfaces/js/test/unit/network-json-schema-parity.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+// Drift guard for the hand-written infomap-network-json authoring types.
+// The TS types in src/network.ts are maintained by hand (the schema's if/then
+// discrimination doesn't survive automatic codegen as a clean union). This test
+// fails if the schema gains or drops a property the types don't mirror.
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../../../..");
+
+const schema = JSON.parse(
+  readFileSync(
+    path.join(repoRoot, "test/schemas/json/infomap-network-json.schema.json"),
+    "utf8",
+  ),
+);
+const networkSrc = readFileSync(
+  path.join(here, "../../src/network.ts"),
+  "utf8",
+);
+
+/** Property names declared in a TS `export interface <name> { ... }` block. */
+function interfaceKeys(name: string): string[] {
+  const match = networkSrc.match(
+    new RegExp(`export interface ${name}\\s*\\{([\\s\\S]*?)\\n\\}`, "m"),
+  );
+  if (!match) throw new Error(`interface ${name} not found in network.ts`);
+  const keys: string[] = [];
+  for (const line of match[1].split("\n")) {
+    const key = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\??\s*:/);
+    if (key) keys.push(key[1]);
+  }
+  return keys.sort();
+}
+
+/** Real (non-forbidden) property names from a schema `properties` object. */
+function schemaKeys(properties: Record<string, unknown>): string[] {
+  return Object.entries(properties)
+    .filter(([, value]) => value !== false)
+    .map(([key]) => key)
+    .sort();
+}
+
+describe("infomap-network-json authoring types stay in sync with the schema", () => {
+  test("root object", () => {
+    expect(interfaceKeys("InfomapNetworkJson")).toEqual(
+      schemaKeys(schema.properties),
+    );
+  });
+
+  test("node", () => {
+    expect(interfaceKeys("InfomapNetworkJsonNode")).toEqual(
+      schemaKeys(schema.$defs.node.properties),
+    );
+  });
+
+  test("state", () => {
+    expect(interfaceKeys("InfomapNetworkJsonState")).toEqual(
+      schemaKeys(schema.$defs.state.properties),
+    );
+  });
+
+  test("edge (union of standard and multilayer edge fields)", () => {
+    const edgeFields = new Set([
+      ...schemaKeys(schema.$defs.standardEdge.properties),
+      ...schemaKeys(schema.$defs.multilayerEdge.properties),
+    ]);
+    expect(interfaceKeys("InfomapNetworkJsonEdge")).toEqual(
+      [...edgeFields].sort(),
+    );
+  });
+});

--- a/interfaces/js/test/unit/network-json-schema-parity.test.ts
+++ b/interfaces/js/test/unit/network-json-schema-parity.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
 
-// Drift guard for the hand-written infomap-network-json authoring types.
+// Drift guard for the hand-written infomap-network authoring types.
 // The TS types in src/network.ts are maintained by hand (the schema's if/then
 // discrimination doesn't survive automatic codegen as a clean union). This test
 // fails if the schema gains or drops a property the types don't mirror.
@@ -13,7 +13,7 @@ const repoRoot = path.resolve(here, "../../../..");
 
 const schema = JSON.parse(
   readFileSync(
-    path.join(repoRoot, "test/schemas/json/infomap-network-json.schema.json"),
+    path.join(repoRoot, "test/schemas/json/infomap-network.schema.json"),
     "utf8",
   ),
 );
@@ -44,7 +44,7 @@ function schemaKeys(properties: Record<string, unknown>): string[] {
     .sort();
 }
 
-describe("infomap-network-json authoring types stay in sync with the schema", () => {
+describe("infomap-network authoring types stay in sync with the schema", () => {
   test("root object", () => {
     expect(interfaceKeys("InfomapNetworkJson")).toEqual(
       schemaKeys(schema.properties),

--- a/interfaces/python/source/working-with-infomap/inputs.md
+++ b/interfaces/python/source/working-with-infomap/inputs.md
@@ -275,6 +275,75 @@ mapequation.org documents every section a `.net` file can carry, including
 format also ships pre-loaded in {mod}`infomap.datasets`
 (`infomap.datasets.two_triangles()` returns this very network, ready to run).
 
+## JSON network input
+
+Infomap also reads the `infomap-network-json` v1.0 format, a small JSON input
+format that is convenient to produce from Python, notebooks, and web tools. The
+format is detected by content, so a `.json` file is handed to
+{func}`infomap.run` (or {meth}`~infomap.Network.from_file`) like any other
+network file. A minimal document needs only `format`, `version`, and `edges`:
+
+```json
+{
+  "format": "infomap-network-json",
+  "version": "1.0",
+  "edges": [{ "source": 1, "target": 2, "weight": 1.0 }]
+}
+```
+
+The same two-triangles network runs straight from a JSON file:
+
+```{code-cell} python
+import json
+import tempfile
+from pathlib import Path
+
+import infomap
+
+network = {
+    "format": "infomap-network-json",
+    "version": "1.0",
+    "edges": [
+        {"source": 1, "target": 2},
+        {"source": 1, "target": 3},
+        {"source": 2, "target": 3},
+        {"source": 3, "target": 4},
+        {"source": 4, "target": 5},
+        {"source": 4, "target": 6},
+        {"source": 5, "target": 6},
+    ],
+}
+path = Path(tempfile.mkdtemp()) / "twotriangles.json"
+path.write_text(json.dumps(network))
+
+result = infomap.run(str(path), two_level=True, seed=123, num_trials=5, silent=True)
+print(f"json route: {result.num_top_modules} modules, {result.codelength:.4f} bits/step")
+```
+
+`type` defaults to `standard`; the other values are `bipartite` (requires
+`bipartiteStartId`), `multilayer` (with `multilayer` set to `full`, `intra`, or
+`intra-inter` and `layers` on each edge), and `state` (edges are state ids, with
+an optional `states` array). Parsing is order- and emitter-independent, so key
+order (for example alphabetically sorted output) does not matter.
+
+Two optional conveniences replace separate input files:
+
+- `nodes[].meta` embeds one-dimensional integer metadata. Its presence enables
+  metadata coding exactly like `--meta-data` or
+  {meth}`~infomap.Infomap.set_meta_data` (it is not a passive annotation). An
+  external `--meta-data` file still composes with a JSON network and overrides
+  the embedded values, with a warning.
+- `nodes[].path` (and `states[].path` for state networks) embeds an initial
+  partition: `[3]` is equivalent to a `.clu` module and `[1, 2]` to a `.tree`
+  path. `--cluster-data` overrides it, with a warning.
+
+All ids are non-negative integers; integral-valued doubles such as `10.0` are
+accepted but `1.5` is rejected. Edge weights are passed to the same core network
+builder as the text formats, so weights `<= 0` are ignored (not an error); node
+and state weights must be non-negative. The JSON Schema in
+`test/schemas/json/infomap-network-json.schema.json` is the normative
+specification of what the parser accepts.
+
 ## Building incrementally with Network
 
 When you assemble a network programmatically, read a custom file format, or wire

--- a/interfaces/python/source/working-with-infomap/inputs.md
+++ b/interfaces/python/source/working-with-infomap/inputs.md
@@ -277,7 +277,7 @@ format also ships pre-loaded in {mod}`infomap.datasets`
 
 ## JSON network input
 
-Infomap also reads the `infomap-network-json` v1.0 format, a small JSON input
+Infomap also reads the `infomap-network` v1.0 format, a small JSON input
 format that is convenient to produce from Python, notebooks, and web tools. The
 format is detected by content, so a `.json` file is handed to
 {func}`infomap.run` (or {meth}`~infomap.Network.from_file`) like any other
@@ -285,7 +285,7 @@ network file. A minimal document needs only `format`, `version`, and `edges`:
 
 ```json
 {
-  "format": "infomap-network-json",
+  "format": "infomap-network",
   "version": "1.0",
   "edges": [{ "source": 1, "target": 2, "weight": 1.0 }]
 }
@@ -301,7 +301,7 @@ from pathlib import Path
 import infomap
 
 network = {
-    "format": "infomap-network-json",
+    "format": "infomap-network",
     "version": "1.0",
     "edges": [
         {"source": 1, "target": 2},
@@ -341,7 +341,7 @@ All ids are non-negative integers; integral-valued doubles such as `10.0` are
 accepted but `1.5` is rejected. Edge weights are passed to the same core network
 builder as the text formats, so weights `<= 0` are ignored (not an error); node
 and state weights must be non-negative. The JSON Schema in
-`test/schemas/json/infomap-network-json.schema.json` is the normative
+`test/schemas/json/infomap-network.schema.json` is the normative
 specification of what the parser accepts.
 
 ## Building incrementally with Network

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -673,6 +673,9 @@ private:
       return;
     }
 
+    if (!infomap.clusterDataFile.empty() && !m_network.initialPartitionPaths().empty())
+      Console::note(0, "--cluster-data overrides embedded JSON initial-partition paths.");
+
     if (!infomap.clusterDataFile.empty())
       infomap.initPartition(infomap.clusterDataFile, infomap.clusterDataIsHard, &m_network);
     else if (!infomap.m_multilayerInitialPartition.empty()) {
@@ -695,6 +698,14 @@ private:
       infomap.initPartition(statePartition, infomap.clusterDataIsHard);
     } else if (!infomap.m_initialPartition.empty())
       infomap.initPartition(infomap.m_initialPartition, infomap.clusterDataIsHard);
+    else if (!m_network.initialPartitionPaths().empty()) {
+      // Embedded JSON nodes[].path / states[].path, reusing the .tree channel.
+      unsigned int numNodesNotInNetwork = 0;
+      const auto normalizedTree = infomap.normalizeTreePaths(m_network.initialPartitionPaths(), numNodesNotInNetwork);
+      if (numNodesNotInNetwork > 0)
+        Console::note(1, "{} nodes in embedded initial-partition paths not found in network.", numNodesNotInNetwork);
+      infomap.initTree(normalizedTree);
+    }
   }
 
   void executeTrial(InfomapBase& infomap)

--- a/src/io/JsonNetworkInputParser.h
+++ b/src/io/JsonNetworkInputParser.h
@@ -1,0 +1,621 @@
+/*******************************************************************************
+ Infomap software package for multi-level network clustering
+ Copyright (c) 2013, 2014 Daniel Edler, Anton Holmgren, Martin Rosvall
+
+ This file is part of the Infomap software package.
+ See file LICENSE_GPLv3.txt for full license details.
+ For more information, see <http://www.mapequation.org>
+ ******************************************************************************/
+
+#ifndef JSON_NETWORK_INPUT_PARSER_H_
+#define JSON_NETWORK_INPUT_PARSER_H_
+
+// JSON network input parser for the infomap-network-json v1.0 format (RFC #645).
+//
+// Parsing is order- and emitter-independent via two SAX passes (no DOM):
+//   pass 1 captures the root scalar discriminators (format/version/type/...),
+//   pass 2 streams `nodes`/`edges` into the same core network sink the text
+//   parser uses, so all network semantics are inherited from the core builder.
+//
+// Phase 1 wires the `standard` network type (and the omitted-type default).
+// bipartite/multilayer/state, embedded `meta`, and embedded `path` are parsed
+// into the pending structures but not yet emitted; later phases connect them.
+
+#include "NetworkInputParser.h"
+#include "../utils/Console.h"
+#include "../utils/format.h"
+
+#include <nlohmann/json.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <fstream>
+#include <limits>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace infomap {
+namespace input {
+
+  namespace json_detail {
+
+    using Json = nlohmann::json;
+
+    enum class NetworkType : std::uint8_t { Standard,
+                                            Bipartite,
+                                            Multilayer,
+                                            State };
+
+    enum class MultilayerMode : std::uint8_t { Full,
+                                               Intra,
+                                               IntraInter };
+
+    struct JsonHeader {
+      std::string format;
+      std::string version;
+      std::string type = "standard";
+      std::string multilayer = "full";
+      bool hasDirected = false;
+      bool directed = false;
+      bool hasBipartiteStartId = false;
+      unsigned int bipartiteStartId = 0;
+      bool hasNodes = false;
+      bool hasStates = false;
+    };
+
+    // Integer coercion (RFC): integral-valued doubles are accepted, non-integral
+    // values are rejected, ids are bounded by unsigned int (uint32) max.
+    inline bool coerceUnsigned(double value, unsigned int& out)
+    {
+      if (std::floor(value) != value)
+        return false;
+      if (value < 0.0)
+        return false;
+      if (value > static_cast<double>(std::numeric_limits<unsigned int>::max()))
+        return false;
+      out = static_cast<unsigned int>(value);
+      return true;
+    }
+
+    inline bool coerceUnsigned(std::int64_t value, unsigned int& out)
+    {
+      if (value < 0)
+        return false;
+      if (static_cast<std::uint64_t>(value) > std::numeric_limits<unsigned int>::max())
+        return false;
+      out = static_cast<unsigned int>(value);
+      return true;
+    }
+
+    inline bool coerceUnsigned(std::uint64_t value, unsigned int& out)
+    {
+      if (value > std::numeric_limits<unsigned int>::max())
+        return false;
+      out = static_cast<unsigned int>(value);
+      return true;
+    }
+
+    // A numeric value flowing through the SAX callbacks, normalized to double
+    // plus an exactly-integral marker so id coercion can reject e.g. 1.5.
+    struct Number {
+      double value = 0.0;
+      bool integral = false;
+    };
+
+    // Pass 1: capture root scalars, skip the big arrays without materializing them.
+    struct HeaderSaxHandler {
+      JsonHeader& header;
+      std::size_t objectDepth = 0;
+      std::size_t arrayDepth = 0;
+      std::string currentKey;
+
+      explicit HeaderSaxHandler(JsonHeader& h) : header(h) {}
+
+      bool atRoot() const { return objectDepth == 1 && arrayDepth == 0; }
+
+      bool null() { return true; }
+      bool boolean(bool val)
+      {
+        if (atRoot() && currentKey == "directed") {
+          header.hasDirected = true;
+          header.directed = val;
+        }
+        return true;
+      }
+      bool number_integer(std::int64_t val) { return number_unsigned(static_cast<std::uint64_t>(val < 0 ? 0 : val)); }
+      bool number_unsigned(std::uint64_t val)
+      {
+        if (atRoot() && currentKey == "bipartiteStartId") {
+          unsigned int id = 0;
+          if (coerceUnsigned(val, id)) {
+            header.hasBipartiteStartId = true;
+            header.bipartiteStartId = id;
+          }
+        }
+        return true;
+      }
+      bool number_float(double, const std::string&) { return true; }
+      bool string(std::string& val)
+      {
+        if (atRoot()) {
+          if (currentKey == "format")
+            header.format = val;
+          else if (currentKey == "version")
+            header.version = val;
+          else if (currentKey == "type")
+            header.type = val;
+          else if (currentKey == "multilayer")
+            header.multilayer = val;
+        }
+        return true;
+      }
+      bool binary(Json::binary_t&) { return true; }
+      bool start_object(std::size_t) { ++objectDepth; return true; }
+      bool key(std::string& val) { currentKey = val; return true; }
+      bool end_object() { --objectDepth; return true; }
+      bool start_array(std::size_t)
+      {
+        if (objectDepth == 1 && arrayDepth == 0) {
+          if (currentKey == "nodes")
+            header.hasNodes = true;
+          else if (currentKey == "states")
+            header.hasStates = true;
+        }
+        ++arrayDepth;
+        return true;
+      }
+      bool end_array() { --arrayDepth; return true; }
+      bool parse_error(std::size_t position, const std::string& last_token, const Json::exception& ex)
+      {
+        throw std::runtime_error(fmt::format(FMT_STRING("JSON parse error at byte {} (near '{}'): {}"), position, last_token, ex.what()));
+      }
+    };
+
+    // Accumulated fields of the current `nodes[]` / `states[]` / `edges[]` element.
+    struct PendingNode {
+      bool hasId = false;
+      unsigned int id = 0;
+      std::string name;
+      bool hasWeight = false;
+      double weight = 1.0;
+      bool hasMeta = false;
+      int meta = 0;
+      std::vector<unsigned int> path; // collected; emitted in a later phase
+    };
+
+    struct PendingEdge {
+      bool hasSource = false;
+      unsigned int source = 0;
+      bool hasTarget = false;
+      unsigned int target = 0;
+      bool hasWeight = false;
+      double weight = 1.0;
+      std::vector<unsigned int> layers; // multilayer only
+    };
+
+    struct PendingState {
+      bool hasId = false;
+      unsigned int id = 0;
+      bool hasNode = false;
+      unsigned int node = 0;
+      std::string name;
+      bool hasWeight = false;
+      double weight = 1.0;
+      std::vector<unsigned int> path; // collected; emitted in a later phase
+    };
+
+    // Pass 2: stream nodes/edges into the core network sink.
+    template <typename Sink>
+    struct ContentSaxHandler {
+      const JsonHeader& header;
+      Sink& sink;
+      const NetworkInputOptions& options;
+
+      enum class Section : std::uint8_t { None,
+                                          Nodes,
+                                          Edges,
+                                          States };
+      Section section = Section::None;
+      std::size_t objectDepth = 0;
+      std::size_t arrayDepth = 0;
+      std::string currentKey;
+      std::set<std::string> warnedUnknown;
+
+      NetworkType networkType = NetworkType::Standard;
+      MultilayerMode multilayerMode = MultilayerMode::Full;
+
+      PendingNode node;
+      PendingEdge edge;
+      PendingState state;
+      std::set<unsigned int> emittedImplicitStates;
+
+      ContentSaxHandler(const JsonHeader& h, Sink& s, const NetworkInputOptions& o)
+          : header(h), sink(s), options(o)
+      {
+        if (header.type == "bipartite")
+          networkType = NetworkType::Bipartite;
+        else if (header.type == "multilayer")
+          networkType = NetworkType::Multilayer;
+        else if (header.type == "state")
+          networkType = NetworkType::State;
+
+        if (header.multilayer == "intra")
+          multilayerMode = MultilayerMode::Intra;
+        else if (header.multilayer == "intra-inter")
+          multilayerMode = MultilayerMode::IntraInter;
+      }
+
+      bool inRootScalar() const { return objectDepth == 1 && arrayDepth == 0; }
+      bool inElement() const { return objectDepth == 2; }
+      bool inFieldArray() const { return objectDepth == 2 && arrayDepth == 2; }
+
+      void warnUnknown(const std::string& context, const std::string& field)
+      {
+        const std::string label = context + "." + field;
+        if (warnedUnknown.insert(label).second)
+          Console::note(0, "Ignoring unrecognized JSON field '{}'.", label);
+      }
+
+      void onElementNumber(const Number& number)
+      {
+        if (section == Section::Nodes) {
+          if (currentKey == "id") {
+            if (!coerceUnsigned(number.value, node.id) || !number.integral)
+              throw std::runtime_error(fmt::format(FMT_STRING("Invalid node id '{:g}' (must be a non-negative integer <= {})"), number.value, std::numeric_limits<unsigned int>::max()));
+            node.hasId = true;
+          } else if (currentKey == "weight") {
+            node.weight = number.value;
+            node.hasWeight = true;
+          } else if (currentKey == "meta") {
+            unsigned int meta = 0;
+            if (!coerceUnsigned(number.value, meta) || !number.integral)
+              throw std::runtime_error(fmt::format(FMT_STRING("Invalid node meta '{:g}' (must be a non-negative integer)"), number.value));
+            node.meta = static_cast<int>(meta);
+            node.hasMeta = true;
+          } else if (currentKey == "path" && inFieldArray()) {
+            unsigned int module = 0;
+            if (!coerceUnsigned(number.value, module) || !number.integral || module == 0)
+              throw std::runtime_error(fmt::format(FMT_STRING("Invalid path module '{:g}' (must be a positive integer)"), number.value));
+            node.path.push_back(module);
+          }
+        } else if (section == Section::States) {
+          if (currentKey == "id") {
+            if (!coerceUnsigned(number.value, state.id) || !number.integral)
+              throw std::runtime_error(fmt::format(FMT_STRING("Invalid state id '{:g}' (must be a non-negative integer <= {})"), number.value, std::numeric_limits<unsigned int>::max()));
+            state.hasId = true;
+          } else if (currentKey == "node") {
+            if (!coerceUnsigned(number.value, state.node) || !number.integral)
+              throw std::runtime_error(fmt::format(FMT_STRING("Invalid state physical node '{:g}' (must be a non-negative integer)"), number.value));
+            state.hasNode = true;
+          } else if (currentKey == "weight") {
+            state.weight = number.value;
+            state.hasWeight = true;
+          } else if (currentKey == "path" && inFieldArray()) {
+            unsigned int module = 0;
+            if (!coerceUnsigned(number.value, module) || !number.integral || module == 0)
+              throw std::runtime_error(fmt::format(FMT_STRING("Invalid path module '{:g}' (must be a positive integer)"), number.value));
+            state.path.push_back(module);
+          }
+        } else if (section == Section::Edges) {
+          if (currentKey == "source") {
+            if (!coerceUnsigned(number.value, edge.source) || !number.integral)
+              throw std::runtime_error(fmt::format(FMT_STRING("Invalid edge source '{:g}' (must be a non-negative integer <= {})"), number.value, std::numeric_limits<unsigned int>::max()));
+            edge.hasSource = true;
+          } else if (currentKey == "target") {
+            if (!coerceUnsigned(number.value, edge.target) || !number.integral)
+              throw std::runtime_error(fmt::format(FMT_STRING("Invalid edge target '{:g}' (must be a non-negative integer <= {})"), number.value, std::numeric_limits<unsigned int>::max()));
+            edge.hasTarget = true;
+          } else if (currentKey == "weight") {
+            edge.weight = number.value;
+            edge.hasWeight = true;
+          } else if (currentKey == "layers" && inFieldArray()) {
+            unsigned int layer = 0;
+            if (!coerceUnsigned(number.value, layer) || !number.integral)
+              throw std::runtime_error(fmt::format(FMT_STRING("Invalid layer id '{:g}' (must be a non-negative integer)"), number.value));
+            edge.layers.push_back(layer);
+          }
+        }
+      }
+
+      void flushNode()
+      {
+        if (!node.hasId)
+          throw std::runtime_error("JSON node is missing the required 'id' field");
+        if (networkType == NetworkType::Multilayer && !node.path.empty())
+          throw std::runtime_error("'path' on a node is invalid for a multilayer network; use type 'state' with states[].path");
+        ParsedVertex vertex;
+        vertex.id = node.id;
+        vertex.name = node.name;
+        vertex.hasWeight = node.hasWeight;
+        vertex.weight = node.weight;
+        sink.onPhysicalNode(vertex);
+        // Embedded one-dimensional meta enables meta coding the same way the
+        // in-memory set_meta_data / --meta-data inputs do (presence enables).
+        if (node.hasMeta)
+          sink.onMetaData(node.id, std::vector<int> { node.meta });
+        if (!node.path.empty())
+          sink.onInitialPartitionPath(node.id, node.path, /*stateLevel=*/false);
+        node = PendingNode {};
+      }
+
+      void flushState()
+      {
+        if (!state.hasId || !state.hasNode)
+          throw std::runtime_error("JSON state is missing the required 'id'/'node' field");
+        ParsedStateNode parsed;
+        parsed.node.id = state.id;
+        parsed.node.physicalId = state.node;
+        parsed.node.name = state.name;
+        parsed.hasWeight = state.hasWeight;
+        if (state.hasWeight)
+          parsed.node.weight = state.weight;
+        sink.onStateNode(parsed);
+        emittedImplicitStates.insert(state.id);
+        if (!state.path.empty())
+          sink.onInitialPartitionPath(state.id, state.path, /*stateLevel=*/true);
+        state = PendingState {};
+      }
+
+      // For state networks without an explicit states[] array, infer one state
+      // per edge endpoint with an identity physical mapping (physicalId == id).
+      void ensureImplicitState(unsigned int stateId)
+      {
+        if (networkType != NetworkType::State || header.hasStates)
+          return;
+        if (!emittedImplicitStates.insert(stateId).second)
+          return;
+        ParsedStateNode parsed;
+        parsed.node.id = stateId;
+        parsed.node.physicalId = stateId;
+        sink.onStateNode(parsed);
+      }
+
+      ParsedLink toLink() const
+      {
+        ParsedLink link;
+        link.source = edge.source;
+        link.target = edge.target;
+        link.weight = edge.hasWeight ? edge.weight : 1.0;
+        return link;
+      }
+
+      void flushMultilayerEdge()
+      {
+        const double weight = edge.hasWeight ? edge.weight : 1.0;
+        const std::size_t numLayers = edge.layers.size();
+
+        if (multilayerMode == MultilayerMode::Intra) {
+          if (numLayers != 1)
+            throw std::runtime_error("multilayer 'intra' edge requires exactly one layer id");
+          sink.onMultilayerIntraLink(ParsedMultilayerIntraLink { edge.layers[0], edge.source, edge.target, weight });
+        } else if (multilayerMode == MultilayerMode::IntraInter) {
+          if (numLayers == 1) {
+            sink.onMultilayerIntraLink(ParsedMultilayerIntraLink { edge.layers[0], edge.source, edge.target, weight });
+          } else if (numLayers == 2) {
+            if (edge.source != edge.target)
+              throw std::runtime_error("multilayer 'intra-inter' inter-layer edge requires source == target (use multilayer 'full' for non-diagonal inter-layer links)");
+            sink.onMultilayerInterLink(ParsedMultilayerInterLink { edge.layers[0], edge.source, edge.layers[1], weight });
+          } else {
+            throw std::runtime_error("multilayer 'intra-inter' edge requires one or two layer ids");
+          }
+        } else { // Full
+          if (numLayers != 2)
+            throw std::runtime_error("multilayer 'full' edge requires exactly two layer ids");
+          sink.onMultilayerLink(ParsedMultilayerLink { edge.layers[0], edge.source, edge.layers[1], edge.target, weight });
+        }
+      }
+
+      void flushEdge()
+      {
+        if (networkType == NetworkType::Multilayer) {
+          if (!edge.hasSource || !edge.hasTarget)
+            throw std::runtime_error("JSON multilayer edge is missing the required 'source'/'target' field");
+          if (edge.layers.empty())
+            throw std::runtime_error("JSON multilayer edge is missing the required 'layers' field");
+          flushMultilayerEdge();
+          edge = PendingEdge {};
+          return;
+        }
+
+        if (!edge.hasSource || !edge.hasTarget)
+          throw std::runtime_error("JSON edge is missing the required 'source'/'target' field");
+
+        if (networkType == NetworkType::Bipartite) {
+          const ParsedLink link = toLink();
+          sink.onBipartiteLink(fmt::format(FMT_STRING("{} {} {:g}"), link.source, link.target, link.weight), link);
+        } else if (networkType == NetworkType::State) {
+          ensureImplicitState(edge.source);
+          ensureImplicitState(edge.target);
+          sink.onLink(toLink());
+        } else {
+          sink.onLink(toLink());
+        }
+        edge = PendingEdge {};
+      }
+
+      bool routeNumber(const Number& number)
+      {
+        if (inRootScalar())
+          return true; // header scalars already captured in pass 1
+        if (objectDepth >= 2)
+          onElementNumber(number);
+        return true;
+      }
+
+      bool null() { return true; }
+      bool boolean(bool) { return true; }
+      bool number_integer(std::int64_t val)
+      {
+        return routeNumber(Number { static_cast<double>(val), true });
+      }
+      bool number_unsigned(std::uint64_t val)
+      {
+        return routeNumber(Number { static_cast<double>(val), true });
+      }
+      bool number_float(double val, const std::string&)
+      {
+        return routeNumber(Number { val, std::floor(val) == val });
+      }
+      bool string(std::string& val)
+      {
+        if (inElement() && currentKey == "name") {
+          if (section == Section::Nodes)
+            node.name = val;
+          else if (section == Section::States)
+            state.name = val;
+        }
+        return true;
+      }
+      bool binary(Json::binary_t&) { return true; }
+
+      bool start_object(std::size_t)
+      {
+        ++objectDepth;
+        return true;
+      }
+      bool key(std::string& val)
+      {
+        currentKey = val;
+        if (inElement()) {
+          if (section == Section::Nodes && !(val == "id" || val == "name" || val == "weight" || val == "meta" || val == "path"))
+            warnUnknown("node", val);
+          else if (section == Section::States && !(val == "id" || val == "node" || val == "name" || val == "weight" || val == "path"))
+            warnUnknown("state", val);
+          else if (section == Section::Edges) {
+            const bool knownEdgeField = val == "source" || val == "target" || val == "weight"
+                || (networkType == NetworkType::Multilayer && val == "layers");
+            if (!knownEdgeField)
+              warnUnknown("edge", val);
+          }
+        }
+        return true;
+      }
+      bool end_object()
+      {
+        if (objectDepth == 2) {
+          if (section == Section::Nodes)
+            flushNode();
+          else if (section == Section::States)
+            flushState();
+          else if (section == Section::Edges)
+            flushEdge();
+        }
+        --objectDepth;
+        return true;
+      }
+      bool start_array(std::size_t)
+      {
+        ++arrayDepth;
+        if (objectDepth == 1 && arrayDepth == 1) {
+          if (currentKey == "nodes")
+            section = Section::Nodes;
+          else if (currentKey == "edges")
+            section = Section::Edges;
+          else if (currentKey == "states")
+            section = Section::States;
+        }
+        return true;
+      }
+      bool end_array()
+      {
+        --arrayDepth;
+        if (objectDepth == 1 && arrayDepth == 0)
+          section = Section::None;
+        return true;
+      }
+      bool parse_error(std::size_t position, const std::string& last_token, const Json::exception& ex)
+      {
+        throw std::runtime_error(fmt::format(FMT_STRING("JSON parse error at byte {} (near '{}'): {}"), position, last_token, ex.what()));
+      }
+    };
+
+    inline void validateHeader(const JsonHeader& header, const NetworkInputOptions& options)
+    {
+      if (header.format != "infomap-network-json")
+        throw std::runtime_error(fmt::format(FMT_STRING("Not an infomap-network-json document (format = '{}')"), header.format));
+      if (header.version != "1.0")
+        throw std::runtime_error(fmt::format(FMT_STRING("Unsupported infomap-network-json version '{}' (this build supports 1.0)"), header.version));
+
+      const bool validType = header.type == "standard" || header.type == "bipartite"
+          || header.type == "multilayer" || header.type == "state";
+      if (!validType)
+        throw std::runtime_error(fmt::format(FMT_STRING("Unknown infomap-network-json type '{}'"), header.type));
+
+      // 'directed' is advisory (like *Edges/*Arcs in the text format): the run
+      // flag governs the flow model. Multilayer flow handles direction itself.
+      if (header.hasDirected && header.type != "multilayer") {
+        const bool fileDirected = header.directed;
+        const bool runDirected = !options.undirectedFlow;
+        if (fileDirected != runDirected) {
+          Log() << "\n";
+          Console::note(0, "JSON 'directed': {} but flow parsed as {}.", fileDirected ? "true" : "false", runDirected ? "directed" : "undirected");
+        }
+      }
+
+      if (header.type == "bipartite" && !header.hasBipartiteStartId)
+        throw std::runtime_error("infomap-network-json type 'bipartite' requires a numeric 'bipartiteStartId'");
+
+      if (header.type == "multilayer") {
+        const bool validMode = header.multilayer == "full" || header.multilayer == "intra" || header.multilayer == "intra-inter";
+        if (!validMode)
+          throw std::runtime_error(fmt::format(FMT_STRING("Unknown multilayer mode '{}'"), header.multilayer));
+      }
+    }
+
+  } // namespace json_detail
+
+  // Detect infomap-network-json by content: first non-whitespace byte is '{'.
+  inline bool looksLikeJsonNetwork(const std::string& filename)
+  {
+    std::ifstream file(filename);
+    if (!file)
+      return false;
+    char c = 0;
+    while (file.get(c)) {
+      if (c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '\f' || c == '\v')
+        continue;
+      return c == '{';
+    }
+    return false;
+  }
+
+  template <typename Sink>
+  void parseJsonNetworkInput(const std::string& filename, Sink& sink, const NetworkInputOptions& options)
+  {
+    using namespace json_detail;
+    Console::detail(1, "parsing infomap-network-json from {}", filename);
+
+    JsonHeader header;
+    {
+      std::ifstream file(filename);
+      if (!file)
+        throw std::runtime_error(fmt::format(FMT_STRING("Can't open file '{}'"), filename));
+      HeaderSaxHandler handler(header);
+      Json::sax_parse(file, &handler);
+    }
+
+    validateHeader(header, options);
+    Console::detail(1, "infomap-network-json type '{}'", header.type);
+
+    // The bipartite boundary is a discriminator known from the header pass, so
+    // emit it before any links regardless of nodes/edges key order.
+    if (header.type == "bipartite")
+      sink.onBipartiteStart(header.bipartiteStartId);
+
+    {
+      std::ifstream file(filename);
+      if (!file)
+        throw std::runtime_error(fmt::format(FMT_STRING("Can't open file '{}'"), filename));
+      ContentSaxHandler<Sink> handler(header, sink, options);
+      Json::sax_parse(file, &handler);
+    }
+
+    Console::detail(1, "done");
+  }
+
+} // namespace input
+} // namespace infomap
+
+#endif // JSON_NETWORK_INPUT_PARSER_H_

--- a/src/io/JsonNetworkInputParser.h
+++ b/src/io/JsonNetworkInputParser.h
@@ -478,7 +478,13 @@ namespace input {
       bool key(std::string& val)
       {
         currentKey = val;
-        if (inElement()) {
+        if (objectDepth == 1 && arrayDepth == 0) {
+          const bool knownRoot = val == "format" || val == "version" || val == "type"
+              || val == "directed" || val == "multilayer" || val == "bipartiteStartId"
+              || val == "nodes" || val == "states" || val == "edges";
+          if (!knownRoot)
+            warnUnknown("(root)", val);
+        } else if (inElement()) {
           if (section == Section::Nodes && !(val == "id" || val == "name" || val == "weight" || val == "meta" || val == "path"))
             warnUnknown("node", val);
           else if (section == Section::States && !(val == "id" || val == "node" || val == "name" || val == "weight" || val == "path"))

--- a/src/io/JsonNetworkInputParser.h
+++ b/src/io/JsonNetworkInputParser.h
@@ -10,7 +10,7 @@
 #ifndef JSON_NETWORK_INPUT_PARSER_H_
 #define JSON_NETWORK_INPUT_PARSER_H_
 
-// JSON network input parser for the infomap-network-json v1.0 format (RFC #645).
+// JSON network input parser for the infomap-network v1.0 format (RFC #645).
 //
 // Parsing is order- and emitter-independent via two SAX passes (no DOM):
 //   pass 1 captures the root scalar discriminators (format/version/type/...),
@@ -539,15 +539,15 @@ namespace input {
 
     inline void validateHeader(const JsonHeader& header, const NetworkInputOptions& options)
     {
-      if (header.format != "infomap-network-json")
-        throw std::runtime_error(fmt::format(FMT_STRING("Not an infomap-network-json document (format = '{}')"), header.format));
+      if (header.format != "infomap-network")
+        throw std::runtime_error(fmt::format(FMT_STRING("Not an infomap-network document (format = '{}')"), header.format));
       if (header.version != "1.0")
-        throw std::runtime_error(fmt::format(FMT_STRING("Unsupported infomap-network-json version '{}' (this build supports 1.0)"), header.version));
+        throw std::runtime_error(fmt::format(FMT_STRING("Unsupported infomap-network version '{}' (this build supports 1.0)"), header.version));
 
       const bool validType = header.type == "standard" || header.type == "bipartite"
           || header.type == "multilayer" || header.type == "state";
       if (!validType)
-        throw std::runtime_error(fmt::format(FMT_STRING("Unknown infomap-network-json type '{}'"), header.type));
+        throw std::runtime_error(fmt::format(FMT_STRING("Unknown infomap-network type '{}'"), header.type));
 
       // 'directed' is advisory (like *Edges/*Arcs in the text format): the run
       // flag governs the flow model. Multilayer flow handles direction itself.
@@ -561,7 +561,7 @@ namespace input {
       }
 
       if (header.type == "bipartite" && !header.hasBipartiteStartId)
-        throw std::runtime_error("infomap-network-json type 'bipartite' requires a numeric 'bipartiteStartId'");
+        throw std::runtime_error("infomap-network type 'bipartite' requires a numeric 'bipartiteStartId'");
 
       if (header.type == "multilayer") {
         const bool validMode = header.multilayer == "full" || header.multilayer == "intra" || header.multilayer == "intra-inter";
@@ -572,7 +572,7 @@ namespace input {
 
   } // namespace json_detail
 
-  // Detect infomap-network-json by content: first non-whitespace byte is '{'.
+  // Detect infomap-network by content: first non-whitespace byte is '{'.
   inline bool looksLikeJsonNetwork(const std::string& filename)
   {
     std::ifstream file(filename);
@@ -591,7 +591,7 @@ namespace input {
   void parseJsonNetworkInput(const std::string& filename, Sink& sink, const NetworkInputOptions& options)
   {
     using namespace json_detail;
-    Console::detail(1, "parsing infomap-network-json from {}", filename);
+    Console::detail(1, "parsing infomap-network from {}", filename);
 
     JsonHeader header;
     {
@@ -603,7 +603,7 @@ namespace input {
     }
 
     validateHeader(header, options);
-    Console::detail(1, "infomap-network-json type '{}'", header.type);
+    Console::detail(1, "infomap-network type '{}'", header.type);
 
     // The bipartite boundary is a discriminator known from the header pass, so
     // emit it before any links regardless of nodes/edges key order.

--- a/src/io/Network.cpp
+++ b/src/io/Network.cpp
@@ -64,6 +64,9 @@ void Network::clear()
   // Meta data
   m_metaData.clear();
   m_numMetaDataColumns = 0;
+
+  // Embedded initial partition
+  m_initialPartitionPaths.clear();
 }
 
 void Network::readInputData(std::string filename, bool accumulate)
@@ -107,6 +110,9 @@ void Network::postProcessInputData()
 
 void Network::readMetaData(const std::string& filename)
 {
+  if (!m_metaData.empty()) {
+    Console::note(0, "External meta-data '{}' overrides {} meta-data entries already on the network (e.g. embedded JSON 'meta').", filename, m_metaData.size());
+  }
   try {
     buildMetaDataFromInput(*this, filename);
   } catch (const InfomapError&) {
@@ -866,6 +872,11 @@ unsigned int Network::addMultilayerNode(unsigned int stateId, unsigned int layer
   layerIt[physicalId] = stateNode.id;
   m_layers.insert(layerId);
   return stateNode.id;
+}
+
+void Network::addInitialPartitionPath(unsigned int nodeId, const Path& path, TreeLeafIdType idType)
+{
+  m_initialPartitionPaths.push_back(TreePath { nodeId, path, idType });
 }
 
 void Network::addMetaData(unsigned int nodeId, int meta)

--- a/src/io/Network.h
+++ b/src/io/Network.h
@@ -11,6 +11,9 @@
 #define NETWORK_H_
 
 #include "Config.h"
+#ifndef SWIG
+#include "ClusterMap.h"
+#endif
 #include "../core/StateNetwork.h"
 
 #include <limits>
@@ -44,6 +47,13 @@ private:
   // Meta data
   std::map<unsigned int, std::vector<int>> m_metaData;
   unsigned int m_numMetaDataColumns = 0;
+
+#ifndef SWIG
+  // Embedded initial partition paths (from JSON nodes[].path / states[].path).
+  // Hierarchical, reusing the same TreePaths model as a .tree cluster file.
+  // Internal plumbing (JSON parser -> initTrialPartition); not a binding API.
+  TreePaths m_initialPartitionPaths;
+#endif
 
 public:
   Network() { init(); }
@@ -85,6 +95,11 @@ public:
 
   [[nodiscard]] unsigned int numMetaDataColumns() const { return m_numMetaDataColumns; }
   [[nodiscard]] const std::map<unsigned int, std::vector<int>>& metaData() const override { return m_metaData; }
+
+#ifndef SWIG
+  void addInitialPartitionPath(unsigned int nodeId, const Path& path, TreeLeafIdType idType);
+  [[nodiscard]] const TreePaths& initialPartitionPaths() const { return m_initialPartitionPaths; }
+#endif
 
   [[nodiscard]] bool isMultilayerNetwork() const { return !m_layerNodeToStateId.empty(); }
   [[nodiscard]] const std::map<unsigned int, std::map<unsigned int, unsigned int>>& layerNodeToStateId() const { return m_layerNodeToStateId; }

--- a/src/io/NetworkBuilder.cpp
+++ b/src/io/NetworkBuilder.cpp
@@ -10,6 +10,7 @@
 #include "NetworkBuilder.h"
 #include "Network.h"
 #include "NetworkInputParser.h"
+#include "JsonNetworkInputParser.h"
 #include "../utils/FileURI.h"
 #include "../utils/format.h"
 
@@ -111,6 +112,11 @@ public:
     m_network.addMetaData(nodeId, metaData);
   }
 
+  void onInitialPartitionPath(unsigned int id, const std::vector<unsigned int>& path, bool stateLevel)
+  {
+    m_network.addInitialPartitionPath(id, path, stateLevel ? TreeLeafIdType::state : TreeLeafIdType::physical);
+  }
+
 private:
   Network& m_network;
 };
@@ -121,7 +127,11 @@ void buildNetworkFromInput(Network& network, const std::string& filename)
 
   NetworkIntakeAdapter sink(network);
   sink.onFileInput();
-  input::parseNetworkInput(filename, sink, sink.inputOptions());
+  if (input::looksLikeJsonNetwork(filename)) {
+    input::parseJsonNetworkInput(filename, sink, sink.inputOptions());
+  } else {
+    input::parseNetworkInput(filename, sink, sink.inputOptions());
+  }
   sink.onNetworkParsed();
 }
 

--- a/test/cpp/test_network.cpp
+++ b/test/cpp/test_network.cpp
@@ -3,6 +3,7 @@
 #include "io/Config.h"
 #include "io/Network.h"
 #include "io/NetworkInputParser.h"
+#include "io/JsonNetworkInputParser.h"
 
 #include "TestUtils.h"
 
@@ -38,6 +39,13 @@ struct FakeInputSink {
   std::vector<infomap::input::ParsedLink> bipartiteLinks;
   std::vector<std::vector<int>> metaDataRows;
 
+  struct InitialPath {
+    unsigned int id;
+    std::vector<unsigned int> path;
+    bool stateLevel;
+  };
+  std::vector<InitialPath> initialPaths;
+
   unsigned int numPhysicalNodes() const { return vertices.size(); }
   unsigned int numLinks() const { return links.size(); }
   unsigned int numIntraLayerLinks() const { return intraLinks.size() + countExplicitIntraLinks(); }
@@ -58,6 +66,7 @@ struct FakeInputSink {
   void onBipartiteStart(unsigned int startId) { bipartiteStartId = startId; }
   void onBipartiteLink(const std::string&, const infomap::input::ParsedLink& link) { bipartiteLinks.push_back(link); }
   void onMetaData(unsigned int, const std::vector<int>& metaData) { metaDataRows.push_back(metaData); }
+  void onInitialPartitionPath(unsigned int id, const std::vector<unsigned int>& path, bool stateLevel) { initialPaths.push_back({ id, path, stateLevel }); }
 
 private:
   unsigned int countExplicitIntraLinks() const
@@ -595,6 +604,356 @@ TEST_CASE("StateNetwork builds CSR link storage after finalize [fast][core][csr]
   CHECK(std::get<0>(seen[0]) == 1);
   CHECK(std::get<1>(seen[0]) == 2);
   CHECK(std::get<2>(seen[2]) == doctest::Approx(4.0));
+}
+
+TEST_CASE("looksLikeJsonNetwork detects JSON by content [fast][core][parser][json]")
+{
+  CHECK(infomap::input::looksLikeJsonNetwork(infomap::test::repoPath("test/fixtures/networks/json/standard_minimal.json")));
+  CHECK_FALSE(infomap::input::looksLikeJsonNetwork(infomap::test::repoPath("test/fixtures/networks/states.net")));
+}
+
+TEST_CASE("JSON parser emits link events for a standard network [fast][core][parser][json]")
+{
+  FakeInputSink sink;
+
+  infomap::input::parseJsonNetworkInput(infomap::test::repoPath("test/fixtures/networks/json/standard_minimal.json"), sink, defaultInputOptions);
+
+  CHECK(sink.vertices.empty());
+  CHECK(sink.links.size() == 3);
+  CHECK(sink.links.front().source == 1);
+  CHECK(sink.links.front().target == 2);
+  CHECK(sink.links.front().weight == doctest::Approx(1.0));
+}
+
+TEST_CASE("JSON parser emits vertex events with names and weights [fast][core][parser][json]")
+{
+  FakeInputSink sink;
+
+  infomap::input::parseJsonNetworkInput(infomap::test::repoPath("test/fixtures/networks/json/standard.json"), sink, defaultInputOptions);
+
+  CHECK(sink.vertices.size() == 2);
+  CHECK(sink.vertices.front().id == 1);
+  CHECK(sink.vertices.front().name == "Species A");
+  CHECK(sink.vertices.front().hasWeight);
+  CHECK(sink.vertices.front().weight == doctest::Approx(2.0));
+  CHECK(sink.vertices.back().id == 2);
+  CHECK_FALSE(sink.vertices.back().hasWeight);
+  CHECK(sink.links.size() == 1);
+}
+
+TEST_CASE("JSON parser is emitter-independent (edges before discriminators) [fast][core][parser][json]")
+{
+  FakeInputSink sink;
+
+  infomap::input::parseJsonNetworkInput(infomap::test::repoPath("test/fixtures/networks/json/standard_keys_sorted.json"), sink, defaultInputOptions);
+
+  CHECK(sink.links.size() == 1);
+  CHECK(sink.links.front().source == 1);
+  CHECK(sink.links.front().target == 2);
+}
+
+TEST_CASE("JSON parser accepts integral-valued doubles as ids [fast][core][parser][json]")
+{
+  FakeInputSink sink;
+
+  infomap::input::parseJsonNetworkInput(infomap::test::repoPath("test/fixtures/networks/json/coercion_integral_double.json"), sink, defaultInputOptions);
+
+  CHECK(sink.vertices.size() == 1);
+  CHECK(sink.vertices.front().id == 10);
+  CHECK(sink.links.size() == 1);
+  CHECK(sink.links.front().source == 10);
+  CHECK(sink.links.front().target == 11);
+}
+
+TEST_CASE("JSON parser rejects non-integral ids [fast][core][parser][json]")
+{
+  FakeInputSink sink;
+
+  CHECK_THROWS_AS(
+      infomap::input::parseJsonNetworkInput(infomap::test::repoPath("test/fixtures/networks/json/invalid/noninteger_id.json"), sink, defaultInputOptions),
+      std::runtime_error);
+}
+
+TEST_CASE("Network builds a standard network from JSON via format detection [fast][core][parser][json]")
+{
+  Config config;
+  config.silent = true;
+  Network network(config);
+
+  network.readInputData(infomap::test::repoPath("test/fixtures/networks/json/standard_minimal.json"));
+
+  CHECK_FALSE(network.haveMemoryInput());
+  CHECK(network.numNodes() == 3);
+  CHECK(network.numLinks() == 3);
+}
+
+TEST_CASE("JSON parser tolerates unknown fields [fast][core][parser][json]")
+{
+  const std::string path = "json_unknown_field_test.json";
+  {
+    std::ofstream out(path.c_str());
+    out << R"({"format":"infomap-network-json","version":"1.0",)"
+        << R"("edges":[{"source":1,"target":2,"wieght":5.0}]})";
+  }
+
+  FakeInputSink sink;
+  infomap::input::parseJsonNetworkInput(path, sink, defaultInputOptions);
+
+  CHECK(sink.links.size() == 1);
+  CHECK(sink.links.front().weight == doctest::Approx(1.0)); // typo'd weight ignored, default used
+
+  std::remove(path.c_str());
+}
+
+TEST_CASE("JSON parser emits bipartite events [fast][core][parser][json]")
+{
+  FakeInputSink sink;
+  sink.onBipartiteStart(0);
+
+  infomap::input::parseJsonNetworkInput(infomap::test::repoPath("test/fixtures/networks/json/bipartite.json"), sink, defaultInputOptions);
+
+  CHECK(sink.bipartiteStartId == 4);
+  CHECK(sink.bipartiteLinks.size() == 1);
+  CHECK(sink.bipartiteLinks.front().source == 1);
+  CHECK(sink.bipartiteLinks.front().target == 4);
+  CHECK(sink.vertices.size() == 2);
+}
+
+TEST_CASE("JSON parser rejects bipartite without start id [fast][core][parser][json]")
+{
+  FakeInputSink sink;
+
+  CHECK_THROWS_AS(
+      infomap::input::parseJsonNetworkInput(infomap::test::repoPath("test/fixtures/networks/json/invalid/bipartite_no_start.json"), sink, defaultInputOptions),
+      std::runtime_error);
+}
+
+TEST_CASE("JSON parser emits explicit state events [fast][core][parser][json]")
+{
+  FakeInputSink sink;
+
+  infomap::input::parseJsonNetworkInput(infomap::test::repoPath("test/fixtures/networks/json/state.json"), sink, defaultInputOptions);
+
+  CHECK(sink.vertices.size() == 2);
+  CHECK(sink.stateNodes.size() == 2);
+  CHECK(sink.stateNodes.front().node.id == 1);
+  CHECK(sink.stateNodes.front().node.physicalId == 1);
+  CHECK(sink.stateNodes.front().hasWeight);
+  CHECK(sink.stateNodes.front().node.weight == doctest::Approx(0.4));
+  CHECK(sink.links.size() == 1);
+}
+
+TEST_CASE("JSON parser infers identity states when states[] omitted [fast][core][parser][json]")
+{
+  const std::string path = "json_state_inferred_test.json";
+  {
+    std::ofstream out(path.c_str());
+    out << R"({"format":"infomap-network-json","version":"1.0","type":"state",)"
+        << R"("edges":[{"source":1,"target":2},{"source":2,"target":3}]})";
+  }
+
+  FakeInputSink sink;
+  infomap::input::parseJsonNetworkInput(path, sink, defaultInputOptions);
+
+  CHECK(sink.stateNodes.size() == 3); // 1, 2, 3 inferred once each
+  CHECK(sink.stateNodes.front().node.id == sink.stateNodes.front().node.physicalId);
+  CHECK(sink.links.size() == 2);
+
+  std::remove(path.c_str());
+}
+
+TEST_CASE("JSON parser emits full multilayer events [fast][core][parser][json]")
+{
+  FakeInputSink sink;
+
+  infomap::input::parseJsonNetworkInput(infomap::test::repoPath("test/fixtures/networks/json/multilayer_full.json"), sink, defaultInputOptions);
+
+  REQUIRE(sink.multilayerLinks.size() == 1);
+  CHECK(sink.multilayerLinks.front().sourceLayer == 1);
+  CHECK(sink.multilayerLinks.front().sourceNode == 1);
+  CHECK(sink.multilayerLinks.front().targetLayer == 2);
+  CHECK(sink.multilayerLinks.front().targetNode == 2);
+}
+
+TEST_CASE("JSON parser emits intra-layer multilayer events [fast][core][parser][json]")
+{
+  FakeInputSink sink;
+
+  infomap::input::parseJsonNetworkInput(infomap::test::repoPath("test/fixtures/networks/json/multilayer_intra.json"), sink, defaultInputOptions);
+
+  REQUIRE(sink.intraLinks.size() == 1);
+  CHECK(sink.intraLinks.front().layer == 1);
+  CHECK(sink.intraLinks.front().sourceNode == 1);
+  CHECK(sink.intraLinks.front().targetNode == 2);
+}
+
+TEST_CASE("JSON parser emits intra-inter multilayer events [fast][core][parser][json]")
+{
+  FakeInputSink sink;
+
+  infomap::input::parseJsonNetworkInput(infomap::test::repoPath("test/fixtures/networks/json/multilayer_intra_inter.json"), sink, defaultInputOptions);
+
+  REQUIRE(sink.intraLinks.size() == 1);
+  REQUIRE(sink.interLinks.size() == 1);
+  CHECK(sink.intraLinks.front().layer == 1);
+  CHECK(sink.interLinks.front().sourceLayer == 1);
+  CHECK(sink.interLinks.front().node == 1);
+  CHECK(sink.interLinks.front().targetLayer == 2);
+}
+
+TEST_CASE("JSON parser rejects full multilayer edge with one layer [fast][core][parser][json]")
+{
+  FakeInputSink sink;
+
+  CHECK_THROWS_AS(
+      infomap::input::parseJsonNetworkInput(infomap::test::repoPath("test/fixtures/networks/json/invalid/multilayer_full_one_layer.json"), sink, defaultInputOptions),
+      std::runtime_error);
+}
+
+TEST_CASE("JSON parser rejects intra-inter inter-layer edge with source != target [fast][core][parser][json]")
+{
+  const std::string path = "json_intra_inter_bad_test.json";
+  {
+    std::ofstream out(path.c_str());
+    out << R"({"format":"infomap-network-json","version":"1.0","type":"multilayer","multilayer":"intra-inter",)"
+        << R"("edges":[{"layers":[1,2],"source":1,"target":2}]})";
+  }
+
+  FakeInputSink sink;
+  CHECK_THROWS_AS(infomap::input::parseJsonNetworkInput(path, sink, defaultInputOptions), std::runtime_error);
+
+  std::remove(path.c_str());
+}
+
+TEST_CASE("Network builds a higher-order state network from JSON [fast][core][parser][json]")
+{
+  // Two states (1, 2) on the same physical node 1 makes this genuinely
+  // higher-order; the RFC state.json example uses an identity mapping that the
+  // core (correctly) does not treat as memory input.
+  const std::string path = "json_state_higher_order_test.json";
+  {
+    std::ofstream out(path.c_str());
+    out << R"({"format":"infomap-network-json","version":"1.0","type":"state",)"
+        << R"("states":[{"id":1,"node":1},{"id":2,"node":1},{"id":3,"node":2}],)"
+        << R"("edges":[{"source":1,"target":3},{"source":2,"target":3}]})";
+  }
+
+  Config config;
+  config.silent = true;
+  Network network(config);
+
+  network.readInputData(path);
+
+  CHECK(network.haveMemoryInput());
+  CHECK(network.numNodes() == 3);
+  CHECK(network.numPhysicalNodes() == 2);
+
+  std::remove(path.c_str());
+}
+
+TEST_CASE("Network builds a multilayer network from JSON [fast][core][parser][json]")
+{
+  Config config;
+  config.silent = true;
+  Network network(config);
+
+  network.readInputData(infomap::test::repoPath("test/fixtures/networks/json/multilayer_intra.json"));
+
+  CHECK(network.haveMemoryInput());
+  CHECK(network.isMultilayerNetwork());
+}
+
+TEST_CASE("JSON parser emits embedded meta events [fast][core][parser][json]")
+{
+  FakeInputSink sink;
+
+  infomap::input::parseJsonNetworkInput(infomap::test::repoPath("test/fixtures/networks/json/standard.json"), sink, defaultInputOptions);
+
+  REQUIRE(sink.metaDataRows.size() == 2);
+  CHECK(sink.metaDataRows.front().size() == 1);
+  CHECK(sink.metaDataRows.front().front() == 10);
+  CHECK(sink.metaDataRows.back().front() == 20);
+}
+
+TEST_CASE("Network loads embedded meta from JSON (presence enables, like set_meta_data) [fast][core][parser][json]")
+{
+  Config config;
+  config.silent = true;
+  Network network(config);
+
+  network.readInputData(infomap::test::repoPath("test/fixtures/networks/json/standard.json"));
+
+  CHECK(network.numMetaDataColumns() == 1);
+  CHECK(network.metaData().size() == 2);
+  CHECK(network.metaData().at(1).front() == 10);
+  CHECK(network.metaData().at(2).front() == 20);
+}
+
+TEST_CASE("JSON parser emits node initial-partition paths [fast][core][parser][json]")
+{
+  FakeInputSink sink;
+
+  infomap::input::parseJsonNetworkInput(infomap::test::repoPath("test/fixtures/networks/json/standard.json"), sink, defaultInputOptions);
+
+  REQUIRE(sink.initialPaths.size() == 2);
+  CHECK(sink.initialPaths.front().id == 1);
+  CHECK(sink.initialPaths.front().path == std::vector<unsigned int> { 1 });
+  CHECK_FALSE(sink.initialPaths.front().stateLevel);
+  CHECK(sink.initialPaths.back().path == std::vector<unsigned int> { 1, 2 });
+}
+
+TEST_CASE("JSON parser emits state-level initial-partition paths [fast][core][parser][json]")
+{
+  FakeInputSink sink;
+
+  infomap::input::parseJsonNetworkInput(infomap::test::repoPath("test/fixtures/networks/json/state.json"), sink, defaultInputOptions);
+
+  REQUIRE(sink.initialPaths.size() == 2);
+  CHECK(sink.initialPaths.front().stateLevel);
+  CHECK(sink.initialPaths.front().path == std::vector<unsigned int> { 1 });
+  CHECK(sink.initialPaths.back().path == std::vector<unsigned int> { 1, 2 });
+}
+
+TEST_CASE("JSON parser rejects path on a multilayer node [fast][core][parser][json]")
+{
+  FakeInputSink sink;
+
+  CHECK_THROWS_AS(
+      infomap::input::parseJsonNetworkInput(infomap::test::repoPath("test/fixtures/networks/json/invalid/multilayer_node_path.json"), sink, defaultInputOptions),
+      std::runtime_error);
+}
+
+TEST_CASE("Network retains embedded initial-partition paths from JSON [fast][core][parser][json]")
+{
+  Config config;
+  config.silent = true;
+  Network network(config);
+
+  network.readInputData(infomap::test::repoPath("test/fixtures/networks/json/twotriangles_paths.json"));
+
+  CHECK(network.initialPartitionPaths().size() == 6);
+}
+
+TEST_CASE("External --meta-data composes with a JSON network [fast][core][parser][json]")
+{
+  const std::string meta = "json_external_meta_test.meta";
+  {
+    std::ofstream out(meta.c_str());
+    out << "1 5\n2 5\n3 7\n";
+  }
+
+  Config config;
+  config.silent = true;
+  Network network(config);
+
+  network.readInputData(infomap::test::repoPath("test/fixtures/networks/json/standard_minimal.json"));
+  network.readMetaData(meta);
+
+  CHECK(network.numMetaDataColumns() == 1);
+  CHECK(network.metaData().size() == 3);
+  CHECK(network.metaData().at(3).front() == 7);
+
+  std::remove(meta.c_str());
 }
 
 } // namespace

--- a/test/cpp/test_network.cpp
+++ b/test/cpp/test_network.cpp
@@ -693,6 +693,7 @@ TEST_CASE("JSON parser tolerates unknown fields [fast][core][parser][json]")
   {
     std::ofstream out(path.c_str());
     out << R"({"format":"infomap-network-json","version":"1.0",)"
+        << R"("description":"a comment","customRootAttr":42,)"
         << R"("edges":[{"source":1,"target":2,"wieght":5.0}]})";
   }
 

--- a/test/cpp/test_network.cpp
+++ b/test/cpp/test_network.cpp
@@ -692,7 +692,7 @@ TEST_CASE("JSON parser tolerates unknown fields [fast][core][parser][json]")
   const std::string path = "json_unknown_field_test.json";
   {
     std::ofstream out(path.c_str());
-    out << R"({"format":"infomap-network-json","version":"1.0",)"
+    out << R"({"format":"infomap-network","version":"1.0",)"
         << R"("description":"a comment","customRootAttr":42,)"
         << R"("edges":[{"source":1,"target":2,"wieght":5.0}]})";
   }
@@ -749,7 +749,7 @@ TEST_CASE("JSON parser infers identity states when states[] omitted [fast][core]
   const std::string path = "json_state_inferred_test.json";
   {
     std::ofstream out(path.c_str());
-    out << R"({"format":"infomap-network-json","version":"1.0","type":"state",)"
+    out << R"({"format":"infomap-network","version":"1.0","type":"state",)"
         << R"("edges":[{"source":1,"target":2},{"source":2,"target":3}]})";
   }
 
@@ -816,7 +816,7 @@ TEST_CASE("JSON parser rejects intra-inter inter-layer edge with source != targe
   const std::string path = "json_intra_inter_bad_test.json";
   {
     std::ofstream out(path.c_str());
-    out << R"({"format":"infomap-network-json","version":"1.0","type":"multilayer","multilayer":"intra-inter",)"
+    out << R"({"format":"infomap-network","version":"1.0","type":"multilayer","multilayer":"intra-inter",)"
         << R"("edges":[{"layers":[1,2],"source":1,"target":2}]})";
   }
 
@@ -834,7 +834,7 @@ TEST_CASE("Network builds a higher-order state network from JSON [fast][core][pa
   const std::string path = "json_state_higher_order_test.json";
   {
     std::ofstream out(path.c_str());
-    out << R"({"format":"infomap-network-json","version":"1.0","type":"state",)"
+    out << R"({"format":"infomap-network","version":"1.0","type":"state",)"
         << R"("states":[{"id":1,"node":1},{"id":2,"node":1},{"id":3,"node":2}],)"
         << R"("edges":[{"source":1,"target":3},{"source":2,"target":3}]})";
   }

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -465,6 +465,20 @@ TEST_CASE("Hard cluster-data preserves the imposed coarse partition [fast][core]
   infomap::test::checkCanonicalPartition(im, { { 1, 2, 3 }, { 4, 5, 6 } });
 }
 
+TEST_CASE("Embedded JSON path seeds the initial partition [fast][core][partition][json]")
+{
+  // The embedded nodes[].path assigns three modules {1,2}, {3,4}, {5,6}.
+  // With --no-infomap the result is exactly that imposed initial partition,
+  // proving the embedded path fed initPartition during the trial.
+  InfomapWrapper im(infomap::test::defaultFlags("--no-infomap"));
+  im.readInputData(infomap::test::repoPath("test/fixtures/networks/json/twotriangles_paths.json"));
+
+  im.run();
+
+  CHECK(im.numTopModules() == 3);
+  infomap::test::checkCanonicalPartition(im, { { 1, 2 }, { 3, 4 }, { 5, 6 } });
+}
+
 TEST_CASE("Hard cluster-data reinit and rerun stay stable on the same instance [fast][core][partition][lifecycle]")
 {
   InfomapWrapper im(infomap::test::defaultFlags());

--- a/test/fixtures/networks/json/bipartite.json
+++ b/test/fixtures/networks/json/bipartite.json
@@ -1,0 +1,13 @@
+{
+  "format": "infomap-network-json",
+  "version": "1.0",
+  "type": "bipartite",
+  "bipartiteStartId": 4,
+  "nodes": [
+    { "id": 1, "name": "Node 1" },
+    { "id": 4, "name": "Feature 1" }
+  ],
+  "edges": [
+    { "source": 1, "target": 4, "weight": 1.0 }
+  ]
+}

--- a/test/fixtures/networks/json/bipartite.json
+++ b/test/fixtures/networks/json/bipartite.json
@@ -1,5 +1,5 @@
 {
-  "format": "infomap-network-json",
+  "format": "infomap-network",
   "version": "1.0",
   "type": "bipartite",
   "bipartiteStartId": 4,

--- a/test/fixtures/networks/json/coercion_integral_double.json
+++ b/test/fixtures/networks/json/coercion_integral_double.json
@@ -1,5 +1,5 @@
 {
-  "format": "infomap-network-json",
+  "format": "infomap-network",
   "version": "1.0",
   "nodes": [
     { "id": 10.0, "meta": 20.0, "path": [1.0] }

--- a/test/fixtures/networks/json/coercion_integral_double.json
+++ b/test/fixtures/networks/json/coercion_integral_double.json
@@ -1,0 +1,10 @@
+{
+  "format": "infomap-network-json",
+  "version": "1.0",
+  "nodes": [
+    { "id": 10.0, "meta": 20.0, "path": [1.0] }
+  ],
+  "edges": [
+    { "source": 10.0, "target": 11, "weight": 1.0 }
+  ]
+}

--- a/test/fixtures/networks/json/invalid/bad_format.json
+++ b/test/fixtures/networks/json/invalid/bad_format.json
@@ -1,0 +1,5 @@
+{
+  "format": "infomap-network",
+  "version": "1.0",
+  "edges": [{ "source": 1, "target": 2 }]
+}

--- a/test/fixtures/networks/json/invalid/bad_format.json
+++ b/test/fixtures/networks/json/invalid/bad_format.json
@@ -1,5 +1,5 @@
 {
-  "format": "infomap-network",
+  "format": "infomap-net",
   "version": "1.0",
   "edges": [{ "source": 1, "target": 2 }]
 }

--- a/test/fixtures/networks/json/invalid/bipartite_no_start.json
+++ b/test/fixtures/networks/json/invalid/bipartite_no_start.json
@@ -1,0 +1,6 @@
+{
+  "format": "infomap-network-json",
+  "version": "1.0",
+  "type": "bipartite",
+  "edges": [{ "source": 1, "target": 4 }]
+}

--- a/test/fixtures/networks/json/invalid/bipartite_no_start.json
+++ b/test/fixtures/networks/json/invalid/bipartite_no_start.json
@@ -1,5 +1,5 @@
 {
-  "format": "infomap-network-json",
+  "format": "infomap-network",
   "version": "1.0",
   "type": "bipartite",
   "edges": [{ "source": 1, "target": 4 }]

--- a/test/fixtures/networks/json/invalid/missing_edges.json
+++ b/test/fixtures/networks/json/invalid/missing_edges.json
@@ -1,0 +1,5 @@
+{
+  "format": "infomap-network-json",
+  "version": "1.0",
+  "nodes": [{ "id": 1 }, { "id": 2 }]
+}

--- a/test/fixtures/networks/json/invalid/missing_edges.json
+++ b/test/fixtures/networks/json/invalid/missing_edges.json
@@ -1,5 +1,5 @@
 {
-  "format": "infomap-network-json",
+  "format": "infomap-network",
   "version": "1.0",
   "nodes": [{ "id": 1 }, { "id": 2 }]
 }

--- a/test/fixtures/networks/json/invalid/multilayer_full_one_layer.json
+++ b/test/fixtures/networks/json/invalid/multilayer_full_one_layer.json
@@ -1,5 +1,5 @@
 {
-  "format": "infomap-network-json",
+  "format": "infomap-network",
   "version": "1.0",
   "type": "multilayer",
   "multilayer": "full",

--- a/test/fixtures/networks/json/invalid/multilayer_full_one_layer.json
+++ b/test/fixtures/networks/json/invalid/multilayer_full_one_layer.json
@@ -1,0 +1,7 @@
+{
+  "format": "infomap-network-json",
+  "version": "1.0",
+  "type": "multilayer",
+  "multilayer": "full",
+  "edges": [{ "layers": [1], "source": 1, "target": 2 }]
+}

--- a/test/fixtures/networks/json/invalid/multilayer_node_path.json
+++ b/test/fixtures/networks/json/invalid/multilayer_node_path.json
@@ -1,0 +1,8 @@
+{
+  "format": "infomap-network-json",
+  "version": "1.0",
+  "type": "multilayer",
+  "multilayer": "full",
+  "nodes": [{ "id": 1, "path": [1] }],
+  "edges": [{ "layers": [1, 2], "source": 1, "target": 2 }]
+}

--- a/test/fixtures/networks/json/invalid/multilayer_node_path.json
+++ b/test/fixtures/networks/json/invalid/multilayer_node_path.json
@@ -1,5 +1,5 @@
 {
-  "format": "infomap-network-json",
+  "format": "infomap-network",
   "version": "1.0",
   "type": "multilayer",
   "multilayer": "full",

--- a/test/fixtures/networks/json/invalid/negative_node_weight.json
+++ b/test/fixtures/networks/json/invalid/negative_node_weight.json
@@ -1,0 +1,6 @@
+{
+  "format": "infomap-network-json",
+  "version": "1.0",
+  "nodes": [{ "id": 1, "weight": -1.0 }],
+  "edges": [{ "source": 1, "target": 2 }]
+}

--- a/test/fixtures/networks/json/invalid/negative_node_weight.json
+++ b/test/fixtures/networks/json/invalid/negative_node_weight.json
@@ -1,5 +1,5 @@
 {
-  "format": "infomap-network-json",
+  "format": "infomap-network",
   "version": "1.0",
   "nodes": [{ "id": 1, "weight": -1.0 }],
   "edges": [{ "source": 1, "target": 2 }]

--- a/test/fixtures/networks/json/invalid/noninteger_id.json
+++ b/test/fixtures/networks/json/invalid/noninteger_id.json
@@ -1,5 +1,5 @@
 {
-  "format": "infomap-network-json",
+  "format": "infomap-network",
   "version": "1.0",
   "edges": [{ "source": 1.5, "target": 2 }]
 }

--- a/test/fixtures/networks/json/invalid/noninteger_id.json
+++ b/test/fixtures/networks/json/invalid/noninteger_id.json
@@ -1,0 +1,5 @@
+{
+  "format": "infomap-network-json",
+  "version": "1.0",
+  "edges": [{ "source": 1.5, "target": 2 }]
+}

--- a/test/fixtures/networks/json/invalid/state_meta.json
+++ b/test/fixtures/networks/json/invalid/state_meta.json
@@ -1,0 +1,7 @@
+{
+  "format": "infomap-network-json",
+  "version": "1.0",
+  "type": "state",
+  "states": [{ "id": 1, "node": 1, "meta": 10 }],
+  "edges": [{ "source": 1, "target": 2 }]
+}

--- a/test/fixtures/networks/json/invalid/state_meta.json
+++ b/test/fixtures/networks/json/invalid/state_meta.json
@@ -1,5 +1,5 @@
 {
-  "format": "infomap-network-json",
+  "format": "infomap-network",
   "version": "1.0",
   "type": "state",
   "states": [{ "id": 1, "node": 1, "meta": 10 }],

--- a/test/fixtures/networks/json/invalid/unknown_type.json
+++ b/test/fixtures/networks/json/invalid/unknown_type.json
@@ -1,0 +1,6 @@
+{
+  "format": "infomap-network-json",
+  "version": "1.0",
+  "type": "hypergraph",
+  "edges": [{ "source": 1, "target": 2 }]
+}

--- a/test/fixtures/networks/json/invalid/unknown_type.json
+++ b/test/fixtures/networks/json/invalid/unknown_type.json
@@ -1,5 +1,5 @@
 {
-  "format": "infomap-network-json",
+  "format": "infomap-network",
   "version": "1.0",
   "type": "hypergraph",
   "edges": [{ "source": 1, "target": 2 }]

--- a/test/fixtures/networks/json/multilayer_full.json
+++ b/test/fixtures/networks/json/multilayer_full.json
@@ -1,0 +1,9 @@
+{
+  "format": "infomap-network-json",
+  "version": "1.0",
+  "type": "multilayer",
+  "multilayer": "full",
+  "edges": [
+    { "layers": [1, 2], "source": 1, "target": 2, "weight": 1.0 }
+  ]
+}

--- a/test/fixtures/networks/json/multilayer_full.json
+++ b/test/fixtures/networks/json/multilayer_full.json
@@ -1,5 +1,5 @@
 {
-  "format": "infomap-network-json",
+  "format": "infomap-network",
   "version": "1.0",
   "type": "multilayer",
   "multilayer": "full",

--- a/test/fixtures/networks/json/multilayer_intra.json
+++ b/test/fixtures/networks/json/multilayer_intra.json
@@ -1,0 +1,9 @@
+{
+  "format": "infomap-network-json",
+  "version": "1.0",
+  "type": "multilayer",
+  "multilayer": "intra",
+  "edges": [
+    { "layers": [1], "source": 1, "target": 2, "weight": 1.0 }
+  ]
+}

--- a/test/fixtures/networks/json/multilayer_intra.json
+++ b/test/fixtures/networks/json/multilayer_intra.json
@@ -1,5 +1,5 @@
 {
-  "format": "infomap-network-json",
+  "format": "infomap-network",
   "version": "1.0",
   "type": "multilayer",
   "multilayer": "intra",

--- a/test/fixtures/networks/json/multilayer_intra_inter.json
+++ b/test/fixtures/networks/json/multilayer_intra_inter.json
@@ -1,0 +1,10 @@
+{
+  "format": "infomap-network-json",
+  "version": "1.0",
+  "type": "multilayer",
+  "multilayer": "intra-inter",
+  "edges": [
+    { "layers": [1], "source": 1, "target": 2, "weight": 1.0 },
+    { "layers": [1, 2], "source": 1, "target": 1, "weight": 0.2 }
+  ]
+}

--- a/test/fixtures/networks/json/multilayer_intra_inter.json
+++ b/test/fixtures/networks/json/multilayer_intra_inter.json
@@ -1,5 +1,5 @@
 {
-  "format": "infomap-network-json",
+  "format": "infomap-network",
   "version": "1.0",
   "type": "multilayer",
   "multilayer": "intra-inter",

--- a/test/fixtures/networks/json/standard.json
+++ b/test/fixtures/networks/json/standard.json
@@ -1,0 +1,12 @@
+{
+  "format": "infomap-network-json",
+  "version": "1.0",
+  "directed": false,
+  "nodes": [
+    { "id": 1, "name": "Species A", "weight": 2.0, "meta": 10, "path": [1] },
+    { "id": 2, "name": "Species B", "meta": 20, "path": [1, 2] }
+  ],
+  "edges": [
+    { "source": 1, "target": 2, "weight": 1.0 }
+  ]
+}

--- a/test/fixtures/networks/json/standard.json
+++ b/test/fixtures/networks/json/standard.json
@@ -1,5 +1,5 @@
 {
-  "format": "infomap-network-json",
+  "format": "infomap-network",
   "version": "1.0",
   "directed": false,
   "nodes": [

--- a/test/fixtures/networks/json/standard_keys_sorted.json
+++ b/test/fixtures/networks/json/standard_keys_sorted.json
@@ -1,0 +1,9 @@
+{
+  "directed": false,
+  "edges": [
+    { "source": 1, "target": 2, "weight": 1.0 }
+  ],
+  "format": "infomap-network-json",
+  "type": "standard",
+  "version": "1.0"
+}

--- a/test/fixtures/networks/json/standard_keys_sorted.json
+++ b/test/fixtures/networks/json/standard_keys_sorted.json
@@ -3,7 +3,7 @@
   "edges": [
     { "source": 1, "target": 2, "weight": 1.0 }
   ],
-  "format": "infomap-network-json",
+  "format": "infomap-network",
   "type": "standard",
   "version": "1.0"
 }

--- a/test/fixtures/networks/json/standard_minimal.json
+++ b/test/fixtures/networks/json/standard_minimal.json
@@ -1,0 +1,9 @@
+{
+  "format": "infomap-network-json",
+  "version": "1.0",
+  "edges": [
+    { "source": 1, "target": 2 },
+    { "source": 2, "target": 3 },
+    { "source": 3, "target": 1 }
+  ]
+}

--- a/test/fixtures/networks/json/standard_minimal.json
+++ b/test/fixtures/networks/json/standard_minimal.json
@@ -1,5 +1,5 @@
 {
-  "format": "infomap-network-json",
+  "format": "infomap-network",
   "version": "1.0",
   "edges": [
     { "source": 1, "target": 2 },

--- a/test/fixtures/networks/json/state.json
+++ b/test/fixtures/networks/json/state.json
@@ -1,5 +1,5 @@
 {
-  "format": "infomap-network-json",
+  "format": "infomap-network",
   "version": "1.0",
   "type": "state",
   "nodes": [

--- a/test/fixtures/networks/json/state.json
+++ b/test/fixtures/networks/json/state.json
@@ -1,0 +1,16 @@
+{
+  "format": "infomap-network-json",
+  "version": "1.0",
+  "type": "state",
+  "nodes": [
+    { "id": 1, "name": "Species A" },
+    { "id": 2, "name": "Species B" }
+  ],
+  "states": [
+    { "id": 1, "node": 1, "name": "State 1", "weight": 0.4, "path": [1] },
+    { "id": 2, "node": 2, "name": "State 2", "path": [1, 2] }
+  ],
+  "edges": [
+    { "source": 1, "target": 2, "weight": 1.0 }
+  ]
+}

--- a/test/fixtures/networks/json/twotriangles.json
+++ b/test/fixtures/networks/json/twotriangles.json
@@ -1,5 +1,5 @@
 {
-  "format": "infomap-network-json",
+  "format": "infomap-network",
   "version": "1.0",
   "edges": [
     { "source": 1, "target": 2 },

--- a/test/fixtures/networks/json/twotriangles.json
+++ b/test/fixtures/networks/json/twotriangles.json
@@ -1,0 +1,13 @@
+{
+  "format": "infomap-network-json",
+  "version": "1.0",
+  "edges": [
+    { "source": 1, "target": 2 },
+    { "source": 1, "target": 3 },
+    { "source": 2, "target": 3 },
+    { "source": 3, "target": 4 },
+    { "source": 4, "target": 5 },
+    { "source": 4, "target": 6 },
+    { "source": 5, "target": 6 }
+  ]
+}

--- a/test/fixtures/networks/json/twotriangles_meta.json
+++ b/test/fixtures/networks/json/twotriangles_meta.json
@@ -1,5 +1,5 @@
 {
-  "format": "infomap-network-json",
+  "format": "infomap-network",
   "version": "1.0",
   "nodes": [
     { "id": 1, "meta": 0 },

--- a/test/fixtures/networks/json/twotriangles_meta.json
+++ b/test/fixtures/networks/json/twotriangles_meta.json
@@ -1,0 +1,21 @@
+{
+  "format": "infomap-network-json",
+  "version": "1.0",
+  "nodes": [
+    { "id": 1, "meta": 0 },
+    { "id": 2, "meta": 0 },
+    { "id": 3, "meta": 1 },
+    { "id": 4, "meta": 1 },
+    { "id": 5, "meta": 0 },
+    { "id": 6, "meta": 0 }
+  ],
+  "edges": [
+    { "source": 1, "target": 2 },
+    { "source": 1, "target": 3 },
+    { "source": 2, "target": 3 },
+    { "source": 3, "target": 4 },
+    { "source": 4, "target": 5 },
+    { "source": 4, "target": 6 },
+    { "source": 5, "target": 6 }
+  ]
+}

--- a/test/fixtures/networks/json/twotriangles_paths.json
+++ b/test/fixtures/networks/json/twotriangles_paths.json
@@ -1,0 +1,21 @@
+{
+  "format": "infomap-network-json",
+  "version": "1.0",
+  "nodes": [
+    { "id": 1, "path": [1] },
+    { "id": 2, "path": [1] },
+    { "id": 3, "path": [2] },
+    { "id": 4, "path": [2] },
+    { "id": 5, "path": [3] },
+    { "id": 6, "path": [3] }
+  ],
+  "edges": [
+    { "source": 1, "target": 2 },
+    { "source": 1, "target": 3 },
+    { "source": 2, "target": 3 },
+    { "source": 3, "target": 4 },
+    { "source": 4, "target": 5 },
+    { "source": 4, "target": 6 },
+    { "source": 5, "target": 6 }
+  ]
+}

--- a/test/fixtures/networks/json/twotriangles_paths.json
+++ b/test/fixtures/networks/json/twotriangles_paths.json
@@ -1,5 +1,5 @@
 {
-  "format": "infomap-network-json",
+  "format": "infomap-network",
   "version": "1.0",
   "nodes": [
     { "id": 1, "path": [1] },

--- a/test/python/test_network_input_contract.py
+++ b/test/python/test_network_input_contract.py
@@ -4,6 +4,9 @@ import pytest
 pytestmark = pytest.mark.fast
 
 
+TWO_TRIANGLES = [(1, 2), (1, 3), (2, 3), (3, 4), (4, 5), (4, 6), (5, 6)]
+
+
 def test_add_state_nodes_accepts_pairs_and_mapping(make_infomap):
     pairs = make_infomap()
     pairs.add_state_nodes([(10, 1), (11, 1), (20, 2)])
@@ -13,3 +16,53 @@ def test_add_state_nodes_accepts_pairs_and_mapping(make_infomap):
 
     assert pairs.num_nodes == 3
     assert mapping.num_nodes == pairs.num_nodes
+
+
+def test_json_standard_matches_in_memory(
+    make_infomap, network_fixture_path, canonical_modules
+):
+    """A JSON network yields the same partition as the equivalent in-memory input."""
+    in_memory = make_infomap()
+    in_memory.add_links(TWO_TRIANGLES)
+    in_memory.run()
+
+    from_json = make_infomap()
+    from_json.read_file(str(network_fixture_path("json/twotriangles.json")))
+    from_json.run()
+
+    assert from_json.num_nodes == in_memory.num_nodes
+    assert canonical_modules(from_json.get_modules()) == canonical_modules(
+        in_memory.get_modules()
+    )
+
+
+def test_json_embedded_meta_matches_set_meta_data(
+    make_infomap, network_fixture_path, canonical_modules
+):
+    """Embedded JSON meta enables coding identically to set_meta_data (Option B)."""
+    meta = {1: 0, 2: 0, 3: 1, 4: 1, 5: 0, 6: 0}
+
+    in_memory = make_infomap(num_trials=10)
+    in_memory.add_links(TWO_TRIANGLES)
+    for node_id, category in meta.items():
+        in_memory.set_meta_data(node_id, category)
+    in_memory.run(meta_data_rate=2)
+
+    from_json = make_infomap(num_trials=10)
+    from_json.read_file(str(network_fixture_path("json/twotriangles_meta.json")))
+    from_json.run(meta_data_rate=2)
+
+    assert canonical_modules(from_json.get_modules()) == canonical_modules(
+        in_memory.get_modules()
+    )
+
+
+def test_json_embedded_path_seeds_initial_partition(
+    make_infomap, network_fixture_path, canonical_modules
+):
+    """nodes[].path imposes the initial partition; --no-infomap leaves it intact."""
+    im = make_infomap()
+    im.read_file(str(network_fixture_path("json/twotriangles_paths.json")))
+    im.run("--no-infomap")
+
+    assert canonical_modules(im.get_modules()) == [[1, 2], [3, 4], [5, 6]]

--- a/test/python/test_network_json_schema.py
+++ b/test/python/test_network_json_schema.py
@@ -1,0 +1,72 @@
+"""Schema parity tests for the infomap-network-json v1.0 input format (RFC #645).
+
+These validate the JSON Schema's accept/reject set. The SAX parser implemented
+in later phases must match this set; the same fixtures are reused as parser
+inputs to prove parity.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+SCHEMA_NAME = "infomap-network-json.schema.json"
+
+_FIXTURE_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "networks" / "json"
+_VALID = sorted(_FIXTURE_DIR.glob("*.json"))
+_INVALID = sorted((_FIXTURE_DIR / "invalid").glob("*.json"))
+
+
+def _load(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_fixtures_exist() -> None:
+    assert _VALID, "expected valid JSON network fixtures"
+    assert _INVALID, "expected invalid JSON network fixtures"
+
+
+@pytest.mark.parametrize("path", _VALID, ids=lambda p: p.name)
+def test_valid_fixtures_pass_schema(path: Path, validate_json_schema) -> None:
+    validate_json_schema(_load(path), SCHEMA_NAME)
+
+
+@pytest.mark.parametrize("path", _INVALID, ids=lambda p: p.name)
+def test_invalid_fixtures_rejected_by_schema(path: Path, validate_json_schema) -> None:
+    with pytest.raises(AssertionError):
+        validate_json_schema(_load(path), SCHEMA_NAME)
+
+
+def test_integral_doubles_accepted_non_integral_rejected(validate_json_schema) -> None:
+    """Integer coercion: 10.0 is a valid id, 1.5 is not (RFC integer coercion)."""
+    base = {"format": "infomap-network-json", "version": "1.0"}
+
+    validate_json_schema(
+        {**base, "edges": [{"source": 10.0, "target": 11}]}, SCHEMA_NAME
+    )
+    with pytest.raises(AssertionError):
+        validate_json_schema(
+            {**base, "edges": [{"source": 1.5, "target": 2}]}, SCHEMA_NAME
+        )
+
+
+def test_negative_edge_weight_is_valid_but_negative_node_weight_is_not(
+    validate_json_schema,
+) -> None:
+    """Edge weights <= 0 are ignored by the core (not errors); node weights must be >= 0."""
+    base = {"format": "infomap-network-json", "version": "1.0"}
+
+    validate_json_schema(
+        {**base, "edges": [{"source": 1, "target": 2, "weight": -1.0}]}, SCHEMA_NAME
+    )
+    with pytest.raises(AssertionError):
+        validate_json_schema(
+            {
+                **base,
+                "nodes": [{"id": 1, "weight": -1.0}],
+                "edges": [{"source": 1, "target": 2}],
+            },
+            SCHEMA_NAME,
+        )

--- a/test/python/test_network_json_schema.py
+++ b/test/python/test_network_json_schema.py
@@ -1,4 +1,4 @@
-"""Schema parity tests for the infomap-network-json v1.0 input format (RFC #645).
+"""Schema parity tests for the infomap-network v1.0 input format (RFC #645).
 
 These validate the JSON Schema's accept/reject set. The SAX parser implemented
 in later phases must match this set; the same fixtures are reused as parser
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-SCHEMA_NAME = "infomap-network-json.schema.json"
+SCHEMA_NAME = "infomap-network.schema.json"
 
 _FIXTURE_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "networks" / "json"
 _VALID = sorted(_FIXTURE_DIR.glob("*.json"))
@@ -41,7 +41,7 @@ def test_invalid_fixtures_rejected_by_schema(path: Path, validate_json_schema) -
 
 def test_integral_doubles_accepted_non_integral_rejected(validate_json_schema) -> None:
     """Integer coercion: 10.0 is a valid id, 1.5 is not (RFC integer coercion)."""
-    base = {"format": "infomap-network-json", "version": "1.0"}
+    base = {"format": "infomap-network", "version": "1.0"}
 
     validate_json_schema(
         {**base, "edges": [{"source": 10.0, "target": 11}]}, SCHEMA_NAME
@@ -56,7 +56,7 @@ def test_negative_edge_weight_is_valid_but_negative_node_weight_is_not(
     validate_json_schema,
 ) -> None:
     """Edge weights <= 0 are ignored by the core (not errors); node weights must be >= 0."""
-    base = {"format": "infomap-network-json", "version": "1.0"}
+    base = {"format": "infomap-network", "version": "1.0"}
 
     validate_json_schema(
         {**base, "edges": [{"source": 1, "target": 2, "weight": -1.0}]}, SCHEMA_NAME

--- a/test/schemas/json/README.md
+++ b/test/schemas/json/README.md
@@ -8,8 +8,8 @@ artifacts, not C++ output contracts.
 
 ## Input contracts
 
-`infomap-network-json.schema.json` is the normative schema for the
-`infomap-network-json` v1.0 **input** format (RFC #645). Unlike the output
+`infomap-network.schema.json` is the normative schema for the
+`infomap-network` v1.0 **input** format (RFC #645). Unlike the output
 schemas it constrains data the parser reads, so it is authoritative for the SAX
 parser's accept/reject set: the fixtures in `test/fixtures/networks/json/`
 (valid) and `test/fixtures/networks/json/invalid/` (rejected) prove parity, and

--- a/test/schemas/json/README.md
+++ b/test/schemas/json/README.md
@@ -5,3 +5,14 @@ the internal C++/JS output-format metadata.
 
 Benchmark reports are intentionally excluded because they are Python CI
 artifacts, not C++ output contracts.
+
+## Input contracts
+
+`infomap-network-json.schema.json` is the normative schema for the
+`infomap-network-json` v1.0 **input** format (RFC #645). Unlike the output
+schemas it constrains data the parser reads, so it is authoritative for the SAX
+parser's accept/reject set: the fixtures in `test/fixtures/networks/json/`
+(valid) and `test/fixtures/networks/json/invalid/` (rejected) prove parity, and
+the same valid fixtures are reused as parser inputs in later phases. Edge weights
+are deliberately unbounded (`<= 0` is ignored by the core, not an error); only
+node/state weights must be non-negative.

--- a/test/schemas/json/infomap-network-json.schema.json
+++ b/test/schemas/json/infomap-network-json.schema.json
@@ -1,0 +1,287 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mapequation.org/infomap/test-schemas/infomap-network-json.schema.json",
+  "title": "Infomap Network JSON",
+  "description": "Normative schema for the infomap-network-json v1.0 input format (RFC #645). The SAX parser's accept/reject set must match this schema.",
+  "type": "object",
+  "required": ["format", "version", "edges"],
+  "properties": {
+    "format": { "const": "infomap-network-json" },
+    "version": { "const": "1.0" },
+    "type": {
+      "enum": ["standard", "bipartite", "multilayer", "state"],
+      "default": "standard"
+    },
+    "directed": { "type": "boolean", "default": false },
+    "nodes": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/node" }
+    },
+    "states": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/state" }
+    },
+    "edges": {
+      "type": "array"
+    },
+    "bipartiteStartId": { "$ref": "#/$defs/id" },
+    "multilayer": {
+      "enum": ["full", "intra", "intra-inter"],
+      "default": "full"
+    },
+    "layers": false
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "type": { "const": "bipartite" }
+        },
+        "required": ["type"]
+      },
+      "then": {
+        "required": ["bipartiteStartId"],
+        "properties": {
+          "edges": {
+            "type": "array",
+            "items": { "$ref": "#/$defs/standardEdge" }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": { "const": "multilayer" }
+        },
+        "required": ["type"]
+      },
+      "then": {
+        "not": {
+          "required": ["nodes"],
+          "properties": {
+            "nodes": {
+              "type": "array",
+              "contains": { "required": ["path"] }
+            }
+          }
+        },
+        "properties": {
+          "edges": {
+            "type": "array",
+            "items": { "$ref": "#/$defs/multilayerEdge" }
+          }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "multilayer": { "const": "intra" }
+              },
+              "required": ["multilayer"]
+            },
+            "then": {
+              "properties": {
+                "edges": {
+                  "type": "array",
+                  "items": { "$ref": "#/$defs/multilayerIntraEdge" }
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "multilayer": { "const": "intra-inter" }
+              },
+              "required": ["multilayer"]
+            },
+            "then": {
+              "properties": {
+                "edges": {
+                  "type": "array",
+                  "items": { "$ref": "#/$defs/multilayerIntraInterEdge" }
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "not": {
+                "properties": {
+                  "multilayer": {
+                    "enum": ["intra", "intra-inter"]
+                  }
+                },
+                "required": ["multilayer"]
+              }
+            },
+            "then": {
+              "properties": {
+                "edges": {
+                  "type": "array",
+                  "items": { "$ref": "#/$defs/multilayerFullEdge" }
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": { "const": "state" }
+        },
+        "required": ["type"]
+      },
+      "then": {
+        "properties": {
+          "edges": {
+            "type": "array",
+            "items": { "$ref": "#/$defs/standardEdge" }
+          },
+          "states": {
+            "type": "array",
+            "items": { "$ref": "#/$defs/state" }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "not": {
+          "properties": {
+            "type": {
+              "enum": ["bipartite", "multilayer", "state"]
+            }
+          },
+          "required": ["type"]
+        }
+      },
+      "then": {
+        "properties": {
+          "edges": {
+            "type": "array",
+            "items": { "$ref": "#/$defs/standardEdge" }
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "positiveId": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "weight": {
+      "type": "number",
+      "minimum": 0
+    },
+    "edgeWeight": {
+      "description": "Edge weights are not bounded: values <= 0 (or below --weight-threshold) are ignored by the core network builder, not rejected (StateNetwork::addLink). Only node/state weights must be non-negative.",
+      "type": "number"
+    },
+    "path": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/positiveId" }
+    },
+    "node": {
+      "type": "object",
+      "required": ["id"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "name": { "type": "string" },
+        "weight": { "$ref": "#/$defs/weight" },
+        "meta": { "$ref": "#/$defs/id" },
+        "path": { "$ref": "#/$defs/path" },
+        "label": false
+      }
+    },
+    "state": {
+      "type": "object",
+      "required": ["id", "node"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "node": { "$ref": "#/$defs/id" },
+        "name": { "type": "string" },
+        "weight": { "$ref": "#/$defs/weight" },
+        "path": { "$ref": "#/$defs/path" },
+        "meta": false
+      }
+    },
+    "standardEdge": {
+      "type": "object",
+      "required": ["source", "target"],
+      "properties": {
+        "source": { "$ref": "#/$defs/id" },
+        "target": { "$ref": "#/$defs/id" },
+        "weight": { "$ref": "#/$defs/edgeWeight" },
+        "layers": false,
+        "layer": false
+      }
+    },
+    "multilayerEdge": {
+      "type": "object",
+      "required": ["layers", "source", "target"],
+      "properties": {
+        "layers": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 2,
+          "items": { "$ref": "#/$defs/id" }
+        },
+        "source": { "$ref": "#/$defs/id" },
+        "target": { "$ref": "#/$defs/id" },
+        "weight": { "$ref": "#/$defs/edgeWeight" }
+      }
+    },
+    "multilayerFullEdge": {
+      "allOf": [
+        { "$ref": "#/$defs/multilayerEdge" },
+        {
+          "properties": {
+            "layers": {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "items": { "$ref": "#/$defs/id" }
+            }
+          }
+        }
+      ]
+    },
+    "multilayerIntraEdge": {
+      "allOf": [
+        { "$ref": "#/$defs/multilayerEdge" },
+        {
+          "properties": {
+            "layers": {
+              "type": "array",
+              "minItems": 1,
+              "maxItems": 1,
+              "items": { "$ref": "#/$defs/id" }
+            }
+          }
+        }
+      ]
+    },
+    "multilayerIntraInterEdge": {
+      "description": "For two-layer intra-inter edges, source == target is required by the RFC but cannot be expressed in standard JSON Schema 2020-12 without non-standard data references.",
+      "allOf": [
+        { "$ref": "#/$defs/multilayerEdge" },
+        {
+          "anyOf": [
+            { "$ref": "#/$defs/multilayerIntraEdge" },
+            { "$ref": "#/$defs/multilayerFullEdge" }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/test/schemas/json/infomap-network.schema.json
+++ b/test/schemas/json/infomap-network.schema.json
@@ -1,12 +1,12 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://mapequation.org/infomap/test-schemas/infomap-network-json.schema.json",
+  "$id": "https://mapequation.org/infomap/test-schemas/infomap-network.schema.json",
   "title": "Infomap Network JSON",
-  "description": "Normative schema for the infomap-network-json v1.0 input format (RFC #645). The SAX parser's accept/reject set must match this schema.",
+  "description": "Normative schema for the infomap-network v1.0 input format (RFC #645). The SAX parser's accept/reject set must match this schema.",
   "type": "object",
   "required": ["format", "version", "edges"],
   "properties": {
-    "format": { "const": "infomap-network-json" },
+    "format": { "const": "infomap-network" },
     "version": { "const": "1.0" },
     "type": {
       "enum": ["standard", "bipartite", "multilayer", "state"],


### PR DESCRIPTION
Implements the v1 input format from the RFC in #645.

A two-pass SAX parser (no DOM) reads `infomap-network-json` v1.0, detected by
content and feeding the **same core network builder** as the text formats, so
it inherits all network semantics (weight thresholding, `<= 0` ignored,
duplicate aggregation, self-link handling, implicit node creation).

## What's included
- **Types**: standard, bipartite, multilayer (`full`/`intra`/`intra-inter`), state.
- **Embedded `meta`** — presence enables meta coding, consistent with the
  in-memory `set_meta_data` and `--meta-data` (see the [Option B correction](https://github.com/mapequation/infomap/issues/645#issuecomment-4716103727)).
  External `--meta-data` composes with a JSON network and overrides with a warning.
- **Embedded `path`** (`nodes[].path` / `states[].path`) routed through the
  existing `.tree`/`initTree` initial-partition channel; `--cluster-data`
  overrides with a warning.
- Integer coercion (integral doubles accepted, `1.5` rejected, uint32 bound),
  order- and emitter-independent parsing, unknown-field warnings.
- **Normative JSON Schema** + valid/invalid fixtures proving parser parity.
- Python/R `read_file()` work with zero binding change; internal `Network`
  additions are `#ifndef SWIG`-guarded so generated wrappers are unchanged.
- JS `InfomapNetworkJson` authoring types + a vitest guard that fails if the
  types drift from the schema. JSON input already works via the `network:` string.
- Docs in `interfaces/python/source/usage.rst`.

## Verification
- C++: network 42/142, partition 34/450 assertions (Apple-clang build).
- Python: schema parity 22, input contract incl. 3 cross-interface parity tests
  (JSON ≡ in-memory; embedded meta ≡ `set_meta_data`; path seeds partition).
- Python & R SWIG freshness: unchanged. JS typecheck + biome lint + 4 guard tests.

## Notes
- A weight-parity fix to the attached schema: edge weights are unbounded (`<= 0`
  ignored by core, not an error); only node/state weights must be non-negative.
- Round-trip / writer, Flow JSON, compressed input, and `type: "paths"` remain
  out of v1 per the RFC.
