### PR TITLE
build: add pre-commit hooks mirroring existing lint/format gates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,121 @@
+# Pre-commit hooks for Infomap.
+#
+# These mirror -- and slightly exceed -- the lint gates already enforced in CI,
+# so contributors get the feedback locally before pushing instead of on a red
+# CI run.
+#
+#   Install once:   make hooks           (or: pre-commit install)
+#   Run manually:   pre-commit run --all-files
+#
+# Generated and vendored artifacts are never touched by any hook: the SWIG and R
+# outputs are freshness-checked in CI and must stay byte-for-byte reproducible,
+# vendored third-party code is upstream's to format, and LICENSE text must remain
+# verbatim.
+exclude: |
+  (?x)(
+      ^vendor/
+    | /vendor/
+    | ^node_modules/
+    | ^build/
+    | ^dist/
+    | ^interfaces/python/generated/
+    | ^interfaces/R/generated/
+    | ^interfaces/python/src/infomap/_swig\.py$
+    | ^examples/networks/
+    | ^LICENSE_GPLv3\.txt$
+  )
+
+ci:
+  autoupdate_schedule: monthly
+  autoupdate_commit_msg: "build(deps): pre-commit autoupdate"
+
+repos:
+  # Python lint. CI already runs `ruff check` on the package + examples/python
+  # (via `make test-python-doctest`); this runs it repo-wide with autofix.
+  # Pinned to the ruff version in the project venv so local and hook agree.
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.8
+    hooks:
+      - id: ruff
+        name: ruff (lint)
+        args: [--fix]
+        # Notebooks are published-article companions with a couple of known
+        # findings; they are linted deliberately, not as a drive-by here.
+        exclude: ^examples/notebooks/
+    # ruff-format is intentionally NOT enabled: the committed tree predates the
+    # current ruff formatter, so turning it on would reformat ~31 files. Adopt it
+    # as its own deliberate reformat commit if/when desired.
+
+  # C++ formatting for the core sources. The equivalent CI job is currently
+  # disabled (see #479), but `src/` is already clean under this clang-format
+  # version, so the hook keeps it that way locally. Scope matches the Makefile's
+  # HEADERS/SOURCES (find src -name '*.h'/'*.cpp').
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v20.1.7
+    hooks:
+      - id: clang-format
+        name: clang-format (C++ src)
+        files: ^src/.*\.(cpp|h)$
+
+  # Generic safety nets. These only *check*, they never rewrite files.
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-case-conflict
+      - id: check-added-large-files
+        args: [--maxkb=1024]
+    # end-of-file-fixer / trailing-whitespace are intentionally omitted: on the
+    # current tree they would rewrite ~15 files across notebooks, hand-written
+    # SWIG .i sources (which feed the freshness-checked generators), and data
+    # fixtures. Add them behind a dedicated cleanup commit if that churn is
+    # acceptable, ideally scoped to src/ and the Python package.
+
+  # Repo-native gates, run through the same tools CI uses so local and CI agree.
+  # Each is scoped by file type via `files:`, so a contributor only needs a given
+  # toolchain (node, air) when they actually touch that language's files. These
+  # are fast and static -- none of them build or regenerate anything. Heavier
+  # gates (clang-tidy, pyright, SWIG/binding freshness) stay CI-only.
+  - repo: local
+    hooks:
+      - id: cpp-stream-policy
+        name: C++ stream policy
+        language: system
+        entry: python3 scripts/check_cpp_stream_policy.py
+        pass_filenames: false
+        files: ^src/.*\.(cpp|h)$
+      - id: biome-lint
+        name: biome (JS lint)
+        language: system
+        entry: npm run --silent lint
+        pass_filenames: false
+        files: ^(interfaces/js/|package\.json$)
+      - id: biome-format
+        name: biome (JS format)
+        language: system
+        entry: npm run --silent format:check
+        pass_filenames: false
+        files: ^(interfaces/js/|package\.json$)
+      - id: air-format
+        name: air (R format)
+        language: system
+        # Run the curated Make target rather than a bare `\.R$` glob: the target's
+        # R_FORMAT_TARGETS deliberately excludes generated (options.R) and helper
+        # (bootstrap.R, scripts/r_check.R) files that must not be reformatted.
+        entry: make format-r-check
+        pass_filenames: false
+        files: \.R$
+      # pyright runs at PUSH time, not on every commit: it is slower and its
+      # results depend on installed deps. Scoped to the core surface (io/, tl/
+      # excluded) so it stays deterministic across dev machines -- see the
+      # test-python-typecheck-core target. Full-scope pyright stays a manual /
+      # future-CI check.
+      - id: pyright-core
+        name: pyright (core, pre-push)
+        language: system
+        entry: make test-python-typecheck-core
+        pass_filenames: false
+        files: \.py$
+        stages: [pre-push]

