### PR TITLE
docs: scope infomap skill to analysis use and ground method-selection in the literature

### DIFF
--- a/skills/infomap/SKILL.md
+++ b/skills/infomap/SKILL.md
@@ -1,11 +1,15 @@
 ---
 name: infomap
-description: Use when helping researchers use Infomap, the map equation, or the Infomap CLI, Python package, or R package for community detection workflows, including reproducible analysis, method selection, notebooks, and multilayer, memory/state, metadata, bipartite, or flow-model choices.
+description: Use when helping someone USE Infomap as an analysis tool — running the map equation for community detection via the Infomap CLI, Python package, R package, or notebooks; choosing a network representation or flow model (multilayer, memory/state, metadata, bipartite); reproducible analysis; result interpretation; or method selection. NOT for developing the Infomap software itself: editing its source (src/, the C++/SWIG bindings, CMake, CI, vendored libs) or building/debugging/testing the codebase is ordinary software development, not an Infomap analysis task.
 ---
 
 # Infomap Research Workflows
 
 Use this skill to help researchers run, explain, adapt, or troubleshoot Infomap analyses with the CLI, Python package, R package, and survey companion notebooks.
+
+## When NOT to use this skill
+
+This skill is for *using* Infomap to analyze networks. It is **not** for developing Infomap itself. If the task is editing, building, profiling, debugging, or testing the Infomap source — the C++ in `src/`, the SWIG Python/R bindings, CMake/CI, vendored libraries, the CLI parameter catalog, or the repo's own test suite — that is ordinary software development; do not use this skill, even when working inside the Infomap repository. The presence of Infomap source files or CLI/option names in the task is not a trigger; the trigger is a user analyzing a network with Infomap.
 
 ## First classify the task
 

--- a/skills/infomap/references/method-selection.md
+++ b/skills/infomap/references/method-selection.md
@@ -2,6 +2,14 @@
 
 Use this reference when the user needs help turning a research problem into an Infomap analysis design.
 
+## Is Infomap the right tool?
+
+There is no single "true" partition of a network; the method should match the question.
+
+- **Use Infomap (flow-based) when a real dynamical process moves on the network** — movement, dispersal, biomass or gene flow, citations, traffic, spreading, money, web transitions — and when direction and weights carry that process. The map equation finds modules that trap that flow.
+- **Prefer modularity (Q) or a stochastic block model when the question is purely structural** — density-based groups relative to a random-expectation null (modularity), or structurally-equivalent *roles* (SBM).
+- Because Infomap follows flow, strongly connected groups can **merge** once the flow between them grows past a threshold — a modeling consequence of following flow, not a bug — whereas unweighted modularity may keep them split. If a user expects fixed structural blocks regardless of flow strength, flow-based clustering may not be what they want (see Farage et al. 2021).
+
 ## Survey frame
 
 The survey article (`https://doi.org/10.1145/3779648`) organizes map equation workflows as:
@@ -12,7 +20,15 @@ The survey article (`https://doi.org/10.1145/3779648`) organizes map equation wo
 
 Ask only the questions needed for the task. If the user wants code immediately, infer reasonable defaults and state them briefly.
 
-## Representation choices
+## Choosing a representation
+
+Balance simplicity and accuracy. The map equation selects models by description length: the best model gives the shortest code, trading model fit against model complexity, so too-few modules underfit and too-many overfit.
+
+- **Incorporate weights and direction when they are available and meaningful** — they usually improve accuracy at little cost.
+- **Reach for richer representations** (memory/state, multilayer, metadata, bipartite) **when the data actually encode that structure or the question requires it** — not by reflex. Let the research question drive the choice.
+- Two practical cautions: richer representations create many more state nodes and links and are **harder to optimize**, so they may need more trials to reach a good solution; and use codelength to compare **module counts or regularization strength within one representation**, not as a way to pick between representations (that is a modeling decision driven by the question and the data).
+
+Representation options:
 
 - **Simple pairwise network**: use when interactions are ordinary node-node links. Preserve weights and direction when they are meaningful and available.
 - **Directed network**: use when link orientation represents the process, such as citations, transitions, web links, pathways, or asymmetric movement.
@@ -22,6 +38,25 @@ Ask only the questions needed for the task. If the user wants code immediately, 
 - **Metadata network**: use when node attributes should influence the module description, such as known categories, labels, environments, or annotations.
 - **Bipartite network**: use when links only connect two node types, such as documents-terms, plants-pollinators, users-items, or features-samples.
 - **Incomplete-data workflow**: use when observed links are sparse samples of an underlying flow process and regularization or Bayesian prior assumptions matter.
