### PR TITLE
perf(python): compute effective-num-modules lazily in Result

### DIFF
--- a/interfaces/python/src/infomap/result.py
+++ b/interfaces/python/src/infomap/result.py
@@ -172,8 +172,9 @@ class Result:
     """Immutable snapshot of an Infomap run.
 
     Returned by :meth:`Infomap.run` (and the functional :func:`infomap.run`) and
-    used to back the legacy on-instance accessors. Holds eager scalars;
-    node/tree/dataframe data is materialized lazily and guarded against the
+    used to back the legacy on-instance accessors. Holds eager O(1) scalars;
+    tree-derived metrics (the ``effective_num_*`` modules) and
+    node/tree/dataframe data are materialized lazily and guarded against the
     engine being re-run.
 
     Read scalars as **properties** and collections as **methods** (with
@@ -238,8 +239,7 @@ class Result:
         "_meta_entropy",
         "_elapsed_time",
         "_num_leaf_modules",
-        "_effective_num_top_modules",
-        "_effective_num_leaf_modules",
+        "_effective_cache",
         "_snapshots",
         "__weakref__",
     )
@@ -283,16 +283,12 @@ class Result:
         object.__setattr__(
             self, "_num_leaf_modules", sum(1 for _ in core.iterLeafModules())
         )
-        object.__setattr__(
-            self,
-            "_effective_num_top_modules",
-            self._compute_effective_num_modules(core, 1),
-        )
-        object.__setattr__(
-            self,
-            "_effective_num_leaf_modules",
-            self._compute_effective_num_modules(core, -1),
-        )
+        # The effective-number-of-modules metrics each require a full Python-side
+        # tree traversal, so they are computed lazily on first access and cached,
+        # keyed by depth (see ``_effective_num_modules_cached``). Computing them
+        # eagerly here roughly doubled run() wall-clock for callers that never
+        # read them.
+        object.__setattr__(self, "_effective_cache", {})
         # Lazy node-data cache, keyed by (level, states).
         object.__setattr__(self, "_snapshots", {})
 
@@ -303,6 +299,22 @@ class Result:
         if core.haveMemory() and not states:
             return core.iterTreePhysical(depth)
         return core.iterTree(depth)
+
+    def _effective_num_modules_cached(self, depth: int) -> float:
+        """Lazily compute and cache the effective number of modules at ``depth``.
+
+        Each computation walks the result tree, so it is deferred until first
+        access and memoized. The generation guard fires only if the bound engine
+        was re-run *before* the first read at this depth; a value read while the
+        Result was fresh stays valid afterwards (snapshot semantics).
+        """
+        cache = self._effective_cache
+        if depth not in cache:
+            self._check_generation()
+            cache[depth] = self._compute_effective_num_modules(
+                self._engine._core, depth
+            )
+        return cache[depth]
 
     @classmethod
     def _compute_effective_num_modules(cls, core, depth: int) -> float:
@@ -460,16 +472,18 @@ class Result:
         """The flow-weighted effective number of top modules.
 
         Measured as the perplexity of the top-module flow distribution.
+        Computed lazily on first access (see :meth:`effective_num_modules`).
         """
-        return self._effective_num_top_modules
+        return self._effective_num_modules_cached(1)
 
     @property
     def effective_num_leaf_modules(self) -> float:
         """The flow-weighted effective number of leaf modules.
 
         Measured as the perplexity of the leaf-module flow distribution.
+        Computed lazily on first access (see :meth:`effective_num_modules`).
         """
-        return self._effective_num_leaf_modules
+        return self._effective_num_modules_cached(-1)
 
     @property
     def have_memory(self) -> bool:
@@ -615,8 +629,7 @@ class Result:
             The module level. ``1`` (default) is the top (coarsest) level;
             ``-1`` the bottom (leaf-module) level.
         """
