### PR TITLE
perf: build multilayer networks directly into CSR link storage

### DIFF
--- a/src/core/StateNetwork.h
+++ b/src/core/StateNetwork.h
@@ -232,10 +232,10 @@ public:
 #endif
 
   // Mode A (first-order and the main multilayer network) defers dedup to
-  // finalizeLinks(), so these counts are only valid afterwards -- ensure it. A
-  // read before the build is complete (e.g. printSummary() calling numLinks()
-  // before the multilayer expansion populates the main network) just finalizes
-  // early; the next addLink re-opens the buffer via definalize(). Mode B (the
+  // finalizeLinks(), so these counts are only valid afterwards -- ensure it. An
+  // early read (e.g. an in-memory numLinks() before the multilayer expansion
+  // populates the main network) just finalizes early; the next addLink re-opens
+  // the buffer via definalize(). Mode B (the
   // transient per-layer networks) keeps the counts eager and must NOT finalize:
   // those networks are read through nodeLinkMap()/outWeights() and discarded,
   // never consumed as CSR. The ensureFinalized() call is guarded so SWIG never

--- a/src/core/StateNetwork.h
+++ b/src/core/StateNetwork.h
@@ -231,12 +231,16 @@ public:
   }
 #endif
 
-  // Mode A (first-order) defers dedup to finalizeLinks(), so these counts are
-  // only valid afterwards -- ensure it. Mode B (multilayer) keeps them eager and
-  // must NOT finalize here: printSummary() reads numLinks() before the multilayer
-  // expansion populates the network. The ensureFinalized() call is guarded so
-  // SWIG never parses a reference to the hidden method (the compiled library the
-  // wrapper calls still lazy-finalizes).
+  // Mode A (first-order and the main multilayer network) defers dedup to
+  // finalizeLinks(), so these counts are only valid afterwards -- ensure it. A
+  // read before the build is complete (e.g. printSummary() calling numLinks()
+  // before the multilayer expansion populates the main network) just finalizes
+  // early; the next addLink re-opens the buffer via definalize(). Mode B (the
+  // transient per-layer networks) keeps the counts eager and must NOT finalize:
+  // those networks are read through nodeLinkMap()/outWeights() and discarded,
+  // never consumed as CSR. The ensureFinalized() call is guarded so SWIG never
+  // parses a reference to the hidden method (the compiled library the wrapper
+  // calls still lazy-finalizes).
   unsigned int numAggregatedLinks() const
   {
 #ifndef SWIG

--- a/src/io/Network.cpp
+++ b/src/io/Network.cpp
@@ -171,9 +171,12 @@ void Network::addMultilayerLink(unsigned int stateId1, unsigned int layer1, unsi
     ++m_numInterLayerLinks;
   }
 
-  // Multilayer builds the state network through the nested map (mode B); set
-  // before addLink so the main network never enters the flat-buffer path.
-  m_useMapBuild = true;
+  // The main expanded network builds through the flat buffer (mode A), exactly
+  // like ordinary/state networks: this is a write-only sink during expansion
+  // (the only main-map read was already dead code) and during explicit
+  // *Multilayer parsing, so aggregation can be deferred to finalizeLinks()
+  // instead of paying a per-source std::map. Mode is left at its default (A);
+  // only the transient per-layer networks stay mode B (see addMultilayerIntraLink).
   addLink(stateId1, stateId2, weight);
 }
 