--- a/interfaces/R/infomap/tests/testthat/test-state-names.R
+++ b/interfaces/R/infomap/tests/testthat/test-state-names.R
@@ -71,7 +71,15 @@ test_that("state node names are exposed via get_state_names() and the data.frame
 
 test_that("as.data.frame omits state_name for first-order networks", {
   im <- Infomap(silent = TRUE, num_trials = 1L)
-  im$add_links(list(c(1, 2), c(2, 3), c(3, 1), c(3, 4), c(4, 5), c(5, 6), c(6, 4)))
+  im$add_links(list(
+    c(1, 2),
+    c(2, 3),
+    c(3, 1),
+    c(3, 4),
+    c(4, 5),
+    c(5, 6),
+    c(6, 4)
+  ))
   im$run()
 
   expect_false(im$have_memory)

--- a/interfaces/python/pyrightconfig-core.json
+++ b/interfaces/python/pyrightconfig-core.json
@@ -1,0 +1,13 @@
+{
+  "include": ["src/infomap"],
+  "exclude": [
+    "src/infomap/_swig.py",
+    "src/infomap/io",
+    "src/infomap/tl",
+    "**/__pycache__"
+  ],
+  "pythonVersion": "3.11",
+  "typeCheckingMode": "standard",
+  "reportMissingModuleSource": false,
+  "reportUnsupportedDunderAll": false
+}

--- a/interfaces/python/src/infomap/__init__.py
+++ b/interfaces/python/src/infomap/__init__.py
@@ -37,7 +37,7 @@ __all__ = list(_VERSION_ALL)
 try:
     from ._facade import __all__ as _FACADE_ALL
     from ._facade import *  # noqa: F401,F403
-    from ._facade import _construct_args as _construct_args
+    from ._options import _construct_args as _construct_args
 
     from . import tl as tl
 

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -21,6 +21,7 @@ PIP ?= $(PYTHON) -m pip
 PYTEST ?= $(PYTHON) -m pytest
 RUFF ?= $(PYTHON) -m ruff
 PYRIGHT ?= $(PYTHON) -m pyright
+PRECOMMIT ?= $(PYTHON) -m pre_commit
 NPM ?= npm
 NODE ?= node
 SWIG ?= swig
@@ -120,7 +121,7 @@ endif
 endif
 endif
 
-.PHONY: help doctor dev-bootstrap clean build-binding-options
+.PHONY: help doctor dev-bootstrap hooks clean build-binding-options
 
 help:
 	@printf "%s\n" \
@@ -173,7 +174,8 @@ help:
 		"  format-r-check        Verify R sources are Air-format clean." \
 		"  tidy-native           Run clang-tidy over C++ source files." \
 		"  dev-cpp-check         Run the fast C++ developer feedback suite." \
-		"  dev-bootstrap         Install Python dev dependencies and run npm ci." \
+		"  dev-bootstrap         Install Python dev dependencies, run npm ci, and install git hooks." \
+		"  hooks                 Install the pre-commit git hook (lint/format on commit)." \
 		"  dev-python-install    Install the built Python package in editable mode." \
 		"  dev-python-notebooks-install Install notebook execution dependencies." \
 		"  clean                 Remove native, Python, and JS build outputs." \
@@ -265,12 +267,29 @@ doctor:
 dev-bootstrap:
 	@$(PIP) install -e '.[test,docs,examples,release]'
 	@$(NPM) ci
+	@$(MAKE) --no-print-directory hooks
 	@printf "%s\n" \
 		"Bootstrap complete." \
 		"Next steps:" \
 		"  make build-native" \
 		"  make build-python dev-python-install" \
 		"  make test-fast"
+
+# Install the pre-commit git hook. Idempotent; safe to re-run. Never fails the
+# build: a native-only checkout may not have pre-commit yet, and a repo with
+# core.hooksPath set (pre-commit refuses to auto-install there) can still lint
+# via `pre-commit run --all-files` or CI.
+hooks:
+	@if ! $(PRECOMMIT) --version >/dev/null 2>&1; then \
+		printf "pre-commit not installed; run 'make dev-bootstrap' or 'pip install pre-commit'.\n"; \
+	elif $(PRECOMMIT) install --hook-type pre-commit --hook-type pre-push >/dev/null 2>&1; then \
+		printf "pre-commit and pre-push git hooks installed.\n"; \
+	else \
+		printf "pre-commit is installed but the git hook was not auto-installed:\n"; \
+		printf "  core.hooksPath is set (%s), so pre-commit refuses to manage it.\n" "$$(git config core.hooksPath)"; \
+		printf "  Run 'git config --unset core.hooksPath && make hooks', or just use\n"; \
+		printf "  'pre-commit run --all-files' / rely on CI.\n"; \
+	fi
 
 clean: clean-native clean-python clean-r clean-js
 	@true

--- a/mk/python.mk
+++ b/mk/python.mk
@@ -47,6 +47,7 @@ PYTHON_BUILD_ENV = \
 	test-python-unit \
 	test-python-doctest \
 	test-python-typecheck \
+	test-python-typecheck-core \
 	test-python-examples \
 	test-python-notebooks-smoke \
 	test-python-notebooks-full \
@@ -110,6 +111,15 @@ test-python-examples:
 # explicitly or in a dedicated CI job.
 test-python-typecheck:
 	@$(PYRIGHT)
+
+# Type check only the core API/algorithm surface, excluding the optional
+# third-party integration adapters (io/, tl/) whose pyright diagnostics vary
+# with which optional deps + stub packages are installed. Used by the pre-push
+# hook so the gate is deterministic across dev machines; the full-scope check
+# above (and pyproject's [tool.pyright]) still covers everything. Scope lives in
+# interfaces/python/pyrightconfig-core.json.
+test-python-typecheck-core:
+	@$(PYRIGHT) -p interfaces/python/pyrightconfig-core.json
 
 test-python-notebooks-smoke:
 	@cd $(NOTEBOOK_DIR) && $(PYTHON) ../../scripts/notebook_manifest.py --manifest notebooks.toml --suite smoke --print0 | \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ test = [
   "anndata",
   "igraph",
   "jsonschema>=4.18",
+  "pre-commit",
   "pyright",
   "pytest",
   "networkx",


### PR DESCRIPTION
## What

Adds a `pre-commit` setup so contributors get the lint/format feedback locally that CI already enforces (and a bit more), across all four language surfaces.

### Commit-stage hooks
- **ruff** (lint, pinned to the version in the dev venv), **clang-format** (scoped to `src/`, verified 0/87 churn), and non-modifying safety checks (yaml/toml/merge-conflict/case-conflict/large-files).
- **repo-local hooks** that shell out to the project's *own* tooling for exact CI parity, each scoped by file type so a contributor only needs a given toolchain when they touch that language:
  - C++ stream policy — `scripts/check_cpp_stream_policy.py`
  - biome — `npm run lint` / `format:check`
  - R format — `make format-r-check` (uses the curated `R_FORMAT_TARGETS`, so generated `options.R` and helpers are not reformatted)

### Pre-push hook
- **pyright**, scoped to the core surface via `interfaces/python/pyrightconfig-core.json` (excludes `io/` and `tl/`). Their diagnostics vary with which optional deps + stub packages are installed, so a full-scope local gate would be non-deterministic across machines. The canonical `[tool.pyright]` / `make test-python-typecheck` stays full-scope.

### Wiring
- `make hooks` installs both the pre-commit and pre-push git hooks; `make dev-bootstrap` runs it. `pre-commit` added to the `test` extra.

## Deliberately out of scope
- **ruff-format** and the whitespace fixers (`end-of-file-fixer`, `trailing-whitespace`) are omitted — on the current tree they would rewrite ~31 and ~15 files respectively (the format boundary predates the current ruff formatter; the whitespace churn lands on notebooks, hand-written SWIG `.i` sources, and data fixtures).
- Heavier gates (clang-tidy, **full-scope** pyright, SWIG/binding/JS-metadata freshness) stay CI-only.

## Incidental fixes surfaced by the new hooks
- `__init__.py` now imports `_construct_args` from `._options` (its defining module) rather than via `._facade`, which does not re-export it (`reportPrivateImportUsage`). Behaviour-identical.
- Reformatted `test-state-names.R` to satisfy Air (drifted in #700; `format-r-check` is not currently a CI gate).

## Notes
- The pre-push pyright hook requires the dev environment (pyright + deps), which `make dev-bootstrap` provides.
- Not wired here (possible follow-ups): CI enforcement (`pre-commit.ci` — the `ci:` block is present — or a GitHub Actions lint job) and full-scope pyright as a pinned-env CI job.
