### PR TITLE
feat: expose state node names in Python and R results

### DIFF
--- a/interfaces/R/generated/infomap.R
+++ b/interfaces/R/generated/infomap.R
@@ -23633,6 +23633,42 @@ attr(`InfomapWrapper_getNames`, 'returnType') = '_p_std__mapT_unsigned_int_std__
 attr(`InfomapWrapper_getNames`, "inputTypes") = c('_p_infomap__InfomapWrapper')
 class(`InfomapWrapper_getNames`) = c("SWIGFunction", class('InfomapWrapper_getNames'))
 
+# Start of InfomapWrapper_getStateNames
+
+`InfomapWrapper_getStateNames` = function(self, .copy = FALSE)
+{
+  if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
+  ;ans = .Call('R_swig_InfomapWrapper_getStateNames', self, as.logical(.copy), PACKAGE='infomap');
+  ans <- if (is.null(ans)) ans
+  else new("_p_std__mapT_unsigned_int_std__string_t", ref=ans);
+  
+  ans
+  
+}
+
+attr(`InfomapWrapper_getStateNames`, 'returnType') = '_p_std__mapT_unsigned_int_std__string_t'
+attr(`InfomapWrapper_getStateNames`, "inputTypes") = c('_p_infomap__InfomapWrapper')
+class(`InfomapWrapper_getStateNames`) = c("SWIGFunction", class('InfomapWrapper_getStateNames'))
+
+# Start of InfomapWrapper_getStateName
+
+`InfomapWrapper_getStateName` = function(self, stateId, .copy = FALSE)
+{
+  if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
+  stateId = as.integer(stateId);
+  
+  if(length(stateId) > 1) {
+    warning("using only the first element of stateId");
+  };
+  
+  ;.Call('R_swig_InfomapWrapper_getStateName', self, stateId, as.logical(.copy), PACKAGE='infomap');
+  
+}
+
+attr(`InfomapWrapper_getStateName`, 'returnType') = 'character'
+attr(`InfomapWrapper_getStateName`, "inputTypes") = c('_p_infomap__InfomapWrapper', 'integer')
+class(`InfomapWrapper_getStateName`) = c("SWIGFunction", class('InfomapWrapper_getStateName'))
+
 # Start of InfomapWrapper_addPhysicalNode
 
 `InfomapWrapper_addPhysicalNode__SWIG_0` = function(self, id, name)
