### PR TITLE
docs(python): add options guide notebook and polish notebooks

### DIFF
--- a/examples/notebooks/4.1 The Two-level Phase.ipynb
+++ b/examples/notebooks/4.1 The Two-level Phase.ipynb
@@ -84,9 +84,9 @@
    "source": [
     "## Stage 1, core loop #1\n",
     "\n",
-    "For stage 1, we use `tune_iteration_limit=1` to just run the core algorithm once without any tuning.\n",
+    "For stage 1, we use `tune_iteration_limit=1` to run the core algorithm once without any tuning.\n",
     "\n",
-    "We set `core_loop_limit=1` to just loop through the nodes once, and `core_level_limit` to not re-apply the core loops on the merged level. After one core loop we get this result:"
+    "We set `core_loop_limit=1` to loop through the nodes once, and `core_level_limit` to not re-apply the core loops on the merged level. After one core loop we get this result:"
    ],
    "id": "013eac19a110"
   },

--- a/examples/notebooks/5.4 Modeling Multi-body Interactions.ipynb
+++ b/examples/notebooks/5.4 Modeling Multi-body Interactions.ipynb
@@ -72,7 +72,7 @@
     "\n",
     "3. **Weights (optional)**  \n",
     "   Per-node hyperedge weights `gamma`.  \n",
-    "   If omitted, all node–hyperedge incidences default to **1**.\n",
+    "   If omitted, all node-hyperedge incidences default to **1**.\n",
     "\n",
     "#### Example Hypergraph File"
    ],

--- a/examples/notebooks/README.md
+++ b/examples/notebooks/README.md
@@ -5,6 +5,9 @@ notebook for running Infomap in Jupyter, inspecting the notebook-native result
 summary, drawing a small readable partition, and exporting results for further
 analysis.
 
+Then read [`options-guide.ipynb`](options-guide.ipynb) for what every Infomap
+option is for, with runnable examples and a complete reference table.
+
 Most numbered notebooks accompany [Community Detection with the Map Equation
 and Infomap: Theory and Applications](https://doi.org/10.1145/3779648).
 Descriptive, unnumbered notebooks cover practical Python workflows that are

--- a/examples/notebooks/benchmark-performance.ipynb
+++ b/examples/notebooks/benchmark-performance.ipynb
@@ -520,7 +520,9 @@
     "   memory, it runs about 1.5× faster and 30% lighter.\n",
     "\n",
     "These come from one machine, so use them as ratios and anchor points, then calibrate\n",
-    "with one small run of your own (or re-run with `RUN_BENCHMARK = True`)."
+    "with one small run of your own (or re-run with `RUN_BENCHMARK = True`).\n",
+    "\n",
+    "For what these options do, see the {doc}`options guide <options-guide>`; for a first run, see the {doc}`quickstart <quickstart>`."
    ]
   }
  ],

--- a/examples/notebooks/compare-infomap-louvain-leiden-igraph.ipynb
+++ b/examples/notebooks/compare-infomap-louvain-leiden-igraph.ipynb
@@ -187,7 +187,7 @@
    "source": [
     "## Annotate vertices for downstream igraph use\n",
     "\n",
-    "Use `module_attribute` and `flow_attribute` when you want Infomap results stored directly on the igraph vertices for plotting, filtering, or export.\n"
+    "Use `module_attribute` and `flow_attribute` when you want Infomap results stored on the igraph vertices for plotting, filtering, or export.\n"
    ]
   },
   {
@@ -221,9 +221,11 @@
    "id": "louvain_leiden_igraph_14",
    "metadata": {},
    "source": [
-    "## Citation\n",
+    "## Citation and further reading\n",
     "\n",
-    "If you use Infomap in published work, cite the Infomap software and the map equation literature. See the repository and Infomap user guide for the current recommended references.\n"
+    "If you use Infomap in published work, mapequation.org recommends citing two things: the map equation paper (Rosvall and Bergstrom, 2008, <https://doi.org/10.1073/pnas.0706851105>) for the method, and the MapEquation software package (Edler, Holmgren, and Rosvall) for the implementation and version. See [How to cite](https://www.mapequation.org/publications/) for BibTeX.\n",
+    "\n",
+    "See also the {doc}`quickstart <quickstart>` for a first run, the {doc}`options guide <options-guide>` for the parameters used here, and {doc}`compare-infomap-louvain-networkx <compare-infomap-louvain-networkx>` for the same comparison in a NetworkX workflow."
    ]
   }
  ],

--- a/examples/notebooks/compare-infomap-louvain-networkx.ipynb
+++ b/examples/notebooks/compare-infomap-louvain-networkx.ipynb
@@ -62,7 +62,7 @@
    "source": [
     "## Run the community methods\n",
     "\n",
-    "`infomap.find_communities()` follows the NetworkX convention of returning a partition as `list[set]` while preserving the original node labels. NetworkX provides Louvain directly through `nx.community.louvain_communities()`.\n"
+    "`infomap.find_communities()` follows the NetworkX convention of returning a partition as `list[set]` while preserving the original node labels. NetworkX provides Louvain through `nx.community.louvain_communities()`.\n"
    ]
   },
   {
@@ -257,9 +257,11 @@
    "id": "louvain_networkx_16",
    "metadata": {},
    "source": [
-    "## Citation\n",
+    "## Citation and further reading\n",
     "\n",
-    "If you use Infomap in published work, cite the Infomap software and the map equation literature. See the citation information in the repository and the Infomap user guide for the current recommended references.\n"
+    "If you use Infomap in published work, mapequation.org recommends citing two things: the map equation paper (Rosvall and Bergstrom, 2008, <https://doi.org/10.1073/pnas.0706851105>) for the method, and the MapEquation software package (Edler, Holmgren, and Rosvall) for the implementation and version. See [How to cite](https://www.mapequation.org/publications/) for BibTeX.\n",
+    "\n",
+    "See also the {doc}`quickstart <quickstart>` for a first run, the {doc}`options guide <options-guide>` for the parameters used here, and {doc}`compare-infomap-louvain-leiden-igraph <compare-infomap-louvain-leiden-igraph>` for the same comparison with igraph-native clustering objects."
    ]
   }
  ],

