### PR TITLE
docs: fix drift from 2026-06 documentation audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,9 +18,9 @@ Do not bundle unrelated cleanup into the same change.
 - `src/`: C++ runtime behavior, algorithms, parsing, IO, and CLI semantics
 - `interfaces/python/`: Python package sources, tracked SWIG outputs, and Sphinx source
 - `interfaces/R/`: R package skeleton (`infomap/`) and tracked SWIG-generated R outputs (`generated/`)
-- `interfaces/js/`: JavaScript package sources, legacy parser package, and TypeScript sources
+- `interfaces/js/`: JavaScript package sources and TypeScript sources
 - `interfaces/swig/`: SWIG interface files shared by Python and R bindings
-- `test/`: Python-facing regression tests and fixtures
+- `test/`: C++ doctest suites (`test/cpp/`), Python regression tests (`test/python/`), native benchmarks (`test/bench/`), and shared fixtures
 - `examples/python/`: executable Python examples used by `make test-python`
 - `examples/R/`: executable R examples used by `make test-r-examples`
 - `.github/workflows/`: CI, release, and packaging workflows

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -121,7 +121,6 @@ Internal-supported images:
 
 - Python build/test image (`docker/python.Dockerfile`)
 - Ubuntu compatibility image (`docker/ubuntu.Dockerfile`)
-- RStudio image (`docker/rstudio.Dockerfile`)
 
 Supported images should stay aligned with the current Make-based workflows and
 retain smoke coverage in CI.

--- a/BUILD.md
+++ b/BUILD.md
@@ -388,7 +388,6 @@ Internal-supported images:
 
 - Python build/test image: `docker/python.Dockerfile`
 - Ubuntu compatibility image: `docker/ubuntu.Dockerfile`
-- RStudio image: `docker/rstudio.Dockerfile`
 
 Use Docker Compose v2 commands with the local compose file, for example:
 

--- a/examples/R/README.md
+++ b/examples/R/README.md
@@ -25,10 +25,13 @@ make dev-r-install
 
 ```sh
 Rscript examples/R/example-minimal.R
-Rscript examples/R/example-igraph.R   # also requires `igraph`
+Rscript examples/R/example-igraph.R       # also requires `igraph`
+Rscript examples/R/example-multilayer.R
 ```
 
 `example-minimal.R` constructs a small directed network programmatically and
 prints the resulting partition. `example-igraph.R` shows how to import an
 existing `igraph` graph and convert the result back into an
-`igraph::communities` object.
+`igraph::communities` object. `example-multilayer.R` clusters a two-layer
+network with `cluster_infomap_multilayer()` and the lower-level
+`add_multilayer_intra_link()` / `add_multilayer_inter_link()` R6 API.