@@ -714,10 +717,11 @@ void Network::simulateInterLayerLinks()
 void Network::addMultilayerIntraLink(unsigned int layer, unsigned int n1, unsigned int n2, double weight)
 {
   m_higherOrderInputMethodCalled = true;
-  // Mode B for both the main network (gets expansion links later) and the
-  // transient per-layer network (its nested map + outWeights are read directly
-  // during expansion). Set before addLink so neither enters the buffer path.
-  m_useMapBuild = true;
+  // The main network gets its expansion links later and builds via the flat
+  // buffer (mode A) like ordinary/state networks, so it is left at its default
+  // mode. Only the transient per-layer network stays mode B: its nested map +
+  // outWeights are read directly during expansion, so set before addLink so it
+  // does not enter the buffer path.
   auto& layerNetwork = m_networks[layer];
   layerNetwork.m_useMapBuild = true;
   bool added = layerNetwork.addLink(n1, n2, weight);
@@ -749,10 +753,11 @@ void Network::addMultilayerInterLink(unsigned int layer1, unsigned int n, unsign
     throw std::runtime_error(fmt::format(FMT_STRING("Inter-layer link (layer1, node, layer2): {}, {}, {} must have layer1 != layer2"), layer1, n, layer2));
   }
   m_higherOrderInputMethodCalled = true;
-  // Multilayer main network builds via the nested map (mode B); set before
-  // printSummary() can read numLinks() so it never triggers a premature finalize.
-  m_useMapBuild = true;
-
+  // Inter-layer links are buffered in m_interLinks and only realized on the main
+  // network during expansion, which builds via the flat buffer (mode A). The
+  // main network is left at its default mode here. printSummary() reading
+  // numLinks() before expansion now finalizes an empty buffer (cheap); the first
+  // expansion addLink re-opens it via definalize().
   auto& interLinks = m_interLinks[LayerNode(layer1, n)];
   auto it = interLinks.find(layer2);
 

--- a/src/io/Network.cpp
+++ b/src/io/Network.cpp
@@ -754,10 +754,10 @@ void Network::addMultilayerInterLink(unsigned int layer1, unsigned int n, unsign
   }
   m_higherOrderInputMethodCalled = true;
   // Inter-layer links are buffered in m_interLinks and only realized on the main
-  // network during expansion, which builds via the flat buffer (mode A). The
-  // main network is left at its default mode here. printSummary() reading
-  // numLinks() before expansion now finalizes an empty buffer (cheap); the first
-  // expansion addLink re-opens it via definalize().
+  // network during expansion, which builds via the flat buffer (mode A). The main
+  // network is left at its default mode here. (File input expands before any
+  // numLinks() read; an in-memory numLinks() read before expansion just finalizes
+  // an empty buffer, which the first expansion addLink re-opens via definalize().)
   auto& interLinks = m_interLinks[LayerNode(layer1, n)];
   auto it = interLinks.find(layer2);
 


### PR DESCRIPTION
## What

Follow-up to #670 (issue #672, "main win"). #670 moved ordinary/state networks from the nested `std::map` to a flat-buffer → CSR build (mode A) but left **multilayer** on the map (mode B). This takes the main expanded multilayer network to mode A as well.

The main expanded network is a write-only aggregating sink during expansion (the only main-map read was already dead code; every live read is of the per-layer networks) and during explicit `*Multilayer` parsing. So it can append synthesized triples to the flat buffer and aggregate in `finalizeLinks()`, exactly like ordinary/state, dropping the dominant per-source `std::map`. The transient per-layer networks stay mode B (their nested map + `outWeights` are read during expansion, then discarded).

`printSummary()` reading `numLinks()` before expansion now finalizes an empty buffer (cheap); the first expansion `addLink` re-opens it via `definalize()`.

## Diff

Three `m_useMapBuild = true` assignments removed from the main network in `Network.cpp` (the per-layer one is kept), plus a corrected comment in `StateNetwork.h`. No public header type changes, so no SWIG regeneration.

## Verification

- **Byte-identical** `.tree`/`.clu`/`.states` vs `master` across every multilayer path: explicit inter-links (directed + undirected), `*Intra`/`*Inter` format, simulated inter-links (default relax rate, `--multilayer-relax-limit`, `--multilayer-relax-by-jsd`), and the `FEATURES=regularized-multilayer` build (weak + strong `--regularization-strength`). 54 default + 12 regularized output files, all identical; the comparison harness is self-consistency-validated (master-vs-master = identical).
- **ctest** green for both default and `regularized-multilayer`.

## Performance (intake-isolated, `--no-infomap`, OMP=1, Apple M2 Pro)

| path | wall time | peak RSS |
|---|---|---|
| explicit 5M-link | 22.4 s → **14.0 s** (−37%) | 1.1 GB → **0.8 GB** (−25%) |
| simulated expansion (700K intra → 10.9M) | 21.6 s → **18.2 s** (−15%) | 1.9 GB → **1.3 GB** (−30%) |

## Out of scope (deferred)

- Per-layer networks (`m_networks`) stay map-backed — the larger scope noted in #672. Evaluated as feasible but modest/workload-dependent benefit at high byte-identical risk (JSD merge rewrite, presence-checked CSR access, and an undirected-default blocker via `undirectedToDirected`).
- Re-measuring the benchmark notebook (#671) is tracked separately in #679: its committed results are not reproducible in the current environment, so the multilayer rows there can't be cleanly spliced.

Closes #672.
