### PR TITLE
feat(js): add Node.js build for testing and JS pipeline

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ Infomap
 
 Infomap is a network clustering algorithm based on the `Map equation`_.
 This repository contains the native CLI, the Python package, the R package,
-the JavaScript web worker, the Docker images, the tutorial notebooks, and the
-source for the published Python documentation.
+the JavaScript browser worker and Node.js package, the Docker images, the
+tutorial notebooks, and the source for the published Python documentation.
 
 Start with `mapequation.org/infomap/`_ for the user guide, the
 `Infomap Python API`_ for Python examples and tutorial notebooks, and
@@ -160,11 +160,33 @@ standard completion directories.
 JavaScript package
 ^^^^^^^^^^^^^^^^^^
 
-The browser worker package is published on `NPM`_:
+The package is published on `NPM`_ and provides a browser web worker, a Node.js
+module, and an ``infomap`` command line tool:
 
 .. code-block:: bash
 
     npm install @mapequation/infomap
+
+Quick start in Node.js with the ``@mapequation/infomap/node`` entry point:
+
+.. code-block:: javascript
+
+    import { run } from "@mapequation/infomap/node";
+
+    const network = "0 1\n0 2\n0 3\n1 2\n3 4\n3 5\n4 5";
+    const result = await run(network, { args: ["-o", "tree,json", "-2"] });
+
+    console.log(result.json.codelength);
+    console.log(result.tree);
+
+Installing the package also provides an ``infomap`` command that behaves like
+the native binary:
+
+.. code-block:: bash
+
+    npx @mapequation/infomap network.net . --tree
+
+Browser worker and React usage are documented on the `NPM`_ package page.
 
 .. _NPM: https://www.npmjs.com/package/@mapequation/infomap
 

--- a/interfaces/js/README.md
+++ b/interfaces/js/README.md
@@ -3,8 +3,9 @@
 
 # @mapequation/infomap
 