--- a/interfaces/R/infomap/README.md
+++ b/interfaces/R/infomap/README.md
@@ -20,7 +20,7 @@ Source install from a release tarball — pick the version from the
 [GitHub releases page](https://github.com/mapequation/infomap/releases):
 
 ```r
-# Replace VERSION with the desired tag, e.g. "2.9.2".
+# Replace VERSION with the desired tag, e.g. "2.13.0".
 install.packages(
   paste0("https://github.com/mapequation/infomap/releases/download/v",
          "VERSION", "/infomap_", "VERSION", ".tar.gz"),
@@ -75,6 +75,32 @@ as.data.frame(im)         # one row per node, with path / flow / name / module_i
 See `?cluster_infomap` for the one-call helper, `?Infomap` for the
 low-level constructor plus the `InfomapClass` method and active-binding
 reference, and `?infomap_options` for the complete list of named options.
+
+## Multilayer networks
+
+Cluster a multilayer network with `cluster_infomap_multilayer()`. Pass a
+data frame of intra-layer links (`layer`, `node_from`, `node_to`) and let
+Infomap couple layers automatically via `multilayer_relax_rate`, or pass
+full multilayer links (`layer_from`, `node_from`, `layer_to`, `node_to`,
+optional `weight`) to set inter-layer couplings explicitly:
+
+```r
+intra <- data.frame(
+  layer     = c(1, 1, 1, 2, 2, 2),
+  node_from = c(1, 2, 3, 1, 2, 3),
+  node_to   = c(2, 3, 1, 2, 3, 1)
+)
+
+result <- cluster_infomap_multilayer(intra, silent = TRUE, num_trials = 10)
+result$codelength
+result$nodes        # one row per state node, including a `layer_id` column
+```
+
+For weighted inter-layer couplings that come from a different source than
+the intra-layer links, use the low-level R6 API with
+`im$add_multilayer_intra_link()` and `im$add_multilayer_inter_link()`. See
+`?cluster_infomap_multilayer` and `examples/R/example-multilayer.R` for a
+full walkthrough.
 
 ## Working with igraph
 

--- a/skills/infomap/references/notebooks.md
+++ b/skills/infomap/references/notebooks.md
@@ -24,6 +24,14 @@ Notebook runtimes can grow quickly when examples download data, build layouts, c
 
 ## Notebook topics
 
+Flagship notebooks (start here for most tasks):
+
+- `quickstart.ipynb` — Python quickstart with a notebook-native summary and a small network visualization;
+- `options-guide.ipynb` — goal-oriented tour of Infomap's options with a reference table generated from the installed package;
+- `run-infomap-on-hpc.ipynb` — native trial sharding, scheduler-aware threads, and Python shard merging;
+- `benchmark-performance.ipynb` — committed time/memory benchmarks for planning runs by size, threads, trials, and depth;
+- `run-infomap-on-graphrag-tables.ipynb` — GraphRAG-style Parquet workflow with a Leiden comparison.
+
 The survey companion notebooks cover:
 
 - two-level map equation and two-level search;

--- a/skills/infomap/references/reproducibility.md
+++ b/skills/infomap/references/reproducibility.md
@@ -25,7 +25,7 @@ Record:
 
 ## Runtime planning
 
-Use these local benchmark results only as order-of-magnitude guidance. They were measured on macOS arm64 with Infomap 2.10.1, `seed=123`, no file output, and wall-clock time around `read_file + run`. Python used the package API from a virtual environment; R includes one-shot `Rscript` startup overhead.
+Use these local benchmark results only as order-of-magnitude guidance. They were measured on macOS arm64 with Infomap 2.10.1, `seed=123`, no file output, and wall-clock time around `read_file + run`; the 2.11–2.13 releases added several performance improvements, so treat these numbers as upper bounds and prefer the regenerated figures in `examples/notebooks/benchmark-performance.ipynb`. Python used the package API from a virtual environment; R includes one-shot `Rscript` startup overhead.
 
 | Network | Size | States | Links | Trials | CLI | Python | R |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
@@ -36,6 +36,8 @@ Use these local benchmark results only as order-of-magnitude guidance. They were
 | first-order edge list | 16.9 MB | 0 | 1M | 1 | 3.80s | 4.11s | 8.22s |
 | first-order edge list | 16.9 MB | 0 | 1M | 5 | 16.68s | 17.55s | 41.40s |
 | state network | 19.2 MB | 400k | 800k | 1 | 10.62s | 11.51s | 26.49s |
+
+For large or repeated runs, prefer convergence-aware and parallel options over a fixed high trial count: `--converge` stops trials on a codelength plateau, `--parallel-trials` runs independent trials concurrently, and `--num-threads` auto-detects cpuset/SLURM/OpenMP limits. On HPC, shard trials across jobs with `--trial-offset`/`--trial-results` and merge with the `infomap.merge` helper (see `run-infomap-on-hpc.ipynb`).
 
 Practical gating:
 


### PR DESCRIPTION
## Summary

Fixes the confirmed documentation drift found in a full audit of the project docs against the current code (v2.13.0). Documentation-only — no code, build files, or Sphinx `.rst` source touched.

- **Remove stale references** (`6b4d72ea`): drop the non-existent `docker/rstudio.Dockerfile` from ARCHITECTURE.md and BUILD.md; fix the AGENTS.md repo map (remove the parser package deleted in #410, complete the `test/` description to cover `test/cpp/` and `test/bench/`).
- **Document the multilayer R helper** (`e699e9d8`): add a "Multilayer networks" section to the R package README covering `cluster_infomap_multilayer()` and the R6 `add_multilayer_intra_link()`/`add_multilayer_inter_link()` API; list `example-multilayer.R` in `examples/R/README.md`; bump the stale `2.9.2` install-example placeholder to `2.13.0`.
- **Refresh the infomap skill references** (`d632eb39`): add the flagship notebooks (quickstart, options-guide, HPC, benchmark, GraphRAG) to `notebooks.md`; reframe the `reproducibility.md` benchmark table as a historical baseline (measured on 2.10.1; 2.11–2.13 improved perf) and add `--converge`/`--parallel-trials`/`--num-threads` and trial-sharding guidance.

Deliberately **not** included: a GraphRAG API reference page (left to the existing notebook — maintainer call) and soft mentions in `method-selection.md`/`faq.md` (written defensively, no factual error). The auto-generated surfaces (CHANGELOG, version files, CLI option catalog, `_options.py`/`options.rst`, JS `parameters.json`) were verified already in sync.

## Test Plan

- [x] No code/build/`.rst` changes — markdown prose only.
- [x] `grep` confirms no remaining `rstudio` references in ARCHITECTURE.md/BUILD.md/docker/.
- [x] `test/cpp`, `test/python`, `test/bench`, `test/fixtures` exist (AGENTS map).
- [x] `cluster_infomap_multilayer` exported in R NAMESPACE; both R6 multilayer methods present; `examples/R/example-multilayer.R` exists.
- [x] All five flagship notebooks exist; `--converge`/`--parallel-trials`/`--num-threads`/`--trial-offset`/`--trial-results` present in `ParameterCatalog.cpp`; `infomap.merge` exists.