### PR TITLE
feat: add cooperative interrupt hooks for long-running runs

### DIFF
--- a/interfaces/R/generated/infomap_wrap.cpp
+++ b/interfaces/R/generated/infomap_wrap.cpp
@@ -1946,15 +1946,22 @@ namespace {
 // R_ToplevelExec runs it inside a context that catches that longjmp (so it never
 // unwinds the C++ stack and skips destructors) and reports it as a non-TRUE
 // result. Must run on R's main thread only — guaranteed by the owner-thread gate.
+// NOTE: because R_ToplevelExec consumes the interrupt, a cancelled run surfaces
+// to R as a regular error (SWIG_RuntimeError -> Rf_error: "Infomap run
+// interrupted."), NOT an R "interrupt" condition — handle it with
+// tryCatch(error=), not tryCatch(interrupt=).
 void infomapRCheckInterrupt(void*) { R_CheckUserInterrupt(); }
 bool infomapHostInterruptPoll(void*) { return R_ToplevelExec(infomapRCheckInterrupt, nullptr) != TRUE; }
 } // namespace
 #elif defined(SWIGPYTHON)
+namespace infomap { extern InterruptCallback g_runInterruptCallback; } // defined in main.cpp
 namespace {
 // PyErr_CheckSignals runs pending Python signal handlers (e.g. turns a queued
 // SIGINT into KeyboardInterrupt) and returns non-zero if one raised. Needs the
 // GIL and the main thread, both held when the core calls back on the owner
-// thread during a normal im.run().
+// thread during a normal im.run(). Off the main thread it is a no-op, so a run
+// launched from a non-main Python thread is simply non-interruptible (not an
+// error).
 bool infomapHostInterruptPoll(void*) { return PyErr_CheckSignals() != 0; }
 } // namespace
 #endif

--- a/interfaces/R/generated/infomap_wrap.cpp
+++ b/interfaces/R/generated/infomap_wrap.cpp
@@ -1938,6 +1938,28 @@ void addMultilayerInterLinksFromNumpy2D(InfomapWrapper& infomap, PyObject* links
 #endif
 
 
+#if defined(SWIGR)
+#include <R_ext/Utils.h>   // R_CheckUserInterrupt
+#include <Rinternals.h>    // R_ToplevelExec
+namespace {
+// R_CheckUserInterrupt longjmps to R's top level when an interrupt is pending.
+// R_ToplevelExec runs it inside a context that catches that longjmp (so it never
+// unwinds the C++ stack and skips destructors) and reports it as a non-TRUE
+// result. Must run on R's main thread only — guaranteed by the owner-thread gate.
+void infomapRCheckInterrupt(void*) { R_CheckUserInterrupt(); }
+bool infomapHostInterruptPoll(void*) { return R_ToplevelExec(infomapRCheckInterrupt, nullptr) != TRUE; }
+} // namespace
+#elif defined(SWIGPYTHON)
+namespace {
+// PyErr_CheckSignals runs pending Python signal handlers (e.g. turns a queued
+// SIGINT into KeyboardInterrupt) and returns non-zero if one raised. Needs the
+// GIL and the main thread, both held when the core calls back on the owner
+// thread during a normal im.run().
+bool infomapHostInterruptPoll(void*) { return PyErr_CheckSignals() != 0; }
+} // namespace
+#endif
+
+
 #include <string>
 
 
@@ -41050,11 +41072,22 @@ R_swig_InfomapBase_run__SWIG_0 ( SEXP self, SEXP parameters)
       arg2 = ptr;
     }
     {
+      arg1->setInterruptHandler(&infomapHostInterruptPoll, nullptr);
       try {
         (arg1)->run((std::string const &)*arg2);
+      } catch (const infomap::InterruptionError&) {
+        arg1->clearInterruptHandler();
+        
+        
+        
+        
+        
+        SWIG_exception(SWIG_RuntimeError, "Infomap run interrupted.");
       } catch (const std::exception& e) {
+        arg1->clearInterruptHandler();
         SWIG_exception(SWIG_RuntimeError, e.what());
       }
+      arg1->clearInterruptHandler();
     }
     r_ans = R_NilValue;
     if (SWIG_IsNewObj(res2)) delete arg2;
@@ -41087,11 +41120,22 @@ R_swig_InfomapBase_run__SWIG_1 ( SEXP self)
     }
     arg1 = reinterpret_cast< infomap::InfomapBase * >(argp1);
     {
+      arg1->setInterruptHandler(&infomapHostInterruptPoll, nullptr);
       try {
         (arg1)->run();
+      } catch (const infomap::InterruptionError&) {
+        arg1->clearInterruptHandler();
+        
+        
+        
+        
+        
+        SWIG_exception(SWIG_RuntimeError, "Infomap run interrupted.");
       } catch (const std::exception& e) {
+        arg1->clearInterruptHandler();
         SWIG_exception(SWIG_RuntimeError, e.what());
       }
+      arg1->clearInterruptHandler();
     }
     r_ans = R_NilValue;
     vmaxset(r_vmax);
@@ -41133,11 +41177,22 @@ R_swig_InfomapBase_run__SWIG_2 ( SEXP self, SEXP network)
     }
     arg2 = reinterpret_cast< infomap::Network * >(argp2);
     {
+      arg1->setInterruptHandler(&infomapHostInterruptPoll, nullptr);
       try {
         (arg1)->run(*arg2);
+      } catch (const infomap::InterruptionError&) {
+        arg1->clearInterruptHandler();
+        
+        
+        
+        
+        
+        SWIG_exception(SWIG_RuntimeError, "Infomap run interrupted.");
       } catch (const std::exception& e) {
+        arg1->clearInterruptHandler();
         SWIG_exception(SWIG_RuntimeError, e.what());
       }
+      arg1->clearInterruptHandler();
     }
     r_ans = R_NilValue;
     vmaxset(r_vmax);
@@ -48774,11 +48829,22 @@ R_swig_InfomapWrapper_run__SWIG_0 ( SEXP self, SEXP parameters)
       arg2 = ptr;
     }
     {
+      arg1->setInterruptHandler(&infomapHostInterruptPoll, nullptr);
       try {
         (arg1)->run((std::string const &)*arg2);
+      } catch (const infomap::InterruptionError&) {
+        arg1->clearInterruptHandler();
+        
+        
+        
+        
+        
+        SWIG_exception(SWIG_RuntimeError, "Infomap run interrupted.");
       } catch (const std::exception& e) {
+        arg1->clearInterruptHandler();
         SWIG_exception(SWIG_RuntimeError, e.what());
       }
+      arg1->clearInterruptHandler();
     }
     r_ans = R_NilValue;
     if (SWIG_IsNewObj(res2)) delete arg2;
@@ -48811,11 +48877,22 @@ R_swig_InfomapWrapper_run__SWIG_1 ( SEXP self)
     }
     arg1 = reinterpret_cast< infomap::InfomapWrapper * >(argp1);
     {
+      arg1->setInterruptHandler(&infomapHostInterruptPoll, nullptr);
       try {
         (arg1)->run();
+      } catch (const infomap::InterruptionError&) {
+        arg1->clearInterruptHandler();
+        
+        
+        
+        
+        
+        SWIG_exception(SWIG_RuntimeError, "Infomap run interrupted.");
       } catch (const std::exception& e) {
+        arg1->clearInterruptHandler();
         SWIG_exception(SWIG_RuntimeError, e.what());
       }
+      arg1->clearInterruptHandler();
     }
     r_ans = R_NilValue;
     vmaxset(r_vmax);
@@ -48857,11 +48934,22 @@ R_swig_InfomapWrapper_run__SWIG_2 ( SEXP self, SEXP network)
     }
     arg2 = reinterpret_cast< infomap::Network * >(argp2);
     {
+      arg1->setInterruptHandler(&infomapHostInterruptPoll, nullptr);
       try {
         (arg1)->run(*arg2);
+      } catch (const infomap::InterruptionError&) {
+        arg1->clearInterruptHandler();
+        
+        
+        
+        
+        
+        SWIG_exception(SWIG_RuntimeError, "Infomap run interrupted.");
       } catch (const std::exception& e) {
+        arg1->clearInterruptHandler();
         SWIG_exception(SWIG_RuntimeError, e.what());
       }
+      arg1->clearInterruptHandler();
     }
     r_ans = R_NilValue;
     vmaxset(r_vmax);