-`@mapequation/infomap` packages Infomap as a browser web worker built with
-Emscripten.
+`@mapequation/infomap` packages Infomap, compiled to WebAssembly with
+Emscripten. It ships a browser web worker, a Node.js module
+(`@mapequation/infomap/node`), and an `infomap` command line tool.
 
 Infomap is a network clustering algorithm based on the
 [Map equation](https://www.mapequation.org/publications.html#Rosvall-Axelsson-Bergstrom-2009-Map-equation).
@@ -117,9 +118,56 @@ With JSDelivr, the package is available as `window.infomap.default`.
 </html>
 ```
 
+## Use in Node.js
+
+The `@mapequation/infomap/node` entrypoint runs Infomap in Node.js. It exposes
+an async `run(network, options)` that resolves to the output files, keyed by
+format (the default `@mapequation/infomap` entrypoint targets the browser and
+relies on worker APIs that are unavailable in Node).
+
+```js
+import { run } from "@mapequation/infomap/node";
+
+const network = `#source target
+0 1
+0 2
+0 3
+1 2
+3 4
+3 5
+4 5`;
+
+const result = await run(network, { args: ["-o", "tree,json", "-2"] });
+
+console.log(result.json.codelength);
+console.log(result.tree); // .tree file contents as a string
+```
+
+`options.args` accepts a string or an array of Infomap CLI options, and the
+result contains only the formats Infomap produced. The network is processed in
+memory and Infomap's console output is suppressed. The same entrypoint works
+with CommonJS:
+
+```js
+const { run } = require("@mapequation/infomap/node");
+```
+
+## Command line
+
+Installing the package provides an `infomap` command that behaves like the
+native binary, reading and writing real files (`network_file out_directory
+[options]`):
+
+```bash
+npx @mapequation/infomap network.net . --tree --clu
+npx @mapequation/infomap --help
+```
+
 ## Package notes
 
 - `@mapequation/infomap/react` is the supported React entrypoint.
+- `@mapequation/infomap/node` is the Node.js entrypoint; the default
+  `@mapequation/infomap` entrypoint is browser-only.
 
 ## More information
 

--- a/interfaces/js/rollup.config.mjs
+++ b/interfaces/js/rollup.config.mjs
@@ -44,7 +44,13 @@ const packageEntries = {
   network: path.join(sourceRoot, "network.ts"),
   react: path.join(sourceRoot, "react.ts"),
   result: path.join(sourceRoot, "result.ts"),
+  node: path.join(sourceRoot, "node.ts"),
 };
+
+// The Emscripten Node artifacts (copied into the package by
+// prepare_npm_package.py) stay external so node.js/cli.js import them at runtime
+// rather than inlining the wasm twice.
+const external = ["react", /infomap\.(node|cli)\.mjs$/];
 
 const basePlugins = [
   workerSourcePlugin(),
@@ -70,7 +76,7 @@ export default [
       format: "es",
       sourcemap: true,
     },
-    external: ["react"],
+    external,
     plugins: basePlugins,
   },
   {
@@ -78,11 +84,29 @@ export default [
     output: {
       dir: outputDir,
       entryFileNames: "[name].cjs",
+      // Shared chunks must also be .cjs: a .js chunk holding CommonJS code can't
+      // be require()'d in this "type": "module" package (Node treats .js as ESM).
+      chunkFileNames: "[name]-[hash].cjs",
       format: "cjs",
       exports: "named",
       sourcemap: true,
+      // Keep `await import("./infomap.node.mjs")` as a real dynamic import so the
+      // CommonJS build can load the ES-module artifact instead of require()'ing it.
+      dynamicImportInCjs: true,
     },
-    external: ["react"],
+    external,
+    plugins: basePlugins,
+  },
+  {
+    // `infomap` bin: ESM only, with a shebang. Backed by the NODERAWFS artifact.
+    input: path.join(sourceRoot, "cli.ts"),
+    output: {
+      file: path.join(outputDir, "cli.js"),
+      format: "es",
+      banner: "#!/usr/bin/env node",
+      sourcemap: true,
+    },
+    external,
     plugins: basePlugins,
   },
   {

--- a/interfaces/js/scripts/verify-package.mjs
+++ b/interfaces/js/scripts/verify-package.mjs
@@ -17,9 +17,15 @@ for (const file of [
   "arguments.js",
   "filetypes.js",
   "network.js",
+  "node.js",
+  "node.cjs",
+  "cli.js",
+  "infomap.node.mjs",
+  "infomap.cli.mjs",
   "index.d.ts",
   "react.d.ts",
   "result.d.ts",
+  "node.d.ts",
   "package.json",
 ]) {
   assert.ok(

--- a/interfaces/js/src/cli.ts
+++ b/interfaces/js/src/cli.ts
@@ -1,0 +1,20 @@
+// `infomap` bin, published as the package's bin entry. Backed by the NODERAWFS
+// Emscripten build, it forwards process arguments straight to main(), so it
+// behaves like the native Infomap binary on real files:
+//
+//   npx @mapequation/infomap network.net . --tree
+import createInfomapModule from "./infomap.cli.mjs";
+
+const Module = await createInfomapModule({ noInitialRun: true });
+
+try {
+  const status = Module.callMain(process.argv.slice(2));
+  process.exit(typeof status === "number" ? status : 0);
+} catch (error) {
+  // Emscripten throws an ExitStatus object when the program calls exit().
+  if (error && typeof error === "object" && "status" in error) {
+    process.exit(Number((error as { status: unknown }).status) || 0);
+  }
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/interfaces/js/src/globals.d.ts
+++ b/interfaces/js/src/globals.d.ts
@@ -2,3 +2,39 @@ declare module "*.worker.js" {
   const source: string;
   export default source;
 }
+
+// Minimal surface of the Emscripten MODULARIZE factory emitted by
+// `make build-node` (build/js/infomap.node.mjs and infomap.cli.mjs). The wasm is
+// inlined (SINGLE_FILE), main() is driven via callMain, and FS is the in-memory
+// filesystem used to stage networks and read results for the library build.
+interface InfomapEmscriptenFS {
+  mkdir(path: string): void;
+  writeFile(path: string, data: string | ArrayBufferView): void;
+  readFile(path: string, options: { encoding: "utf8" }): string;
+  readdir(path: string): string[];
+}
+
+interface InfomapEmscriptenModule {
+  callMain(args: string[]): number | undefined;
+  FS: InfomapEmscriptenFS;
+}
+
+interface InfomapModuleOptions {
+  noInitialRun?: boolean;
+  print?: (line: string) => void;
+  printErr?: (line: string) => void;
+}
+
+type InfomapModuleFactory = (
+  options?: InfomapModuleOptions,
+) => Promise<InfomapEmscriptenModule>;
+
+declare module "*.node.mjs" {
+  const createModule: InfomapModuleFactory;
+  export default createModule;
+}
+
+declare module "*.cli.mjs" {
+  const createModule: InfomapModuleFactory;
+  export default createModule;
+}

--- a/interfaces/js/src/node.ts
+++ b/interfaces/js/src/node.ts
@@ -1,0 +1,129 @@
+// Programmatic Node.js entry point, published as `@mapequation/infomap/node`.
+//
+// This mirrors how the Python package ships a programmatic module alongside a
+// bundled binary: `run()` here is the module, the `infomap` bin (cli.ts) is the
+// binary. Both are backed by Emscripten builds of the same C++ engine.
+//
+//   import { run } from "@mapequation/infomap/node";
+//   const result = await run(network, { args: ["-o", "tree,json", "-2"] });
+//   console.log(result.json?.codelength, result.tree);
+//
+// The library artifact uses an in-memory filesystem, so networks never touch
+// disk and Infomap's output is captured rather than printed. The result is keyed
+// exactly like the browser worker package (clu, tree, ftree, json, ...) and
+// contains only the formats Infomap produced.
+import outputFormatsManifest from "../generated/output-formats.json";
+import type { Result } from "./index";
+
+export type { Result };
+export type { Tree, StateTree, Module, Header } from "./index";
+
+export interface RunOptions {
+  /** Virtual input filename; its basename also names the outputs. */
+  filename?: string;
+  /** Extra Infomap CLI options, as a string or pre-split array. */
+  args?: string | string[];
+  /** Override the output basename (passed as --out-name). */
+  outName?: string;
+}
+
+const formatByKey = new Map(
+  outputFormatsManifest.formats
+    .flatMap((format) => format.files)
+    .map((file) => [file.key, file] as const),
+);
+
+const resultFiles = outputFormatsManifest.resultOrder.map((key) => {
+  const format = formatByKey.get(key);
+  if (!format) {
+    throw new Error(`Missing output format metadata for ${key}`);
+  }
+  return { key, suffix: format.suffix, extension: format.extension };
+});
+
+function basenameWithoutExtension(filename: string) {
+  return filename.replace(/\.[^./\\]+$/, "");
+}
+
+function exitStatusCode(error: unknown) {
+  if (error && typeof error === "object" && "status" in error) {
+    return Number((error as { status: unknown }).status) || 0;
+  }
+  return null;
+}
+
+/**
+ * Run Infomap on an in-memory network string and return the output files.
+ *
+ * Infomap's progress is captured (not printed); on a non-zero exit its stderr is
+ * included in the thrown error. Pass `--silent` in `args` to quiet the engine.
+ */
+export async function run(
+  network: string,
+  options: RunOptions = {},
+): Promise<Result> {
+  if (typeof network !== "string") {
+    throw new TypeError("run(network, options): network must be a string");
+  }
+
+  const { filename = "network.net", args = [], outName } = options;
+  const extraArgs =
+    typeof args === "string" ? args.split(/\s+/).filter(Boolean) : [...args];
+  const base = outName ?? basenameWithoutExtension(filename);
+  if (outName) {
+    extraArgs.push("--out-name", outName);
+  }
+
+  const { default: createInfomapModule } = await import("./infomap.node.mjs");
+
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const Module = await createInfomapModule({
+    noInitialRun: true,
+    print: (line) => {
+      stdout.push(line);
+    },
+    printErr: (line) => {
+      stderr.push(line);
+    },
+  });
+
+  const workDir = "/work";
+  Module.FS.mkdir(workDir);
+  const inputPath = `${workDir}/${filename}`;
+  Module.FS.writeFile(inputPath, network);
+
+  let status = 0;
+  try {
+    const returned = Module.callMain([inputPath, workDir, ...extraArgs]);
+    status = typeof returned === "number" ? returned : 0;
+  } catch (error) {
+    const code = exitStatusCode(error);
+    if (code === null) {
+      throw error;
+    }
+    status = code;
+  }
+
+  if (status !== 0) {
+    throw new Error(
+      `Infomap exited with status ${status}\n${stderr.join("\n")}`,
+    );
+  }
+
+  const result: Result = {};
+  for (const file of resultFiles) {
+    const outputPath = `${workDir}/${base}${file.suffix}.${file.extension}`;
+    let content: string;
+    try {
+      content = Module.FS.readFile(outputPath, { encoding: "utf8" });
+    } catch {
+      continue;
+    }
+    (result as Record<string, unknown>)[file.key] =
+      file.extension === "json" ? JSON.parse(content) : content;
+  }
+  return result;
+}
+
+export default run;

--- a/interfaces/js/test/node/test-node.mjs
+++ b/interfaces/js/test/node/test-node.mjs
@@ -1,0 +1,83 @@
+// Fast smoke test for the Emscripten Node artifacts (`make build-node`),
+// exercising both at the raw module level before the heavier npm package build
+// (the packaged ./node API and `infomap` bin are verified by `make test-js`):
+//
+//   build/js/infomap.node.mjs  MEMFS library  -> in-memory run, capturable output
+//   build/js/infomap.cli.mjs   NODERAWFS bin   -> reads/writes real files
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import createCliModule from "../../../../build/js/infomap.cli.mjs";
+import createLibModule from "../../../../build/js/infomap.node.mjs";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../..",
+);
+const network = fs.readFileSync(
+  path.join(repoRoot, "examples/networks/twotriangles.net"),
+  "utf8",
+);
+
+// 1. Library artifact (MEMFS): stage in memory, run, read results back, and
+//    confirm Infomap's output is captured rather than printed.
+{
+  const stdout = [];
+  const Module = await createLibModule({
+    noInitialRun: true,
+    print: (line) => stdout.push(line),
+    printErr: (line) => stdout.push(line),
+  });
+  Module.FS.mkdir("/work");
+  Module.FS.writeFile("/work/network.net", network);
+  const status = Module.callMain([
+    "/work/network.net",
+    "/work",
+    "-o",
+    "tree,json",
+    "-2",
+  ]);
+  assert.ok(
+    status === 0 || status === undefined,
+    `lib artifact exited with status ${status}`,
+  );
+  const tree = Module.FS.readFile("/work/network.tree", { encoding: "utf8" });
+  const json = JSON.parse(
+    Module.FS.readFile("/work/network.json", { encoding: "utf8" }),
+  );
+  assert.ok(tree.length > 0, "lib artifact produced an empty tree");
+  assert.ok(
+    Array.isArray(json.nodes) && json.nodes.length > 0,
+    "lib json nodes",
+  );
+  assert.ok(stdout.length > 0, "lib artifact output should be capturable");
+  console.log(
+    `✓ Library artifact (MEMFS) ran in memory (${json.nodes.length} nodes, codelength ${json.codelength})`,
+  );
+}
+
+// 2. Bin artifact (NODERAWFS): write to a real directory like the native CLI.
+{
+  const outDir = fs.mkdtempSync(path.join(os.tmpdir(), "infomap-node-cli-"));
+  try {
+    const inputPath = path.join(outDir, "twotriangles.net");
+    fs.writeFileSync(inputPath, network);
+    const Module = await createCliModule({ noInitialRun: true });
+    const status = Module.callMain([inputPath, outDir, "--tree", "--clu"]);
+    assert.ok(
+      status === 0 || status === undefined,
+      `cli artifact exited with status ${status}`,
+    );
+    const tree = path.join(outDir, "twotriangles.tree");
+    const clu = path.join(outDir, "twotriangles.clu");
+    assert.ok(fs.existsSync(tree) && fs.statSync(tree).size > 0, "cli .tree");
+    assert.ok(fs.existsSync(clu), "cli .clu");
+    console.log("✓ Bin artifact (NODERAWFS) wrote twotriangles.tree and .clu");
+  } finally {
+    fs.rmSync(outDir, { recursive: true, force: true });
+  }
+}
+
+console.log("test-node: all checks passed");

--- a/interfaces/js/test/package/consumer.ts
+++ b/interfaces/js/test/package/consumer.ts
@@ -1,6 +1,7 @@
 import Infomap from "@mapequation/infomap";
 import type { Arguments } from "@mapequation/infomap/arguments";
 import type { FileTypes } from "@mapequation/infomap/filetypes";
+import { run } from "@mapequation/infomap/node";
 import { useInfomap } from "@mapequation/infomap/react";
 import { getResultFiles, getResultMetadata } from "@mapequation/infomap/result";
 
@@ -10,6 +11,7 @@ const files: FileTypes = [];
 void args;
 void files;
 void Infomap;
+void run;
 void useInfomap(args, { collectOutput: true }).outputText;
 void getResultFiles;
 void getResultMetadata;

--- a/interfaces/js/test/package/runtime-check.mjs
+++ b/interfaces/js/test/package/runtime-check.mjs
@@ -1,19 +1,25 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { createRequire } from "node:module";
 
 const packageDir = path.resolve("dist/npm/unpacked/package");
 const esmEntry = pathToFileURL(path.join(packageDir, "index.js")).href;
 const reactEntry = pathToFileURL(path.join(packageDir, "react.js")).href;
 const resultEntry = pathToFileURL(path.join(packageDir, "result.js")).href;
+const nodeEntry = pathToFileURL(path.join(packageDir, "node.js")).href;
 const require = createRequire(import.meta.url);
 
 const esmModule = await import(esmEntry);
 const reactModule = await import(reactEntry);
 const resultModule = await import(resultEntry);
+const nodeModule = await import(nodeEntry);
 const cjsModule = require(path.join(packageDir, "index.cjs"));
 const resultCjsModule = require(path.join(packageDir, "result.cjs"));
+const nodeCjsModule = require(path.join(packageDir, "node.cjs"));
 
 assert.equal(typeof esmModule.default, "function");
 assert.equal(typeof cjsModule.default, "function");
@@ -21,3 +27,38 @@ assert.equal(typeof reactModule.useInfomap, "function");
 assert.equal(typeof resultModule.getResultFiles, "function");
 assert.equal(typeof resultCjsModule.getResultFiles, "function");
 assert.equal(esmModule.default.__version__, cjsModule.default.__version__);
+assert.equal(typeof nodeModule.run, "function");
+assert.equal(typeof nodeCjsModule.run, "function");
+
+// Exercise the Node library (ESM and CJS) end to end against the real wasm.
+const network = "*Vertices 4\n*Edges\n1 2\n2 3\n3 1\n3 4\n";
+for (const { label, run } of [
+  { label: "esm", run: nodeModule.run },
+  { label: "cjs", run: nodeCjsModule.run },
+]) {
+  const result = await run(network, { args: ["-o", "tree,json", "-2"] });
+  assert.equal(typeof result.tree, "string", `${label} run produced no tree`);
+  assert.ok(result.tree.length > 0, `${label} run tree is empty`);
+  assert.ok(
+    result.json &&
+      Array.isArray(result.json.nodes) &&
+      result.json.nodes.length > 0,
+    `${label} run produced no json nodes`,
+  );
+}
+
+// Exercise the `infomap` bin on real files, like the native binary.
+const binPath = path.join(packageDir, "cli.js");
+const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "infomap-bin-check-"));
+try {
+  const inputPath = path.join(binDir, "network.net");
+  fs.writeFileSync(inputPath, network);
+  execFileSync(process.execPath, [binPath, inputPath, binDir, "--tree"], {
+    stdio: "inherit",
+  });
+  const treePath = path.join(binDir, "network.tree");
+  assert.ok(fs.existsSync(treePath), "bin did not produce network.tree");
+  assert.ok(fs.statSync(treePath).size > 0, "bin network.tree is empty");
+} finally {
+  fs.rmSync(binDir, { recursive: true, force: true });
+}

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -137,6 +137,7 @@ help:
 		"  build-binding-options Regenerate Python, R, and TypeScript option APIs from C++ metadata." \
 		"  build-js-metadata     Refresh the tracked JS parameter metadata." \
 		"  build-js              Build the JS worker bundle and npm package assets from tracked metadata." \
+		"  build-node            Build the Emscripten Node module (CLI + programmatic) into build/js/." \
 		"  build-docs            Build the Python docs site into docs/ (untracked output)." \
 		"" \
 		"Test" \
@@ -155,6 +156,7 @@ help:
 		"  test-binding-options-freshness Verify tracked binding option APIs are current." \
 		"  test-js-metadata      Regenerate JS metadata in a temp dir and verify tracked files are current." \
 		"  test-js               Run JS lint/typecheck/unit/browser/package verification for the built npm package." \
+		"  test-node             Build the Node module and smoke-test its CLI and programmatic API." \
 		"  test-fast             Run the fast native + Python feedback suite." \
 		"  test-sanitizers       Run the C++ test suite under ASan/UBSan." \
 		"  bench-native          Run the native benchmark and memory baseline harness." \
@@ -199,6 +201,7 @@ help:
 		"  make build-binding-options test-binding-options-freshness" \
 		"  make build-js-metadata test-js-metadata" \
 		"  make build-js test-js" \
+		"  make build-node test-node" \
 		"  make build-docs"
 
 build-binding-options: build-native

--- a/mk/js.mk
+++ b/mk/js.mk
@@ -1,5 +1,13 @@
 WORKER_FILENAME := infomap.worker.js
 JS_WORKER_TARGET := build/js/$(WORKER_FILENAME)
+# Node builds: a MEMFS library artifact (in-memory, quiet) backs the
+# @mapequation/infomap/node API, and a NODERAWFS artifact (real files) backs the
+# `infomap` bin. Both are MODULARIZE'd ES modules with the wasm inlined
+# (SINGLE_FILE) so each ships as a single self-contained file.
+JS_NODE_TARGET := build/js/infomap.node.mjs
+JS_CLI_TARGET := build/js/infomap.cli.mjs
+JS_NODE_TEST := interfaces/js/test/node/test-node.mjs
+EMXX_NODE_FLAGS := -std=c++14 -O3 $(INFOMAP_VENDOR_CPPFLAGS) -s SINGLE_FILE=1 -s ALLOW_MEMORY_GROWTH=1 -s DISABLE_EXCEPTION_CATCHING=0 -s ENVIRONMENT=node -s MODULARIZE=1 -s EXPORT_ES6=1 -s INVOKE_RUN=0 -s EXIT_RUNTIME=0
 PRE_WORKER_MODULE := interfaces/js/pre-worker-module.js
 JS_METADATA_DIR := interfaces/js/generated
 JS_PARAMETERS_JSON := $(JS_METADATA_DIR)/parameters.json
@@ -11,13 +19,13 @@ NPM_STAGE_DIR := dist/npm/package
 NPM_UNPACK_DIR := dist/npm/unpacked
 NPM_PACK_JSON := dist/npm/npm-pack.json
 
-.PHONY: build-js build-js-metadata test-js-metadata test-js clean-js format-js
+.PHONY: build-js build-js-metadata test-js-metadata test-js build-node test-node clean-js format-js
 
-build-js: $(JS_WORKER_TARGET) $(JS_METADATA_FILES)
+build-js: $(JS_WORKER_TARGET) $(JS_NODE_TARGET) $(JS_CLI_TARGET) $(JS_METADATA_FILES)
 	$(RM) -r $(NPM_STAGE_DIR)
 	@mkdir -p $(NPM_STAGE_DIR)
 	$(NPM) run build:package
-	@$(PYTHON_FOR_BUILD_CONFIG) scripts/prepare_npm_package.py --source-package package.json --readme interfaces/js/README.md --readme-rst README.rst --license LICENSE_GPLv3.txt --output-dir $(NPM_STAGE_DIR)
+	@$(PYTHON_FOR_BUILD_CONFIG) scripts/prepare_npm_package.py --source-package package.json --readme interfaces/js/README.md --readme-rst README.rst --license LICENSE_GPLv3.txt --node-module $(JS_NODE_TARGET) --cli-module $(JS_CLI_TARGET) --output-dir $(NPM_STAGE_DIR)
 	@echo "Built $^ into $(NPM_STAGE_DIR)"
 
 build-js-metadata: build-native
@@ -54,6 +62,27 @@ test-js: build-js
 	tar -xzf dist/npm/"$$pkg" -C $(NPM_UNPACK_DIR)
 	$(NPM) run test:package
 	$(NPM) run test:browser
+
+build-node: $(JS_NODE_TARGET) $(JS_CLI_TARGET)
+	@echo "Built $(JS_NODE_TARGET) (library, MEMFS) and $(JS_CLI_TARGET) (bin, NODERAWFS)"
+
+# Library artifact: MEMFS keeps everything in memory, so src/node.ts can write a
+# network, run, and read results back without touching disk, and Infomap's output
+# stays capturable (quiet by default). FS is exported for that staging.
+$(JS_NODE_TARGET): $(SOURCES) $(HEADERS) $(MK_FILES) Makefile
+	@echo "Compiling the Infomap Node library (MEMFS) with Emscripten..."
+	@mkdir -p $(dir $@)
+	$(EMXX) $(EMXX_NODE_FLAGS) -s EXPORTED_RUNTIME_METHODS=callMain,FS -o $@ $(SOURCES)
+
+# Bin artifact: NODERAWFS maps the filesystem to the real one, so the `infomap`
+# command reads and writes files exactly like the native binary on any path.
+$(JS_CLI_TARGET): $(SOURCES) $(HEADERS) $(MK_FILES) Makefile
+	@echo "Compiling the Infomap Node CLI (NODERAWFS) with Emscripten..."
+	@mkdir -p $(dir $@)
+	$(EMXX) $(EMXX_NODE_FLAGS) -s NODERAWFS=1 -s EXPORTED_RUNTIME_METHODS=callMain -o $@ $(SOURCES)
+
+test-node: build-node
+	$(NODE) $(JS_NODE_TEST)
 
 clean-js:
 	$(RM) -r build/js dist/npm

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "files": [
     "*.js",
     "*.cjs",
+    "*.mjs",
     "*.d.ts",
     "*.map",
     "LICENSE_GPLv3.txt"
@@ -54,7 +55,16 @@
       "require": "./network.cjs",
       "default": "./network.js"
     },
+    "./node": {
+      "types": "./node.d.ts",
+      "import": "./node.js",
+      "require": "./node.cjs",
+      "default": "./node.js"
+    },
     "./package.json": "./package.json"
+  },
+  "bin": {
+    "infomap": "./cli.js"
   },
   "sideEffects": false,
   "scripts": {

--- a/scripts/prepare_npm_package.py
+++ b/scripts/prepare_npm_package.py
@@ -18,6 +18,7 @@ KEEP_PACKAGE_FIELDS = [
     "types",
     "type",
     "exports",
+    "bin",
     "sideEffects",
     "repository",
     "keywords",
@@ -43,6 +44,14 @@ def main():
     parser.add_argument("--readme", default="interfaces/js/README.md")
     parser.add_argument("--readme-rst", default="README.rst")
     parser.add_argument("--license", default="LICENSE_GPLv3.txt")
+    parser.add_argument(
+        "--node-module",
+        help="Emscripten Node library artifact to stage (infomap.node.mjs).",
+    )
+    parser.add_argument(
+        "--cli-module",
+        help="Emscripten Node bin artifact to stage (infomap.cli.mjs).",
+    )
     parser.add_argument("--output-dir", default="dist/npm/package")
     args = parser.parse_args()
 
@@ -56,6 +65,11 @@ def main():
     copy_file(args.readme, output_dir, "README.md")
     copy_file(args.readme_rst, output_dir, "README.rst")
     copy_file(args.license, output_dir, "LICENSE_GPLv3.txt")
+
+    if args.node_module:
+        copy_file(args.node_module, output_dir)
+    if args.cli_module:
+        copy_file(args.cli_module, output_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds an Emscripten Node.js build of Infomap alongside the existing browser
worker, mirroring the Python and R packages (a programmatic module plus a
bundled binary). Node support is additive — the default browser entrypoint
(`@mapequation/infomap`) is unchanged, so existing consumers are unaffected.

- `make build-node` compiles two single-file artifacts: a MEMFS library
  (in-memory, quiet output) and a NODERAWFS bin (real files, any path).
- `make test-node` smoke-tests both artifacts directly, without a browser.
- New published surface via a subpath export + bin, leaving `exports["."]`
  untouched:
  - `import { run } from "@mapequation/infomap/node"` —
    `run(network, options) -> Result`, works from ESM and CommonJS.
  - `npx @mapequation/infomap network.net . --tree` — behaves like the native
    binary.
- Package build, staging (`scripts/prepare_npm_package.py`), and verification
  (`verify-package`, `runtime-check`, `consumer.ts`) cover the new entry and
  bin. CJS shared chunks now use a `.cjs` extension so they can be `require()`d
  in this `type: module` package.
- Node API and CLI documented in `interfaces/js/README.md` (the npm README) and
  `README.rst`.

## Verification

- `make test-node` — both artifacts (MEMFS in-memory run, NODERAWFS bin on real
  files).
- `make test-js` — biome lint, typecheck, 31 unit tests, package verification
  (Node ESM + CJS `run()` end-to-end against the wasm, plus the `infomap` bin),
  and the browser smoke test.
- `format:check` clean; the documented README examples run as shown.

## Notes

- The two single-file artifacts add ~2.9 MB unpacked (~2.4 MB gzipped tarball).
  A shared-`.wasm` + thin-loaders variant could roughly halve that if desired.

Closes #685