--- a/examples/notebooks/compare-infomap-scanpy-workflow.ipynb
+++ b/examples/notebooks/compare-infomap-scanpy-workflow.ipynb
@@ -180,9 +180,13 @@
    "source": [
     "## Notes on graph choices\n",
     "\n",
-    "By default, Infomap uses `adata.obsp[\"connectivities\"]`. Pass `neighbors_key` when using a named Scanpy neighbor graph, or `obsp`/`adjacency` when selecting a graph directly. Use `directed=True` for directed observation graphs and `use_weights=False` for unweighted treatment of nonzero sparse entries.\n",
+    "By default, Infomap uses `adata.obsp[\"connectivities\"]`. Pass `neighbors_key` when using a named Scanpy neighbor graph, or `obsp`/`adjacency` when selecting a graph. Use `directed=True` for directed observation graphs and `use_weights=False` for unweighted treatment of nonzero sparse entries.\n",
     "\n",
-    "If you use Infomap in published work, cite the Infomap software and the map equation literature. See the repository and Infomap user guide for the current recommended references.\n"
+    "## Citation and further reading\n",
+    "\n",
+    "If you use Infomap in published work, mapequation.org recommends citing two things: the map equation paper (Rosvall and Bergstrom, 2008, <https://doi.org/10.1073/pnas.0706851105>) for the method, and the MapEquation software package (Edler, Holmgren, and Rosvall) for the implementation and version. See [How to cite](https://www.mapequation.org/publications/) for BibTeX.\n",
+    "\n",
+    "See also the {doc}`quickstart <quickstart>` for a first run and the {doc}`options guide <options-guide>` for the parameters used here."
    ]
   }
  ],

--- a/examples/notebooks/notebooks.toml
+++ b/examples/notebooks/notebooks.toml
@@ -4,6 +4,11 @@ tier = "smoke"
 description = "Flagship Infomap Python quickstart with notebook-native summary and static network visualization."
 
 [[notebooks]]
+path = "options-guide.ipynb"
+tier = "smoke"
+description = "Goal-oriented guide to Infomap's options with runnable examples and a complete reference table generated from the installed package."
+
+[[notebooks]]
 path = "run-infomap-on-hpc.ipynb"
 tier = "smoke"
 description = "HPC recipe notebook for native trial sharding, scheduler-aware threads, and Python shard merging."

