### PR TITLE
docs(python): stop the FAQ from dismissing the survey citation

### DIFF
--- a/interfaces/python/source/faq.md
+++ b/interfaces/python/source/faq.md
@@ -196,6 +196,8 @@ See {doc}`The map equation <concepts/the-map-equation>`.
 
 ### How do I cite Infomap?
 
-Cite both the 2008 PNAS paper and the MapEquation software package, not the
-survey article. BibTeX and guidance on citing specific extensions are in
+Cite both the 2008 PNAS paper (the map equation) and the MapEquation software
+package (the implementation and version, for reproducibility). Cite the survey
+{cite:t}`smiljanic2026survey` as well when your work builds on the wider
+framework. BibTeX and guidance on citing specific extensions are in
 {doc}`How to cite Infomap <citing>`.


### PR DESCRIPTION
Follow-up to #704.

The prose audit in #704 made `citing.md` recommend the survey
{cite:t}`smiljanic2026survey` for the wider map-equation framework, but the
FAQ's "How do I cite Infomap?" answer still told readers to cite the 2008 PNAS
paper and the software package **"not the survey article"** — directly
contradicting the citing page.

Align the FAQ with `citing.md`: cite both canonical references (PNAS 2008 for the
method, the MapEquation software package for the implementation/version), and
cite the survey as well when the work builds on the broader framework.

One file, docs-only. Builds clean under `sphinx-build -W`.