+
+## Scale and resolution
+
+How fine or coarse the modules come out is a modeling choice, not just an output. The main levers:
+
+- **Markov time** is the scale knob. Longer Markov time favors **fewer, larger** modules (coarser, shallower hierarchies); shorter Markov time (< 1) favors **more, smaller** modules (finer, deeper). It changes the model, so report it whenever it is non-default (Kheirkhahzadeh et al. 2016).
+- **Field-of-view limit**: on large, *sparse* structures a random walker stays local and can shatter one big sparse community into many small look-alike ones (overfitting). If a large sparse network — street grids, sparse occurrence or bipartite data, brain pathways — fragments into many tiny modules that shift across seeds, suspect the field-of-view limit and look for a *variable Markov time* option rather than just adding trials (Edler et al. 2022).
+- **Resolution limit**: the map equation's resolution limit depends on the **cut size** (the number of links *between* modules), not on the total number of links as in modularity — so it is comparatively mild. If you suspect genuinely small modules are being merged, prefer the **multilevel (hierarchical)** solution and/or sweep Markov time before forcing a target module count; the hierarchical remedy works when real nested structure exists (Kawamoto et al. 2015).
+- A unipartite **projection of a bipartite network behaves roughly like doubling the Markov time**, i.e. it coarsens — prefer modeling the bipartite structure directly when scale matters (Kheirkhahzadeh et al. 2016).
+
+Treat forced module counts (e.g. a preferred-number-of-modules knob) as sensitivity analysis, not as evidence the data contain that many modules.
+
+## Higher-order, multilayer, and temporal configuration
+
+- **Memory / state networks** need actual pathway or sequence data (trajectories of steps); a second-order model **cannot be recovered from an aggregated first-order network**. Expect smaller, often **overlapping** modules and shifted node rankings. A second-order model usually captures most of the gain, with diminishing returns at higher orders — so prefer second order unless the data clearly justify more (Rosvall et al. 2014).
+- **Multilayer coupling** is governed by the inter-layer **relax rate** `r`: `r = 0` keeps layers fully separate, `r = 1` fully aggregates them. The right value is **system-dependent** — common working values are `r = 0.15` (a frequent default) and a note that results are often robust around `0.25`, but tune to the data and use explicit inter-layer links when you actually have them (De Domenico et al. 2015; Edler et al. 2017).
+- **Intermittent or asynchronous communities**: uniform (whole-layer) or adjacent-layer coupling can dilute boundaries and merge communities that recur at different times. For communities that appear intermittently, prefer **node-level similarity-based coupling** (neighborhood / Jensen-Shannon) over uniform coupling (Aslak et al. 2017).
+
+Verify the exact option names for Markov time, variable Markov time, relax rate, and coupling from the installed CLI help or API before generating code, since names and availability differ across versions and interfaces.
 
 ## Metadata and bipartite prompts
 
@@ -41,8 +76,8 @@ For bipartite workflows, clarify:
 
 ## Flow-model choices
 
-- For undirected pairwise structure, the default unbiased random-walk model is usually enough.
-- For directed links, use directed flow modeling instead of symmetrizing unless the research question explicitly ignores direction.
+- For undirected pairwise structure, the default unbiased random-walk model is usually enough; teleportation is not needed on undirected networks.
+- For directed links, use directed flow modeling instead of symmetrizing unless the research question explicitly ignores direction. Teleportation choice affects directed clustering — prefer the established default (unrecorded-link teleportation) over hand-tuning the teleportation rate (Lambiotte & Rosvall 2012).
 - For observed flows or transition counts, consider whether precomputed or raw directed flow better matches the data; verify current option names from CLI help or API docs.
 - For higher-order, temporal, or multi-context data, model state nodes or layers explicitly instead of flattening if flattening would mix distinct flows.
 - For metadata or bipartite workflows, verify the current interface support before generating code because details differ across CLI, Python, and R.


### PR DESCRIPTION
## Summary

Two improvements to the bundled `infomap` skill (the research-workflow guide), found while it kept over-triggering during local development of this repo.

- **Scope the skill to *using* Infomap, not developing it** (`ed7dead`): rewrote the `description` and added a "When NOT to use this skill" section so the skill no longer activates for codebase work (editing `src/`, the C++/SWIG bindings, CMake/CI, vendored libs, the CLI parameter catalog, or the repo's own tests) — only for analyzing networks with Infomap.
- **Ground `method-selection.md` in the map-equation literature** (`1cf3dac`): turned the flat representation catalog into decision guidance with tradeoffs and pitfalls — a flow-vs-topology "is Infomap the right tool?" gate, the simplicity-vs-accuracy (description-length) framing, a Scale and resolution section (Markov-time direction, field-of-view limit, cut-size resolution limit, bipartite-projection≈doubling), and higher-order/multilayer/temporal configuration guidance (memory needs path data; relax-rate `r` is system-dependent; intermittent communities need similarity coupling). API specifics still defer to the installed help.

## Validation

The trigger-scope change was tested with isolated subagent discovery decisions under realistic in-repo pressure:
- RED: the *old* description falsely triggers on "add a CLI option + regenerate the SWIG bindings".
- GREEN: the *new* description rejects that and all other dev tasks (warning fix, rebuild+ctest, writing repo tests) while still triggering on every research/usage case — including usage questions that mention CLI options or `.tree` output.

The method-selection rework was retrieval-tested: given only the new file, subagents correctly recommended a second-order memory network for airline-itinerary data and diagnosed the field-of-view limit (→ variable Markov time) for a fragmenting sparse street grid. All literature claims were fact-checked against the source papers; two draft overstatements (a cross-representation "let codelength pick" rule and a "0.15–0.25 robust default" relax rate) were corrected before writing.

## Notes
- Doc-only; no code, build, or `.rst` changes.
- The skill also has a separately-maintained active copy under `~/.claude/skills/infomap/`; both copies were updated in sync locally.