@@ -24501,7 +24537,7 @@ class(`InfomapWrapper_run__SWIG_2`) = c("SWIGFunction", class('InfomapWrapper_ru
 setMethod('$', '_p_infomap__InfomapWrapper', function(x, name)
 
 {
-  accessorFuns = list('readInputData' = InfomapWrapper_readInputData, 'addNode' = InfomapWrapper_addNode, 'addName' = InfomapWrapper_addName, 'getName' = InfomapWrapper_getName, 'getNames' = InfomapWrapper_getNames, 'addPhysicalNode' = InfomapWrapper_addPhysicalNode, 'addStateNode' = InfomapWrapper_addStateNode, 'addLink' = InfomapWrapper_addLink, 'addLinks' = InfomapWrapper_addLinks, 'addMultilayerLink' = InfomapWrapper_addMultilayerLink, 'addMultilayerLinks' = InfomapWrapper_addMultilayerLinks, 'addMultilayerIntraLink' = InfomapWrapper_addMultilayerIntraLink, 'addMultilayerIntraLinks' = InfomapWrapper_addMultilayerIntraLinks, 'addMultilayerInterLink' = InfomapWrapper_addMultilayerInterLink, 'addMultilayerInterLinks' = InfomapWrapper_addMultilayerInterLinks, 'getMultilayerStateId' = InfomapWrapper_getMultilayerStateId, 'setBipartiteStartId' = InfomapWrapper_setBipartiteStartId, 'getLinks' = InfomapWrapper_getLinks, 'getLinkResults' = InfomapWrapper_getLinkResults, 'getModules' = InfomapWrapper_getModules, 'codelength' = InfomapWrapper_codelength, 'getEntropyRate' = InfomapWrapper_getEntropyRate, 'getMultilevelModules' = InfomapWrapper_getMultilevelModules, 'iterLeafNodes' = InfomapWrapper_iterLeafNodes, 'iterTree' = InfomapWrapper_iterTree, 'run' = InfomapWrapper_run);
+  accessorFuns = list('readInputData' = InfomapWrapper_readInputData, 'addNode' = InfomapWrapper_addNode, 'addName' = InfomapWrapper_addName, 'getName' = InfomapWrapper_getName, 'getNames' = InfomapWrapper_getNames, 'getStateNames' = InfomapWrapper_getStateNames, 'getStateName' = InfomapWrapper_getStateName, 'addPhysicalNode' = InfomapWrapper_addPhysicalNode, 'addStateNode' = InfomapWrapper_addStateNode, 'addLink' = InfomapWrapper_addLink, 'addLinks' = InfomapWrapper_addLinks, 'addMultilayerLink' = InfomapWrapper_addMultilayerLink, 'addMultilayerLinks' = InfomapWrapper_addMultilayerLinks, 'addMultilayerIntraLink' = InfomapWrapper_addMultilayerIntraLink, 'addMultilayerIntraLinks' = InfomapWrapper_addMultilayerIntraLinks, 'addMultilayerInterLink' = InfomapWrapper_addMultilayerInterLink, 'addMultilayerInterLinks' = InfomapWrapper_addMultilayerInterLinks, 'getMultilayerStateId' = InfomapWrapper_getMultilayerStateId, 'setBipartiteStartId' = InfomapWrapper_setBipartiteStartId, 'getLinks' = InfomapWrapper_getLinks, 'getLinkResults' = InfomapWrapper_getLinkResults, 'getModules' = InfomapWrapper_getModules, 'codelength' = InfomapWrapper_codelength, 'getEntropyRate' = InfomapWrapper_getEntropyRate, 'getMultilevelModules' = InfomapWrapper_getMultilevelModules, 'iterLeafNodes' = InfomapWrapper_iterLeafNodes, 'iterTree' = InfomapWrapper_iterTree, 'run' = InfomapWrapper_run);
   ;        idx = pmatch(name, names(accessorFuns));
   if(is.na(idx)) 
   return(callNextMethod(x, name));

--- a/interfaces/R/generated/infomap_wrap.cpp
+++ b/interfaces/R/generated/infomap_wrap.cpp
@@ -47328,6 +47328,86 @@ R_swig_InfomapWrapper_getNames ( SEXP self, SEXP s_swig_copy)
 
 
 SWIGEXPORT SEXP
+R_swig_InfomapWrapper_getStateNames ( SEXP self, SEXP s_swig_copy)
+{
+  {
+    std::map< unsigned int,std::string,std::less< unsigned int >,std::allocator< std::pair< unsigned int const,std::string > > > result;
+    infomap::InfomapWrapper *arg1 = 0 ;
+    void *argp1 = 0 ;
+    int res1 = 0 ;
+    unsigned int r_nprotect = 0;
+    SEXP r_ans = R_NilValue ;
+    VMAXTYPE r_vmax = vmaxget() ;
+    
+    res1 = SWIG_R_ConvertPtr(self, &argp1, SWIGTYPE_p_infomap__InfomapWrapper, 0 |  0 );
+    if (!SWIG_IsOK(res1)) {
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapWrapper_getStateNames" "', argument " "1"" of type '" "infomap::InfomapWrapper const *""'"); 
+    }
+    arg1 = reinterpret_cast< infomap::InfomapWrapper * >(argp1);
+    {
+      try {
+        result = ((infomap::InfomapWrapper const *)arg1)->getStateNames();
+      } catch (const std::exception& e) {
+        SWIG_exception(SWIG_RuntimeError, e.what());
+      }
+    }
+    r_ans = swig::from(static_cast< std::map< unsigned int,std::string,std::less< unsigned int >,std::allocator< std::pair< unsigned int const,std::string > > > >(result));
+    vmaxset(r_vmax);
+    if(r_nprotect)  Rf_unprotect(r_nprotect);
+    
+    return r_ans;
+    fail: SWIGUNUSED;
+  }
+  Rf_error("%s %s", SWIG_ErrorType(SWIG_lasterror_code), SWIG_lasterror_msg);
+  return R_NilValue;
+}
+
+
+SWIGEXPORT SEXP
+R_swig_InfomapWrapper_getStateName ( SEXP self, SEXP stateId, SEXP s_swig_copy)
+{
+  {
+    std::string result;
+    infomap::InfomapWrapper *arg1 = 0 ;
+    unsigned int arg2 ;
+    void *argp1 = 0 ;
+    int res1 = 0 ;
+    int val2 ;
+    int ecode2 = 0 ;
+    unsigned int r_nprotect = 0;
+    SEXP r_ans = R_NilValue ;
+    VMAXTYPE r_vmax = vmaxget() ;
+    
+    res1 = SWIG_R_ConvertPtr(self, &argp1, SWIGTYPE_p_infomap__InfomapWrapper, 0 |  0 );
+    if (!SWIG_IsOK(res1)) {
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapWrapper_getStateName" "', argument " "1"" of type '" "infomap::InfomapWrapper const *""'"); 
+    }
+    arg1 = reinterpret_cast< infomap::InfomapWrapper * >(argp1);
+    ecode2 = SWIG_AsVal_int(stateId, &val2);
+    if (!SWIG_IsOK(ecode2)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "InfomapWrapper_getStateName" "', argument " "2"" of type '" "unsigned int""'");
+    } 
+    arg2 = static_cast< unsigned int >(val2);
+    {
+      try {
+        result = ((infomap::InfomapWrapper const *)arg1)->getStateName(arg2);
+      } catch (const std::exception& e) {
+        SWIG_exception(SWIG_RuntimeError, e.what());
+      }
+    }
+    r_ans = SWIG_From_std_string(static_cast< std::string >(result));
+    vmaxset(r_vmax);
+    if(r_nprotect)  Rf_unprotect(r_nprotect);
+    
+    return r_ans;
+    fail: SWIGUNUSED;
+  }
+  Rf_error("%s %s", SWIG_ErrorType(SWIG_lasterror_code), SWIG_lasterror_msg);
+  return R_NilValue;
+}
+
+
+SWIGEXPORT SEXP
 R_swig_InfomapWrapper_addPhysicalNode__SWIG_0 ( SEXP self, SEXP id, SEXP name)
 {
   {
@@ -50016,6 +50096,7 @@ SWIGINTERN R_CallMethodDef CallEntries[] = {
    {"R_swig_Config_haveMetaData", (DL_FUNC) &R_swig_Config_haveMetaData, 2},
    {"R_swig_InfomapBase_getElapsedTime", (DL_FUNC) &R_swig_InfomapBase_getElapsedTime, 2},
    {"R_swig_vector_double_pop", (DL_FUNC) &R_swig_vector_double_pop, 2},
+   {"R_swig_InfomapWrapper_getStateName", (DL_FUNC) &R_swig_InfomapWrapper_getStateName, 3},
    {"R_swig_Config_multilayerRelaxLimitUp_get", (DL_FUNC) &R_swig_Config_multilayerRelaxLimitUp_get, 2},
    {"R_swig_InfomapWrapper_getName", (DL_FUNC) &R_swig_InfomapWrapper_getName, 3},
    {"R_swig_InfomapIterator_getMetaData__SWIG_0", (DL_FUNC) &R_swig_InfomapIterator_getMetaData__SWIG_0, 3},
@@ -50426,6 +50507,7 @@ SWIGINTERN R_CallMethodDef CallEntries[] = {
    {"R_swig_InfomapIterator_initClean", (DL_FUNC) &R_swig_InfomapIterator_initClean, 1},
    {"R_swig_InfomapParentIterator_disposeInfomap", (DL_FUNC) &R_swig_InfomapParentIterator_disposeInfomap, 2},
    {"R_swig_InfomapIterator_expandChildren", (DL_FUNC) &R_swig_InfomapIterator_expandChildren, 2},
+   {"R_swig_InfomapWrapper_getStateNames", (DL_FUNC) &R_swig_InfomapWrapper_getStateNames, 2},
    {"R_swig_Config_noSelfLinks_set", (DL_FUNC) &R_swig_Config_noSelfLinks_set, 2},
    {"R_swig_Config_numRandomMoves_set", (DL_FUNC) &R_swig_Config_numRandomMoves_set, 2},
    {"R_swig_InfoNode_children__SWIG_0", (DL_FUNC) &R_swig_InfoNode_children__SWIG_0, 2},

--- a/interfaces/R/infomap/R/Infomap.R
+++ b/interfaces/R/infomap/R/Infomap.R
@@ -1169,6 +1169,41 @@ InfomapClass <- R6::R6Class(
       out[nzchar(out)]
     },
 
+    #' @description Look up a state node's name.
+    #' @param state_id Integer state node id.
+    #' @param default Value returned when the state node has no name.
+    #' @return Character (or `default`).
+    get_state_name = function(state_id, default = NULL) {
+      name <- private$.swig$getStateName(as.integer(state_id))
+      if (identical(name, "")) {
+        return(default)
+      }
+      name
+    },
+
+    #' @description Get all assigned state node names.
+    #' @details
+    #' Populated for higher-order (state/memory) networks whose `*States`
+    #' section names the state nodes; empty otherwise. Physical node names
+    #' are available separately via `get_names()`.
+    #' @return A named character vector mapping state id to name.
+    get_state_names = function() {
+      # SWIG R returns std::map as an opaque pointer, so walk state nodes
+      # and ask for each name individually.
+      ids <- self$get_nodes(depth_level = 1L, states = TRUE)$state_id
+      ids <- unique(ids)
+      out <- vapply(
+        ids,
+        function(id) {
+          name <- private$.swig$getStateName(as.integer(id))
+          if (is.null(name)) "" else name
+        },
+        character(1L)
+      )
+      names(out) <- as.character(ids)
+      out[nzchar(out)]
+    },
+
     # ----------------------------------------
     # Writers
     # ----------------------------------------

--- a/interfaces/R/infomap/R/as_data_frame.R
+++ b/interfaces/R/infomap/R/as_data_frame.R
@@ -17,8 +17,11 @@
 #' @param ... Unused.
 #'
 #' @return A `data.frame` (or a `tibble` when `tibble = TRUE`) with
-#'   columns `state_id`, `node_id`, `module_id`, `flow`, `name` and
-#'   (for multilayer networks) `layer_id`.
+#'   columns `state_id`, `node_id`, `module_id`, `flow`, `name`,
+#'   (for multilayer networks) `layer_id` and (for higher-order
+#'   networks) `state_name`. The `name` column always carries the
+#'   physical node name; `state_name` carries the per-state-node name,
+#'   falling back to the physical name when a state node is unnamed.
 #'
 #' @examples
 #' im <- Infomap(silent = TRUE)
@@ -57,6 +60,24 @@ as.data.frame.Infomap <- function(
     },
     character(1L)
   )
+
+  # For higher-order networks, expose the per-state-node name alongside the
+  # physical `name`. Mirrors the conditional `layer_id` column above; omitted
+  # for first-order networks where it would just duplicate `name`.
+  if (isTRUE(x$have_memory)) {
+    state_name <- vapply(
+      raw$state_id,
+      function(id) {
+        nm <- x$get_state_name(id, default = NA_character_)
+        if (is.null(nm) || is.na(nm)) NA_character_ else as.character(nm)
+      },
+      character(1L)
+    )
+    # Fall back to the physical name where a state node has no name.
+    missing <- is.na(state_name)
+    state_name[missing] <- df$name[missing]
+    df$state_name <- state_name
+  }
 
   if (isTRUE(tibble)) {
     if (!requireNamespace("tibble", quietly = TRUE)) {

--- a/interfaces/R/infomap/man/Infomap.Rd
+++ b/interfaces/R/infomap/man/Infomap.Rd
@@ -154,6 +154,8 @@ merged within a module).}
 \item \href{#method-Infomap-get_links}{\code{InfomapClass$get_links()}}
 \item \href{#method-Infomap-get_name}{\code{InfomapClass$get_name()}}
 \item \href{#method-Infomap-get_names}{\code{InfomapClass$get_names()}}
+\item \href{#method-Infomap-get_state_name}{\code{InfomapClass$get_state_name()}}
+\item \href{#method-Infomap-get_state_names}{\code{InfomapClass$get_state_names()}}
 \item \href{#method-Infomap-write_clu}{\code{InfomapClass$write_clu()}}
 \item \href{#method-Infomap-write_tree}{\code{InfomapClass$write_tree()}}
 \item \href{#method-Infomap-write_flow_tree}{\code{InfomapClass$write_flow_tree()}}
@@ -829,6 +831,47 @@ Get all assigned node names.
 
 \subsection{Returns}{
 A named character vector mapping node id to name.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Infomap-get_state_name"></a>}}
+\if{latex}{\out{\hypertarget{method-Infomap-get_state_name}{}}}
+\subsection{Method \code{get_state_name()}}{
+Look up a state node's name.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{InfomapClass$get_state_name(state_id, default = NULL)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{state_id}}{Integer state node id.}
+
+\item{\code{default}}{Value returned when the state node has no name.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+Character (or \code{default}).
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Infomap-get_state_names"></a>}}
+\if{latex}{\out{\hypertarget{method-Infomap-get_state_names}{}}}
+\subsection{Method \code{get_state_names()}}{
+Get all assigned state node names.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{InfomapClass$get_state_names()}\if{html}{\out{</div>}}
+}
+
+\subsection{Details}{
+Populated for higher-order (state/memory) networks whose \code{*States}
+section names the state nodes; empty otherwise. Physical node names
+are available separately via \code{get_names()}.
+}
+
+\subsection{Returns}{
+A named character vector mapping state id to name.
 }
 }
 \if{html}{\out{<hr>}}

--- a/interfaces/R/infomap/man/as.data.frame.Infomap.Rd
+++ b/interfaces/R/infomap/man/as.data.frame.Infomap.Rd
@@ -36,8 +36,11 @@ return type is independent of installed packages.}
 }
 \value{
 A \code{data.frame} (or a \code{tibble} when \code{tibble = TRUE}) with
-columns \code{state_id}, \code{node_id}, \code{module_id}, \code{flow}, \code{name} and
-(for multilayer networks) \code{layer_id}.
+columns \code{state_id}, \code{node_id}, \code{module_id}, \code{flow}, \code{name},
+(for multilayer networks) \code{layer_id} and (for higher-order
+networks) \code{state_name}. The \code{name} column always carries the
+physical node name; \code{state_name} carries the per-state-node name,
+falling back to the physical name when a state node is unnamed.
 }
 \description{
 Returns one row per leaf node in the partitioned tree. Mirrors

--- a/interfaces/R/infomap/tests/testthat/test-state-names.R
+++ b/interfaces/R/infomap/tests/testthat/test-state-names.R
@@ -1,0 +1,82 @@
+make_state_network_file <- function() {
+  net <- tempfile(fileext = ".net")
+  writeLines(
+    c(
+      "*Vertices 5",
+      "1 \"i\"",
+      "2 \"j\"",
+      "3 \"k\"",
+      "4 \"l\"",
+      "5 \"m\"",
+      "*States",
+      "1 1 \"a_i\"",
+      "2 2 \"b_j\"",
+      "3 3 \"c_k\"",
+      "4 1 \"d_i\"",
+      "5 4 \"e_l\"",
+      "6 5 \"f_m\"",
+      "*Links",
+      "1 2 0.8",
+      "1 3 0.8",
+      "1 5 0.2",
+      "1 6 0.2",
+      "2 1 1",
+      "2 3 1",
+      "3 1 1",
+      "3 2 1",
+      "4 5 0.8",
+      "4 6 0.8",
+      "4 2 0.2",
+      "4 3 0.2",
+      "5 4 1",
+      "5 6 1",
+      "6 4 1",
+      "6 5 1"
+    ),
+    net
+  )
+  net
+}
+
+test_that("state node names are exposed via get_state_names() and the data.frame", {
+  net <- make_state_network_file()
+  on.exit(unlink(net))
+
+  im <- Infomap(silent = TRUE, num_trials = 1L)
+  im$read_file(net)
+  im$run()
+  expect_true(im$have_memory)
+
+  # New accessor: state id -> state-node name.
+  state_names <- im$get_state_names()
+  expect_setequal(
+    unname(state_names),
+    c("a_i", "b_j", "c_k", "d_i", "e_l", "f_m")
+  )
+  # Physical names stay separate, keyed by node id.
+  expect_setequal(unname(im$get_names()), c("i", "j", "k", "l", "m"))
+
+  df <- as.data.frame(im, states = TRUE)
+  expect_true("state_name" %in% names(df))
+  # "name" is the physical name; "state_name" the per-state-node name.
+  expect_setequal(unique(df$name), c("i", "j", "k", "l", "m"))
+  expect_setequal(df$state_name, c("a_i", "b_j", "c_k", "d_i", "e_l", "f_m"))
+
+  # State nodes 1 and 4 are both physical node 1: the physical name collapses
+  # them to "i", while state_name keeps them distinct.
+  node1 <- df[df$node_id == 1L, ]
+  expect_setequal(node1$name, "i")
+  expect_setequal(node1$state_name, c("a_i", "d_i"))
+})
+
+test_that("as.data.frame omits state_name for first-order networks", {
+  im <- Infomap(silent = TRUE, num_trials = 1L)
+  im$add_links(list(c(1, 2), c(2, 3), c(3, 1), c(3, 4), c(4, 5), c(5, 6), c(6, 4)))
+  im$run()
+
+  expect_false(im$have_memory)
+  expect_length(im$get_state_names(), 0L)
+
+  df <- as.data.frame(im)
+  expect_false("state_name" %in% names(df))
+})

--- a/interfaces/python/generated/infomap_wrap.cpp
+++ b/interfaces/python/generated/infomap_wrap.cpp
@@ -56833,6 +56833,73 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_InfomapWrapper_getStateNames(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  infomap::InfomapWrapper *arg1 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  std::map< unsigned int,std::string,std::less< unsigned int >,std::allocator< std::pair< unsigned int const,std::string > > > result;
+  
+  (void)self;
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__InfomapWrapper, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapWrapper_getStateNames" "', argument " "1"" of type '" "infomap::InfomapWrapper const *""'"); 
+  }
+  arg1 = reinterpret_cast< infomap::InfomapWrapper * >(argp1);
+  {
+    try {
+      result = ((infomap::InfomapWrapper const *)arg1)->getStateNames();
+    } catch (const std::exception& e) {
+      SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+  }
+  resultobj = swig::from(static_cast< std::map< unsigned int,std::string,std::less< unsigned int >,std::allocator< std::pair< unsigned int const,std::string > > > >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_InfomapWrapper_getStateName(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  infomap::InfomapWrapper *arg1 = 0 ;
+  unsigned int arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned int val2 ;
+  int ecode2 = 0 ;
+  PyObject *swig_obj[2] ;
+  std::string result;
+  
+  (void)self;
+  if (!SWIG_Python_UnpackTuple(args, "InfomapWrapper_getStateName", 2, 2, swig_obj)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__InfomapWrapper, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapWrapper_getStateName" "', argument " "1"" of type '" "infomap::InfomapWrapper const *""'"); 
+  }
+  arg1 = reinterpret_cast< infomap::InfomapWrapper * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_int(swig_obj[1], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "InfomapWrapper_getStateName" "', argument " "2"" of type '" "unsigned int""'");
+  } 
+  arg2 = static_cast< unsigned int >(val2);
+  {
+    try {
+      result = ((infomap::InfomapWrapper const *)arg1)->getStateName(arg2);
+    } catch (const std::exception& e) {
+      SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+  }
+  resultobj = SWIG_From_std_string(static_cast< std::string >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_InfomapWrapper_addPhysicalNode__SWIG_0(PyObject *self, Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   infomap::InfomapWrapper *arg1 = 0 ;
@@ -60380,6 +60447,8 @@ static PyMethodDef SwigMethods[] = {
 	 { "InfomapWrapper_addName", _wrap_InfomapWrapper_addName, METH_VARARGS, NULL},
 	 { "InfomapWrapper_getName", _wrap_InfomapWrapper_getName, METH_VARARGS, NULL},
 	 { "InfomapWrapper_getNames", _wrap_InfomapWrapper_getNames, METH_O, NULL},
+	 { "InfomapWrapper_getStateNames", _wrap_InfomapWrapper_getStateNames, METH_O, NULL},
+	 { "InfomapWrapper_getStateName", _wrap_InfomapWrapper_getStateName, METH_VARARGS, NULL},
 	 { "InfomapWrapper_addPhysicalNode", _wrap_InfomapWrapper_addPhysicalNode, METH_VARARGS, NULL},
 	 { "InfomapWrapper_addStateNode", _wrap_InfomapWrapper_addStateNode, METH_VARARGS, NULL},
 	 { "InfomapWrapper_addLink", _wrap_InfomapWrapper_addLink, METH_VARARGS, NULL},

--- a/interfaces/python/src/infomap/_results.py
+++ b/interfaces/python/src/infomap/_results.py
@@ -54,9 +54,14 @@ def _to_dataframe_sort_columns(sort, dataframe_columns):
     return sort_columns
 
 
-def _to_dataframe_column_getter(requested, resolved, names):
+def _to_dataframe_column_getter(requested, resolved, names, state_names):
     if resolved == "name":
         return lambda node: names.get(node.node_id, node.node_id)
+
+    if resolved == "state_name":
+        return lambda node: state_names.get(node.state_id) or names.get(
+            node.node_id, node.node_id
+        )
 
     def get_column_value(node):
         try:
@@ -72,6 +77,7 @@ def _to_dataframe_column_getter(requested, resolved, names):
                         "layer_id",
                         "modular_centrality",
                         "state_id",
+                        "state_name",
                     }
                 )
             )
@@ -147,6 +153,9 @@ class _InfomapResultsMixin:
 
     def _get_names_impl(self):
         return self._core.getNames()
+
+    def _get_state_names_impl(self):
+        return self._core.getStateNames()
 
     def _leaf_modules_impl(self):
         return self._core.iterLeafModules()
@@ -736,7 +745,10 @@ class _InfomapResultsMixin:
         ----------
         columns : sequence of str, optional
             Columns to include. ``"community"`` is accepted as an alias for
-            ``"module_id"``. Default
+            ``"module_id"``. ``"name"`` resolves the physical node name; the
+            opt-in ``"state_name"`` resolves the per-state-node name for a
+            higher-order network (falling back to the physical name, then
+            ``node_id``). Default
             ``["node_id", "module_id", "flow", "path", "name"]``.
         states : bool, optional
             Use state-node iterators when ``True`` and physical-node iterators
@@ -772,9 +784,14 @@ class _InfomapResultsMixin:
             _DATAFRAME_COLUMN_ALIASES.get(column, column)
             for column in requested_columns
         ]
-        names = self._get_names_impl() if "name" in resolved_columns else None
+        # "state_name" falls back to the physical name, so it needs both maps.
+        need_names = bool({"name", "state_name"} & set(resolved_columns))
+        names = self._get_names_impl() if need_names else None
+        state_names = (
+            self._get_state_names_impl() if "state_name" in resolved_columns else None
+        )
         column_getters = [
-            _to_dataframe_column_getter(requested, resolved, names)
+            _to_dataframe_column_getter(requested, resolved, names, state_names)
             for requested, resolved in zip(
                 requested_columns, resolved_columns, strict=True
             )
@@ -863,6 +880,49 @@ class _InfomapResultsMixin:
             Use ``result = im.run(); result.names``.
         """
         return self._get_names_impl()
+
+    def get_state_names(self):
+        """Get all state-node names.
+
+        Populated for higher-order (state/memory) networks whose ``*States``
+        section names the state nodes; empty otherwise. Physical node names are
+        available separately via :meth:`get_names`.
+
+        See Also
+        --------
+        get_names
+        state_names
+
+        Returns
+        -------
+        dict of string
+            A dict with state ids as keys and state-node names as values.
+
+        .. deprecated::
+            Use ``result = im.run(); result.state_names``.
+        """
+        return self._get_state_names_impl()
+
+    @property
+    def state_names(self):
+        """Get all state-node names.
+
+        Short-hand for ``get_state_names``.
+
+        See Also
+        --------
+        get_state_names
+        names
+
+        Returns
+        -------
+        dict of string
+            A dict with state ids as keys and state-node names as values.
+
+        .. deprecated::
+            Use ``result = im.run(); result.state_names``.
+        """
+        return self._get_state_names_impl()
 
     def get_links(self, data="weight"):
         """A view of the currently assigned links and their weights or flow.

--- a/interfaces/python/src/infomap/_swig.py
+++ b/interfaces/python/src/infomap/_swig.py
@@ -3074,6 +3074,12 @@ class InfomapWrapper(InfomapBase):
     def getNames(self):
         return _infomap.InfomapWrapper_getNames(self)
 
+    def getStateNames(self):
+        return _infomap.InfomapWrapper_getStateNames(self)
+
+    def getStateName(self, stateId):
+        return _infomap.InfomapWrapper_getStateName(self, stateId)
+
     def addPhysicalNode(self, *args):
         return _infomap.InfomapWrapper_addPhysicalNode(self, *args)
 
@@ -3157,6 +3163,9 @@ class InfomapWrapper(InfomapBase):
 
     def getNames(self):
         return dict(_infomap.InfomapWrapper_getNames(self))
+
+    def getStateNames(self):
+        return dict(_infomap.InfomapWrapper_getStateNames(self))
 
     def getLinks(self, flow=False):
         return dict(_infomap.InfomapWrapper_getLinks(self, flow))

--- a/interfaces/python/src/infomap/result.py
+++ b/interfaces/python/src/infomap/result.py
@@ -90,6 +90,7 @@ class TreeNode:
         "modular_centrality",
         "path",
         "name",
+        "state_name",
     )
 
     def __init__(
@@ -105,6 +106,7 @@ class TreeNode:
         modular_centrality: float,
         path: tuple,
         name: Any,
+        state_name: Any,
     ) -> None:
         object.__setattr__(self, "node_id", node_id)
         object.__setattr__(self, "state_id", state_id)
@@ -116,6 +118,7 @@ class TreeNode:
         object.__setattr__(self, "modular_centrality", modular_centrality)
         object.__setattr__(self, "path", path)
         object.__setattr__(self, "name", name)
+        object.__setattr__(self, "state_name", state_name)
 
     def __setattr__(self, name: str, value: Any) -> None:
         raise AttributeError("TreeNode is immutable")
@@ -220,6 +223,7 @@ class Result:
         "_engine",
         "_generation",
         "_names",
+        "_state_names",
         "_have_memory",
         "_directed",
         "_codelength",
@@ -250,6 +254,10 @@ class Result:
         object.__setattr__(self, "_generation", generation)
         # Names are needed for the "name" column; capture eagerly (cheap dict).
         object.__setattr__(self, "_names", dict(core.getNames()))
+        # State-node names ({state_id: name}) for the optional "state_name"
+        # column; empty for first-order networks. Captured eagerly alongside the
+        # physical names so a Result stays a self-contained snapshot.
+        object.__setattr__(self, "_state_names", dict(core.getStateNames()))
         object.__setattr__(self, "_have_memory", core.haveMemory())
         # Captured eagerly so a Result is a stable artifact: exporters read the
         # directedness off the snapshot, not the live engine.
@@ -481,6 +489,16 @@ class Result:
         """All node names, as ``{node_id: name}``."""
         return dict(self._names)
 
+    @property
+    def state_names(self) -> dict:
+        """All state-node names, as ``{state_id: name}``.
+
+        Populated for higher-order (state/memory) networks whose ``*States``
+        section names the state nodes; empty otherwise. Physical node names are
+        available separately via :attr:`names`.
+        """
+        return dict(self._state_names)
+
     # -- collection accessors (§9: methods with defaults) -------------------
 
     def modules(self, depth: int = 1, *, states: bool = False) -> dict:
@@ -503,8 +521,10 @@ class Result:
         """Iterate leaf :class:`TreeNode` views, depth first from the root."""
         snapshot = self._snapshot(depth, states)
         names = self._names
+        state_names = self._state_names
         for i in range(len(snapshot)):
             node_id = snapshot.node_id[i]
+            name = names.get(node_id, node_id)
             yield TreeNode(
                 node_id=node_id,
                 state_id=snapshot.state_id[i],
@@ -515,7 +535,8 @@ class Result:
                 child_index=snapshot.child_index[i],
                 modular_centrality=snapshot.modular_centrality[i],
                 path=snapshot.path[i],
-                name=names.get(node_id, node_id),
+                name=name,
+                state_name=state_names.get(snapshot.state_id[i]) or name,
             )
 
     def tree(self, depth: int = 1, *, states: bool = False):
@@ -632,8 +653,11 @@ class Result:
 
         Byte-identical to the legacy ``Infomap.to_dataframe``. Default columns
         ``("node_id", "module_id", "flow", "path", "name")``; ``"community"``
-        is an alias for ``"module_id"``; ``"name"`` is resolved via the node
-        name map (falling back to the integer ``node_id``).
+        is an alias for ``"module_id"``; ``"name"`` is resolved via the physical
+        node name map (falling back to the integer ``node_id``). The opt-in
+        ``"state_name"`` column resolves the per-state-node name for a
+        higher-order network (falling back to the physical name, then
+        ``node_id``); see :attr:`state_names`.
         """
         if pandas is None:
             raise ImportError(
@@ -675,6 +699,12 @@ class Result:
     ) -> list:
         if resolved == "name":
             return [names.get(nid, nid) for nid in snapshot.node_id]
+        if resolved == "state_name":
+            state_names = self._state_names
+            return [
+                state_names.get(sid) or names.get(nid, nid)
+                for sid, nid in zip(snapshot.state_id, snapshot.node_id)
+            ]
         if resolved in _SNAPSHOT_COLUMNS:
             return list(getattr(snapshot, resolved))
         available = ", ".join(
@@ -687,6 +717,7 @@ class Result:
                     "layer_id",
                     "modular_centrality",
                     "state_id",
+                    "state_name",
                 }
             )
         )

--- a/interfaces/swig/Infomap.i
+++ b/interfaces/swig/Infomap.i
@@ -481,6 +481,9 @@ int run(const std::string& flags);
         def getNames(self):
             return dict(_infomap.InfomapWrapper_getNames(self))
 
+        def getStateNames(self):
+            return dict(_infomap.InfomapWrapper_getStateNames(self))
+
         def getLinks(self, flow=False):
             return dict(_infomap.InfomapWrapper_getLinks(self, flow))
     %}

--- a/src/Infomap.h
+++ b/src/Infomap.h
@@ -88,6 +88,31 @@ public:
 
   const std::map<unsigned int, std::string>& getNames() const { return m_network.names(); }
 
+  // State-id -> name for higher-order (state/memory) networks. Physical names
+  // live in getNames(), keyed by physical id; state nodes carry their own
+  // optional name parsed from the *States section (StateNode::name). Only
+  // non-empty names are returned, so a first-order network (no per-state names)
+  // yields an empty map and callers fall back to the physical name.
+  std::map<unsigned int, std::string> getStateNames() const
+  {
+    std::map<unsigned int, std::string> stateNames;
+    for (const auto& entry : m_network.nodes()) {
+      if (!entry.second.name.empty())
+        stateNames[entry.first] = entry.second.name;
+    }
+    return stateNames;
+  }
+
+  // Name of a single state node, or "" if the id is unknown or unnamed. The
+  // scalar counterpart of getStateNames(), mirroring getName(); the R binding
+  // walks state nodes calling this since SWIG-R exposes std::map opaquely.
+  std::string getStateName(unsigned int stateId) const
+  {
+    const auto& nodes = m_network.nodes();
+    auto it = nodes.find(stateId);
+    return it != nodes.end() ? it->second.name : "";
+  }
+
   void addPhysicalNode(unsigned int id, const std::string& name = "") { m_network.addPhysicalNode(id, name); }
   void addStateNode(unsigned int id, unsigned int physId) { m_network.addStateNode(id, physId); }
 

--- a/test/python/test_result.py
+++ b/test/python/test_result.py
@@ -100,6 +100,76 @@ def test_result_modules_raises_on_higher_order_without_states(network_fixture_pa
     assert result.modules(states=True) == im.get_modules(1, True)
 
 
+_STATES_NET_STATE_NAMES = {
+    1: "α~_i",
+    2: "β~_j",
+    3: "γ~_k",
+    4: "δ~_i",
+    5: "ε~_l",
+    6: "ζ~_m",
+}
+_STATES_NET_PHYSICAL_NAMES = {1: "i", 2: "j", 3: "k", 4: "l", 5: "m"}
+
+
+@pytest.mark.fast
+def test_state_names_accessor_exposes_state_node_names(network_fixture_path):
+    im = Infomap(silent=True, no_file_output=True)
+    im.read_file(str(network_fixture_path("states.net")))
+    result = im.run()
+
+    # New accessor: state_id -> state-node name (parsed from the *States section).
+    assert result.state_names == _STATES_NET_STATE_NAMES
+    # Physical names stay keyed by node_id, unchanged.
+    assert result.names == _STATES_NET_PHYSICAL_NAMES
+
+
+@pytest.mark.fast
+def test_to_dataframe_state_name_column_distinguishes_state_nodes(
+    network_fixture_path,
+):
+    pytest.importorskip("pandas")
+    im = Infomap(silent=True, no_file_output=True)
+    im.read_file(str(network_fixture_path("states.net")))
+    result = im.run()
+
+    df = result.to_dataframe(
+        states=True, columns=["state_id", "node_id", "name", "state_name"]
+    )
+
+    # The "state_name" column carries the per-state-node name.
+    assert dict(zip(df["state_id"], df["state_name"])) == _STATES_NET_STATE_NAMES
+    # The "name" column is unchanged: the physical name keyed by node_id.
+    assert all(
+        name == _STATES_NET_PHYSICAL_NAMES[node_id]
+        for node_id, name in zip(df["node_id"], df["name"])
+    )
+    # State nodes 1 and 4 are both physical node 1: the physical name collapses
+    # them to "i", while state_name keeps them distinct.
+    node1 = df[df["node_id"] == 1]
+    assert sorted(node1["state_name"]) == ["α~_i", "δ~_i"]
+    assert list(node1["name"]) == ["i", "i"]
+
+    # nodes() exposes the same state_name on each TreeNode.
+    assert {n.state_id: n.state_name for n in result.nodes(states=True)} == (
+        _STATES_NET_STATE_NAMES
+    )
+
+
+@pytest.mark.fast
+def test_state_name_falls_back_to_physical_name_for_first_order(example_network_path):
+    pytest.importorskip("pandas")
+    im = Infomap(silent=True, no_file_output=True)
+    im.read_file(str(example_network_path("twotriangles.net")))
+    result = im.run()
+
+    # A first-order network has no per-state names.
+    assert result.state_names == {}
+
+    df = result.to_dataframe(columns=["node_id", "name", "state_name"])
+    # state_name falls back to the physical name.
+    assert list(df["state_name"]) == list(df["name"])
+
+
 @pytest.mark.fast
 def test_stale_result_raises_on_node_access_but_keeps_scalars():
     im = _two_triangles()

--- a/test/python/test_result_parity.py
+++ b/test/python/test_result_parity.py
@@ -82,6 +82,8 @@ _DATAFRAME_VARIANTS = [
     {"columns": ["node_id", "module_id"], "depth_level": 2, "sort": True},
     {"columns": ["node_id", "module_id"], "level": -1},
     {"columns": ["node_id", "name"]},
+    {"columns": ["state_id", "node_id", "name", "state_name"], "states": True},
+    {"columns": ["node_id", "state_name"]},
 ]
 
 
@@ -172,6 +174,7 @@ def test_scalar_parity(network, example_network_path):
     assert result.meta_codelength == im.meta_codelength
     assert result.have_memory == im.have_memory
     assert result.names == im.names
+    assert result.state_names == im.state_names
 
 
 @pytest.mark.parametrize("network", sorted(_BUILDERS))


### PR DESCRIPTION
## Summary

State node names parsed from the `*States` section of a higher-order network were stored in `StateNetwork::m_nodes` but never surfaced in any result — the Python **and** R bindings resolved `"name"` by the **physical** `node_id`, so distinct state nodes of the same physical node showed the same name. On `examples/networks/states.net`, state nodes 1 and 4 (both physical node 1) both showed `"i"` instead of `"α~_i"` / `"δ~_i"`.

Closes #699.

## Approach (non-breaking)

C++ wrapper (`src/Infomap.h`): add state-name accessors mirroring `getName`/`getNames`:
- `getStateNames()` → `{state_id: name}` map (used by Python).
- `getStateName(state_id)` → scalar (used by R, since SWIG-R exposes `std::map` opaquely and the existing `get_names()` already walks nodes per id).

Both SWIG wrappers (Python + R) regenerated.

**Python:**
- New opt-in `state_name` dataframe column on both `Result.to_dataframe` and the legacy `Infomap.to_dataframe`, resolving by state id with fallback to the physical name then `node_id`.
- New `state_names` (`{state_id: name}`) accessor on `Result` and the legacy `Infomap` (plus `get_state_names()`), and `state_name` on each `TreeNode` from `Result.nodes()`.

**R:**
- New `state_name` column in `as.data.frame.Infomap` for higher-order networks (mirroring the conditional `layer_id` column), falling back to the physical name.
- New `get_state_name()` / `get_state_names()` methods on the `Infomap` R6 class.

The existing `"name"` column keeps meaning **physical name**, so parity with the CLI `.tree`/`.clu`/json/csv output is preserved. First-order networks have no per-state names, so the state-name map is empty and `state_name` falls back to the physical name (R omits the column entirely).

## Example (Python)

```python
from infomap import Infomap
im = Infomap(silent=True)
im.read_file("examples/networks/states.net")
result = im.run()
result.to_dataframe(states=True, columns=["state_id", "node_id", "name", "state_name"])
```

```
 state_id  node_id name state_name
        1        1    i       α~_i
        4        1    i       δ~_i      ← same physical node, distinct state name
        ...
```

## Tests

- **Python**: new `test_result.py` cases (state_names accessor, distinct `state_name` per state node with `name` unchanged, first-order fallback); extended `test_result_parity.py` to cover the `state_name` columns and `state_names` across the new and legacy APIs. Full suite: 447 passed, 2 skipped; doctests pass; SWIG freshness passes.
- **R**: new `test-state-names.R` (reads a named state network, checks the `state_name` column + `get_state_names()`, and that first-order networks omit the column). `R CMD check --as-cran` clean (282 testthat tests pass); R SWIG freshness passes.

## Out of scope

The C++ CLI state-level output (`_states.tree`, etc.) also shows physical names for state nodes; aligning that is a larger cross-language/parity change, noted in #699.