--- a/interfaces/R/generated/infomap_wrap.cpp
+++ b/interfaces/R/generated/infomap_wrap.cpp
@@ -1942,26 +1942,19 @@ void addMultilayerInterLinksFromNumpy2D(InfomapWrapper& infomap, PyObject* links
 #include <R_ext/Utils.h>   // R_CheckUserInterrupt
 #include <Rinternals.h>    // R_ToplevelExec
 namespace {
-// R_CheckUserInterrupt longjmps to R's top level when an interrupt is pending.
-// R_ToplevelExec runs it inside a context that catches that longjmp (so it never
-// unwinds the C++ stack and skips destructors) and reports it as a non-TRUE
-// result. Must run on R's main thread only — guaranteed by the owner-thread gate.
-// NOTE: because R_ToplevelExec consumes the interrupt, a cancelled run surfaces
-// to R as a regular error (SWIG_RuntimeError -> Rf_error: "Infomap run
-// interrupted."), NOT an R "interrupt" condition — handle it with
-// tryCatch(error=), not tryCatch(interrupt=).
+// R_ToplevelExec contains R_CheckUserInterrupt's longjmp (so C++ destructors run)
+// and reports a pending interrupt as a non-TRUE result. R main thread only.
+// A cancel surfaces to R as a plain error (-> Rf_error), NOT an "interrupt"
+// condition — handle with tryCatch(error=), not tryCatch(interrupt=).
 void infomapRCheckInterrupt(void*) { R_CheckUserInterrupt(); }
 bool infomapHostInterruptPoll(void*) { return R_ToplevelExec(infomapRCheckInterrupt, nullptr) != TRUE; }
 } // namespace
 #elif defined(SWIGPYTHON)
 namespace infomap { extern InterruptCallback g_runInterruptCallback; } // defined in main.cpp
 namespace {
-// PyErr_CheckSignals runs pending Python signal handlers (e.g. turns a queued
-// SIGINT into KeyboardInterrupt) and returns non-zero if one raised. Needs the
-// GIL and the main thread, both held when the core calls back on the owner
-// thread during a normal im.run(). Off the main thread it is a no-op, so a run
-// launched from a non-main Python thread is simply non-interruptible (not an
-// error).
+// PyErr_CheckSignals runs pending Python signal handlers (turns a queued SIGINT
+// into KeyboardInterrupt). Needs the GIL + main thread; off the main thread it is
+// a no-op, so such a run is simply non-interruptible.
 bool infomapHostInterruptPoll(void*) { return PyErr_CheckSignals() != 0; }
 } // namespace
 #endif
@@ -41088,7 +41081,6 @@ R_swig_InfomapBase_run__SWIG_0 ( SEXP self, SEXP parameters)
         
         
         
-        
         SWIG_exception(SWIG_RuntimeError, "Infomap run interrupted.");
       } catch (const std::exception& e) {
         arg1->clearInterruptHandler();
@@ -41132,7 +41124,6 @@ R_swig_InfomapBase_run__SWIG_1 ( SEXP self)
         (arg1)->run();
       } catch (const infomap::InterruptionError&) {
         arg1->clearInterruptHandler();
-        
         
         
         
@@ -41189,7 +41180,6 @@ R_swig_InfomapBase_run__SWIG_2 ( SEXP self, SEXP network)
         (arg1)->run(*arg2);
       } catch (const infomap::InterruptionError&) {
         arg1->clearInterruptHandler();
-        
         
         
         
@@ -48845,7 +48835,6 @@ R_swig_InfomapWrapper_run__SWIG_0 ( SEXP self, SEXP parameters)
         
         
         
-        
         SWIG_exception(SWIG_RuntimeError, "Infomap run interrupted.");
       } catch (const std::exception& e) {
         arg1->clearInterruptHandler();
@@ -48889,7 +48878,6 @@ R_swig_InfomapWrapper_run__SWIG_1 ( SEXP self)
         (arg1)->run();
       } catch (const infomap::InterruptionError&) {
         arg1->clearInterruptHandler();
-        
         
         
         
@@ -48946,7 +48934,6 @@ R_swig_InfomapWrapper_run__SWIG_2 ( SEXP self, SEXP network)
         (arg1)->run(*arg2);
       } catch (const infomap::InterruptionError&) {
         arg1->clearInterruptHandler();
-        
         
         
         

--- a/interfaces/python/generated/infomap_wrap.cpp
+++ b/interfaces/python/generated/infomap_wrap.cpp
@@ -3500,64 +3500,66 @@ SWIG_Python_NonDynamicSetAttr(PyObject *obj, PyObject *name, PyObject *value) {
 #define SWIGTYPE_p_infomap__InfomapModuleIterator swig_types[54]
 #define SWIGTYPE_p_infomap__InfomapParentIterator swig_types[55]
 #define SWIGTYPE_p_infomap__InfomapWrapper swig_types[56]
-#define SWIGTYPE_p_infomap__LayerNode swig_types[57]
-#define SWIGTYPE_p_infomap__MemDeltaFlow swig_types[58]
-#define SWIGTYPE_p_infomap__Network swig_types[59]
-#define SWIGTYPE_p_infomap__PhysData swig_types[60]
-#define SWIGTYPE_p_infomap__StateNetwork swig_types[61]
-#define SWIGTYPE_p_infomap__StateNetwork__PhysNode swig_types[62]
-#define SWIGTYPE_p_infomap__StateNetwork__StateNode swig_types[63]
-#define SWIGTYPE_p_infomap__detail__PartitionQueue swig_types[64]
-#define SWIGTYPE_p_infomap__detail__PerLevelStat swig_types[65]
-#define SWIGTYPE_p_infomap_child_iterator swig_types[66]
-#define SWIGTYPE_p_infomap_child_iterator_wrapper swig_types[67]
-#define SWIGTYPE_p_infomap_iterator_wrapper swig_types[68]
-#define SWIGTYPE_p_key_type swig_types[69]
-#define SWIGTYPE_p_leaf_module_iterator swig_types[70]
-#define SWIGTYPE_p_leaf_node_iterator swig_types[71]
-#define SWIGTYPE_p_mapped_type swig_types[72]
-#define SWIGTYPE_p_p_PyObject swig_types[73]
-#define SWIGTYPE_p_post_depth_first_iterator swig_types[74]
-#define SWIGTYPE_p_second_type swig_types[75]
-#define SWIGTYPE_p_size_t swig_types[76]
-#define SWIGTYPE_p_size_type swig_types[77]
-#define SWIGTYPE_p_std__allocatorT_double_t swig_types[78]
-#define SWIGTYPE_p_std__allocatorT_std__pairT_std__pairT_unsigned_int_unsigned_int_t_const_double_t_t swig_types[79]
-#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_std__string_t_t swig_types[80]
-#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_std__vectorT_unsigned_int_t_t_t swig_types[81]
-#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t swig_types[82]
-#define SWIGTYPE_p_std__allocatorT_unsigned_int_t swig_types[83]
-#define SWIGTYPE_p_std__dequeT_infomap__InfoNode_p_std__allocatorT_infomap__InfoNode_p_t_t__size_type swig_types[84]
-#define SWIGTYPE_p_std__dequeT_unsigned_int_t swig_types[85]
-#define SWIGTYPE_p_std__invalid_argument swig_types[86]
-#define SWIGTYPE_p_std__lessT_std__pairT_unsigned_int_unsigned_int_t_t swig_types[87]
-#define SWIGTYPE_p_std__lessT_unsigned_int_t swig_types[88]
-#define SWIGTYPE_p_std__mapT_std__pairT_unsigned_int_unsigned_int_t_double_t swig_types[89]
-#define SWIGTYPE_p_std__mapT_unsigned_int_double_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_double_t_t_t swig_types[90]
-#define SWIGTYPE_p_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t swig_types[91]
-#define SWIGTYPE_p_std__mapT_unsigned_int_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t_t_t_t swig_types[92]
-#define SWIGTYPE_p_std__mapT_unsigned_int_std__string_t swig_types[93]
-#define SWIGTYPE_p_std__mapT_unsigned_int_std__vectorT_int_std__allocatorT_int_t_t_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_std__vectorT_int_std__allocatorT_int_t_t_t_t_t swig_types[94]
-#define SWIGTYPE_p_std__mapT_unsigned_int_std__vectorT_unsigned_int_t_t swig_types[95]
-#define SWIGTYPE_p_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t swig_types[96]
-#define SWIGTYPE_p_std__ostream swig_types[97]
-#define SWIGTYPE_p_std__pairT_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t__iterator_bool_t swig_types[98]
-#define SWIGTYPE_p_std__pairT_std__mapT_unsigned_int_std__string_t__iterator_bool_t swig_types[99]
-#define SWIGTYPE_p_std__pairT_unsigned_int_unsigned_int_t swig_types[100]
-#define SWIGTYPE_p_std__vectorT_ParsedOption_std__allocatorT_ParsedOption_t_t swig_types[101]
-#define SWIGTYPE_p_std__vectorT_double_t swig_types[102]
-#define SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator swig_types[103]
-#define SWIGTYPE_p_std__vectorT_infomap__InfoNode_p_std__allocatorT_infomap__InfoNode_p_t_t swig_types[104]
-#define SWIGTYPE_p_std__vectorT_infomap__PhysData_std__allocatorT_infomap__PhysData_t_t swig_types[105]
-#define SWIGTYPE_p_std__vectorT_infomap__detail__PerLevelStat_std__allocatorT_infomap__detail__PerLevelStat_t_t swig_types[106]
-#define SWIGTYPE_p_std__vectorT_int_std__allocatorT_int_t_t swig_types[107]
-#define SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t swig_types[108]
-#define SWIGTYPE_p_std__vectorT_unsigned_int_t swig_types[109]
-#define SWIGTYPE_p_swig__SwigPyIterator swig_types[110]
-#define SWIGTYPE_p_tree_iterator swig_types[111]
-#define SWIGTYPE_p_value_type swig_types[112]
-static swig_type_info *swig_types[114];
-static swig_module_info swig_module = {swig_types, 113, 0, 0, 0, 0};
+#define SWIGTYPE_p_infomap__InterruptionError swig_types[57]
+#define SWIGTYPE_p_infomap__LayerNode swig_types[58]
+#define SWIGTYPE_p_infomap__MemDeltaFlow swig_types[59]
+#define SWIGTYPE_p_infomap__Network swig_types[60]
+#define SWIGTYPE_p_infomap__PhysData swig_types[61]
+#define SWIGTYPE_p_infomap__StateNetwork swig_types[62]
+#define SWIGTYPE_p_infomap__StateNetwork__PhysNode swig_types[63]
+#define SWIGTYPE_p_infomap__StateNetwork__StateNode swig_types[64]
+#define SWIGTYPE_p_infomap__detail__PartitionQueue swig_types[65]
+#define SWIGTYPE_p_infomap__detail__PerLevelStat swig_types[66]
+#define SWIGTYPE_p_infomap_child_iterator swig_types[67]
+#define SWIGTYPE_p_infomap_child_iterator_wrapper swig_types[68]
+#define SWIGTYPE_p_infomap_iterator_wrapper swig_types[69]
+#define SWIGTYPE_p_key_type swig_types[70]
+#define SWIGTYPE_p_leaf_module_iterator swig_types[71]
+#define SWIGTYPE_p_leaf_node_iterator swig_types[72]
+#define SWIGTYPE_p_mapped_type swig_types[73]
+#define SWIGTYPE_p_p_PyObject swig_types[74]
+#define SWIGTYPE_p_post_depth_first_iterator swig_types[75]
+#define SWIGTYPE_p_second_type swig_types[76]
+#define SWIGTYPE_p_size_t swig_types[77]
+#define SWIGTYPE_p_size_type swig_types[78]
+#define SWIGTYPE_p_std__allocatorT_double_t swig_types[79]
+#define SWIGTYPE_p_std__allocatorT_std__pairT_std__pairT_unsigned_int_unsigned_int_t_const_double_t_t swig_types[80]
+#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_std__string_t_t swig_types[81]
+#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_std__vectorT_unsigned_int_t_t_t swig_types[82]
+#define SWIGTYPE_p_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t swig_types[83]
+#define SWIGTYPE_p_std__allocatorT_unsigned_int_t swig_types[84]
+#define SWIGTYPE_p_std__dequeT_infomap__InfoNode_p_std__allocatorT_infomap__InfoNode_p_t_t__size_type swig_types[85]
+#define SWIGTYPE_p_std__dequeT_unsigned_int_t swig_types[86]
+#define SWIGTYPE_p_std__invalid_argument swig_types[87]
+#define SWIGTYPE_p_std__lessT_std__pairT_unsigned_int_unsigned_int_t_t swig_types[88]
+#define SWIGTYPE_p_std__lessT_unsigned_int_t swig_types[89]
+#define SWIGTYPE_p_std__mapT_std__pairT_unsigned_int_unsigned_int_t_double_t swig_types[90]
+#define SWIGTYPE_p_std__mapT_unsigned_int_double_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_double_t_t_t swig_types[91]
+#define SWIGTYPE_p_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t swig_types[92]
+#define SWIGTYPE_p_std__mapT_unsigned_int_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t_t_t_t swig_types[93]
+#define SWIGTYPE_p_std__mapT_unsigned_int_std__string_t swig_types[94]
+#define SWIGTYPE_p_std__mapT_unsigned_int_std__vectorT_int_std__allocatorT_int_t_t_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_std__vectorT_int_std__allocatorT_int_t_t_t_t_t swig_types[95]
+#define SWIGTYPE_p_std__mapT_unsigned_int_std__vectorT_unsigned_int_t_t swig_types[96]
+#define SWIGTYPE_p_std__mapT_unsigned_int_unsigned_int_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_unsigned_int_t_t_t swig_types[97]
+#define SWIGTYPE_p_std__ostream swig_types[98]
+#define SWIGTYPE_p_std__pairT_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t__iterator_bool_t swig_types[99]
+#define SWIGTYPE_p_std__pairT_std__mapT_unsigned_int_std__string_t__iterator_bool_t swig_types[100]
+#define SWIGTYPE_p_std__pairT_unsigned_int_unsigned_int_t swig_types[101]
+#define SWIGTYPE_p_std__runtime_error swig_types[102]
+#define SWIGTYPE_p_std__vectorT_ParsedOption_std__allocatorT_ParsedOption_t_t swig_types[103]
+#define SWIGTYPE_p_std__vectorT_double_t swig_types[104]
+#define SWIGTYPE_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator swig_types[105]
+#define SWIGTYPE_p_std__vectorT_infomap__InfoNode_p_std__allocatorT_infomap__InfoNode_p_t_t swig_types[106]
+#define SWIGTYPE_p_std__vectorT_infomap__PhysData_std__allocatorT_infomap__PhysData_t_t swig_types[107]
+#define SWIGTYPE_p_std__vectorT_infomap__detail__PerLevelStat_std__allocatorT_infomap__detail__PerLevelStat_t_t swig_types[108]
+#define SWIGTYPE_p_std__vectorT_int_std__allocatorT_int_t_t swig_types[109]
+#define SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t swig_types[110]
+#define SWIGTYPE_p_std__vectorT_unsigned_int_t swig_types[111]
+#define SWIGTYPE_p_swig__SwigPyIterator swig_types[112]
+#define SWIGTYPE_p_tree_iterator swig_types[113]
+#define SWIGTYPE_p_value_type swig_types[114]
+static swig_type_info *swig_types[116];
+static swig_module_info swig_module = {swig_types, 115, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -59514,6 +59516,9 @@ static void *_p_infomap__InfomapLeafIteratorPhysicalTo_p_infomap__InfomapIterato
 static void *_p_infomap__NetworkTo_p_infomap__StateNetwork(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((infomap::StateNetwork *)  ((infomap::Network *) x));
 }
+static void *_p_infomap__InterruptionErrorTo_p_std__runtime_error(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((std::runtime_error *)  ((infomap::InterruptionError *) x));
+}
 static swig_type_info _swigt__p_ChildIteratorT_infomap__InfoNode_const_p_t = {"_p_ChildIteratorT_infomap__InfoNode_const_p_t", "infomap::InfoNode::const_child_iterator *|ChildIterator< infomap::InfoNode const * > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_ChildIteratorT_infomap__InfoNode_p_t = {"_p_ChildIteratorT_infomap__InfoNode_p_t", "infomap::InfoNode::child_iterator *|ChildIterator< infomap::InfoNode * > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_Date = {"_p_Date", "Date *", 0, 0, (void*)0, 0};
@@ -59615,6 +59620,8 @@ static swig_type_info _swigt__p_std__ostream = {"_p_std__ostream", "std::ostream
 static swig_type_info _swigt__p_std__pairT_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t__iterator_bool_t = {"_p_std__pairT_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t__iterator_bool_t", "std::pair< infomap::StateNetwork::NodeMap::iterator,bool > *|std::pair< std::map< unsigned int,infomap::StateNetwork::StateNode,std::less< unsigned int >,std::allocator< std::pair< unsigned int const,infomap::StateNetwork::StateNode > > >::iterator,bool > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__pairT_std__mapT_unsigned_int_std__string_t__iterator_bool_t = {"_p_std__pairT_std__mapT_unsigned_int_std__string_t__iterator_bool_t", "std::pair< std::map< unsigned int,std::string,std::less< unsigned int >,std::allocator< std::pair< unsigned int const,std::string > > >::iterator,bool > *|std::pair< std::map< unsigned int,std::string >::iterator,bool > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__pairT_unsigned_int_unsigned_int_t = {"_p_std__pairT_unsigned_int_unsigned_int_t", "std::pair< unsigned int,unsigned int > *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_std__runtime_error = {"_p_std__runtime_error", "std::runtime_error *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_infomap__InterruptionError = {"_p_infomap__InterruptionError", 0, 0, 0, 0, 0};
 static swig_type_info _swigt__p_std__vectorT_ParsedOption_std__allocatorT_ParsedOption_t_t = {"_p_std__vectorT_ParsedOption_std__allocatorT_ParsedOption_t_t", "std::vector< ParsedOption,std::allocator< ParsedOption > > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__vectorT_double_t = {"_p_std__vectorT_double_t", "std::vector< double,std::allocator< double > > *|std::vector< double > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator = {"_p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator", "infomap::InfoNode::edge_iterator *|std::vector< infomap::InfoEdge *,std::allocator< infomap::InfoEdge * > >::iterator *", 0, 0, (void*)0, 0};
@@ -59686,6 +59693,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_infomap__InfomapModuleIterator,
   &_swigt__p_infomap__InfomapParentIterator,
   &_swigt__p_infomap__InfomapWrapper,
+  &_swigt__p_infomap__InterruptionError,
   &_swigt__p_infomap__LayerNode,
   &_swigt__p_infomap__MemDeltaFlow,
   &_swigt__p_infomap__Network,
@@ -59730,6 +59738,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_std__pairT_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t__iterator_bool_t,
   &_swigt__p_std__pairT_std__mapT_unsigned_int_std__string_t__iterator_bool_t,
   &_swigt__p_std__pairT_unsigned_int_unsigned_int_t,
+  &_swigt__p_std__runtime_error,
   &_swigt__p_std__vectorT_ParsedOption_std__allocatorT_ParsedOption_t_t,
   &_swigt__p_std__vectorT_double_t,
   &_swigt__p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator,
@@ -59845,6 +59854,8 @@ static swig_cast_info _swigc__p_std__ostream[] = {  {&_swigt__p_std__ostream, 0,
 static swig_cast_info _swigc__p_std__pairT_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t__iterator_bool_t[] = {  {&_swigt__p_std__pairT_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t__iterator_bool_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__pairT_std__mapT_unsigned_int_std__string_t__iterator_bool_t[] = {  {&_swigt__p_std__pairT_std__mapT_unsigned_int_std__string_t__iterator_bool_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__pairT_unsigned_int_unsigned_int_t[] = {  {&_swigt__p_std__pairT_unsigned_int_unsigned_int_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_infomap__InterruptionError[] = {{&_swigt__p_infomap__InterruptionError, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_std__runtime_error[] = {  {&_swigt__p_std__runtime_error, 0, 0, 0},  {&_swigt__p_infomap__InterruptionError, _p_infomap__InterruptionErrorTo_p_std__runtime_error, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__vectorT_ParsedOption_std__allocatorT_ParsedOption_t_t[] = {  {&_swigt__p_std__vectorT_ParsedOption_std__allocatorT_ParsedOption_t_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__vectorT_double_t[] = {  {&_swigt__p_std__vectorT_double_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator[] = {  {&_swigt__p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator, 0, 0, 0},{0, 0, 0, 0}};
@@ -59916,6 +59927,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_infomap__InfomapModuleIterator,
   _swigc__p_infomap__InfomapParentIterator,
   _swigc__p_infomap__InfomapWrapper,
+  _swigc__p_infomap__InterruptionError,
   _swigc__p_infomap__LayerNode,
   _swigc__p_infomap__MemDeltaFlow,
   _swigc__p_infomap__Network,
@@ -59960,6 +59972,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_std__pairT_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t__iterator_bool_t,
   _swigc__p_std__pairT_std__mapT_unsigned_int_std__string_t__iterator_bool_t,
   _swigc__p_std__pairT_unsigned_int_unsigned_int_t,
+  _swigc__p_std__runtime_error,
   _swigc__p_std__vectorT_ParsedOption_std__allocatorT_ParsedOption_t_t,
   _swigc__p_std__vectorT_double_t,
   _swigc__p_std__vectorT_infomap__InfoEdge_p_std__allocatorT_infomap__InfoEdge_p_t_t__iterator,

--- a/interfaces/python/generated/infomap_wrap.cpp
+++ b/interfaces/python/generated/infomap_wrap.cpp
@@ -4031,15 +4031,22 @@ namespace {
 // R_ToplevelExec runs it inside a context that catches that longjmp (so it never
 // unwinds the C++ stack and skips destructors) and reports it as a non-TRUE
 // result. Must run on R's main thread only — guaranteed by the owner-thread gate.
+// NOTE: because R_ToplevelExec consumes the interrupt, a cancelled run surfaces
+// to R as a regular error (SWIG_RuntimeError -> Rf_error: "Infomap run
+// interrupted."), NOT an R "interrupt" condition — handle it with
+// tryCatch(error=), not tryCatch(interrupt=).
 void infomapRCheckInterrupt(void*) { R_CheckUserInterrupt(); }
 bool infomapHostInterruptPoll(void*) { return R_ToplevelExec(infomapRCheckInterrupt, nullptr) != TRUE; }
 } // namespace
 #elif defined(SWIGPYTHON)
+namespace infomap { extern InterruptCallback g_runInterruptCallback; } // defined in main.cpp
 namespace {
 // PyErr_CheckSignals runs pending Python signal handlers (e.g. turns a queued
 // SIGINT into KeyboardInterrupt) and returns non-zero if one raised. Needs the
 // GIL and the main thread, both held when the core calls back on the owner
-// thread during a normal im.run().
+// thread during a normal im.run(). Off the main thread it is a no-op, so a run
+// launched from a non-main Python thread is simply non-interruptible (not an
+// error).
 bool infomapHostInterruptPoll(void*) { return PyErr_CheckSignals() != 0; }
 } // namespace
 #endif
@@ -55449,6 +55456,9 @@ SWIGINTERN PyObject *_wrap_run(PyObject *self, PyObject *args) {
   {
     try {
       result = (int)infomap::run((std::string const &)*arg1);
+    } catch (const infomap::InterruptionError&) {
+      if (PyErr_Occurred()) SWIG_fail;
+      SWIG_exception(SWIG_RuntimeError, "Infomap run interrupted.");
     } catch (const std::exception& e) {
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
@@ -60729,6 +60739,9 @@ SWIGINTERN int SWIG_mod_exec(PyObject *m) {
 #endif
   
   SWIG_InstallConstants(d,swig_const_table);
+  
+  
+  infomap::g_runInterruptCallback = &infomapHostInterruptPoll;
   
   SWIG_Python_SetConstant(d, "FlowModel_undirected",SWIG_From_int(static_cast< int >(infomap::FlowModel::undirected)));
   SWIG_Python_SetConstant(d, "FlowModel_directed",SWIG_From_int(static_cast< int >(infomap::FlowModel::directed)));

--- a/interfaces/python/generated/infomap_wrap.cpp
+++ b/interfaces/python/generated/infomap_wrap.cpp
@@ -4027,26 +4027,19 @@ void addMultilayerInterLinksFromNumpy2D(InfomapWrapper& infomap, PyObject* links
 #include <R_ext/Utils.h>   // R_CheckUserInterrupt
 #include <Rinternals.h>    // R_ToplevelExec
 namespace {
-// R_CheckUserInterrupt longjmps to R's top level when an interrupt is pending.
-// R_ToplevelExec runs it inside a context that catches that longjmp (so it never
-// unwinds the C++ stack and skips destructors) and reports it as a non-TRUE
-// result. Must run on R's main thread only — guaranteed by the owner-thread gate.
-// NOTE: because R_ToplevelExec consumes the interrupt, a cancelled run surfaces
-// to R as a regular error (SWIG_RuntimeError -> Rf_error: "Infomap run
-// interrupted."), NOT an R "interrupt" condition — handle it with
-// tryCatch(error=), not tryCatch(interrupt=).
+// R_ToplevelExec contains R_CheckUserInterrupt's longjmp (so C++ destructors run)
+// and reports a pending interrupt as a non-TRUE result. R main thread only.
+// A cancel surfaces to R as a plain error (-> Rf_error), NOT an "interrupt"
+// condition — handle with tryCatch(error=), not tryCatch(interrupt=).
 void infomapRCheckInterrupt(void*) { R_CheckUserInterrupt(); }
 bool infomapHostInterruptPoll(void*) { return R_ToplevelExec(infomapRCheckInterrupt, nullptr) != TRUE; }
 } // namespace
 #elif defined(SWIGPYTHON)
 namespace infomap { extern InterruptCallback g_runInterruptCallback; } // defined in main.cpp
 namespace {
-// PyErr_CheckSignals runs pending Python signal handlers (e.g. turns a queued
-// SIGINT into KeyboardInterrupt) and returns non-zero if one raised. Needs the
-// GIL and the main thread, both held when the core calls back on the owner
-// thread during a normal im.run(). Off the main thread it is a no-op, so a run
-// launched from a non-main Python thread is simply non-interruptible (not an
-// error).
+// PyErr_CheckSignals runs pending Python signal handlers (turns a queued SIGINT
+// into KeyboardInterrupt). Needs the GIL + main thread; off the main thread it is
+// a no-op, so such a run is simply non-interruptible.
 bool infomapHostInterruptPoll(void*) { return PyErr_CheckSignals() != 0; }
 } // namespace
 #endif
@@ -48226,8 +48219,7 @@ SWIGINTERN PyObject *_wrap_InfomapBase_run__SWIG_0(PyObject *self, Py_ssize_t no
     } catch (const infomap::InterruptionError&) {
       arg1->clearInterruptHandler();
       
-      // PyErr_CheckSignals already set KeyboardInterrupt — propagate it rather
-      // than masking it with a generic RuntimeError.
+      // Propagate the pending KeyboardInterrupt rather than masking it.
       if (PyErr_Occurred()) SWIG_fail;
       
       SWIG_exception(SWIG_RuntimeError, "Infomap run interrupted.");
@@ -48266,8 +48258,7 @@ SWIGINTERN PyObject *_wrap_InfomapBase_run__SWIG_1(PyObject *self, Py_ssize_t no
     } catch (const infomap::InterruptionError&) {
       arg1->clearInterruptHandler();
       
-      // PyErr_CheckSignals already set KeyboardInterrupt — propagate it rather
-      // than masking it with a generic RuntimeError.
+      // Propagate the pending KeyboardInterrupt rather than masking it.
       if (PyErr_Occurred()) SWIG_fail;
       
       SWIG_exception(SWIG_RuntimeError, "Infomap run interrupted.");
@@ -48315,8 +48306,7 @@ SWIGINTERN PyObject *_wrap_InfomapBase_run__SWIG_2(PyObject *self, Py_ssize_t no
     } catch (const infomap::InterruptionError&) {
       arg1->clearInterruptHandler();
       
-      // PyErr_CheckSignals already set KeyboardInterrupt — propagate it rather
-      // than masking it with a generic RuntimeError.
+      // Propagate the pending KeyboardInterrupt rather than masking it.
       if (PyErr_Occurred()) SWIG_fail;
       
       SWIG_exception(SWIG_RuntimeError, "Infomap run interrupted.");
@@ -57997,8 +57987,7 @@ SWIGINTERN PyObject *_wrap_InfomapWrapper_run__SWIG_0(PyObject *self, Py_ssize_t
     } catch (const infomap::InterruptionError&) {
       arg1->clearInterruptHandler();
       
-      // PyErr_CheckSignals already set KeyboardInterrupt — propagate it rather
-      // than masking it with a generic RuntimeError.
+      // Propagate the pending KeyboardInterrupt rather than masking it.
       if (PyErr_Occurred()) SWIG_fail;
       
       SWIG_exception(SWIG_RuntimeError, "Infomap run interrupted.");
@@ -58037,8 +58026,7 @@ SWIGINTERN PyObject *_wrap_InfomapWrapper_run__SWIG_1(PyObject *self, Py_ssize_t
     } catch (const infomap::InterruptionError&) {
       arg1->clearInterruptHandler();
       
-      // PyErr_CheckSignals already set KeyboardInterrupt — propagate it rather
-      // than masking it with a generic RuntimeError.
+      // Propagate the pending KeyboardInterrupt rather than masking it.
       if (PyErr_Occurred()) SWIG_fail;
       
       SWIG_exception(SWIG_RuntimeError, "Infomap run interrupted.");
@@ -58086,8 +58074,7 @@ SWIGINTERN PyObject *_wrap_InfomapWrapper_run__SWIG_2(PyObject *self, Py_ssize_t
     } catch (const infomap::InterruptionError&) {
       arg1->clearInterruptHandler();
       
-      // PyErr_CheckSignals already set KeyboardInterrupt — propagate it rather
-      // than masking it with a generic RuntimeError.
+      // Propagate the pending KeyboardInterrupt rather than masking it.
       if (PyErr_Occurred()) SWIG_fail;
       
       SWIG_exception(SWIG_RuntimeError, "Infomap run interrupted.");

--- a/interfaces/python/generated/infomap_wrap.cpp
+++ b/interfaces/python/generated/infomap_wrap.cpp
@@ -4023,6 +4023,28 @@ void addMultilayerInterLinksFromNumpy2D(InfomapWrapper& infomap, PyObject* links
 #endif
 
 
+#if defined(SWIGR)
+#include <R_ext/Utils.h>   // R_CheckUserInterrupt
+#include <Rinternals.h>    // R_ToplevelExec
+namespace {
+// R_CheckUserInterrupt longjmps to R's top level when an interrupt is pending.
+// R_ToplevelExec runs it inside a context that catches that longjmp (so it never
+// unwinds the C++ stack and skips destructors) and reports it as a non-TRUE
+// result. Must run on R's main thread only — guaranteed by the owner-thread gate.
+void infomapRCheckInterrupt(void*) { R_CheckUserInterrupt(); }
+bool infomapHostInterruptPoll(void*) { return R_ToplevelExec(infomapRCheckInterrupt, nullptr) != TRUE; }
+} // namespace
+#elif defined(SWIGPYTHON)
+namespace {
+// PyErr_CheckSignals runs pending Python signal handlers (e.g. turns a queued
+// SIGINT into KeyboardInterrupt) and returns non-zero if one raised. Needs the
+// GIL and the main thread, both held when the core calls back on the owner
+// thread during a normal im.run().
+bool infomapHostInterruptPoll(void*) { return PyErr_CheckSignals() != 0; }
+} // namespace
+#endif
+
+
 #include <string>
 
 
@@ -48191,11 +48213,22 @@ SWIGINTERN PyObject *_wrap_InfomapBase_run__SWIG_0(PyObject *self, Py_ssize_t no
     arg2 = ptr;
   }
   {
+    arg1->setInterruptHandler(&infomapHostInterruptPoll, nullptr);
     try {
       (arg1)->run((std::string const &)*arg2);
+    } catch (const infomap::InterruptionError&) {
+      arg1->clearInterruptHandler();
+      
+      // PyErr_CheckSignals already set KeyboardInterrupt — propagate it rather
+      // than masking it with a generic RuntimeError.
+      if (PyErr_Occurred()) SWIG_fail;
+      
+      SWIG_exception(SWIG_RuntimeError, "Infomap run interrupted.");
     } catch (const std::exception& e) {
+      arg1->clearInterruptHandler();
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
+    arg1->clearInterruptHandler();
   }
   resultobj = SWIG_Py_Void();
   if (SWIG_IsNewObj(res2)) delete arg2;
@@ -48220,11 +48253,22 @@ SWIGINTERN PyObject *_wrap_InfomapBase_run__SWIG_1(PyObject *self, Py_ssize_t no
   }
   arg1 = reinterpret_cast< infomap::InfomapBase * >(argp1);
   {
+    arg1->setInterruptHandler(&infomapHostInterruptPoll, nullptr);
     try {
       (arg1)->run();
+    } catch (const infomap::InterruptionError&) {
+      arg1->clearInterruptHandler();
+      
+      // PyErr_CheckSignals already set KeyboardInterrupt — propagate it rather
+      // than masking it with a generic RuntimeError.
+      if (PyErr_Occurred()) SWIG_fail;
+      
+      SWIG_exception(SWIG_RuntimeError, "Infomap run interrupted.");
     } catch (const std::exception& e) {
+      arg1->clearInterruptHandler();
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
+    arg1->clearInterruptHandler();
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -48258,11 +48302,22 @@ SWIGINTERN PyObject *_wrap_InfomapBase_run__SWIG_2(PyObject *self, Py_ssize_t no
   }
   arg2 = reinterpret_cast< infomap::Network * >(argp2);
   {
+    arg1->setInterruptHandler(&infomapHostInterruptPoll, nullptr);
     try {
       (arg1)->run(*arg2);
+    } catch (const infomap::InterruptionError&) {
+      arg1->clearInterruptHandler();
+      
+      // PyErr_CheckSignals already set KeyboardInterrupt — propagate it rather
+      // than masking it with a generic RuntimeError.
+      if (PyErr_Occurred()) SWIG_fail;
+      
+      SWIG_exception(SWIG_RuntimeError, "Infomap run interrupted.");
     } catch (const std::exception& e) {
+      arg1->clearInterruptHandler();
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
+    arg1->clearInterruptHandler();
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -57926,11 +57981,22 @@ SWIGINTERN PyObject *_wrap_InfomapWrapper_run__SWIG_0(PyObject *self, Py_ssize_t
     arg2 = ptr;
   }
   {
+    arg1->setInterruptHandler(&infomapHostInterruptPoll, nullptr);
     try {
       (arg1)->run((std::string const &)*arg2);
+    } catch (const infomap::InterruptionError&) {
+      arg1->clearInterruptHandler();
+      
+      // PyErr_CheckSignals already set KeyboardInterrupt — propagate it rather
+      // than masking it with a generic RuntimeError.
+      if (PyErr_Occurred()) SWIG_fail;
+      
+      SWIG_exception(SWIG_RuntimeError, "Infomap run interrupted.");
     } catch (const std::exception& e) {
+      arg1->clearInterruptHandler();
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
+    arg1->clearInterruptHandler();
   }
   resultobj = SWIG_Py_Void();
   if (SWIG_IsNewObj(res2)) delete arg2;
@@ -57955,11 +58021,22 @@ SWIGINTERN PyObject *_wrap_InfomapWrapper_run__SWIG_1(PyObject *self, Py_ssize_t
   }
   arg1 = reinterpret_cast< infomap::InfomapWrapper * >(argp1);
   {
+    arg1->setInterruptHandler(&infomapHostInterruptPoll, nullptr);
     try {
       (arg1)->run();
+    } catch (const infomap::InterruptionError&) {
+      arg1->clearInterruptHandler();
+      
+      // PyErr_CheckSignals already set KeyboardInterrupt — propagate it rather
+      // than masking it with a generic RuntimeError.
+      if (PyErr_Occurred()) SWIG_fail;
+      
+      SWIG_exception(SWIG_RuntimeError, "Infomap run interrupted.");
     } catch (const std::exception& e) {
+      arg1->clearInterruptHandler();
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
+    arg1->clearInterruptHandler();
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -57993,11 +58070,22 @@ SWIGINTERN PyObject *_wrap_InfomapWrapper_run__SWIG_2(PyObject *self, Py_ssize_t
   }
   arg2 = reinterpret_cast< infomap::Network * >(argp2);
   {
+    arg1->setInterruptHandler(&infomapHostInterruptPoll, nullptr);
     try {
       (arg1)->run(*arg2);
+    } catch (const infomap::InterruptionError&) {
+      arg1->clearInterruptHandler();
+      
+      // PyErr_CheckSignals already set KeyboardInterrupt — propagate it rather
+      // than masking it with a generic RuntimeError.
+      if (PyErr_Occurred()) SWIG_fail;
+      
+      SWIG_exception(SWIG_RuntimeError, "Infomap run interrupted.");
     } catch (const std::exception& e) {
+      arg1->clearInterruptHandler();
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
+    arg1->clearInterruptHandler();
   }
   resultobj = SWIG_Py_Void();
   return resultobj;

--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -1834,10 +1834,14 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin, InfomapWrapper):  # no
 
 
 def main():
-    import sys
-
     args = " ".join(sys.argv[1:])
-    return run(args)  # noqa: F405
+    try:
+        return run(args)  # noqa: F405
+    except KeyboardInterrupt:
+        # Ctrl-C during the run: cancelled cooperatively (issue #412). Exit like
+        # the native CLI — a clean message and 130 (128 + SIGINT), no traceback.
+        print("Interrupted.", file=sys.stderr)
+        return 130
 
 
 if __name__ == "__main__":

--- a/interfaces/swig/Infomap.i
+++ b/interfaces/swig/Infomap.i
@@ -319,6 +319,54 @@ void addMultilayerInterLinksFromNumpy2D(InfomapWrapper& infomap, PyObject* links
 #define SWIG_PYTHON_CAST_MODE
 %}
 
+// --- Cooperative interruption host bridge (issue #412) ---
+// run() installs a host poll handler that the core invokes ONLY on the owner
+// (here: the R / Python main) thread; worker threads only read the shared flag.
+// The C++ seam itself is %ignore'd in InfomapBase.i — this is the language glue.
+%{
+#if defined(SWIGR)
+#include <R_ext/Utils.h>   // R_CheckUserInterrupt
+#include <Rinternals.h>    // R_ToplevelExec
+namespace {
+// R_CheckUserInterrupt longjmps to R's top level when an interrupt is pending.
+// R_ToplevelExec runs it inside a context that catches that longjmp (so it never
+// unwinds the C++ stack and skips destructors) and reports it as a non-TRUE
+// result. Must run on R's main thread only — guaranteed by the owner-thread gate.
+void infomapRCheckInterrupt(void*) { R_CheckUserInterrupt(); }
+bool infomapHostInterruptPoll(void*) { return R_ToplevelExec(infomapRCheckInterrupt, nullptr) != TRUE; }
+} // namespace
+#elif defined(SWIGPYTHON)
+namespace {
+// PyErr_CheckSignals runs pending Python signal handlers (e.g. turns a queued
+// SIGINT into KeyboardInterrupt) and returns non-zero if one raised. Needs the
+// GIL and the main thread, both held when the core calls back on the owner
+// thread during a normal im.run().
+bool infomapHostInterruptPoll(void*) { return PyErr_CheckSignals() != 0; }
+} // namespace
+#endif
+%}
+
+#if defined(SWIGR) || defined(SWIGPYTHON)
+%exception infomap::InfomapBase::run {
+  arg1->setInterruptHandler(&infomapHostInterruptPoll, nullptr);
+  try {
+    $action
+  } catch (const infomap::InterruptionError&) {
+    arg1->clearInterruptHandler();
+#if defined(SWIGPYTHON)
+    // PyErr_CheckSignals already set KeyboardInterrupt — propagate it rather
+    // than masking it with a generic RuntimeError.
+    if (PyErr_Occurred()) SWIG_fail;
+#endif
+    SWIG_exception(SWIG_RuntimeError, "Infomap run interrupted.");
+  } catch (const std::exception& e) {
+    arg1->clearInterruptHandler();
+    SWIG_exception(SWIG_RuntimeError, e.what());
+  }
+  arg1->clearInterruptHandler();
+}
+#endif
+
 %include "std_string.i"
 %include "Config.i"
 %include "InfomapBase.i"

--- a/interfaces/swig/Infomap.i
+++ b/interfaces/swig/Infomap.i
@@ -320,34 +320,26 @@ void addMultilayerInterLinksFromNumpy2D(InfomapWrapper& infomap, PyObject* links
 %}
 
 // --- Cooperative interruption host bridge (issue #412) ---
-// run() installs a host poll handler that the core invokes ONLY on the owner
-// (here: the R / Python main) thread; worker threads only read the shared flag.
-// The C++ seam itself is %ignore'd in InfomapBase.i — this is the language glue.
+// run() installs a poll the core invokes only on the owner (R/Python main)
+// thread; the C++ seam is %ignore'd in InfomapBase.i — this is the language glue.
 %{
 #if defined(SWIGR)
 #include <R_ext/Utils.h>   // R_CheckUserInterrupt
 #include <Rinternals.h>    // R_ToplevelExec
 namespace {
-// R_CheckUserInterrupt longjmps to R's top level when an interrupt is pending.
-// R_ToplevelExec runs it inside a context that catches that longjmp (so it never
-// unwinds the C++ stack and skips destructors) and reports it as a non-TRUE
-// result. Must run on R's main thread only — guaranteed by the owner-thread gate.
-// NOTE: because R_ToplevelExec consumes the interrupt, a cancelled run surfaces
-// to R as a regular error (SWIG_RuntimeError -> Rf_error: "Infomap run
-// interrupted."), NOT an R "interrupt" condition — handle it with
-// tryCatch(error=), not tryCatch(interrupt=).
+// R_ToplevelExec contains R_CheckUserInterrupt's longjmp (so C++ destructors run)
+// and reports a pending interrupt as a non-TRUE result. R main thread only.
+// A cancel surfaces to R as a plain error (-> Rf_error), NOT an "interrupt"
+// condition — handle with tryCatch(error=), not tryCatch(interrupt=).
 void infomapRCheckInterrupt(void*) { R_CheckUserInterrupt(); }
 bool infomapHostInterruptPoll(void*) { return R_ToplevelExec(infomapRCheckInterrupt, nullptr) != TRUE; }
 } // namespace
 #elif defined(SWIGPYTHON)
 namespace infomap { extern InterruptCallback g_runInterruptCallback; } // defined in main.cpp
 namespace {
-// PyErr_CheckSignals runs pending Python signal handlers (e.g. turns a queued
-// SIGINT into KeyboardInterrupt) and returns non-zero if one raised. Needs the
-// GIL and the main thread, both held when the core calls back on the owner
-// thread during a normal im.run(). Off the main thread it is a no-op, so a run
-// launched from a non-main Python thread is simply non-interruptible (not an
-// error).
+// PyErr_CheckSignals runs pending Python signal handlers (turns a queued SIGINT
+// into KeyboardInterrupt). Needs the GIL + main thread; off the main thread it is
+// a no-op, so such a run is simply non-interruptible.
 bool infomapHostInterruptPoll(void*) { return PyErr_CheckSignals() != 0; }
 } // namespace
 #endif
@@ -361,8 +353,7 @@ bool infomapHostInterruptPoll(void*) { return PyErr_CheckSignals() != 0; }
   } catch (const infomap::InterruptionError&) {
     arg1->clearInterruptHandler();
 #if defined(SWIGPYTHON)
-    // PyErr_CheckSignals already set KeyboardInterrupt — propagate it rather
-    // than masking it with a generic RuntimeError.
+    // Propagate the pending KeyboardInterrupt rather than masking it.
     if (PyErr_Occurred()) SWIG_fail;
 #endif
     SWIG_exception(SWIG_RuntimeError, "Infomap run interrupted.");
@@ -375,9 +366,7 @@ bool infomapHostInterruptPoll(void*) { return PyErr_CheckSignals() != 0; }
 #endif
 
 #ifdef SWIGPYTHON
-// Register the same poll as the default that the C++ run(flags) free function
-// installs on its internal InfomapWrapper, so the pip `infomap` console script
-// (infomap:main -> run(args)) is interruptible too — not just the OO API.
+// Make the run(flags) free function (the pip `infomap` console script) poll too.
 %init %{
   infomap::g_runInterruptCallback = &infomapHostInterruptPoll;
 %}
@@ -430,9 +419,8 @@ def build_info():
 #endif
 
 #ifdef SWIGPYTHON
-// The free run(flags) entry catches its own exceptions and returns an int, but
-// rethrows InterruptionError under AS_LIB so a Ctrl-C surfaces here: propagate
-// the pending KeyboardInterrupt rather than masking it with a RuntimeError.
+// run(flags) rethrows InterruptionError under AS_LIB; propagate the pending
+// KeyboardInterrupt here rather than masking it with a RuntimeError.
 %exception infomap::run {
   try {
     $action

--- a/interfaces/swig/Infomap.i
+++ b/interfaces/swig/Infomap.i
@@ -332,15 +332,22 @@ namespace {
 // R_ToplevelExec runs it inside a context that catches that longjmp (so it never
 // unwinds the C++ stack and skips destructors) and reports it as a non-TRUE
 // result. Must run on R's main thread only — guaranteed by the owner-thread gate.
+// NOTE: because R_ToplevelExec consumes the interrupt, a cancelled run surfaces
+// to R as a regular error (SWIG_RuntimeError -> Rf_error: "Infomap run
+// interrupted."), NOT an R "interrupt" condition — handle it with
+// tryCatch(error=), not tryCatch(interrupt=).
 void infomapRCheckInterrupt(void*) { R_CheckUserInterrupt(); }
 bool infomapHostInterruptPoll(void*) { return R_ToplevelExec(infomapRCheckInterrupt, nullptr) != TRUE; }
 } // namespace
 #elif defined(SWIGPYTHON)
+namespace infomap { extern InterruptCallback g_runInterruptCallback; } // defined in main.cpp
 namespace {
 // PyErr_CheckSignals runs pending Python signal handlers (e.g. turns a queued
 // SIGINT into KeyboardInterrupt) and returns non-zero if one raised. Needs the
 // GIL and the main thread, both held when the core calls back on the owner
-// thread during a normal im.run().
+// thread during a normal im.run(). Off the main thread it is a no-op, so a run
+// launched from a non-main Python thread is simply non-interruptible (not an
+// error).
 bool infomapHostInterruptPoll(void*) { return PyErr_CheckSignals() != 0; }
 } // namespace
 #endif
@@ -365,6 +372,15 @@ bool infomapHostInterruptPoll(void*) { return PyErr_CheckSignals() != 0; }
   }
   arg1->clearInterruptHandler();
 }
+#endif
+
+#ifdef SWIGPYTHON
+// Register the same poll as the default that the C++ run(flags) free function
+// installs on its internal InfomapWrapper, so the pip `infomap` console script
+// (infomap:main -> run(args)) is interruptible too — not just the OO API.
+%init %{
+  infomap::g_runInterruptCallback = &infomapHostInterruptPoll;
+%}
 #endif
 
 %include "std_string.i"
@@ -411,6 +427,22 @@ def build_info():
     enabled_features = tuple(feature for feature in features.split(",") if feature)
     return {"enabled_features": enabled_features}
 %}
+#endif
+
+#ifdef SWIGPYTHON
+// The free run(flags) entry catches its own exceptions and returns an int, but
+// rethrows InterruptionError under AS_LIB so a Ctrl-C surfaces here: propagate
+// the pending KeyboardInterrupt rather than masking it with a RuntimeError.
+%exception infomap::run {
+  try {
+    $action
+  } catch (const infomap::InterruptionError&) {
+    if (PyErr_Occurred()) SWIG_fail;
+    SWIG_exception(SWIG_RuntimeError, "Infomap run interrupted.");
+  } catch (const std::exception& e) {
+    SWIG_exception(SWIG_RuntimeError, e.what());
+  }
+}
 #endif
 
 namespace infomap {

--- a/interfaces/swig/InfomapBase.i
+++ b/interfaces/swig/InfomapBase.i
@@ -21,5 +21,17 @@ namespace infomap {
     %template(InfomapConfigInfomapBase) InfomapConfig<InfomapBase>;
 }
 
+/* Cooperative interruption (issue #412) is a native C++/embedder seam only;
+   keep it out of the generated language bindings. A function-pointer callback
+   does not wrap meaningfully through SWIG, and host bindings drive cancellation
+   through their own bridge (see the R/Python notes on the issue). */
+%ignore infomap::InterruptCallback;
+%ignore infomap::InterruptionError;
+%ignore infomap::InfomapBase::setInterruptHandler;
+%ignore infomap::InfomapBase::clearInterruptHandler;
+%ignore infomap::InfomapBase::hasInterruptHandler;
+%ignore infomap::InfomapBase::requestInterrupt;
+%ignore infomap::InfomapBase::interruptRequested;
+
 /* Parse the header file to generate wrappers */
 %include "src/core/InfomapBase.h"

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -377,9 +377,8 @@ private:
 
       InfomapBase worker(workerConfig);
       worker.m_initialPartition = m_infomap.m_initialPartition;
-      // Share the main instance's cancel flag so an interrupt is observed across
-      // all trial workers (issue #412). Workers never call the host callback;
-      // they only read this flag and unwind, caught by the per-trial handler below.
+      // Share the cancel flag so workers observe a cancel; they only read it and
+      // unwind, caught by the per-trial handler below (issue #412).
       worker.inheritRuntimeContext(m_infomap);
 
       for (unsigned int trialIndex = static_cast<unsigned int>(workerIndex); trialIndex < m_numTrials; trialIndex += numWorkers) {
@@ -452,9 +451,8 @@ private:
       }
     }
 
-    // A cancelled run surfaces as a clean InterruptionError, not a generic
-    // "Parallel trial failed" (workers catch it as a std::exception above, but
-    // the run was interrupted, not a real failure). Issue #412.
+    // Surface a cancel as InterruptionError, not the generic "Parallel trial
+    // failed" the std::exception handler above would otherwise report (#412).
     if (m_infomap.interruptRequested()) {
       throw InterruptionError();
     }
@@ -994,9 +992,8 @@ void InfomapBase::run(Network& network)
   if (!isMainInfomap())
     throw std::logic_error("Can't run a non-main Infomap with an input network");
 
-  // Stamp the owner thread so the interrupt callback is only ever invoked here,
-  // and clear any cancellation left over from a previous (interrupted) run so
-  // the instance is reusable. Then honour a cancel requested before the run.
+  // Stamp the owner thread (gates the callback) and clear any leftover cancel so
+  // the instance is reusable after an interrupted run (issue #412).
   m_ownerThreadId = std::this_thread::get_id();
   m_cancelRequested.store(false, std::memory_order_relaxed);
   pollInterrupt();
@@ -2351,10 +2348,8 @@ unsigned int InfomapBase::findHierarchicalSuperModules(unsigned int superLevelLi
     auto& superInfomap = getSuperInfomap(tmp)
                              .setTwoLevel(true);
     superInfomap.initNetwork(m_root, true); //.initSuperNetwork();
-    // An InterruptionError from this run() unwinds cleanly: `tmp` owns the super
-    // Infomap, so ~InfoNode frees it on unwinding. Unlike the sub-Infomap sites
-    // (which dispose eagerly before rethrowing), no explicit catch is needed
-    // here because the owner is a local. Issue #412.
+    // No interrupt catch needed: local `tmp` owns the super-Infomap, so
+    // ~InfoNode frees it if run() throws InterruptionError (#412).
     superInfomap.run();
     if (shouldMuteNestedMainRun) {
       Log::setSilent(isSilent);
@@ -2655,8 +2650,7 @@ unsigned int InfomapBase::recursivePartition()
 #endif
     {
       for (auto moduleIndex : spawnOrder) {
-        // Stop spawning once cancelled (issue #412); in-flight tasks bail at
-        // their own entry check. Never throw inside the task region.
+        // Stop spawning once cancelled; never throw inside the task region (#412).
         if (interruptRequested())
           break;
         InfoNode* module = partitionQueue[moduleIndex];
@@ -2675,10 +2669,8 @@ unsigned int InfomapBase::recursivePartition()
   if (shouldMuteNestedMainRun)
     Log::setSilent(isSilent);
 
-  // The task region has joined: now we are back on the thread that entered
-  // recursivePartition (owner thread in serial runs, a trial worker under
-  // --parallel-trials). Throwing here is safe — outside any OpenMP block — and
-  // aborts the recursion if a cancel was requested while tasks were running.
+  // Tasks have joined: throwing here is safe (outside any OpenMP block) and
+  // aborts the recursion if a cancel was requested while tasks ran (#412).
   checkCancelled();
 
   // Aggregate the recorded statistics level by level, visiting the records in
@@ -2808,9 +2800,8 @@ void InfomapBase::partitionModuleRecursively(InfoNode& module, unsigned int leve
   if (module.disposeInfomap())
     module.codelength = calcCodelength(module);
 
-  // Cooperative cancellation (issue #412). This runs inside an OpenMP task, so
-  // we must NOT throw here — bail without spawning a sub-Infomap and let the
-  // owner thread throw once after the task region (see recursivePartition).
+  // Inside an OpenMP task: bail without throwing; recursivePartition throws once
+  // after the region (#412).
   if (interruptRequested()) {
     record.leafCodelength = module.codelength;
     return;
@@ -2828,10 +2819,8 @@ void InfomapBase::partitionModuleRecursively(InfoNode& module, unsigned int leve
   auto& subInfomap = getSubInfomap(module)
                          .initNetwork(module);
   // Run two-level partition + find hierarchically super modules (skip recursion).
-  // An interrupt raised inside the sub-run (on this worker thread) must not
-  // escape the enclosing OpenMP task: contain it, free the sub-Infomap working
-  // set, and bail. The shared cancel flag stays set, so recursivePartition
-  // throws once on the owner/trial thread after the region.
+  // Contain an interrupt from the sub-run so it can't escape the enclosing
+  // OpenMP task; free the sub-Infomap and bail (the flag stays set) (#412).
   try {
     subInfomap.setOnlySuperModules(true).run();
   } catch (const InterruptionError&) {
@@ -2956,8 +2945,7 @@ void InfomapBase::partitionModuleRecursively(InfoNode& module, unsigned int leve
   });
 
   for (auto subModuleIndex : spawnOrder) {
-    // Stop spawning new work once cancelled; in-flight child tasks bail at their
-    // own entry check and the owner thread throws after the region.
+    // Stop spawning once cancelled (in-flight children bail at their own check).
     if (interruptRequested())
       break;
     InfoNode* subModule = materializedSubModules[subModuleIndex];

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -2351,6 +2351,10 @@ unsigned int InfomapBase::findHierarchicalSuperModules(unsigned int superLevelLi
     auto& superInfomap = getSuperInfomap(tmp)
                              .setTwoLevel(true);
     superInfomap.initNetwork(m_root, true); //.initSuperNetwork();
+    // An InterruptionError from this run() unwinds cleanly: `tmp` owns the super
+    // Infomap, so ~InfoNode frees it on unwinding. Unlike the sub-Infomap sites
+    // (which dispose eagerly before rethrowing), no explicit catch is needed
+    // here because the owner is a local. Issue #412.
     superInfomap.run();
     if (shouldMuteNestedMainRun) {
       Log::setSilent(isSilent);

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -314,6 +314,7 @@ private:
       runTrialsUntilConverged(result);
     } else {
       for (unsigned int i = 0; i < m_numTrials; ++i) {
+        m_infomap.pollInterrupt();
         runTrial(i, result);
       }
     }
@@ -331,6 +332,7 @@ private:
     unsigned int trialsSinceImprovement = 0;
     unsigned int i = 0;
     for (; i < m_numTrials; ++i) {
+      m_infomap.pollInterrupt();
       const double bestBefore = result.bestHierarchicalCodelength;
       runTrial(i, result);
 
@@ -375,6 +377,10 @@ private:
 
       InfomapBase worker(workerConfig);
       worker.m_initialPartition = m_infomap.m_initialPartition;
+      // Share the main instance's cancel flag so an interrupt is observed across
+      // all trial workers (issue #412). Workers never call the host callback;
+      // they only read this flag and unwind, caught by the per-trial handler below.
+      worker.inheritRuntimeContext(m_infomap);
 
       for (unsigned int trialIndex = static_cast<unsigned int>(workerIndex); trialIndex < m_numTrials; trialIndex += numWorkers) {
         try {
@@ -444,6 +450,13 @@ private:
           }
         }
       }
+    }
+
+    // A cancelled run surfaces as a clean InterruptionError, not a generic
+    // "Parallel trial failed" (workers catch it as a std::exception above, but
+    // the run was interrupted, not a real failure). Issue #412.
+    if (m_infomap.interruptRequested()) {
+      throw InterruptionError();
     }
 
     if (hasError) {
@@ -980,6 +993,13 @@ void InfomapBase::run(Network& network)
 {
   if (!isMainInfomap())
     throw std::logic_error("Can't run a non-main Infomap with an input network");
+
+  // Stamp the owner thread so the interrupt callback is only ever invoked here,
+  // and clear any cancellation left over from a previous (interrupted) run so
+  // the instance is reusable. Then honour a cancel requested before the run.
+  m_ownerThreadId = std::this_thread::get_id();
+  m_cancelRequested.store(false, std::memory_order_relaxed);
+  pollInterrupt();
 
   TimingRegistry timing;
   Stopwatch totalTimer(true);
@@ -1717,8 +1737,14 @@ void InfomapBase::hierarchicalPartition()
 
           subInfomap.initPartition(modules);
 
-          // Run two-level partition + find hierarchically super modules (skip recursion)
-          subInfomap.setOnlySuperModules(true).run();
+          // Run two-level partition + find hierarchically super modules (skip recursion).
+          // Free the sub-Infomap on interrupt before unwinding (issue #412).
+          try {
+            subInfomap.setOnlySuperModules(true).run();
+          } catch (const InterruptionError&) {
+            module.disposeInfomap();
+            throw;
+          }
 
           // Collect sub Infomap modules
           i = 0;
@@ -2210,7 +2236,13 @@ unsigned int InfomapBase::coarseTune()
       InfomapBase& subInfomap = getSubInfomap(node)
                                     .setTwoLevel(true)
                                     .setTuneIterationLimit(1);
-      subInfomap.initNetwork(node).run();
+      // Free the sub-Infomap on interrupt before unwinding (issue #412).
+      try {
+        subInfomap.initNetwork(node).run();
+      } catch (const InterruptionError&) {
+        node.disposeInfomap();
+        throw;
+      }
 
       auto originalLeafIt = node.begin_child();
       for (auto& subLeafPtr : subInfomap.leafNodes()) {
@@ -2619,6 +2651,10 @@ unsigned int InfomapBase::recursivePartition()
 #endif
     {
       for (auto moduleIndex : spawnOrder) {
+        // Stop spawning once cancelled (issue #412); in-flight tasks bail at
+        // their own entry check. Never throw inside the task region.
+        if (interruptRequested())
+          break;
         InfoNode* module = partitionQueue[moduleIndex];
         detail::PartitionTaskRecord* record = &rootRecords[moduleIndex];
 #ifdef _OPENMP
@@ -2634,6 +2670,12 @@ unsigned int InfomapBase::recursivePartition()
 
   if (shouldMuteNestedMainRun)
     Log::setSilent(isSilent);
+
+  // The task region has joined: now we are back on the thread that entered
+  // recursivePartition (owner thread in serial runs, a trial worker under
+  // --parallel-trials). Throwing here is safe — outside any OpenMP block — and
+  // aborts the recursion if a cancel was requested while tasks were running.
+  checkCancelled();
 
   // Aggregate the recorded statistics level by level, visiting the records in
   // the same order as the former level-synchronous queue concatenated them, so
@@ -2762,6 +2804,14 @@ void InfomapBase::partitionModuleRecursively(InfoNode& module, unsigned int leve
   if (module.disposeInfomap())
     module.codelength = calcCodelength(module);
 
+  // Cooperative cancellation (issue #412). This runs inside an OpenMP task, so
+  // we must NOT throw here — bail without spawning a sub-Infomap and let the
+  // owner thread throw once after the task region (see recursivePartition).
+  if (interruptRequested()) {
+    record.leafCodelength = module.codelength;
+    return;
+  }
+
   // If only trivial substructure is to be found, no need to create infomap instance to find sub-module structures.
   if (module.childDegree() <= 2) {
     module.codelength = calcCodelength(module);
@@ -2773,8 +2823,19 @@ void InfomapBase::partitionModuleRecursively(InfoNode& module, unsigned int leve
 
   auto& subInfomap = getSubInfomap(module)
                          .initNetwork(module);
-  // Run two-level partition + find hierarchically super modules (skip recursion)
-  subInfomap.setOnlySuperModules(true).run();
+  // Run two-level partition + find hierarchically super modules (skip recursion).
+  // An interrupt raised inside the sub-run (on this worker thread) must not
+  // escape the enclosing OpenMP task: contain it, free the sub-Infomap working
+  // set, and bail. The shared cancel flag stays set, so recursivePartition
+  // throws once on the owner/trial thread after the region.
+  try {
+    subInfomap.setOnlySuperModules(true).run();
+  } catch (const InterruptionError&) {
+    module.disposeInfomap();
+    module.codelength = oldModuleCodelength;
+    record.leafCodelength = module.codelength;
+    return;
+  }
 
   double subCodelength = subInfomap.getHierarchicalCodelength();
   double subIndexCodelength = subInfomap.root().codelength;
@@ -2891,6 +2952,10 @@ void InfomapBase::partitionModuleRecursively(InfoNode& module, unsigned int leve
   });
 
   for (auto subModuleIndex : spawnOrder) {
+    // Stop spawning new work once cancelled; in-flight child tasks bail at their
+    // own entry check and the owner thread throws after the region.
+    if (interruptRequested())
+      break;
     InfoNode* subModule = materializedSubModules[subModuleIndex];
     detail::PartitionTaskRecord* childRecord = &record.children[subModuleIndex];
     // Small subtrees run inline: spawning them as tasks costs more in task

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -43,17 +43,13 @@ namespace detail {
   struct PerLevelStat;
 } // namespace detail
 
-// Cooperative cancellation hook for embedders (igraph, R, Python, ...). The
-// callback returns true to request that the current run stop at the next safe
-// checkpoint. It is invoked ONLY on the owner thread (the thread that called
-// run()), so it is safe to enter host-language APIs such as R_CheckUserInterrupt
-// from it. Worker threads never call it; they only observe a thread-safe flag.
-// See issue #412.
+// Cooperative cancellation hook (issue #412). Return true to stop the run at the
+// next checkpoint. Invoked only on the owner thread, so it is safe to enter
+// host-language APIs (R_CheckUserInterrupt, PyErr_CheckSignals) from it.
 using InterruptCallback = bool (*)(void* userData);
 
-// Thrown out of run() when a run is cancelled cooperatively. Derives from
-// std::runtime_error so existing catch(const std::exception&) paths still unwind
-// and release resources cleanly.
+// Thrown out of run() on cancellation; std::runtime_error so existing
+// catch(std::exception) unwinding still applies.
 class InterruptionError : public std::runtime_error {
 public:
   InterruptionError() : std::runtime_error("Infomap run interrupted.") {}
@@ -244,9 +240,8 @@ public:
   // Cooperative interruption (issue #412)
   // ===================================================
 
-  // Register a cancellation poll handler. It is called only on the owner thread
-  // at safe checkpoints during run(); return true from it to abort the run with
-  // an InterruptionError. The default (no handler) path is unchanged.
+  // Polled on the owner thread during run(); return true to abort with an
+  // InterruptionError. No handler = unchanged behavior.
   InfomapBase& setInterruptHandler(InterruptCallback callback, void* userData = nullptr)
   {
     m_interruptCallback = callback;
@@ -263,11 +258,8 @@ public:
 
   bool hasInterruptHandler() const { return m_interruptCallback != nullptr; }
 
-  // Thread-safe, non-throwing. Any thread (e.g. a host UI/cancel thread) may call
-  // this to request cancellation; the owner thread and all worker threads observe
-  // the flag at their next checkpoint. The store is relaxed (the flag carries no
-  // companion data), so visibility is eventual — the real cross-thread ordering
-  // comes from the OpenMP region/taskwait joins, not from this flag.
+  // Thread-safe push from any thread; observed at the next checkpoint. Relaxed
+  // (the flag carries no companion data) — ordering comes from the OpenMP joins.
   void requestInterrupt() noexcept { m_cancel->store(true, std::memory_order_relaxed); }
 
   bool interruptRequested() const noexcept { return m_cancel->load(std::memory_order_relaxed); }
@@ -345,30 +337,24 @@ private:
 
   bool haveHardPartition() const { return !m_originalLeafNodes.empty(); }
 
-  // Share the cancellation flag (and only that) with a sub/worker Infomap so a
-  // cancel requested anywhere in the run tree is observed everywhere. The host
-  // callback is deliberately NOT inherited: only the main Infomap on the owner
-  // thread ever invokes it; sub/worker instances only read the shared flag.
+  // Share the cancel flag (only) with a sub/worker Infomap. The callback is NOT
+  // inherited — only the main instance, on the owner thread, ever invokes it.
   InfomapBase& inheritRuntimeContext(const InfomapBase& other)
   {
     m_cancel = other.m_cancel;
     return *this;
   }
 
-  // Worker-safe: reads the shared atomic only, never the host callback. May be
-  // called from any thread, but only throw where unwinding is legal (not from
-  // inside an OpenMP structured block).
+  // Flag-only, any thread. Call only where a throw can unwind legally — NOT
+  // inside an OpenMP structured block.
   void checkCancelled() const
   {
     if (m_cancel->load(std::memory_order_relaxed))
       throw InterruptionError();
   }
 
-  // Owner-thread checkpoint: invoke the host callback (safe to enter R/Python
-  // here), promote a true result into the shared flag, then throw if cancelled.
   // The thread-id guard keeps the callback off worker threads even when this
-  // very object's methods run inside the task graph; off-thread it degrades to
-  // a plain flag check.
+  // object's methods run inside the task graph (off-thread it is a flag check).
   void pollInterrupt()
   {
     if (m_interruptCallback != nullptr
@@ -693,12 +679,9 @@ protected:
   std::string m_initialParameters;
   std::string m_currentParameters;
 
-  // Cooperative interruption (issue #412). m_cancelRequested is the canonical
-  // flag owned by the main instance; m_cancel points at it (self by default,
-  // re-pointed at the main's flag for sub/worker instances via
-  // inheritRuntimeContext) so the whole run tree shares one observable flag.
-  // The callback lives only on the main instance and is only ever called on the
-  // owner thread (stamped in run(Network&)).
+  // Cooperative interruption (issue #412). m_cancel points at m_cancelRequested
+  // (self) or, for sub/worker instances, at the main's flag (inheritRuntimeContext),
+  // so the run tree shares one flag. m_ownerThreadId is stamped in run(Network&).
   std::atomic<bool> m_cancelRequested { false };
   std::atomic<bool>* m_cancel = &m_cancelRequested;
   InterruptCallback m_interruptCallback = nullptr;

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -27,10 +27,12 @@
 #include <deque>
 #include <map>
 #include <array>
+#include <atomic>
 #include <stdexcept>
 #include <limits>
 #include <memory>
 #include <string>
+#include <thread>
 #include <ostream>
 
 namespace infomap {
@@ -40,6 +42,22 @@ namespace detail {
   struct PartitionTaskRecord;
   struct PerLevelStat;
 } // namespace detail
+
+// Cooperative cancellation hook for embedders (igraph, R, Python, ...). The
+// callback returns true to request that the current run stop at the next safe
+// checkpoint. It is invoked ONLY on the owner thread (the thread that called
+// run()), so it is safe to enter host-language APIs such as R_CheckUserInterrupt
+// from it. Worker threads never call it; they only observe a thread-safe flag.
+// See issue #412.
+using InterruptCallback = bool (*)(void* userData);
+
+// Thrown out of run() when a run is cancelled cooperatively. Derives from
+// std::runtime_error so existing catch(const std::exception&) paths still unwind
+// and release resources cleanly.
+class InterruptionError : public std::runtime_error {
+public:
+  InterruptionError() : std::runtime_error("Infomap run interrupted.") {}
+};
 
 class InfomapBase : public InfomapConfig<InfomapBase> {
   template <typename Objective>
@@ -222,6 +240,36 @@ public:
 
   void run(Network& network);
 
+  // ===================================================
+  // Cooperative interruption (issue #412)
+  // ===================================================
+
+  // Register a cancellation poll handler. It is called only on the owner thread
+  // at safe checkpoints during run(); return true from it to abort the run with
+  // an InterruptionError. The default (no handler) path is unchanged.
+  InfomapBase& setInterruptHandler(InterruptCallback callback, void* userData = nullptr)
+  {
+    m_interruptCallback = callback;
+    m_interruptUserData = userData;
+    return *this;
+  }
+
+  InfomapBase& clearInterruptHandler()
+  {
+    m_interruptCallback = nullptr;
+    m_interruptUserData = nullptr;
+    return *this;
+  }
+
+  bool hasInterruptHandler() const { return m_interruptCallback != nullptr; }
+
+  // Thread-safe, non-throwing. Any thread (e.g. a host UI/cancel thread) may call
+  // this to request cancellation; the owner thread and all worker threads observe
+  // the same flag and stop at the next checkpoint.
+  void requestInterrupt() noexcept { m_cancel->store(true, std::memory_order_relaxed); }
+
+  bool interruptRequested() const noexcept { return m_cancel->load(std::memory_order_relaxed); }
+
 private:
   class RunSession;
 
@@ -253,7 +301,8 @@ private:
     auto& subInfomap = node.setInfomap(getNewInfomapInstance())
                            .setIsMain(false)
                            .setSubLevel(m_subLevel + 1)
-                           .setNonMainConfig(*this);
+                           .setNonMainConfig(*this)
+                           .inheritRuntimeContext(*this);
     // Carry the full-network properties down so entropy bias correction stays consistent
     // across the hierarchy (this used to be a shared static).
     subInfomap.m_optimizer->inheritNetworkPropertiesFrom(*m_optimizer);
@@ -265,7 +314,8 @@ private:
     auto& superInfomap = node.setInfomap(getNewInfomapInstanceWithoutMemory())
                              .setIsMain(false)
                              .setSubLevel(m_subLevel + SUPER_LEVEL_ADDITION)
-                             .setNonMainConfig(*this);
+                             .setNonMainConfig(*this)
+                             .inheritRuntimeContext(*this);
     superInfomap.m_optimizer->inheritNetworkPropertiesFrom(*m_optimizer);
     return superInfomap;
   }
@@ -292,6 +342,39 @@ private:
   bool isMainInfomap() const { return m_isMain; }
 
   bool haveHardPartition() const { return !m_originalLeafNodes.empty(); }
+
+  // Share the cancellation flag (and only that) with a sub/worker Infomap so a
+  // cancel requested anywhere in the run tree is observed everywhere. The host
+  // callback is deliberately NOT inherited: only the main Infomap on the owner
+  // thread ever invokes it; sub/worker instances only read the shared flag.
+  InfomapBase& inheritRuntimeContext(const InfomapBase& other)
+  {
+    m_cancel = other.m_cancel;
+    return *this;
+  }
+
+  // Worker-safe: reads the shared atomic only, never the host callback. May be
+  // called from any thread, but only throw where unwinding is legal (not from
+  // inside an OpenMP structured block).
+  void checkCancelled() const
+  {
+    if (m_cancel->load(std::memory_order_relaxed))
+      throw InterruptionError();
+  }
+
+  // Owner-thread checkpoint: invoke the host callback (safe to enter R/Python
+  // here), promote a true result into the shared flag, then throw if cancelled.
+  // The thread-id guard keeps the callback off worker threads even when this
+  // very object's methods run inside the task graph; off-thread it degrades to
+  // a plain flag check.
+  void pollInterrupt()
+  {
+    if (m_interruptCallback != nullptr
+        && std::this_thread::get_id() == m_ownerThreadId
+        && m_interruptCallback(m_interruptUserData))
+      m_cancel->store(true, std::memory_order_relaxed);
+    checkCancelled();
+  }
 
   // ===================================================
   // Run: *
@@ -607,6 +690,18 @@ protected:
   Stopwatch m_elapsedTime = Stopwatch(false);
   std::string m_initialParameters;
   std::string m_currentParameters;
+
+  // Cooperative interruption (issue #412). m_cancelRequested is the canonical
+  // flag owned by the main instance; m_cancel points at it (self by default,
+  // re-pointed at the main's flag for sub/worker instances via
+  // inheritRuntimeContext) so the whole run tree shares one observable flag.
+  // The callback lives only on the main instance and is only ever called on the
+  // owner thread (stamped in run(Network&)).
+  std::atomic<bool> m_cancelRequested { false };
+  std::atomic<bool>* m_cancel = &m_cancelRequested;
+  InterruptCallback m_interruptCallback = nullptr;
+  void* m_interruptUserData = nullptr;
+  std::thread::id m_ownerThreadId;
 
   std::unique_ptr<InfomapOptimizerBase> m_optimizer;
 };

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -265,7 +265,9 @@ public:
 
   // Thread-safe, non-throwing. Any thread (e.g. a host UI/cancel thread) may call
   // this to request cancellation; the owner thread and all worker threads observe
-  // the same flag and stop at the next checkpoint.
+  // the flag at their next checkpoint. The store is relaxed (the flag carries no
+  // companion data), so visibility is eventual — the real cross-thread ordering
+  // comes from the OpenMP region/taskwait joins, not from this flag.
   void requestInterrupt() noexcept { m_cancel->store(true, std::memory_order_relaxed); }
 
   bool interruptRequested() const noexcept { return m_cancel->load(std::memory_order_relaxed); }

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -258,8 +258,10 @@ public:
 
   bool hasInterruptHandler() const { return m_interruptCallback != nullptr; }
 
-  // Thread-safe push from any thread; observed at the next checkpoint. Relaxed
-  // (the flag carries no companion data) — ordering comes from the OpenMP joins.
+  // Thread-safe push to cancel an in-progress run, observed at the next
+  // checkpoint. A request made before run() is cleared at run entry (so it does
+  // not pre-cancel a fresh run). Relaxed (no companion data) — ordering comes
+  // from the OpenMP joins.
   void requestInterrupt() noexcept { m_cancel->store(true, std::memory_order_relaxed); }
 
   bool interruptRequested() const noexcept { return m_cancel->load(std::memory_order_relaxed); }

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -442,11 +442,8 @@ INFOMAP_HOT inline unsigned int InfomapOptimizer<Objective>::optimizeActiveNetwo
   }
 
   do {
-    // Cooperative cancellation checkpoint (issue #412). This serial outer loop
-    // runs between the inner (possibly parallel) node-move sweeps, so throwing
-    // here never unwinds through an OpenMP region. On the owner thread it polls
-    // the host callback; on worker threads (sub-Infomaps / parallel trials) it
-    // only observes the shared cancel flag.
+    // Cancellation checkpoint (#412): between the inner sweeps, so a throw here
+    // never unwinds through an OpenMP region.
     m_infomap->pollInterrupt();
     ++coreLoopCount;
     unsigned int numNodesMoved = shouldUseInnerParallelization()
@@ -705,10 +702,8 @@ INFOMAP_HOT unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestMod
     // but chunk size 1 costs one scheduler round-trip per iteration.
 #pragma omp for schedule(dynamic, 512)
     for (unsigned int i = 0; i < numNodes; ++i) {
-      // Cooperative cancellation (issue #412): once cancelled, drain the sweep
-      // cheaply without throwing (an exception must not escape this OpenMP
-      // region). The serial outer loop throws at its next checkpoint. The load
-      // is relaxed and effectively free on the no-handler path.
+      // Once cancelled, drain the sweep without throwing (no exception may leave
+      // this OpenMP region); the outer loop throws at its next checkpoint (#412).
       if (m_infomap->interruptRequested())
         continue;
       deltaFlow.startRound();

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -442,6 +442,12 @@ INFOMAP_HOT inline unsigned int InfomapOptimizer<Objective>::optimizeActiveNetwo
   }
 
   do {
+    // Cooperative cancellation checkpoint (issue #412). This serial outer loop
+    // runs between the inner (possibly parallel) node-move sweeps, so throwing
+    // here never unwinds through an OpenMP region. On the owner thread it polls
+    // the host callback; on worker threads (sub-Infomaps / parallel trials) it
+    // only observes the shared cancel flag.
+    m_infomap->pollInterrupt();
     ++coreLoopCount;
     unsigned int numNodesMoved = shouldUseInnerParallelization()
         ? tryMoveEachNodeIntoBestModuleInParallel()
@@ -699,6 +705,12 @@ INFOMAP_HOT unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestMod
     // but chunk size 1 costs one scheduler round-trip per iteration.
 #pragma omp for schedule(dynamic, 512)
     for (unsigned int i = 0; i < numNodes; ++i) {
+      // Cooperative cancellation (issue #412): once cancelled, drain the sweep
+      // cheaply without throwing (an exception must not escape this OpenMP
+      // region). The serial outer loop throws at its next checkpoint. The load
+      // is relaxed and effectively free on the no-handler path.
+      if (m_infomap->interruptRequested())
+        continue;
       deltaFlow.startRound();
 
       // Pick nodes in random order

--- a/src/io/InfomapError.h
+++ b/src/io/InfomapError.h
@@ -27,6 +27,9 @@ enum class ExitCode : std::uint8_t {
   // MemoryEstimateExceeded = 4,
   // NoValidTrials = 5,
   InternalError = 7,
+  // Cooperative cancellation via Ctrl-C (issue #412); 128 + SIGINT(2), the
+  // shell convention for a process terminated by an interrupt.
+  Interrupted = 130,
 };
 
 class InfomapError : public std::runtime_error {

--- a/src/io/InfomapError.h
+++ b/src/io/InfomapError.h
@@ -27,8 +27,7 @@ enum class ExitCode : std::uint8_t {
   // MemoryEstimateExceeded = 4,
   // NoValidTrials = 5,
   InternalError = 7,
-  // Cooperative cancellation via Ctrl-C (issue #412); 128 + SIGINT(2), the
-  // shell convention for a process terminated by an interrupt.
+  // Ctrl-C / cooperative cancellation; 128 + SIGINT(2), the shell convention (#412).
   Interrupted = 130,
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,26 +24,18 @@
 
 namespace infomap {
 
-// Process-global interrupt poll for the single-call run(flags) CLI entry.
-// run() installs it on the InfomapWrapper it creates, so the pip-installed
-// `infomap` console script (which routes through this AS_LIB free function) is
-// interruptible too. The Python binding registers a PyErr_CheckSignals poll in
-// its module init; the native CLI sets its own SIGINT-flag poll below. Default
-// null = no polling (unchanged behavior, e.g. the R extension never sets it).
+// Poll that run() installs on its InfomapWrapper, so the single-call entry (the
+// pip `infomap` console script, via this AS_LIB free function) is interruptible.
+// The Python binding registers a PyErr_CheckSignals poll here at module init;
+// the native CLI uses its own below. Null = no polling (e.g. the R extension).
 InterruptCallback g_runInterruptCallback = nullptr;
 
 #ifndef AS_LIB
 namespace {
-  // CLI cooperative Ctrl-C (issue #412). The handler only assigns a
-  // volatile sig_atomic_t — the single operation guaranteed async-signal-safe in
-  // every C++ standard (the core/CLI builds as C++14). The run polls it on the
-  // main thread through the interrupt hook and cancels cleanly at the next
-  // checkpoint, instead of the default SIGINT hard-killing the process mid-run
-  // (which could leave a half-written output file). Cross-thread visibility to
-  // the OpenMP workers is handled downstream: the main-thread poll flips the
-  // run's lock-free atomic cancel flag, which the workers observe. Library builds
-  // (-DAS_LIB, used by the Python/R bindings) never install this — they own their
-  // own signal handling — so the shared infomap::run() entry is untouched there.
+  // Native CLI Ctrl-C (#412). The handler only assigns a volatile sig_atomic_t —
+  // the one async-signal-safe operation under the C++14 core build (not a
+  // std::atomic, which is signal-safe only from C++17). The owner-thread poll
+  // reads it and flips the run's lock-free atomic cancel flag that workers see.
   volatile std::sig_atomic_t g_cliInterruptRequested = 0;
   extern "C" void cliHandleInterrupt(int) { g_cliInterruptRequested = 1; }
   bool cliInterruptPoll(void*) { return g_cliInterruptRequested != 0; }
@@ -72,15 +64,12 @@ int run(const std::string& flags)
     }
     InfomapWrapper im(config);
 #ifndef AS_LIB
-    // Native CLI: install a SIGINT-flag poll directly. Clear the process-global
-    // flag first so a Ctrl-C from an earlier run() in the same process can't
-    // make this run abort at its first checkpoint (run() can be called more than
-    // once when embedded; the core resets its own atomic but not this flag).
+    // Clear the flag first: a Ctrl-C from an earlier run() in this process must
+    // not abort the next one at its first checkpoint.
     g_cliInterruptRequested = 0;
     std::signal(SIGINT, cliHandleInterrupt);
     im.setInterruptHandler(&cliInterruptPoll);
 #else
-    // Library builds (Python console script): poll whatever the binding registered.
     if (g_runInterruptCallback != nullptr)
       im.setInterruptHandler(g_runInterruptCallback);
 #endif
@@ -89,11 +78,8 @@ int run(const std::string& flags)
     // Help / version / json-parameters CLI flags requested a clean exit.
     return 0;
   } catch (const InterruptionError&) {
-    // Ctrl-C / cooperative cancellation.
 #ifdef AS_LIB
-    // Let the binding surface it (Python: the pending KeyboardInterrupt set by
-    // PyErr_CheckSignals propagates; see the run() %exception in Infomap.i).
-    throw;
+    throw; // let the binding surface it (Python: the pending KeyboardInterrupt)
 #else
     std::cerr << "\nInterrupted.\n";
     return exitCodeValue(ExitCode::Interrupted);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,14 @@
 
 namespace infomap {
 
+// Process-global interrupt poll for the single-call run(flags) CLI entry.
+// run() installs it on the InfomapWrapper it creates, so the pip-installed
+// `infomap` console script (which routes through this AS_LIB free function) is
+// interruptible too. The Python binding registers a PyErr_CheckSignals poll in
+// its module init; the native CLI sets its own SIGINT-flag poll below. Default
+// null = no polling (unchanged behavior, e.g. the R extension never sets it).
+InterruptCallback g_runInterruptCallback = nullptr;
+
 #ifndef AS_LIB
 namespace {
   // CLI cooperative Ctrl-C (issue #412). The handler only assigns a
@@ -64,16 +72,29 @@ int run(const std::string& flags)
     }
     InfomapWrapper im(config);
 #ifndef AS_LIB
+    // Native CLI: install a SIGINT-flag poll directly. Clear the process-global
+    // flag first so a Ctrl-C from an earlier run() in the same process can't
+    // make this run abort at its first checkpoint (run() can be called more than
+    // once when embedded; the core resets its own atomic but not this flag).
+    g_cliInterruptRequested = 0;
     std::signal(SIGINT, cliHandleInterrupt);
     im.setInterruptHandler(&cliInterruptPoll);
+#else
+    // Library builds (Python console script): poll whatever the binding registered.
+    if (g_runInterruptCallback != nullptr)
+      im.setInterruptHandler(g_runInterruptCallback);
 #endif
     im.run();
   } catch (const CleanExit&) {
     // Help / version / json-parameters CLI flags requested a clean exit.
     return 0;
-#ifndef AS_LIB
   } catch (const InterruptionError&) {
-    // Ctrl-C: cancelled cleanly at a checkpoint.
+    // Ctrl-C / cooperative cancellation.
+#ifdef AS_LIB
+    // Let the binding surface it (Python: the pending KeyboardInterrupt set by
+    // PyErr_CheckSignals propagates; see the run() %exception in Infomap.i).
+    throw;
+#else
     std::cerr << "\nInterrupted.\n";
     return exitCodeValue(ExitCode::Interrupted);
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,29 @@
 #include <omp.h>
 #endif
 
+#ifndef AS_LIB
+#include <csignal>
+#endif
+
 namespace infomap {
+
+#ifndef AS_LIB
+namespace {
+  // CLI cooperative Ctrl-C (issue #412). The handler only assigns a
+  // volatile sig_atomic_t — the single operation guaranteed async-signal-safe in
+  // every C++ standard (the core/CLI builds as C++14). The run polls it on the
+  // main thread through the interrupt hook and cancels cleanly at the next
+  // checkpoint, instead of the default SIGINT hard-killing the process mid-run
+  // (which could leave a half-written output file). Cross-thread visibility to
+  // the OpenMP workers is handled downstream: the main-thread poll flips the
+  // run's lock-free atomic cancel flag, which the workers observe. Library builds
+  // (-DAS_LIB, used by the Python/R bindings) never install this — they own their
+  // own signal handling — so the shared infomap::run() entry is untouched there.
+  volatile std::sig_atomic_t g_cliInterruptRequested = 0;
+  extern "C" void cliHandleInterrupt(int) { g_cliInterruptRequested = 1; }
+  bool cliInterruptPoll(void*) { return g_cliInterruptRequested != 0; }
+} // namespace
+#endif
 
 int run(const std::string& flags)
 {
@@ -40,10 +62,21 @@ int run(const std::string& flags)
       std::cout << configFingerprint(config) << '\n';
       return 0;
     }
-    InfomapWrapper(config).run();
+    InfomapWrapper im(config);
+#ifndef AS_LIB
+    std::signal(SIGINT, cliHandleInterrupt);
+    im.setInterruptHandler(&cliInterruptPoll);
+#endif
+    im.run();
   } catch (const CleanExit&) {
     // Help / version / json-parameters CLI flags requested a clean exit.
     return 0;
+#ifndef AS_LIB
+  } catch (const InterruptionError&) {
+    // Ctrl-C: cancelled cleanly at a checkpoint.
+    std::cerr << "\nInterrupted.\n";
+    return exitCodeValue(ExitCode::Interrupted);
+#endif
   } catch (const InfomapError& e) {
     std::cerr << "Error: " << e.what() << '\n';
     return exitCodeValue(e.code());

--- a/test/cpp/test_infomap_wrapper.cpp
+++ b/test/cpp/test_infomap_wrapper.cpp
@@ -140,6 +140,87 @@ double runSingleTrialFixtureWith(unsigned int seed, const std::string& extraFlag
   return im.codelength();
 }
 
+// Interrupt-handler callbacks (signature `bool(*)(void*)`): return true to
+// request cooperative cancellation of the current run.
+bool alwaysInterrupt(void*) { return true; }
+bool neverInterrupt(void*) { return false; }
+
+// Returns false for the first *(int*)data polls, then true — lets the run get
+// past the entry checkpoint so a later poll point is exercised.
+bool interruptAfter(void* data)
+{
+  auto* remaining = static_cast<int*>(data);
+  if (*remaining <= 0)
+    return true;
+  --*remaining;
+  return false;
+}
+
+TEST_CASE("Run throws InterruptionError when the handler requests cancellation [fast][core][lifecycle][crash]")
+{
+  InfomapWrapper im("--silent --seed 1 --num-trials 1 --no-file-output");
+  im.readInputData(infomap::test::repoPath("examples/networks/ninetriangles.net"));
+  im.setInterruptHandler(&alwaysInterrupt);
+
+  CHECK_THROWS_AS(im.run(), infomap::InterruptionError);
+}
+
+TEST_CASE("Interruption part-way through a run still aborts it [fast][core][lifecycle][crash]")
+{
+  InfomapWrapper im("--silent --seed 1 --num-trials 1 --no-file-output");
+  im.readInputData(infomap::test::repoPath("examples/networks/ninetriangles.net"));
+  int polls = 1; // pass the entry checkpoint, then cancel at the next one
+  im.setInterruptHandler(&interruptAfter, &polls);
+
+  CHECK_THROWS_AS(im.run(), infomap::InterruptionError);
+}
+
+TEST_CASE("A non-cancelling interrupt handler leaves the run unchanged [fast][core][lifecycle]")
+{
+  InfomapWrapper im(infomap::test::defaultFlags());
+  infomap::test::addEdgeFixtureLinks(im, "graphs/twotriangles_unweighted.edges");
+  im.setInterruptHandler(&neverInterrupt);
+
+  im.run();
+
+  infomap::test::checkRunSanity(im);
+  CHECK(im.numTopModules() == 2);
+  infomap::test::checkCanonicalPartition(im, { { 1, 2, 3 }, { 4, 5, 6 } });
+}
+
+TEST_CASE("requestInterrupt() aborts the run even when the handler returns false [fast][core][lifecycle][crash]")
+{
+  InfomapWrapper im("--silent --seed 1 --num-trials 1 --no-file-output");
+  im.readInputData(infomap::test::repoPath("examples/networks/ninetriangles.net"));
+  // The handler never returns true; it sets the cancel flag directly, proving
+  // the thread-safe flag path is observed independently of the callback return.
+  im.setInterruptHandler(
+      [](void* data) {
+        static_cast<InfomapWrapper*>(data)->requestInterrupt();
+        return false;
+      },
+      &im);
+
+  CHECK_THROWS_AS(im.run(), infomap::InterruptionError);
+}
+
+TEST_CASE("An interrupted instance runs cleanly after the handler is cleared [fast][core][lifecycle][crash]")
+{
+  InfomapWrapper im("--silent --seed 1 --num-trials 1 --no-file-output");
+  im.readInputData(infomap::test::repoPath("examples/networks/ninetriangles.net"));
+
+  int polls = 3; // get into the optimization phase before cancelling
+  im.setInterruptHandler(&interruptAfter, &polls);
+  CHECK_THROWS_AS(im.run(), infomap::InterruptionError);
+
+  // After clearing the handler the same instance must run to completion, proving
+  // the interrupted run left no corrupt state and the cancel flag was reset.
+  im.clearInterruptHandler();
+  im.run();
+  infomap::test::checkRunSanity(im);
+  CHECK(im.numTopModules() > 1);
+}
+
 TEST_CASE("Infomap partitions the unweighted two-triangle fixture into two modules [fast][core][lifecycle]")
 {
   InfomapWrapper im(infomap::test::defaultFlags());

--- a/test/cpp/test_infomap_wrapper.cpp
+++ b/test/cpp/test_infomap_wrapper.cpp
@@ -165,10 +165,8 @@ bool interruptAfter(void* data)
   return false;
 }
 
-// A network of `clusters` weakly-linked 4-cliques: big and modular enough that
-// the run builds a real hierarchy and spawns OpenMP tasks in recursivePartition,
-// so the in-task cancellation paths are actually exercised (ninetriangles is too
-// small for that).
+// `clusters` weakly-linked 4-cliques — big enough to build a hierarchy and spawn
+// OpenMP tasks, so the in-task cancellation paths are actually exercised.
 void buildClusteredNetwork(InfomapWrapper& im, unsigned int clusters)
 {
   for (unsigned int c = 0; c < clusters; ++c) {
@@ -203,11 +201,9 @@ TEST_CASE("The in-optimizer cancellation checkpoint is reached during a run [fas
   im.run();
 
   infomap::test::checkRunSanity(im);
-  // The owner-thread checkpoints outside optimization are exactly two for a
-  // single-trial run: run() entry and the per-trial loop. Anything beyond that
-  // must come from the optimizer core loop, so > 2 proves the in-optimizer poll
-  // fires. Guards against silently dropping it (which would drop count to 2 and
-  // leave mid-run cancellation untested) — see review finding F1.
+  // A single-trial run has exactly two non-optimizer checkpoints (run() entry +
+  // per-trial loop); > 2 proves the in-optimizer poll fires. Guards against
+  // dropping it (count would fall to 2, leaving mid-run cancellation untested).
   CHECK(polls > 2);
 }
 
@@ -246,12 +242,10 @@ TEST_CASE("requestInterrupt() aborts the run even when the handler returns false
   CHECK_THROWS_AS(im.run(), infomap::InterruptionError);
 }
 
-// Runs `seed-1 ninetriangles`, cancels inside the optimization phase, clears the
-// handler, and reruns to completion — returning the recovered result. NOTE we do
-// NOT compare against a *fresh* instance: the RNG is seeded once at construction
-// and not reset per run(), so an interrupted run advances it by a different
-// amount than a clean run, and a reused instance legitimately differs from a
-// fresh one on this RNG-sensitive network (that is not corruption).
+// Cancel inside optimization, clear the handler, rerun, return the result.
+// We do NOT compare against a *fresh* instance: the RNG is seeded once at
+// construction (not per run()), so a reused instance legitimately differs from a
+// fresh one here — that is RNG continuation, not corruption.
 std::pair<std::vector<std::vector<unsigned int>>, double> interruptThenRecover()
 {
   InfomapWrapper im("--silent --seed 1 --num-trials 1 --no-file-output");
@@ -268,10 +262,8 @@ std::pair<std::vector<std::vector<unsigned int>>, double> interruptThenRecover()
 
 TEST_CASE("An interrupted instance recovers to a sane, deterministic result [fast][core][lifecycle][crash]")
 {
-  // Two instances driven through the identical interrupt+clear+rerun sequence
-  // must produce the identical result: the interrupted run left no corrupt or
-  // nondeterministic state and the cancel flag was reset (F4). A sane recovered
-  // partition (>1 module, finite codelength) is checked via checkRunSanity.
+  // Identical interrupt+clear+rerun on two instances must give identical results:
+  // no corrupt/nondeterministic state left behind, flag reset (F4).
   const auto a = interruptThenRecover();
   const auto b = interruptThenRecover();
 
@@ -280,13 +272,10 @@ TEST_CASE("An interrupted instance recovers to a sane, deterministic result [fas
   CHECK(a.first.size() > 1);
 }
 
-// Cancelling a run from another thread while OpenMP workers are in flight must
-// never let an exception escape an OpenMP region (which would std::terminate),
-// and a cancelled run must surface as InterruptionError — never a generic
-// "Parallel trial failed" / wrong-type error (review finding F3). Both tests are
-// outcome-robust: completing the run (canceller lost the race) is also fine; the
-// only failures are a process terminate (we never reach the assertion) or the
-// wrong exception type.
+// Cancelling from another thread mid-run must never let an exception escape an
+// OpenMP region (std::terminate), and must surface as InterruptionError, not a
+// "Parallel trial failed" / wrong-type error (F3). Outcome-robust: completing
+// (canceller lost the race) is fine too; only terminate or wrong-type fail.
 TEST_CASE("Cancelling a --parallel-trials run never terminates and surfaces InterruptionError [fast][core][lifecycle][crash]")
 {
   InfomapWrapper im("--silent --seed 1 --num-trials 200 --parallel-trials --no-file-output");

--- a/test/cpp/test_infomap_wrapper.cpp
+++ b/test/cpp/test_infomap_wrapper.cpp
@@ -288,9 +288,12 @@ TEST_CASE("Cancelling a --parallel-trials run never terminates and surfaces Inte
   // chance the flag is set while the parallel-trial workers are running.
   im.setInterruptHandler([](void* d) { static_cast<std::atomic<bool>*>(d)->store(true); return false; }, &started);
   std::thread canceller([&] {
-    while (!started.load() && !done.load()) { }
-    while (!done.load())
+    while (!started.load() && !done.load())
+      std::this_thread::yield();
+    while (!done.load()) {
       im.requestInterrupt();
+      std::this_thread::yield();
+    }
   });
 
   std::string outcome;
@@ -320,9 +323,12 @@ TEST_CASE("Cancelling a recursive run from another thread never terminates [fast
   std::atomic<bool> done { false };
   im.setInterruptHandler([](void* d) { static_cast<std::atomic<bool>*>(d)->store(true); return false; }, &started);
   std::thread canceller([&] {
-    while (!started.load() && !done.load()) { }
-    while (!done.load())
+    while (!started.load() && !done.load())
+      std::this_thread::yield();
+    while (!done.load()) {
       im.requestInterrupt();
+      std::this_thread::yield();
+    }
   });
 
   std::string outcome;

--- a/test/cpp/test_infomap_wrapper.cpp
+++ b/test/cpp/test_infomap_wrapper.cpp
@@ -6,11 +6,13 @@
 
 #include "TestUtils.h"
 
+#include <atomic>
 #include <cstdio>
 #include <iostream>
 #include <set>
 #include <sstream>
 #include <string>
+#include <thread>
 #include <tuple>
 #include <vector>
 
@@ -145,6 +147,13 @@ double runSingleTrialFixtureWith(unsigned int seed, const std::string& extraFlag
 bool alwaysInterrupt(void*) { return true; }
 bool neverInterrupt(void*) { return false; }
 
+// Counts how many times the owner-thread checkpoint polled the handler.
+bool countPolls(void* data)
+{
+  ++*static_cast<int*>(data);
+  return false;
+}
+
 // Returns false for the first *(int*)data polls, then true — lets the run get
 // past the entry checkpoint so a later poll point is exercised.
 bool interruptAfter(void* data)
@@ -156,6 +165,25 @@ bool interruptAfter(void* data)
   return false;
 }
 
+// A network of `clusters` weakly-linked 4-cliques: big and modular enough that
+// the run builds a real hierarchy and spawns OpenMP tasks in recursivePartition,
+// so the in-task cancellation paths are actually exercised (ninetriangles is too
+// small for that).
+void buildClusteredNetwork(InfomapWrapper& im, unsigned int clusters)
+{
+  for (unsigned int c = 0; c < clusters; ++c) {
+    const unsigned int b = c * 4 + 1;
+    im.addLink(b, b + 1);
+    im.addLink(b, b + 2);
+    im.addLink(b, b + 3);
+    im.addLink(b + 1, b + 2);
+    im.addLink(b + 1, b + 3);
+    im.addLink(b + 2, b + 3);
+    if (c > 0)
+      im.addLink(b, b - 4);
+  }
+}
+
 TEST_CASE("Run throws InterruptionError when the handler requests cancellation [fast][core][lifecycle][crash]")
 {
   InfomapWrapper im("--silent --seed 1 --num-trials 1 --no-file-output");
@@ -165,27 +193,41 @@ TEST_CASE("Run throws InterruptionError when the handler requests cancellation [
   CHECK_THROWS_AS(im.run(), infomap::InterruptionError);
 }
 
-TEST_CASE("Interruption part-way through a run still aborts it [fast][core][lifecycle][crash]")
+TEST_CASE("The in-optimizer cancellation checkpoint is reached during a run [fast][core][lifecycle]")
 {
   InfomapWrapper im("--silent --seed 1 --num-trials 1 --no-file-output");
   im.readInputData(infomap::test::repoPath("examples/networks/ninetriangles.net"));
-  int polls = 1; // pass the entry checkpoint, then cancel at the next one
-  im.setInterruptHandler(&interruptAfter, &polls);
-
-  CHECK_THROWS_AS(im.run(), infomap::InterruptionError);
-}
-
-TEST_CASE("A non-cancelling interrupt handler leaves the run unchanged [fast][core][lifecycle]")
-{
-  InfomapWrapper im(infomap::test::defaultFlags());
-  infomap::test::addEdgeFixtureLinks(im, "graphs/twotriangles_unweighted.edges");
-  im.setInterruptHandler(&neverInterrupt);
+  int polls = 0;
+  im.setInterruptHandler(&countPolls, &polls);
 
   im.run();
 
   infomap::test::checkRunSanity(im);
-  CHECK(im.numTopModules() == 2);
-  infomap::test::checkCanonicalPartition(im, { { 1, 2, 3 }, { 4, 5, 6 } });
+  // The owner-thread checkpoints outside optimization are exactly two for a
+  // single-trial run: run() entry and the per-trial loop. Anything beyond that
+  // must come from the optimizer core loop, so > 2 proves the in-optimizer poll
+  // fires. Guards against silently dropping it (which would drop count to 2 and
+  // leave mid-run cancellation untested) — see review finding F1.
+  CHECK(polls > 2);
+}
+
+TEST_CASE("A non-cancelling handler produces the same result as a no-handler run [fast][core][lifecycle]")
+{
+  // Reference: no handler installed at all.
+  InfomapWrapper ref("--silent --seed 1 --num-trials 1 --no-file-output");
+  ref.readInputData(infomap::test::repoPath("examples/networks/ninetriangles.net"));
+  ref.run();
+
+  InfomapWrapper im("--silent --seed 1 --num-trials 1 --no-file-output");
+  im.readInputData(infomap::test::repoPath("examples/networks/ninetriangles.net"));
+  im.setInterruptHandler(&neverInterrupt);
+  im.run();
+
+  infomap::test::checkRunSanity(im);
+  // Installing a (non-cancelling) handler must not change the objective or the
+  // partition — the poll points are inert on the no-cancel path (F5).
+  CHECK(infomap::test::canonicalPartition(im.getModules()) == infomap::test::canonicalPartition(ref.getModules()));
+  CHECK(im.codelength() == doctest::Approx(ref.codelength()));
 }
 
 TEST_CASE("requestInterrupt() aborts the run even when the handler returns false [fast][core][lifecycle][crash]")
@@ -204,21 +246,112 @@ TEST_CASE("requestInterrupt() aborts the run even when the handler returns false
   CHECK_THROWS_AS(im.run(), infomap::InterruptionError);
 }
 
-TEST_CASE("An interrupted instance runs cleanly after the handler is cleared [fast][core][lifecycle][crash]")
+// Runs `seed-1 ninetriangles`, cancels inside the optimization phase, clears the
+// handler, and reruns to completion — returning the recovered result. NOTE we do
+// NOT compare against a *fresh* instance: the RNG is seeded once at construction
+// and not reset per run(), so an interrupted run advances it by a different
+// amount than a clean run, and a reused instance legitimately differs from a
+// fresh one on this RNG-sensitive network (that is not corruption).
+std::pair<std::vector<std::vector<unsigned int>>, double> interruptThenRecover()
 {
   InfomapWrapper im("--silent --seed 1 --num-trials 1 --no-file-output");
   im.readInputData(infomap::test::repoPath("examples/networks/ninetriangles.net"));
-
-  int polls = 3; // get into the optimization phase before cancelling
+  int polls = 3; // cancel inside the optimization phase
   im.setInterruptHandler(&interruptAfter, &polls);
   CHECK_THROWS_AS(im.run(), infomap::InterruptionError);
 
-  // After clearing the handler the same instance must run to completion, proving
-  // the interrupted run left no corrupt state and the cancel flag was reset.
   im.clearInterruptHandler();
   im.run();
   infomap::test::checkRunSanity(im);
-  CHECK(im.numTopModules() > 1);
+  return { infomap::test::canonicalPartition(im.getModules()), im.codelength() };
+}
+
+TEST_CASE("An interrupted instance recovers to a sane, deterministic result [fast][core][lifecycle][crash]")
+{
+  // Two instances driven through the identical interrupt+clear+rerun sequence
+  // must produce the identical result: the interrupted run left no corrupt or
+  // nondeterministic state and the cancel flag was reset (F4). A sane recovered
+  // partition (>1 module, finite codelength) is checked via checkRunSanity.
+  const auto a = interruptThenRecover();
+  const auto b = interruptThenRecover();
+
+  CHECK(a.first == b.first);
+  CHECK(a.second == doctest::Approx(b.second));
+  CHECK(a.first.size() > 1);
+}
+
+// Cancelling a run from another thread while OpenMP workers are in flight must
+// never let an exception escape an OpenMP region (which would std::terminate),
+// and a cancelled run must surface as InterruptionError — never a generic
+// "Parallel trial failed" / wrong-type error (review finding F3). Both tests are
+// outcome-robust: completing the run (canceller lost the race) is also fine; the
+// only failures are a process terminate (we never reach the assertion) or the
+// wrong exception type.
+TEST_CASE("Cancelling a --parallel-trials run never terminates and surfaces InterruptionError [fast][core][lifecycle][crash]")
+{
+  InfomapWrapper im("--silent --seed 1 --num-trials 200 --parallel-trials --no-file-output");
+  buildClusteredNetwork(im, 800);
+
+  std::atomic<bool> started { false };
+  std::atomic<bool> done { false };
+  // The handler only signals that the run is underway (never cancels), so the
+  // canceller waits until then before flipping the shared flag — maximising the
+  // chance the flag is set while the parallel-trial workers are running.
+  im.setInterruptHandler([](void* d) { static_cast<std::atomic<bool>*>(d)->store(true); return false; }, &started);
+  std::thread canceller([&] {
+    while (!started.load() && !done.load()) { }
+    while (!done.load())
+      im.requestInterrupt();
+  });
+
+  std::string outcome;
+  try {
+    im.run();
+    outcome = "completed";
+  } catch (const infomap::InterruptionError&) {
+    outcome = "interrupted";
+  } catch (const std::exception& e) {
+    outcome = std::string("wrong-type: ") + e.what();
+  }
+  done.store(true);
+  canceller.join();
+
+  // Completing (the canceller lost the race) or InterruptionError are both fine;
+  // a wrong-type exception fails, and a std::terminate would crash before here.
+  INFO("run outcome: " << outcome);
+  CHECK(outcome.rfind("wrong-type:", 0) != 0);
+}
+
+TEST_CASE("Cancelling a recursive run from another thread never terminates [fast][core][lifecycle][crash]")
+{
+  InfomapWrapper im("--silent --seed 1 --num-trials 1 --no-file-output");
+  buildClusteredNetwork(im, 1200);
+
+  std::atomic<bool> started { false };
+  std::atomic<bool> done { false };
+  im.setInterruptHandler([](void* d) { static_cast<std::atomic<bool>*>(d)->store(true); return false; }, &started);
+  std::thread canceller([&] {
+    while (!started.load() && !done.load()) { }
+    while (!done.load())
+      im.requestInterrupt();
+  });
+
+  std::string outcome;
+  try {
+    im.run();
+    outcome = "completed";
+  } catch (const infomap::InterruptionError&) {
+    outcome = "interrupted";
+  } catch (const std::exception& e) {
+    outcome = std::string("wrong-type: ") + e.what();
+  }
+  done.store(true);
+  canceller.join();
+
+  // Completing (the canceller lost the race) or InterruptionError are both fine;
+  // a wrong-type exception fails, and a std::terminate would crash before here.
+  INFO("run outcome: " << outcome);
+  CHECK(outcome.rfind("wrong-type:", 0) != 0);
 }
 
 TEST_CASE("Infomap partitions the unweighted two-triangle fixture into two modules [fast][core][lifecycle]")

--- a/test/python/test_interrupt.py
+++ b/test/python/test_interrupt.py
@@ -1,0 +1,71 @@
+"""Cooperative interruption of a running Infomap (issue #412).
+
+The C++ seam is covered by the native tests; here we verify the Python host
+bridge end to end: a real SIGINT delivered to a process running ``Infomap.run()``
+surfaces as ``KeyboardInterrupt`` promptly, instead of being queued until the
+(otherwise non-interruptible) C extension call returns.
+
+Signal delivery is POSIX-specific, so the delivery test is skipped on Windows;
+the bridge itself still compiles and runs there.
+"""
+
+import signal
+import subprocess
+import sys
+import time
+
+import pytest
+
+pytestmark = pytest.mark.fast
+
+
+# Builds a network large enough that the run is still going when the signal
+# arrives, then prints READY and runs many trials.
+_CHILD = """
+import sys, infomap
+im = infomap.Infomap("--silent --num-trials 1000 --no-file-output --seed 1")
+clusters = 1500
+for c in range(clusters):
+    base = c * 4
+    nodes = [base + i for i in range(4)]
+    for i in range(4):
+        for j in range(i + 1, 4):
+            im.add_link(nodes[i], nodes[j])
+    if c > 0:
+        im.add_link(base, base - 4)
+print("READY", flush=True)
+try:
+    im.run()
+    print("COMPLETED")
+except KeyboardInterrupt:
+    print("KEYBOARDINTERRUPT")
+    sys.exit(42)
+except BaseException as exc:  # noqa: BLE001
+    print("OTHER", type(exc).__name__)
+    sys.exit(43)
+"""
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX SIGINT delivery")
+def test_sigint_raises_keyboardinterrupt_during_run():
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _CHILD],
+        stdout=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    try:
+        assert proc.stdout.readline().strip() == "READY"
+        time.sleep(1.0)  # let the run get well underway
+        signaled_at = time.time()
+        proc.send_signal(signal.SIGINT)
+        out, _ = proc.communicate(timeout=30)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.communicate()
+
+    assert "KEYBOARDINTERRUPT" in out, out
+    assert proc.returncode == 42, out
+    # The run should stop promptly after the signal, not run all 1000 trials.
+    assert time.time() - signaled_at < 15

--- a/test/python/test_interrupt.py
+++ b/test/python/test_interrupt.py
@@ -1,12 +1,19 @@
 """Cooperative interruption of a running Infomap (issue #412).
 
 The C++ seam is covered by the native tests; here we verify the Python host
-bridge end to end: a real SIGINT delivered to a process running ``Infomap.run()``
-surfaces as ``KeyboardInterrupt`` promptly, instead of being queued until the
-(otherwise non-interruptible) C extension call returns.
+bridges end to end with a REAL SIGINT delivered to a subprocess:
 
-Signal delivery is POSIX-specific, so the delivery test is skipped on Windows;
-the bridge itself still compiles and runs there.
+- the OO API (``Infomap().run()``) surfaces ``KeyboardInterrupt`` mid-run,
+  instead of queueing it until the (otherwise non-interruptible) C call returns;
+- the pip console-script entry (``infomap:main``) exits 130 with "Interrupted.".
+
+Signal delivery is POSIX-specific, so these are skipped on Windows; the bridges
+themselves still compile and run there.
+
+Robustness: the child runs an effectively unbounded number of trials, so it
+cannot finish before the signal — a "completed" outcome therefore means the
+interrupt was IGNORED (a real failure), never just "the machine was fast".
+A broken interrupt instead shows up as the 30s communicate() timeout.
 """
 
 import signal
@@ -18,21 +25,31 @@ import pytest
 
 pytestmark = pytest.mark.fast
 
+# Large trial cap so the run is still going when the signal lands; a working
+# interrupt stops it in well under a second regardless of the cap.
+_TRIALS = "100000"
 
-# Builds a network large enough that the run is still going when the signal
-# arrives, then prints READY and runs many trials.
-_CHILD = """
+
+def _write_clustered_network(path, clusters=1500):
+    """A network of `clusters` weakly-linked 4-cliques (link-list format)."""
+    lines = []
+    for c in range(clusters):
+        base = c * 4 + 1
+        nodes = [base + i for i in range(4)]
+        for i in range(4):
+            for j in range(i + 1, 4):
+                lines.append(f"{nodes[i]} {nodes[j]}")
+        if c > 0:
+            lines.append(f"{base} {base - 4}")
+    path.write_text("\n".join(lines) + "\n")
+
+
+# Reads the network file in argv[1], prints READY, then runs. Exit codes:
+# 42 = KeyboardInterrupt (expected), 0 = completed (interrupt ignored), 43 = other.
+_OO_CHILD = """
 import sys, infomap
-im = infomap.Infomap("--silent --num-trials 1000 --no-file-output --seed 1")
-clusters = 1500
-for c in range(clusters):
-    base = c * 4
-    nodes = [base + i for i in range(4)]
-    for i in range(4):
-        for j in range(i + 1, 4):
-            im.add_link(nodes[i], nodes[j])
-    if c > 0:
-        im.add_link(base, base - 4)
+im = infomap.Infomap("--silent --num-trials %s --no-file-output --seed 1")
+im.read_file(sys.argv[1])
 print("READY", flush=True)
 try:
     im.run()
@@ -43,29 +60,68 @@ except KeyboardInterrupt:
 except BaseException as exc:  # noqa: BLE001
     print("OTHER", type(exc).__name__)
     sys.exit(43)
-"""
+""" % _TRIALS
+
+# Drives the pip console-script entry (infomap:main) without needing it on PATH.
+_CLI_CHILD = "import sys; from infomap import main; sys.exit(main())"
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="POSIX SIGINT delivery")
-def test_sigint_raises_keyboardinterrupt_during_run():
+def _run_until_ready_then_sigint(argv, *, want_ready):
+    """Launch argv, optionally wait for a READY line, send SIGINT ~1s in, return
+    (returncode, stdout, stderr, seconds_after_signal)."""
     proc = subprocess.Popen(
-        [sys.executable, "-c", _CHILD],
+        argv,
         stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
         bufsize=1,
     )
+    out = ""
     try:
-        assert proc.stdout.readline().strip() == "READY"
+        if want_ready:
+            assert proc.stdout.readline().strip() == "READY"
+        else:
+            time.sleep(0.3)  # let process startup + network read finish
         time.sleep(1.0)  # let the run get well underway
         signaled_at = time.time()
         proc.send_signal(signal.SIGINT)
-        out, _ = proc.communicate(timeout=30)
+        out, err = proc.communicate(timeout=30)
     finally:
         if proc.poll() is None:
             proc.kill()
             proc.communicate()
+    return proc.returncode, out, err, time.time() - signaled_at
 
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX SIGINT delivery")
+def test_sigint_raises_keyboardinterrupt_during_run(tmp_path):
+    net = tmp_path / "net.txt"
+    _write_clustered_network(net)
+
+    code, out, _err, elapsed = _run_until_ready_then_sigint(
+        [sys.executable, "-c", _OO_CHILD, str(net)], want_ready=True
+    )
+
+    assert code != 0, f"run completed without raising — interrupt was ignored ({out!r})"
+    assert code != 43, f"run raised the wrong exception type ({out!r})"
+    assert code == 42, (code, out)
     assert "KEYBOARDINTERRUPT" in out, out
-    assert proc.returncode == 42, out
-    # The run should stop promptly after the signal, not run all 1000 trials.
-    assert time.time() - signaled_at < 15
+    assert elapsed < 20, f"took {elapsed:.1f}s to unwind after the signal"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX SIGINT delivery")
+def test_cli_main_exits_130_on_sigint(tmp_path):
+    net = tmp_path / "net.txt"
+    _write_clustered_network(net)
+
+    code, _out, err, elapsed = _run_until_ready_then_sigint(
+        [sys.executable, "-c", _CLI_CHILD, str(net), str(tmp_path / "out"), "--silent", "-N", _TRIALS, "--seed", "1"],
+        want_ready=False,
+    )
+
+    # main() catches the propagated KeyboardInterrupt and exits like the native
+    # CLI: a clean message and 130 (128 + SIGINT), not a hard signal death (-2)
+    # and not 0 (which would mean the interrupt was ignored).
+    assert code == 130, f"expected 130 (clean interrupt), got {code}; stderr={err!r}"
+    assert "Interrupted." in err, err
+    assert elapsed < 20, f"took {elapsed:.1f}s to unwind after the signal"


### PR DESCRIPTION
Closes #412.

Gives embedding hosts a supported way to stop a long Infomap run cleanly instead of killing the process, and wires **all four front-ends** (native CLI, pip console script, Python OO API, R) to it. Redoes the closed #426 experiment without its performance tradeoff.

## The C++ seam

#426 invoked the host callback from inside the optimizer/flow loops (OpenMP worker threads), which forced it to **disable OpenMP whenever a handler was installed**. This PR separates cancellation **state** from the host **callback**:

- A shared `std::atomic<bool>` flag is observed by every thread — main, sub-Infomaps in the OpenMP **task graph**, and `--parallel-trials` workers — wired down via `inheritRuntimeContext`.
- The host callback (`bool(*)(void*)`) runs **only on the owner thread** (stamped in `run(Network&)`, `std::thread::id`-guarded). Workers only read the flag.
- Exceptions never cross an OpenMP region: inside tasks/parallel sweeps the code bails on the flag without throwing; the owner/trial thread throws `InterruptionError` after the region. **Parallelism stays on.**

API on `InfomapBase` (native/embedder only, `%ignore`d in SWIG so binding APIs are unchanged): `setInterruptHandler`, `clearInterruptHandler`, `hasInterruptHandler`, `requestInterrupt` (thread-safe push), `interruptRequested`.

## Front-end bridges

- **R**: handler runs `R_CheckUserInterrupt` inside `R_ToplevelExec` (catches the longjmp so C++ destructors run). Surfaces as a regular R error — handle with `tryCatch(error=)`, not `interrupt=` (documented).
- **Python OO** (`Infomap().run()`): `PyErr_CheckSignals` poll; a pending `KeyboardInterrupt` is propagated, not masked.
- **Native CLI**: SIGINT sets a `volatile sig_atomic_t` flag (the async-signal-safe choice under the C++14 core build); clean cancel → "Interrupted." + exit 130.
- **pip console script** (`infomap:main`): the AS_LIB free function installs the Python poll via a process-global; `main()` exits 130 with "Interrupted.".

## Embedding (igraph and other native C/C++ hosts)

The same public C++ seam serves external embedders with **no further infomap-side code** — it's exactly what #412 was opened for (igraph reducing its vendored-Infomap patch set). The integration is a few lines in the host's own Infomap shim. For igraph:

```cpp
// in igraph's vendored Infomap shim (C++):
im.setInterruptHandler(
    [](void* data) { return igraph_allow_interruption(data) != IGRAPH_SUCCESS; },
    /*userData=*/ctx);
try {
    im.run();
} catch (const infomap::InterruptionError&) {
    return IGRAPH_INTERRUPTED;   // igraph's error code
}
```

The callback runs on the owner thread (the thread that called `run()`), so invoking the host's interruption check there is safe — the same pattern as R's `R_ToplevelExec(R_CheckUserInterrupt)` and Python's `PyErr_CheckSignals`. This code lives in igraph's repo, not here.

## Scope / limitations

- **Flow calculation** is `noexcept` and left non-interruptible; the optimization phase dominates long runs.
- Under `--parallel-trials` the main thread is inside the OpenMP region, so a **poll-based** Ctrl-C is seen at region boundaries; **push-based** `requestInterrupt()` from another thread aborts promptly.
- No build's C++ standard was changed: core/CLI/JS stay **C++14**, the R package **C++17**.

## Self-review

Four independent reviewers audited separate slices (core concurrency, SWIG bridges, CLI/signal, tests). The core design held up — no exception escapes an OpenMP region, the callback is confined to the owner thread, the shared flag is wired correctly, C++14-clean. Findings fixed in this PR:

- **CLI re-entrancy bug**: the native SIGINT flag was process-global and never reset, so a Ctrl-C from an earlier `run()` could make the next run abort spuriously — now reset before installing the poll.
- **Test gaps that let regressions slip silently** (the reason this is now well-covered): the old "mid-run" test actually cancelled *before* the optimizer, so dropping the in-optimizer poll wouldn't fail; and nothing guarded the catastrophic throw-across-OpenMP / `--parallel-trials` paths. Added: an in-optimizer-checkpoint assertion, two cross-thread no-terminate/correct-type guards, a no-handler bit-for-bit invariance test, and a deterministic-recovery test.
- One investigated-and-dismissed "bug": a reused instance differs from a fresh one after an interrupt — that's expected RNG continuation (seeded once at construction), not corruption.

## Verification

- `make test-native` — 14/14 C++ test binaries pass (incl. the new concurrency guards, stable across repeated runs).
- **Python**: 30 tests pass incl. real-SIGINT subprocess tests for both the OO API and the console script (timing-robust; skipped on Windows).
- **R**: 271 testthat pass with the bridge active on every run; a real SIGINT stops a running `Rscript` in ~0.1 s.
- **CLI**: real SIGINT → exit 130 + "Interrupted." + no partial output; normal runs exit 0.
- `make test-{python,r}-swig-freshness`, `make test-binding-options-freshness` — fresh; binding public APIs provably unchanged. `clang-format` — no new `src/` violations.
