### PR TITLE
fix(python): import pandas lazily to avoid OpenMP duplicate-runtime abort

### DIFF
--- a/interfaces/python/src/infomap/_optional.py
+++ b/interfaces/python/src/infomap/_optional.py
@@ -2,11 +2,26 @@ from __future__ import annotations
 
 from typing import Any
 
-try:
-    import pandas as _pandas
-except ImportError:
-    _pandas = None
+_pandas: Any = None
+_pandas_loaded = False
 
 
 def get_pandas() -> Any:
+    """Return the pandas module, or ``None`` if pandas is not installed.
+
+    Imported lazily on first call and cached. Importing pandas eagerly at
+    module load pulls in numpy, which on macOS loads a second OpenMP runtime
+    and aborts ``import infomap`` / the CLI with "OMP: Error #15" in
+    environments (e.g. conda) that ship their own ``libomp``. pandas is an
+    optional dependency, only needed by the DataFrame accessors, so it must
+    not be imported until one of them is actually called.
+    """
+    global _pandas, _pandas_loaded
+    if not _pandas_loaded:
+        _pandas_loaded = True
+        try:
+            import pandas as pd
+        except ImportError:
+            pd = None
+        _pandas = pd
     return _pandas

--- a/interfaces/python/src/infomap/_results.py
+++ b/interfaces/python/src/infomap/_results.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
     from ._core import Core
 
 
-pandas = get_pandas()
 _DEFAULT_DATAFRAME_COLUMNS = ("path", "flow", "name", "node_id")
 _DEFAULT_TO_DATAFRAME_COLUMNS = ("node_id", "module_id", "flow", "path", "name")
 _DATAFRAME_COLUMN_ALIASES = {"community": "module_id"}
@@ -702,6 +701,7 @@ class _InfomapResultsMixin:
             A DataFrame containing the selected columns.
         """
 
+        pandas = get_pandas()
         if pandas is None:
             raise ImportError(
                 "Cannot import package `pandas`. Install it with "
@@ -768,6 +768,7 @@ class _InfomapResultsMixin:
             Use ``result = im.run(); result.to_dataframe(...)``.
         """
 