--- a/examples/notebooks/options-guide.ipynb
+++ b/examples/notebooks/options-guide.ipynb
@@ -1,0 +1,821 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "md01",
+   "metadata": {},
+   "source": [
+    "# Infomap options guide\n",
+    "\n",
+    "Infomap has many options. This guide explains what they are for and shows the\n",
+    "ones you change most often, grouped by what you want to achieve. For a first\n",
+    "end-to-end run, start with the {doc}`quickstart <quickstart>`.\n",
+    "\n",
+    "Infomap finds communities by minimizing the map equation, the description length\n",
+    "of a random walk on the network (Rosvall and Bergstrom, 2008; Rosvall, Axelsson,\n",
+    "and Bergstrom, 2009). Most options below change how that random walk is defined,\n",
+    "how hard the search works, or what gets written. Each section names the paper that\n",
+    "introduced the option, and the References section at the end collects them.\n",
+    "\n",
+    "Every option is the same idea across interfaces. A command-line flag like\n",
+    "`--two-level` is the keyword `two_level=True` in Python and the matching argument\n",
+    "in R. In Python you can set options three ways:\n",
+    "\n",
+    "- keyword arguments: `Infomap(two_level=True, num_trials=20)`\n",
+    "- a raw flag string: `Infomap(args=\"--two-level --num-trials 20\")`\n",
+    "- a reusable `InfomapOptions` object passed to `Infomap.from_options(...)` or\n",
+    "  `Infomap.run_with_options(...)`\n",
+    "\n",
+    "This guide uses keyword arguments. The last section lists every option with its\n",
+    "flag, default, and description, generated from the installed package so it always\n",
+    "matches your version."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code02",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import infomap\n",
+    "from infomap import Infomap\n",
+    "import networkx as nx\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "from pathlib import Path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md03",
+   "metadata": {},
+   "source": [
+    "## Reproducible runs\n",
+    "\n",
+    "Set a `seed` and a meaningful `num_trials` so results are reproducible and stable.\n",
+    "This guide fixes `seed=123` and `num_trials=20`, and runs `silent=True` to keep the\n",
+    "notebook output short."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Infomap version:\", infomap.__version__)\n",
+    "\n",
+    "SEED = 123\n",
+    "NUM_TRIALS = 20"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md05",
+   "metadata": {},
+   "source": [
+    "## Which option should I change?\n",
+    "\n",
+    "Start from your goal and reach for the matching option. Each option has its own\n",
+    "section below, and the full reference is at the end.\n",
+    "\n",
+    "| Your goal | Options to reach for |\n",
+    "| --- | --- |\n",
+    "| Make results reproducible | `seed` |\n",
+    "| Get a better, more stable partition | `num_trials` (higher), `converge` |\n",
+    "| Get fewer, larger modules | `markov_time` (higher), `preferred_number_of_modules`, `two_level` |\n",
+    "| Get more, finer modules | `markov_time` (lower) |\n",
+    "| Control the hierarchy depth | `preferred_number_of_levels`, `two_level` |\n",
+    "| Respect link direction | `directed`, `flow_model` |\n",
+    "| Run faster on large networks | `two_level`, `num_trials` (lower), `converge`, `fast_hierarchical_solution`, `parallel_trials`, `num_threads` |\n",
+    "| Handle sparse, noisy, or incomplete data | `regularized`, `entropy_corrected` |\n",
+    "| Cluster multilayer or temporal networks | `multilayer_relax_rate`, `multilayer_relax_to_self`, `multilayer_relax_limit` |\n",
+    "| Bias the partition with node metadata | `meta_data`, `meta_data_rate` |\n",
+    "| Start from, or only score, a partition | `cluster_data`, `no_infomap` |\n",
+    "| Choose what gets written | `tree`, `ftree`, `clu`, `output`, `out_name`, `no_file_output` |\n",
+    "\n",
+    "For run time and memory planning, see\n",
+    "{doc}`benchmark-performance <benchmark-performance>`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md06",
+   "metadata": {},
+   "source": [
+    "## Accuracy: reproducibility and solution quality\n",
+    "\n",
+    "Infomap is a stochastic search. A single trial can land in a worse local minimum,\n",
+    "so the result depends on the seed. Two options control this.\n",
+    "\n",
+    "- `seed` fixes the random number generator so a run is reproducible.\n",
+    "- `num_trials` runs that many independent searches and keeps the best (lowest\n",
+    "  codelength) one. More trials give a better and more stable result at a higher\n",
+    "  run time.\n",
+    "\n",
+    "Calatayud et al. (2019) found that stochastic searches produce many\n",
+    "near-degenerate solutions, so exploring more of the landscape gives a more\n",
+    "reliable partition."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def run_jazz(**options):\n",
+    "    im = Infomap(silent=True, **options)\n",
+    "    im.read_file(\"data/jazz.net\")\n",
+    "    im.run()\n",
+    "    return im\n",
+    "\n",
+    "\n",
+    "# A single trial varies with the seed: different seeds find different codelengths.\n",
+    "single_trial = pd.DataFrame(\n",
+    "    {\"seed\": s, \"codelength\": round(run_jazz(seed=s, num_trials=1).codelength, 4)}\n",
+    "    for s in range(1, 6)\n",
+    ")\n",
+    "single_trial"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Keeping the best of many trials gives a lower, stable codelength.\n",
+    "pd.DataFrame(\n",
+    "    {\n",
+    "        \"num_trials\": nt,\n",
+    "        \"codelength\": round(run_jazz(seed=SEED, num_trials=nt).codelength, 4),\n",
+    "    }\n",
+    "    for nt in (1, 5, 20, 50)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md09",
+   "metadata": {},
+   "source": [
+    "`converge` treats the trial count as a cap. It runs trials until the best\n",
+    "codelength stops improving, so you can ask for many trials without always paying\n",
+    "for all of them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "im = run_jazz(seed=SEED, num_trials=50, converge=True)\n",
+    "round(im.codelength, 4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md11",
+   "metadata": {},
+   "source": [
+    "## Algorithm: resolution and hierarchy\n",
+    "\n",
+    "These options change *what* partition Infomap looks for, not how hard it searches.\n",
+    "\n",
+    "We use two small example networks: networkx's built-in ring of cliques, and a\n",
+    "synthetic nested hierarchy built inline (networkx has no deep-hierarchy generator).\n",
+    "The inline helper is notebook-local and is not a public Infomap API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def hierarchical_graph():\n",
+    "    # Nested structure at three scales: 2 top groups, each with 2 subgroups,\n",
+    "    # each with 2 cliques of 5 nodes. Edge weights shrink with each scale, so the\n",
+    "    # best map is a deep, four-level hierarchy.\n",
+    "    G = nx.Graph()\n",
+    "    nid = 0\n",
+    "    top_groups = []\n",
+    "    for _ in range(2):\n",
+    "        subgroups = []\n",
+    "        for _ in range(2):\n",
+    "            cliques = []\n",
+    "            for _ in range(2):\n",
+    "                members = list(range(nid, nid + 5))\n",
+    "                nid += 5\n",
+    "                for i in range(len(members)):\n",
+    "                    for j in range(i + 1, len(members)):\n",
+    "                        G.add_edge(members[i], members[j], weight=100.0)\n",
+    "                cliques.append(members)\n",
+    "            for a in range(len(cliques)):\n",
+    "                for b in range(a + 1, len(cliques)):\n",
+    "                    G.add_edge(cliques[a][0], cliques[b][0], weight=10.0)  # within subgroup\n",
+    "            subgroups.append(cliques)\n",
+    "        for a in range(len(subgroups)):\n",
+    "            for b in range(a + 1, len(subgroups)):\n",
+    "                G.add_edge(subgroups[a][0][0], subgroups[b][0][0], weight=1.0)  # within top group\n",
+    "        top_groups.append(subgroups)\n",
+    "    for a in range(len(top_groups)):\n",
+    "        for b in range(a + 1, len(top_groups)):\n",
+    "            G.add_edge(top_groups[a][0][0][0], top_groups[b][0][0][0], weight=0.1)  # across top groups\n",
+    "    return G\n",
+    "\n",
+    "\n",
+    "def run_graph(G, **options):\n",
+    "    im = Infomap(silent=True, seed=SEED, num_trials=NUM_TRIALS, **options)\n",
+    "    im.add_networkx_graph(G)\n",
+    "    im.run()\n",
+    "    return im\n",
+    "\n",
+    "\n",
+    "G_hier = hierarchical_graph()\n",
+    "G_ring = nx.ring_of_cliques(16, 5)  # networkx built-in: 16 cliques of 5 nodes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md13",
+   "metadata": {},
+   "source": [
+    "### `two_level` versus the default multilevel search\n",
+    "\n",
+    "By default Infomap finds a hierarchy with as many levels as the flow supports.\n",
+    "`two_level=True` forces a single flat level of modules. On the nested\n",
+    "network, the multilevel solution builds a four-level hierarchy under the two top\n",
+    "groups, while the two-level solution reports the eight cliques as one flat level.\n",
+    "Rosvall and Bergstrom (2011) introduced the multilevel map equation, which finds\n",
+    "this depth on its own."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rows = []\n",
+    "for two_level in (False, True):\n",
+    "    im = run_graph(G_hier, two_level=two_level)\n",
+    "    rows.append(\n",
+    "        {\n",
+    "            \"two_level\": two_level,\n",
+    "            \"levels\": im.num_levels,\n",
+    "            \"top_modules\": im.num_top_modules,\n",
+    "            \"codelength\": round(im.codelength, 4),\n",
+    "        }\n",
+    "    )\n",
+    "pd.DataFrame(rows)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md15",
+   "metadata": {},
+   "source": [
+    "### `markov_time` sets the resolution\n",
+    "\n",
+    "`markov_time` scales how costly it is to move between modules. Higher values make\n",
+    "module boundaries more expensive to cross, so modules merge and you get fewer,\n",
+    "larger ones. Lower values give more, finer modules. It is the main resolution knob.\n",
+    "Kheirkhahzadeh et al. (2016) made sweeping Markov time across scales efficient.\n",
+    "`variable_markov_time` instead sets a local time per node, so one run handles\n",
+    "sparse and dense regions at once (Edler et al., 2022)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "markov_sweep = pd.DataFrame(\n",
+    "    {\n",
+    "        \"markov_time\": mt,\n",
+    "        \"top_modules\": run_graph(G_ring, two_level=True, markov_time=mt).num_top_modules,\n",
+    "    }\n",
+    "    for mt in (1, 2, 4, 6, 8, 10)\n",
+    ")\n",
+    "markov_sweep"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = markov_sweep.plot(x=\"markov_time\", y=\"top_modules\", marker=\"o\", legend=False)\n",
+    "ax.set(\n",
+    "    xlabel=\"Markov time\",\n",
+    "    ylabel=\"number of top modules\",\n",
+    "    title=\"Higher Markov time merges modules\",\n",
+    ")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md18",
+   "metadata": {},
+   "source": [
+    "### Steering the module and level counts\n",
+    "\n",
+    "When you have a target structure in mind, two soft preferences nudge the search\n",
+    "without hard-coding the answer.\n",
+    "\n",
+    "- `preferred_number_of_modules` penalizes solutions whose module count is far from\n",
+    "  the value you give.\n",
+    "- `preferred_number_of_levels` biases the hierarchy depth. Steering to a shallower\n",
+    "  hierarchy is reliable; deeper is best-effort. Use\n",
+    "  `preferred_number_of_levels_strength` to scale how hard it steers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.DataFrame(\n",
+    "    {\n",
+    "        \"preferred_number_of_modules\": p,\n",
+    "        \"top_modules\": run_graph(\n",
+    "            G_ring, two_level=True, preferred_number_of_modules=p\n",
+    "        ).num_top_modules,\n",
+    "    }\n",
+    "    for p in (2, 4, 8, 16)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rows = []\n",
+    "for levels in (None, 3):\n",
+    "    options = {} if levels is None else {\"preferred_number_of_levels\": levels}\n",
+    "    im = run_graph(G_hier, **options)\n",
+    "    rows.append(\n",
+    "        {\n",
+    "            \"preferred_number_of_levels\": levels or \"default\",\n",
+    "            \"levels\": im.num_levels,\n",
+    "            \"top_modules\": im.num_top_modules,\n",
+    "        }\n",
+    "    )\n",
+    "pd.DataFrame(rows)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md21",
+   "metadata": {},
+   "source": [
+    "## Flow model: how flow is derived from links\n",
+    "\n",
+    "Infomap clusters the flow of a random walker, so the flow model matters. The most\n",
+    "common choice is direction.\n",
+    "\n",
+    "- `directed=True` treats links as directed. It is shorthand for\n",
+    "  `flow_model=\"directed\"`.\n",
+    "- `flow_model` selects among `undirected`, `directed`, `undirdir`, `outdirdir`,\n",
+    "  `rawdir`, and `precomputed` for finer control.\n",
+    "- `teleportation_probability` and `recorded_teleportation` adjust how a directed\n",
+    "  walker teleports and whether those steps are encoded.\n",
+    "\n",
+    "On a directed network, respecting direction can change the partition. Lambiotte\n",
+    "and Rosvall (2012) introduced smart teleportation, which makes directed results\n",
+    "robust to the teleportation rate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "directed_net = nx.DiGraph()\n",
+    "directed_net.add_edges_from(\n",
+    "    [(1, 2), (2, 3), (3, 1), (3, 4), (4, 5), (5, 6), (6, 4)]\n",
+    ")\n",
+    "\n",
+    "rows = []\n",
+    "for flow_model in (\"undirected\", \"directed\"):\n",
+    "    im = Infomap(silent=True, seed=SEED, num_trials=NUM_TRIALS, flow_model=flow_model)\n",
+    "    im.add_networkx_graph(directed_net)\n",
+    "    im.run()\n",
+    "    rows.append(\n",
+    "        {\n",
+    "            \"flow_model\": flow_model,\n",
+    "            \"top_modules\": im.num_top_modules,\n",
+    "            \"codelength\": round(im.codelength, 4),\n",
+    "        }\n",
+    "    )\n",
+    "pd.DataFrame(rows)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md23",
+   "metadata": {},
+   "source": [
+    "## Regularization for sparse, noisy, or incomplete data\n",
+    "\n",
+    "Sparse or under-sampled networks can be over-partitioned: Infomap splits on\n",
+    "sampling noise instead of real structure. Two options make the partition more\n",
+    "conservative.\n",
+    "\n",
+    "- `regularized` adds a fully connected Bayesian prior network, which reduces\n",
+    "  overfitting to missing links and merges weakly supported modules. Scale it with\n",
+    "  `regularization_strength`; larger values merge more.\n",
+    "- `entropy_corrected` corrects the negative entropy bias in small samples, which\n",
+    "  matters most for solutions with many modules.\n",
+    "\n",
+    "Smiljanić, Edler, and Rosvall (2020) derived both from the Bayesian map equation,\n",
+    "which Smiljanić et al. (2021) extended to weighted and directed data.\n",
+    "\n",
+    "On the jazz network, regularization steadily merges the least supported modules.\n",
+    "When the network has missing links, see\n",
+    "[Networks with incomplete data](https://github.com/mapequation/infomap/blob/master/examples/notebooks/7%20Networks%20with%20incomplete%20data.ipynb)\n",
+    "for the full treatment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rows = []\n",
+    "for label, options in [\n",
+    "    (\"baseline\", {}),\n",
+    "    (\"regularized\", {\"regularized\": True}),\n",
+    "    (\"regularized, strength 2\", {\"regularized\": True, \"regularization_strength\": 2.0}),\n",
+    "]:\n",
+    "    im = run_jazz(seed=SEED, num_trials=NUM_TRIALS, **options)\n",
+    "    rows.append(\n",
+    "        {\"setting\": label, \"top_modules\": im.num_top_modules, \"codelength\": round(im.codelength, 4)}\n",
+    "    )\n",
+    "pd.DataFrame(rows)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md25",
+   "metadata": {},
+   "source": [
+    "## Multilayer and temporal networks\n",
+    "\n",
+    "For multilayer or temporal data, a state node can relax to neighboring layers\n",
+    "while the walker moves. These options control that coupling.\n",
+    "\n",
+    "- `multilayer_relax_rate` is the probability of relaxing to other layers instead\n",
+    "  of staying in the current one.\n",
+    "- `multilayer_relax_limit`, `..._up`, and `..._down` restrict relaxation to nearby\n",
+    "  layers, which is useful for ordered (temporal) layers.\n",
+    "- `multilayer_relax_to_self` couples a state node to its own physical node in the\n",
+    "  target layer, building a smaller state network with the same flow.\n",
+    "\n",
+    "De Domenico et al. (2015) introduced the relax rate in the multiplex map equation.\n",
+    "Edler, Bohlin, and Rosvall (2017) cast memory and multilayer networks as one\n",
+    "state-node formulation, and `multilayer_relax_by_jsd` couples layers by flow\n",
+    "similarity for intermittent communities (Aslak et al., 2018).\n",
+    "\n",
+    "Build multilayer input with `add_multilayer_intra_link` (within a layer) and\n",
+    "`add_multilayer_inter_link` (between layers), then set the relax options as usual."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ml = Infomap(silent=True, seed=SEED, num_trials=NUM_TRIALS, multilayer_relax_rate=0.25)\n",
+    "intra = [(1, 2), (2, 3), (3, 1), (4, 5), (5, 6), (6, 4)]  # two triangles per layer\n",
+    "for layer in (1, 2):\n",
+    "    for source, target in intra:\n",
+    "        ml.add_multilayer_intra_link(layer, source, target, 1.0)\n",
+    "ml.run()\n",
+    "ml.num_top_modules"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md27",
+   "metadata": {},
+   "source": [
+    "The dedicated\n",
+    "[Multilayer Networks](https://github.com/mapequation/infomap/blob/master/examples/notebooks/5.2%20Multilayer%20Networks.ipynb)\n",
+    "notebook goes further."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md28",
+   "metadata": {},
+   "source": [
+    "## Metadata\n",
+    "\n",
+    "`meta_data` reads a node attribute from a clu-format file and encodes it alongside\n",
+    "the network, biasing modules toward the metadata groups. `meta_data_rate` sets how\n",
+    "strongly the metadata is weighted. Emmons and Mucha (2019) introduced this tunable\n",
+    "attribute weight, and Bassolas et al. (2022) extended it to nonlocal metadata\n",
+    "relationships. See\n",
+    "[Networks with Metadata](https://github.com/mapequation/infomap/blob/master/examples/notebooks/6.1%20Networks%20with%20Metadata.ipynb)\n",
+    "for the theory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "karate = nx.karate_club_graph()\n",
+    "\n",
+    "# Write a clu-format metadata file: node id (1-based) and a group id.\n",
+    "Path(\"output\").mkdir(exist_ok=True)\n",
+    "with open(\"output/karate-club.meta\", \"w\") as f:\n",
+    "    f.write(\"# node_id metadata\\n\")\n",
+    "    for node in karate.nodes():\n",
+    "        group = 0 if karate.nodes[node][\"club\"] == \"Mr. Hi\" else 1\n",
+    "        f.write(f\"{node + 1} {group}\\n\")\n",
+    "\n",
+    "rows = []\n",
+    "for label, options in [(\"no metadata\", {}), (\"with metadata\", {\"meta_data\": \"output/karate-club.meta\"})]:\n",
+    "    im = run_graph(karate, **options)\n",
+    "    rows.append(\n",
+    "        {\"setting\": label, \"top_modules\": im.num_top_modules, \"codelength\": round(im.codelength, 4)}\n",
+    "    )\n",
+    "pd.DataFrame(rows)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md30",
+   "metadata": {},
+   "source": [
+    "## Shaping the input\n",
+    "\n",
+    "A few options change which network Infomap sees, or reuse an existing partition.\n",
+    "\n",
+    "- `cluster_data` reads an initial partition (a `.clu` file) or a hierarchy (a\n",
+    "  `.tree`/`.ftree` file) to start from.\n",
+    "- `no_infomap` skips the search entirely. Combined with `cluster_data`, it scores\n",
+    "  an existing partition without searching, which lets you compare partitions on the\n",
+    "  same codelength scale.\n",
+    "- `weight_threshold` ignores links below a weight, and `node_limit` reads only up\n",
+    "  to a node id. Both trim the input before clustering.\n",
+    "\n",
+    "Here we cluster a network, save the partition, then score that same partition\n",
+    "without re-running the search."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code31",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "im = run_jazz(seed=SEED, num_trials=NUM_TRIALS)\n",
+    "im.write_clu(\"output/jazz.clu\")\n",
+    "optimized = round(im.codelength, 4)\n",
+    "\n",
+    "scorer = Infomap(silent=True, cluster_data=\"output/jazz.clu\", no_infomap=True)\n",
+    "scorer.read_file(\"data/jazz.net\")\n",
+    "scorer.run()\n",
+    "\n",
+    "pd.DataFrame(\n",
+    "    [\n",
+    "        {\"run\": \"optimized\", \"codelength\": optimized},\n",
+    "        {\"run\": \"scored only (no_infomap)\", \"codelength\": round(scorer.codelength, 4)},\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md32",
+   "metadata": {},
+   "source": [
+    "## Choosing the output\n",
+    "\n",
+    "By default Infomap writes a `.tree` file. You can pick formats explicitly.\n",
+    "\n",
+    "- `tree`, `ftree`, and `clu` enable individual formats. `ftree` adds aggregated\n",
+    "  links between modules and is used by the Network Navigator.\n",
+    "- `output` selects several formats at once, for example\n",
+    "  `output=[\"clu\", \"tree\", \"ftree\"]`.\n",
+    "- `clu_level` chooses the depth for `.clu` output, `out_name` sets the base file\n",
+    "  name, and `no_file_output=True` keeps everything in memory.\n",
+    "- `silent` and `verbosity_level` control console output.\n",
+    "\n",
+    "In a notebook you read the result from the `Infomap` object and its\n",
+    "`to_dataframe(...)`, and write files only when another tool needs them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "im = run_graph(karate)\n",
+    "\n",
+    "# Read results in memory, no files needed.\n",
+    "im.to_dataframe(columns=[\"node_id\", \"module_id\", \"flow\"]).head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code34",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Or write explicit formats for downstream tools.\n",
+    "im.write_clu(\"output/karate.clu\")\n",
+    "im.write_tree(\"output/karate.tree\")\n",
+    "im.write_flow_tree(\"output/karate.ftree\")\n",
+    "sorted(p.name for p in Path(\"output\").glob(\"karate.*\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md35",
+   "metadata": {},
+   "source": [
+    "## Full options reference\n",
+    "\n",
+    "This guide covers the options you reach for most often. For the complete list,\n",
+    "with every flag, default, and description, use any of these:\n",
+    "\n",
+    "```python\n",
+    "from infomap import InfomapOptions\n",
+    "help(InfomapOptions)\n",
+    "```\n",
+    "\n",
+    "From the command line, `infomap --help` lists the common options, `infomap -hh`\n",
+    "adds the advanced ones, and `infomap --print-json-parameters` prints the full\n",
+    "machine-readable catalog. The {doc}`API options reference </api/options>` renders\n",
+    "the same `InfomapOptions` fields as a searchable web page."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md36",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "The options in this guide come from the map equation literature. The survey\n",
+    "(Smiljanić et al., 2026) ties them together; the papers below introduced each one.\n",
+    "\n",
+    "**Foundations**\n",
+    "\n",
+    "- Rosvall and Bergstrom (2008). Maps of random walks on complex networks reveal\n",
+    "  community structure. *PNAS* 105, 1118.\n",
+    "  <https://doi.org/10.1073/pnas.0706851105>\n",
+    "- Rosvall, Axelsson, and Bergstrom (2009). The map equation. *Eur. Phys. J.\n",
+    "  Special Topics* 178, 13. <https://doi.org/10.1140/epjst/e2010-01179-1>\n",
+    "- Smiljanić, Blöcker, Holmgren, Edler, Neuman, and Rosvall (2026). Community\n",
+    "  Detection with the Map Equation and Infomap: Theory and Applications. *ACM\n",
+    "  Computing Surveys* 58(7). <https://doi.org/10.1145/3779648>\n",
+    "\n",
+    "**Hierarchy and resolution** (`two_level`, `preferred_number_of_levels`,\n",
+    "`markov_time`, `variable_markov_time`)\n",
+    "\n",
+    "- Rosvall and Bergstrom (2011). Multilevel compression of random walks on networks\n",
+    "  reveals hierarchical organization. *PLoS ONE* 6(4), e18209.\n",
+    "  <https://doi.org/10.1371/journal.pone.0018209>\n",
+    "- Kawamoto and Rosvall (2015). Estimating the resolution limit of the map equation\n",
+    "  in community detection. *Phys. Rev. E* 91, 012809.\n",
+    "  <https://doi.org/10.1103/PhysRevE.91.012809>\n",
+    "- Kheirkhahzadeh, Lancichinetti, and Rosvall (2016). Efficient community detection\n",
+    "  of network flows for varying Markov times. *Phys. Rev. E* 93, 032309.\n",
+    "  <https://doi.org/10.1103/PhysRevE.93.032309>\n",
+    "- Edler, Smiljanić, Holmgren, Antonelli, and Rosvall (2022). Variable Markov\n",
+    "  dynamics as a multi-focal lens to map multi-scale complex networks.\n",
+    "  <https://arxiv.org/abs/2211.04287>\n",
+    "\n",
+    "**Flow model and teleportation** (`flow_model`, `directed`,\n",
+    "`teleportation_probability`, `recorded_teleportation`)\n",
+    "\n",
+    "- Lambiotte and Rosvall (2012). Ranking and clustering of nodes in networks with\n",
+    "  smart teleportation. *Phys. Rev. E* 85, 056107.\n",
+    "  <https://doi.org/10.1103/PhysRevE.85.056107>\n",
+    "\n",
+    "**Reliability and regularization** (`num_trials`, `converge`, `regularized`,\n",
+    "`entropy_corrected`)\n",
+    "\n",
+    "- Calatayud, Bernardo-Madrid, Neuman, Rojas, and Rosvall (2019). Exploring the\n",
+    "  solution landscape enables more reliable network community detection. *Phys. Rev.\n",
+    "  E* 100, 052308. <https://doi.org/10.1103/PhysRevE.100.052308>\n",
+    "- Smiljanić, Edler, and Rosvall (2020). Mapping flows on sparse networks with\n",
+    "  missing links. *Phys. Rev. E* 102, 012302.\n",
+    "  <https://doi.org/10.1103/PhysRevE.102.012302>\n",
+    "- Smiljanić, Blöcker, Edler, and Rosvall (2021). Mapping flows on weighted and\n",
+    "  directed networks with incomplete observations. *J. Complex Netw.* 9, cnab044.\n",
+    "  <https://doi.org/10.1093/comnet/cnab044>\n",
+    "\n",
+    "**Higher-order, multilayer, metadata, and bipartite** (`multilayer_relax_*`,\n",
+    "`meta_data`, bipartite options)\n",
+    "\n",
+    "- Rosvall, Esquivel, Lancichinetti, West, and Lambiotte (2014). Memory in network\n",
+    "  flows and its effects on spreading dynamics and community detection. *Nature\n",
+    "  Commun.* 5, 4630. <https://doi.org/10.1038/ncomms5630>\n",
+    "- De Domenico, Lancichinetti, Arenas, and Rosvall (2015). Identifying modular flows\n",
+    "  on multilayer networks reveals highly overlapping organization. *Phys. Rev. X* 5,\n",
+    "  011027. <https://doi.org/10.1103/PhysRevX.5.011027>\n",
+    "- Edler, Bohlin, and Rosvall (2017). Mapping higher-order network flows in memory\n",
+    "  and multilayer networks with Infomap. *Algorithms* 10, 112.\n",
+    "  <https://doi.org/10.3390/a10040112>\n",
+    "- Aslak, Rosvall, and Lehmann (2018). Constrained information flows in temporal\n",
+    "  networks reveal intermittent communities. *Phys. Rev. E* 97, 062312.\n",
+    "  <https://doi.org/10.1103/PhysRevE.97.062312>\n",
+    "- Emmons and Mucha (2019). Map equation with metadata: varying the role of\n",
+    "  attributes in community detection. *Phys. Rev. E* 100, 022301.\n",
+    "  <https://doi.org/10.1103/PhysRevE.100.022301>\n",
+    "- Blöcker and Rosvall (2020). Mapping flows on bipartite networks. *Phys. Rev. E*\n",
+    "  102, 052305. <https://doi.org/10.1103/PhysRevE.102.052305>\n",
+    "- Bassolas, Holmgren, Marot, Rosvall, and Nicosia (2022). Mapping nonlocal\n",
+    "  relationships between metadata and network structure. *Sci. Adv.* 8, eabn7558.\n",
+    "  <https://doi.org/10.1126/sciadv.abn7558>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md37",
+   "metadata": {},
+   "source": [
+    "## How to cite\n",
+    "\n",
+    "If you use Infomap in published work, mapequation.org recommends citing two things:\n",
+    "the map equation paper (Rosvall and Bergstrom, 2008,\n",
+    "<https://doi.org/10.1073/pnas.0706851105>) for the method, and the MapEquation\n",
+    "software package (Edler, Holmgren, and Rosvall) for the implementation and version.\n",
+    "See [How to cite](https://www.mapequation.org/publications/) for BibTeX."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md38",
+   "metadata": {},
+   "source": [
+    "## Where to go next\n",
+    "\n",
+    "- {doc}`quickstart <quickstart>` for a first end-to-end run.\n",
+    "- {doc}`benchmark-performance <benchmark-performance>` to plan run time and memory\n",
+    "  for the accuracy and speed options.\n",
+    "- The [Infomap user guide](https://www.mapequation.org/infomap/) documents file\n",
+    "  formats and the algorithm in depth."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/quickstart.ipynb
+++ b/examples/notebooks/quickstart.ipynb
@@ -33,7 +33,7 @@
    "source": [
     "## Run Infomap on a familiar graph\n",
     "\n",
-    "Start with Zachary's Karate Club graph. It is small enough to inspect directly and familiar enough to make the partition easy to judge."
+    "Start with Zachary's Karate Club graph. It is small enough to inspect and familiar enough to make the partition easy to judge."
    ]
   },
   {
@@ -218,6 +218,31 @@
     "\n",
     "result.to_csv(\"output/karate-infomap-nodes.csv\")\n",
     "nx.write_graphml(annotated_graph, \"output/karate-infomap.graphml\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "quickstart_cite",
+   "metadata": {},
+   "source": [
+    "## How to cite\n",
+    "\n",
+    "If you use Infomap in published work, mapequation.org recommends citing two things: the map equation paper (Rosvall and Bergstrom, 2008, <https://doi.org/10.1073/pnas.0706851105>) for the method, and the MapEquation software package (Edler, Holmgren, and Rosvall) for the implementation and version. See [How to cite](https://www.mapequation.org/publications/) for BibTeX."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "quickstart_next",
+   "metadata": {},
+   "source": [
+    "## Where to go next\n",
+    "\n",
+    "- {doc}`options guide <options-guide>` explains every Infomap option.\n",
+    "- {doc}`benchmark-performance <benchmark-performance>` helps you plan run time and memory.\n",
+    "- The compare notebooks put Infomap next to Louvain and Leiden in\n",
+    "  {doc}`NetworkX <compare-infomap-louvain-networkx>`,\n",
+    "  {doc}`igraph <compare-infomap-louvain-leiden-igraph>`, and\n",
+    "  {doc}`Scanpy <compare-infomap-scanpy-workflow>` workflows."
    ]
   }
  ],

--- a/examples/notebooks/run-infomap-on-graphrag-tables.ipynb
+++ b/examples/notebooks/run-infomap-on-graphrag-tables.ipynb
@@ -2,18 +2,25 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7fb27b941602401d91542211134fc71a",
+   "id": "md01",
    "metadata": {},
    "source": [
     "# Run Infomap on GraphRAG-style tables\n",
     "\n",
-    "GraphRAG workflows commonly build hierarchical communities with Leiden. This notebook runs Infomap on the same `entities.parquet` and `relationships.parquet` shape, writes GraphRAG-style community outputs, and compares the result with a small Leiden baseline when `igraph` is installed.\n"
+    "GraphRAG pipelines build a community hierarchy over an entity graph, usually with\n",
+    "Leiden. Infomap is a drop-in alternative that finds communities by compressing\n",
+    "flow rather than maximizing modularity. This notebook reads the GraphRAG\n",
+    "`entities.parquet` and `relationships.parquet` tables, runs Infomap, writes\n",
+    "GraphRAG-style community outputs, and compares the result with Leiden.\n",
+    "\n",
+    "For a first Infomap run, see the {doc}`quickstart <quickstart>`; for the options\n",
+    "used here, see the {doc}`options guide <options-guide>`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "acae54e37e7d407bbb7b55eff062a284",
+   "id": "code02",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -31,9 +38,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "md03",
+   "metadata": {},
+   "source": [
+    "## Build a small entity graph\n",
+    "\n",
+    "GraphRAG stores entities and their relationships as two Parquet tables. Here you\n",
+    "build a tiny example: two triangles, Alpha-Beta-Gamma and Delta-Epsilon-Zeta,\n",
+    "joined by one weak link, so the community structure is easy to check."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
+   "id": "code04",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,9 +81,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "md05",
+   "metadata": {},
+   "source": [
+    "## Read the tables into Infomap\n",
+    "\n",
+    "`read_graphrag` maps entity titles to node ids and loads the weighted edges. The\n",
+    "table below shows each relationship with the node ids Infomap will use."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8dd0d8092fe74a7c96281538738b07e2",
+   "id": "code06",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,9 +106,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "md07",
+   "metadata": {},
+   "source": [
+    "## Run Infomap\n",
+    "\n",
+    "`run_graphrag_communities` clusters the graph and writes GraphRAG-style outputs to\n",
+    "`output_dir`. Set `seed` and `num_trials` for a reproducible, stable result, the\n",
+    "same way you would for any Infomap run."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72eea5119410473aa328ad9291626812",
+   "id": "code08",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,9 +136,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "md09",
+   "metadata": {},
+   "source": [
+    "## Inspect the communities\n",
+    "\n",
+    "Infomap returns the per-node assignments and a GraphRAG-style community table with\n",
+    "one row per community, its level in the hierarchy, and its size."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8edb47106e1a46a883d545849b8ab81b",
+   "id": "code10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10185d26023b46108eb7d9f57d49d2b3",
+   "id": "code11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,9 +169,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "md12",
+   "metadata": {},
+   "source": [
+    "## Compare with Leiden\n",
+    "\n",
+    "Leiden is GraphRAG's default community detector. On this graph both methods recover\n",
+    "the two triangles. Infomap reports the result as a flow-based hierarchy, while\n",
+    "Leiden returns a flat modularity partition."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8763a12b2bbd4a93a75aff182afb95dc",
+   "id": "code13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,6 +234,20 @@
     "\n",
     "pd.DataFrame(comparison_rows)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md14",
+   "metadata": {},
+   "source": [
+    "## Where to go next\n",
+    "\n",
+    "- {doc}`quickstart <quickstart>` for a first end-to-end Infomap run.\n",
+    "- {doc}`options guide <options-guide>` for what `seed`, `num_trials`, and the other\n",
+    "  options do.\n",
+    "- {doc}`compare-infomap-louvain-leiden-igraph <compare-infomap-louvain-leiden-igraph>`\n",
+    "  for a closer Infomap, Louvain, and Leiden comparison."
+   ]
   }
  ],
  "metadata": {
@@ -186,7 +265,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/run-infomap-on-hpc.ipynb
+++ b/examples/notebooks/run-infomap-on-hpc.ipynb
@@ -9,7 +9,9 @@
     "\n",
     "Infomap trials are independent work units. That makes them a good fit for HPC: run many trials on one node with `--parallel-trials`, or split trials across a scheduler job array with `--trial-offset` and merge the shard results afterwards.\n",
     "\n",
-    "This notebook uses Python as orchestration glue. The expensive work runs in the native `Infomap` command-line binary. The final merge uses the Python helper `python -m infomap.merge`, which reads shard JSON files and copies the winning tree without rerunning Infomap."
+    "This notebook uses Python as orchestration glue. The expensive work runs in the native `Infomap` command-line binary. The final merge uses the Python helper `python -m infomap.merge`, which reads shard JSON files and copies the winning tree without rerunning Infomap.\n",
+    "\n",
+    "For what `--parallel-trials`, `--num-threads`, and the other flags do, see the {doc}`options guide <options-guide>`; to estimate run time and memory before scaling, see {doc}`benchmark-performance <benchmark-performance>`."
    ]
   },
   {

--- a/interfaces/python/source/examples/index.rst
+++ b/interfaces/python/source/examples/index.rst
@@ -9,6 +9,8 @@ Choose a notebook
 -----------------
 
 - :doc:`quickstart` — first end-to-end Infomap workflow in Python.
+- :doc:`options-guide` — what every Infomap option is for, with runnable
+  examples and a complete reference table.
 - :doc:`compare-infomap-louvain-networkx` — compare Infomap and Louvain with
   NetworkX when your graph already lives in NetworkX.
 - :doc:`compare-infomap-louvain-leiden-igraph` — compare Infomap, Louvain, and
@@ -57,6 +59,7 @@ Source notebooks
 ----------------
 
 - `quickstart.ipynb <https://github.com/mapequation/infomap/blob/master/examples/notebooks/quickstart.ipynb>`_
+- `options-guide.ipynb <https://github.com/mapequation/infomap/blob/master/examples/notebooks/options-guide.ipynb>`_
 - `compare-infomap-louvain-networkx.ipynb <https://github.com/mapequation/infomap/blob/master/examples/notebooks/compare-infomap-louvain-networkx.ipynb>`_
 - `compare-infomap-louvain-leiden-igraph.ipynb <https://github.com/mapequation/infomap/blob/master/examples/notebooks/compare-infomap-louvain-leiden-igraph.ipynb>`_
 - `compare-infomap-scanpy-workflow.ipynb <https://github.com/mapequation/infomap/blob/master/examples/notebooks/compare-infomap-scanpy-workflow.ipynb>`_
@@ -69,6 +72,7 @@ Source notebooks
    :maxdepth: 1
 
    quickstart
+   options-guide
    compare-infomap-louvain-networkx
    compare-infomap-louvain-leiden-igraph
    compare-infomap-scanpy-workflow

--- a/interfaces/python/source/examples/options-guide.ipynb
+++ b/interfaces/python/source/examples/options-guide.ipynb
@@ -1,0 +1,1 @@
+../../../../examples/notebooks/options-guide.ipynb


### PR DESCRIPTION
## What

Adds a new rendered docs notebook and brings the existing rendered example
notebooks up to a consistent quality bar.

### New: `options-guide.ipynb`
A goal-oriented guide to Infomap's many options:
- A "which option should I change?" table mapping goals to options.
- Runnable deep-dives per option group (accuracy/reproducibility, resolution
  and hierarchy, flow model, regularization, multilayer, metadata, input
  shaping, output), on `nx.ring_of_cliques`, a small synthetic hierarchy,
  Karate Club, and `jazz.net`.
- A pointer to the full reference (`help(InfomapOptions)`, `infomap --help`,
  `--print-json-parameters`, and the API options page).
- Per-section literature grounding plus a grouped References section with DOIs.
- A "how to cite" section matching mapequation.org.

Wired into the Python docs: symlink under `interfaces/python/source/examples/`,
three entries in `examples/index.rst`, a `notebooks.toml` entry (tier `smoke`),
and a README line.

### Polish of the other rendered notebooks
- `run-infomap-on-graphrag-tables`: grown from a near-bare script (1 markdown
  cell) into a structured walkthrough.
- `run-infomap-on-hpc`, `quickstart`, `benchmark-performance`, and the three
  `compare-*` notebooks: cross-links between pages, a consistent how-to-cite
  block (the map equation paper and the MapEquation software package, per
  mapequation.org), and removal of AI writing tells.
- Minor filler cleanup in two theory notebooks (`4.1`, `5.4`).

## Test plan
- `nbmake` passes on all 8 rendered notebooks.
- Local Sphinx build succeeds with no warnings; all `{doc}` cross-links
  resolve and pages render.
- Notebooks committed outputless; no changes to generated binding artifacts.