### PR TITLE
build: mark generated files as linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,27 @@
+# Generated-and-tracked files.
+#
+# These are committed (not .gitignored) on purpose: downstream builds consume
+# them without the generator toolchain. The SWIG wrappers let the PyPI sdist,
+# r-universe, CRAN, and `remotes::install_github` build without SWIG 4.4.1; the
+# option/metadata files and roxygen docs ship in the published packages.
+#
+# `linguist-generated=true` collapses them in GitHub pull-request diffs and
+# drops them from the repository language stats — without changing the build.
+# Regenerate with `make build-python-swig build-r-swig build-binding-options`
+# (+ js metadata) and `devtools::document()` for the R docs; CI verifies
+# freshness for everything except the roxygen output.
+
+# SWIG wrappers + the binding/metadata files that live in the generated/ dirs
+interfaces/**/generated/** linguist-generated=true
+
+# SWIG Python module wrapper (lives in the package source tree)
+interfaces/python/src/infomap/_swig.py linguist-generated=true
+
+# Option APIs generated from C++ metadata by scripts/generate_binding_options.py
+interfaces/python/src/infomap/_options.py linguist-generated=true
+interfaces/R/infomap/R/options.R          linguist-generated=true
+interfaces/js/src/arguments.ts            linguist-generated=true
+
+# roxygen2 output (regenerated with devtools::document())
+interfaces/R/infomap/NAMESPACE   linguist-generated=true
+interfaces/R/infomap/man/*.Rd    linguist-generated=true


### PR DESCRIPTION
## What

Add a `.gitattributes` that tags every generated-and-tracked file as `linguist-generated`.

## Why

These generator outputs are committed (not `.gitignored`) on purpose — downstream builds consume them without the generator toolchain:

- **SWIG wrappers** let the PyPI sdist, r-universe, CRAN, and `remotes::install_github` build **without SWIG 4.4.1** (`setup.py` compiles the wrapper directly; `bootstrap.R`/`configure` copy the tracked outputs into the R package).
- **Option/metadata/roxygen** files ship in the published packages.

So removing them from the repo isn't viable — but the diff/search noise they cause is. `linguist-generated=true` collapses them in GitHub PR diffs and drops them from the repo language stats, **without changing the build or the CI freshness checks**.

## Coverage

Swept `mk/`, `scripts/`, and CI for every generator. Four groups, all tagged:

| Generator | Files |
|---|---|
| SWIG (`generate_{python,r}_swig.py`) | `python/generated/infomap_wrap.cpp`, `python/src/infomap/_swig.py`, `R/generated/infomap_wrap.cpp`, `R/generated/infomap.R` |
| Binding options (`generate_binding_options.py`) | `python/src/infomap/_options.py`, `R/infomap/R/options.R`, `js/src/arguments.ts` |
| JS metadata (`generate_js_metadata.py`) | `js/generated/parameters.json`, `js/generated/output-formats.json` |
| roxygen2 (`devtools::document()`) | `R/infomap/NAMESPACE`, `R/infomap/man/*.Rd` |

Verified with `git check-attr` that all generated paths resolve to `linguist-generated: true` and hand-written files (`_facade.py`, `Infomap.R`, `StateNetwork.cpp`, `Makevars*.in`) stay `unspecified`.

Deliberately excluded: `CHANGELOG.md` / `.release-please-manifest.json` (release tooling, meant to be human-readable) and `Makevars*.in` (hand-edited templates; rendered output is already gitignored).