+        pandas = get_pandas()
         if pandas is None:
             raise ImportError(
                 "Cannot import package `pandas`. Install it with "

--- a/interfaces/python/src/infomap/result.py
+++ b/interfaces/python/src/infomap/result.py
@@ -33,8 +33,6 @@ if TYPE_CHECKING:
     from ._facade import Infomap
 
 
-pandas = get_pandas()
-
 _DEFAULT_TO_DATAFRAME_COLUMNS = ("node_id", "module_id", "flow", "path", "name")
 _DATAFRAME_COLUMN_ALIASES = {"community": "module_id"}
 
@@ -672,6 +670,7 @@ class Result:
         higher-order network (falling back to the physical name, then
         ``node_id``); see :attr:`state_names`.
         """
+        pandas = get_pandas()
         if pandas is None:
             raise ImportError(
                 "Cannot import package `pandas`. Install it with "

--- a/test/python/test_api.py
+++ b/test/python/test_api.py
@@ -235,7 +235,9 @@ def test_to_dataframe_rejects_unknown_columns(make_infomap, example_network_path
 
 def test_get_dataframe_missing_pandas_message(monkeypatch, make_infomap):
     im = make_infomap(no_infomap=True)
-    monkeypatch.setattr(results_module, "pandas", None)
+    # pandas is now resolved lazily via get_pandas() inside the accessor, so
+    # simulate its absence by making that lookup return None.
+    monkeypatch.setattr(results_module, "get_pandas", lambda: None)
 
     with pytest.raises(ImportError, match=r"infomap\[pandas\]"):
         im.get_dataframe()

--- a/test/python/test_no_eager_optional_import.py
+++ b/test/python/test_no_eager_optional_import.py
@@ -1,0 +1,41 @@
+"""Guard: ``import infomap`` must not eagerly import optional heavy deps.
+
+pandas/numpy link an OpenMP runtime. On macOS, importing them at package-load
+time loads a *second* ``libomp`` alongside the wheel-bundled one and aborts
+``import infomap`` / the CLI with "OMP: Error #15" in environments (e.g. conda)
+that ship their own ``libomp``. pandas is optional -- only the DataFrame
+accessors need it -- so it must be imported lazily on first use, never at
+import time.
+
+Regression test for #706.
+"""
+
+import subprocess
+import sys
+
+# Optional, OpenMP-linked deps that ``import infomap`` must not pull in.
+_FORBIDDEN_EAGER = ("pandas", "numpy")
+
+
+def test_import_infomap_does_not_eagerly_import_optional_deps():
+    # Run in a fresh interpreter: the pytest process itself already has
+    # pandas/numpy loaded (by other tests / plugins), so we cannot inspect
+    # ``sys.modules`` in-process.
+    code = (
+        "import sys, infomap;"
+        f"forbidden = {_FORBIDDEN_EAGER!r};"
+        "print(','.join(m for m in forbidden if m in sys.modules))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    leaked = [name for name in result.stdout.strip().split(",") if name]
+    assert leaked == [], (
+        f"`import infomap` eagerly imported {leaked}; on macOS these load a "
+        "second OpenMP runtime and abort with 'OMP: Error #15'. Keep them lazy "
+        "(resolve pandas via infomap._optional.get_pandas() inside the methods "
+        "that need it, not at module scope)."
+    )


### PR DESCRIPTION
## What

Make the optional pandas dependency import lazily so `import infomap` and the
CLI never pull it in.

Fixes #706.

## Why

On macOS, `import infomap` — and therefore the `infomap` CLI — aborted with
`OMP: Error #15: Initializing libomp.dylib, but found libomp.dylib already
initialized` in any environment that ships its own OpenMP runtime (e.g.
conda/conda-forge). Two distinct LLVM `libomp` copies were initialized in one
process: the wheel-bundled `infomap/.dylibs/libomp.dylib`, and the conda
`<env>/lib/libomp.dylib` dragged in by numpy.

numpy was loaded because `import infomap` **eagerly imported pandas**, even
though pandas is only an optional dependency (DataFrame accessors). The eager
chain:

```
infomap/__init__.py -> _facade.py -> _results.py:14  pandas = get_pandas()
                                       -> _optional.py:6  import pandas as _pandas
```

`result.py:36` did the same module-level `pandas = get_pandas()`.

## Change

- `_optional.py`: `get_pandas()` now imports pandas lazily on first call and
  caches the result (returns `None` when pandas is absent, unchanged contract).
- `_results.py` / `result.py`: drop the module-level `pandas = get_pandas()`
  bindings; resolve pandas inside `get_dataframe` / `to_dataframe` where it is
  used. The `ImportError` guidance for a missing pandas is unchanged.
- `tl/__init__.py` already imported pandas lazily inside a function — untouched.
- New regression test `test/python/test_no_eager_optional_import.py`: asserts a
  fresh `import infomap` does not import pandas/numpy.

## Verification

- New regression test passes on this branch; it fails on `master`
  (`eagerly imported ['pandas', 'numpy']`), confirming it guards the bug.
- The exact failing command now runs to completion with **no**
  `KMP_DUPLICATE_LIB_OK`:
  `infomap examples/networks/modular_wd.net output -d --regularized --regularization-strength 0.5`
- `DYLD_PRINT_LIBRARIES` confirms only the bundled `libomp` loads on
  `import infomap`; the conda copy no longer loads.
- DataFrame suites (`test_result.py`, `test_deprecations.py`) pass (28); pandas
  is imported only when a DataFrame accessor is actually called.

## Scope / follow-ups

- This fixes the `import infomap` / CLI path completely. Users who actually call
  the pandas-returning API in a conda env can still hit the underlying
  bundled-vs-conda `libomp` duplication — the standard scientific-Python
  OpenMP-coexistence issue, out of scope here.
- A separate packaging issue was found and tracked in #707 (the macOS
  `_infomap.so` carries a stray `@loader_path/../torch/lib` rpath). Not related
  to this crash.