-        self._check_generation()
-        return self._compute_effective_num_modules(self._engine._core, depth)
+        return self._effective_num_modules_cached(depth)
 
     def to_dataframe(
         self,

--- a/test/python/test_result.py
+++ b/test/python/test_result.py
@@ -56,6 +56,62 @@ def test_run_returns_result_with_eager_scalars():
 
 
 @pytest.mark.fast
+def test_effective_num_modules_is_computed_lazily(monkeypatch):
+    """``effective_num_*`` must not traverse the result tree until read.
+
+    Computing them eagerly in ``Result.__init__`` walked the whole tree (twice)
+    on every ``run()``, roughly doubling ``run()`` wall-clock for mid-size
+    networks even when the caller never reads them.
+    """
+    import infomap.result as result_mod
+
+    calls: list[int] = []
+    original = result_mod.Result._compute_effective_num_modules.__func__
+
+    def counting(cls, core, depth):
+        calls.append(depth)
+        return original(cls, core, depth)
+
+    monkeypatch.setattr(
+        result_mod.Result,
+        "_compute_effective_num_modules",
+        classmethod(counting),
+    )
+
+    im = _two_triangles()
+    result = im.run()
+
+    # Nothing computed just by running.
+    assert calls == []
+
+    # First read computes; depth is the only thing requested.
+    _ = result.effective_num_top_modules
+    assert calls == [1]
+    _ = result.effective_num_leaf_modules
+    assert calls == [1, -1]
+
+    # Cached: a second read does not recompute.
+    _ = result.effective_num_top_modules
+    _ = result.effective_num_leaf_modules
+    assert calls == [1, -1]
+
+
+@pytest.mark.fast
+def test_effective_num_modules_cached_value_survives_rerun():
+    """Once read, the snapshot value is cached and stays valid after a re-run."""
+    im = _two_triangles()
+    result = im.run()
+
+    top = result.effective_num_top_modules
+    leaf = result.effective_num_leaf_modules
+
+    im.run()  # rebuilds the C++ tree
+
+    assert result.effective_num_top_modules == top
+    assert result.effective_num_leaf_modules == leaf
+
+
+@pytest.mark.fast
 def test_result_modules_matches_get_modules():
     im = _two_triangles()
     result = im.run()


### PR DESCRIPTION
## Problem

While benchmarking the modernized Python API against the pre-#694 commit, I found that `run()` got **~1.5–2× slower** for mid-size networks — and it affects *both* the new functional `run()` and the backward-compatible `Infomap.run()` (which now routes through `Result`).

The cause is in [`Result.__init__`](interfaces/python/src/infomap/result.py): it **eagerly** computes `effective_num_top_modules` and `effective_num_leaf_modules`, each of which walks the entire result tree in Python via SWIG iterators (40k+ iterator crossings on a 2000-node network). This runs on **every** `run()`, even when the caller never reads the values.

### Isolation

Built three commits in isolated venvs — `4252d673` (pre-redesign), `459d786a` (#694), `c2696a18` (master). #694 touched only `interfaces/python/`, so the C++ core is identical to the pre-redesign build, yet the full slowdown appears at #694. cProfile confirms:

| | function calls / 10 runs | C++ time | Python time |
|---|---|---|---|
| pre-#694 `run()` | 2,081 | ~16 ms/run | ~0 |
| master `run()` | 552,841 | ~16 ms/run | **~16 ms/run** (the two tree walks) |

The Python post-processing had grown to roughly equal the C++ optimization time.

## Fix

Defer both metrics to first access and memoize them per depth via a generation-guarded cache, unifying them with the already-on-demand `effective_num_modules(depth)` method. `run()` no longer pays for values it isn't asked for. A value read while the `Result` is fresh is cached and stays valid after a re-run (snapshot semantics preserved); the generation guard only fires for a first read at a depth *after* the bound engine was re-run — consistent with the other tree-derived accessors (`modules()`, `nodes()`, `tree()`, `leaf_modules()`).

## Verification

- **Values unchanged** — existing parity tests (`test_new_scalar_parity`, `test_effective_num_modules_parity` over depths 1/2/-1) pass.
- **New tests** (`test_result.py`): assert the metrics are not computed during `run()`, are computed on first access, are cached, and that a value read before a re-run survives it.
- Full `test/python` suite: 361 passed, 54 skipped (optional deps), 0 failures.
- **Perf** (alternating before/after to cancel load drift): `run()` on a 2000-node / ~34k-link network drops **~30 ms → ~17 ms (1.7×)**, matching the pre-#694 baseline.