### PR TITLE
docs(python): fix factual errors and inconsistencies found in docs review

### DIFF
--- a/examples/notebooks/options-guide.ipynb
+++ b/examples/notebooks/options-guide.ipynb
@@ -1124,7 +1124,7 @@
     "{cite:t}`domenico2015multilayer` introduced the relax rate in the multiplex map\n",
     "equation. {cite:t}`edler2017higher` cast memory and multilayer networks as one\n",
     "state-node formulation, and `multilayer_relax_by_jsd` couples layers by flow\n",
-    "similarity for intermittent communities {cite:p}`aslak2017temporal`.\n",
+    "similarity for intermittent communities {cite:p}`aslak2018temporal`.\n",
     "\n",
     "Build multilayer input with `add_multilayer_intra_link` (within a layer) and\n",
     "`add_multilayer_inter_link` (between layers), then set the relax options as usual."

--- a/interfaces/python/source/api/functions.rst
+++ b/interfaces/python/source/api/functions.rst
@@ -20,3 +20,9 @@ Information-theoretic primitives
 .. autofunction:: entropy
 .. autofunction:: perplexity
 .. autofunction:: plogp
+
+Build and CLI entry points
+--------------------------
+
+.. autofunction:: build_info
+.. autofunction:: main

--- a/interfaces/python/source/concepts/flow-and-random-walks.md
+++ b/interfaces/python/source/concepts/flow-and-random-walks.md
@@ -85,9 +85,12 @@ $$
 and the unique stationary solution $\pi$ exists for any $\tau > 0$. At a dangling
 node the walker has no out-links to follow, so it teleports with probability one
 rather than at rate $\tau$. The $1/n$ term is the simplest, uniform
-teleportation; by default Infomap teleports to a node with probability
-proportional to its in-strength. The teleportation steps are unrecorded, as
-described above.
+teleportation; by default Infomap instead teleports to a random *link*
+(proportionally to its weight) and lands at the link's source, so a node
+receives teleporting walkers in proportion to its out-strength. The next
+recorded step is then always a real link traversal. With recorded
+teleportation (`recorded_teleportation=True`) the walker lands at the link's
+target instead, proportionally to in-strength.
 
 These per-node flows $\pi_i$, together with how often the walker crosses between
 candidate modules, are the inputs the map equation needs. The next chapter,

--- a/interfaces/python/source/concepts/index.md
+++ b/interfaces/python/source/concepts/index.md
@@ -6,9 +6,9 @@ it does before running it on your own data.
 
 - {doc}`Flow and random walks <flow-and-random-walks>`: what "flow" means and why
   Infomap models a random walker.
-- {doc}`The map equation <the-map-equation>`: the objective Infomap minimises,
-  codelength, the bits needed to describe that walk, and the partition that makes
-  it shortest.
+- {doc}`The map equation <the-map-equation>`: the objective Infomap minimises —
+  the codelength, i.e. the bits needed to describe that walk — and the partition
+  that makes it shortest.
 - {doc}`Hierarchy and the multilevel map equation <hierarchy-and-the-multilevel-map>`:
   how Infomap discovers nested structure to any depth, with no resolution
   parameter to tune.

--- a/interfaces/python/source/concepts/the-map-equation.md
+++ b/interfaces/python/source/concepts/the-map-equation.md
@@ -110,8 +110,8 @@ $$
 
 and module $i$'s codebook (one codeword per node plus an exit symbol, with
 $p_{\circlearrowright}^i = q_{i\curvearrowright} + \sum_{\alpha\in i} p_\alpha$,
-where $p_\alpha$ is node $\alpha$'s visit frequency from chapter 1) has
-entropy
+where $p_\alpha$ is node $\alpha$'s visit frequency from
+{doc}`flow-and-random-walks`) has entropy
 
 $$
 H(\mathcal{P}^i)
@@ -133,7 +133,10 @@ $q_{i\curvearrowright}$ and $\sum_{\alpha\in i} p_\alpha$ per module; see
 
 Zachary's karate club is a classic benchmark: 34 people, 78 friendships, and a
 known split into two factions. It is small enough to explore interactively and
-has real structure Infomap reliably recovers.
+has real structure Infomap reliably recovers. Note that the NetworkX graph
+carries integer edge weights (interaction counts), and the adapter reads them
+by default, so the walk — and the codelengths below — are weighted; recomputing
+them by hand from the bare topology gives slightly different values.
 
 ```{code-cell} python
 import networkx as nx

--- a/interfaces/python/source/faq.md
+++ b/interfaces/python/source/faq.md
@@ -189,10 +189,10 @@ Yes: the `infomap.tl.graphrag` adapter reads entity/relationship tables (columns
 
 ### How do I make Infomap use only the cores my scheduler allocated?
 
-The default `num_threads="auto"` already resolves the budget from, in priority
-order, `INFOMAP_NUM_THREADS`, `SLURM_CPUS_PER_TASK`, `OMP_NUM_THREADS`, the
-process cpuset, and finally the hardware. Set `num_threads=` to a positive
-integer to override. See {doc}`Running at scale (HPC) <workflows/hpc>`.
+By default (`num_threads` unset, i.e. the engine's `auto` mode) the thread
+budget resolves from, in priority order, `INFOMAP_NUM_THREADS`,
+`SLURM_CPUS_PER_TASK`, `OMP_NUM_THREADS`, the process cpuset, and finally the
+hardware. Set `num_threads=` to a positive integer to override. See {doc}`Running at scale (HPC) <workflows/hpc>`.
 
 ### How do I run many trials across cluster jobs and combine them?
 

--- a/interfaces/python/source/flow-models/bipartite.md
+++ b/interfaces/python/source/flow-models/bipartite.md
@@ -45,9 +45,11 @@ types still receive module assignments.
 
 ```{admonition} Which type goes first?
 :class: note
-Put the nodes whose communities you care about below the threshold. Their
-flow is what the code describes, and `hide_bipartite_nodes=True` can then
-drop the other type from the output entirely.
+Put the nodes whose communities you care about below the threshold: their
+flow is what the code describes. If you also write native output files with
+the stateful {class}`~infomap.Infomap`, `hide_bipartite_nodes=True` drops the
+other type from those files (it does not filter the in-memory
+{class}`~infomap.Result`).
 ```
 
 Two options change this treatment: `skip_adjust_bipartite_flow=True` keeps
@@ -189,16 +191,17 @@ module spans both node types.
   for bipartite networks the source and target should be opposite types.
 - {meth}`infomap.Result.modules` returns a `{node_id: module_id}` dict covering
   both types.
-- The constructor flag `hide_bipartite_nodes=True` omits right-type nodes from
-  the output, which helps when only the left-type assignments matter (projecting
-  a user partition, say).
+- The option `hide_bipartite_nodes=True` omits right-type nodes from written
+  output files (`.tree`, `.clu`, …), which helps when only the left-type
+  assignments matter (projecting a user partition, say). It does not filter
+  {meth}`infomap.Result.modules`, which always covers both types.
 
 ## Options
 
 | Option | Where | Effect |
 |---|---|---|
 | `bipartite_start_id` | {class}`~infomap.Network` attribute | First node id of the second type; declares the network bipartite |
-| `hide_bipartite_nodes` | {func}`infomap.run` | Omit the second-type nodes from the output |
+| `hide_bipartite_nodes` | {func}`infomap.run` | Omit the second-type nodes from written output files (the in-memory result keeps both types) |
 | `skip_adjust_bipartite_flow` | {func}`infomap.run` | Keep flow on the second-type nodes instead of folding it onto the first type |
 | `bipartite_teleportation` | {func}`infomap.run` | On directed runs, teleport with bipartite-aware jumps instead of the two-step unipartite scheme |
 

--- a/interfaces/python/source/flow-models/memory-and-state.md
+++ b/interfaces/python/source/flow-models/memory-and-state.md
@@ -212,7 +212,9 @@ net.add_link(2,  0,  1.0)
 net.add_link(3,  11, 1.0)
 net.add_link(11, 3,  1.0)
 
-result2 = run(net, two_level=True, silent=True)
+# directed=True matches step 1 (a bare Network defaults to undirected flow,
+# unlike the DiGraph route, which enables it automatically)
+result2 = run(net, two_level=True, silent=True, directed=True)
 
 n_physical = len({node.node_id for node in result2.nodes(states=True)})
 print(f"have_memory: {result2.have_memory}")

--- a/interfaces/python/source/flow-models/metadata.md
+++ b/interfaces/python/source/flow-models/metadata.md
@@ -44,9 +44,10 @@ $\eta = 0$ you recover ordinary Infomap. As $\eta$ grows you favour
 attribute-homogeneous modules more, accepting a longer topological description in
 return.
 
-A closely related approach encodes the metadata differently: it biases the
-random walk itself so that walkers tend to stay near nodes with similar
-attributes {cite:p}`bassolas2022metadata`. Both approaches capture the interplay between
+A closely related approach couples metadata to the map equation differently:
+it leaves the walk unchanged but makes the *encoding* of the walk depend on
+the metadata, which maps nonlocal relationships between attributes and
+network structure {cite:p}`bassolas2022metadata`. Both approaches capture the interplay between
 topology and metadata; the Emmons & Mucha formulation is what Infomap implements.
 
 ## An attribute codebook
@@ -130,13 +131,13 @@ term, regardless of $\eta$. The optimisation therefore pushes modules toward
 homogeneity as $\eta$ increases, even splitting topologically tight groups if
 their attribute mixture is expensive to encode.
 
-A complementary approach, the metadata-dependent random walk
-{cite:p}`bassolas2022metadata`, modifies the walk itself: a walker at node $i$ is absorbed at node $j$
-with a probability that depends on the metadata at both $i$ and $j$. Running the
-standard map equation on this absorption-modified flow graph produces
-metadata-informed communities through long-range interactions between topology
-and attributes, rather than a local codebook penalty. The two frameworks share a
-spirit but differ in mechanism.
+A complementary approach, metadata-dependent encoding of random walks
+{cite:p}`bassolas2022metadata`, leaves the walk dynamics unchanged and instead
+makes the *encoding* of the walk depend on the metadata of the nodes the
+walker visits. That captures nonlocal relationships between metadata and
+network structure, rather than the local per-module codebook penalty used
+here. The two frameworks share a spirit but differ in where the metadata
+enters the encoding.
 :::
 
 ## Two triangles, two attributes

--- a/interfaces/python/source/flow-models/multilayer.md
+++ b/interfaces/python/source/flow-models/multilayer.md
@@ -51,8 +51,9 @@ current layer most of the time and crosses to another at rate $r$, the **relax
 rate**. When it rarely crosses ($r$ small), each layer behaves on its own and
 Alice lands in a different module in each of her layers. When it crosses freely
 ($r = 1$), the layers fuse and Alice gets one module. The default $r = 0.15$
-switches layers about once in six steps, enough coupling to respect the
-multiplex structure without washing out the per-layer signal.
+relaxes the layer constraint about once in six steps (the relaxed step can
+land back in the current layer, so actual switches are rarer), enough coupling
+to respect the multiplex structure without washing out the per-layer signal.
 
 The key step is the **physical node / state node** distinction
 ({doc}`/concepts/state-nodes-and-higher-order-flow`): here a state node is a
@@ -111,8 +112,10 @@ out-strength of node $i$ from layer $\alpha$.
 When no empirical inter-layer data are available, setting
 $D_i^{\alpha\beta} = (1-r)\delta_{\alpha\beta}S_i + r\,s_i^\beta$ recovers the
 relax-rate formula above {cite:p}`domenico2015multilayer`. At $r = 0.15$ the
-walker stays in a layer for about $1/r \approx 6$ steps before switching, enough
-coupling for layers to inform each other without fusing.
+walker takes a relaxed step about once every $1/r \approx 6$ steps (and
+switches layers less often still, since the relaxed step is strength-weighted
+over all layers including the current one), enough coupling for layers to
+inform each other without fusing.
 
 The map equation then minimises
 

--- a/interfaces/python/source/flow-models/temporal.md
+++ b/interfaces/python/source/flow-models/temporal.md
@@ -35,7 +35,7 @@ The cost of ignoring time is that naive approaches miss *intermittent*
 communities: groups that form, dissolve, and re-form in a recurring pattern.
 Face-to-face contact networks make this concrete: workplace social groups recur
 daily on a timescale of tens of minutes, but uniform aggregation smears them
-into background noise {cite:p}`aslak2017temporal`. Recovering that
+into background noise {cite:p}`aslak2018temporal`. Recovering that
 intermittent structure takes a model that couples information across time while
 respecting the boundaries between distinct interaction contexts.
 
@@ -78,8 +78,9 @@ The multilayer chapter covers that machinery, including the relax-rate transitio
 probabilities and how state nodes of one physical node share a codeword within a
 module. What is specific to *time* is how the windows should be coupled.
 
-**Uniform relaxation** (the default) couples every layer to every other with
-equal weight. It is the simplest choice and works well when communities change
+**Uniform relaxation** (the default) lets the walker relax to any window,
+weighted only by the node's link strength there — no window is privileged over
+another. It is the simplest choice and works well when communities change
 gradually.
 
 **Neighbourhood flow coupling** (`multilayer_relax_by_jsd`) makes the coupling
@@ -88,7 +89,7 @@ between a node's link patterns in two windows, so windows where its context look
 similar couple strongly. This matters for *intermittent communities* (groups
 that appear, vanish, and reappear), where coupling every window together would
 merge distinct occurrences that happen to share nodes
-{cite:p}`aslak2017temporal`.
+{cite:p}`aslak2018temporal`.
 
 `multilayer_relax_limit` enforces **temporal ordering**: it caps how far the
 walker may relax in layer index, so the walk crosses only into nearby time
@@ -207,7 +208,7 @@ community identity persists. Raising it toward 1 pushes Infomap toward the
 aggregate static solution. The default is `0.15`; values in the 0.15–0.25 range
 are usually a good choice for networks where communities evolve smoothly, and
 neighbourhood flow coupling stays robust across a broad range of relax rates
-(0.15 to 0.7) on benchmark networks {cite:p}`aslak2017temporal`.
+(0.15 to 0.7) on benchmark networks {cite:p}`aslak2018temporal`.
 
 For long time series, `multilayer_relax_limit` caps how far the random walker
 may jump between layers, so coupling stays between temporally nearby windows
@@ -243,7 +244,7 @@ generalises to higher-order and temporal networks {cite:p}`holmgren2023change`.
   distance, enforcing temporal ordering.
 - `multilayer_relax_by_jsd=True` uses neighbourhood flow coupling
   (Jensen-Shannon divergence) instead of uniform coupling; reach for it when
-  communities are intermittent {cite:p}`aslak2017temporal`.
+  communities are intermittent {cite:p}`aslak2018temporal`.
 - {meth}`infomap.Result.nodes` with `states=True` iterates state nodes; each
   exposes `.node_id`, `.layer_id`, and `.module_id` to reconstruct per-layer
   community assignments.
@@ -263,7 +264,7 @@ Temporal coupling is set by the multilayer engine options on {func}`infomap.run`
 
 ## Going deeper
 
-- {cite:t}`aslak2017temporal` introduce neighbourhood flow coupling and
+- {cite:t}`aslak2018temporal` introduce neighbourhood flow coupling and
   validate it on face-to-face contact networks.
 - Alluvial diagrams for higher-order networks, with an interactive generator at
   <https://www.mapequation.org/alluvial> {cite:p}`holmgren2023change`.

--- a/interfaces/python/source/references.bib
+++ b/interfaces/python/source/references.bib
@@ -160,14 +160,14 @@
   doi     = {10.3390/a10040112},
 }
 
-@article{aslak2017temporal,
+@article{aslak2018temporal,
   title   = {Constrained information flows in temporal networks reveal intermittent communities},
   author  = {Aslak, Ulf and Rosvall, Martin and Lehmann, Sune},
   journal = {Physical Review E},
   volume  = {97},
   number  = {6},
   pages   = {062312},
-  year    = {2017},
+  year    = {2018},
   doi     = {10.1103/PhysRevE.97.062312},
 }
 

--- a/interfaces/python/source/the-infomap-class.md
+++ b/interfaces/python/source/the-infomap-class.md
@@ -58,7 +58,7 @@ Each stateful pattern has a direct functional or `Network` equivalent:
 | Top-level modules | `im.get_modules()` | `result.modules()` |
 | Modules at level *k* | `im.get_modules(depth_level=k)` | `result.modules(depth=k)` |
 | State-node modules | `im.get_modules(states=True)` | `result.modules(states=True)` |
-| Per-node flow | `for n in im.nodes: n.data.flow` | `for n in result.nodes(): n.flow` |
+| Per-node flow | `for n in im.nodes: n.data.flow` | `for n in result.nodes(states=True): n.flow` (`im.nodes` iterates state nodes; plain `result.nodes()` gives physical nodes, identical for first-order networks) |
 | DataFrame | `im.to_dataframe([...])` | `result.to_dataframe([...])` |
 | Scalar metrics | `im.codelength`, `im.num_top_modules` | `result.codelength`, `result.num_top_modules` |
 | Graph-file export | `infomap.io.export.write_graphml(graph, im, path)` | `nx.write_graphml(infomap.to_networkx(result), path)` |

--- a/interfaces/python/source/workflows/hpc.md
+++ b/interfaces/python/source/workflows/hpc.md
@@ -50,9 +50,10 @@ seed, total trial count, and algorithm settings.
 
 ## Trials as independent work units
 
-`num_trials` is the total trial budget, and `trial_offset` shifts where a
-task's trials begin in that budget. If you want 100 trials in total and split
-them across four array tasks:
+Each task runs `num_trials` trials of its own — the *per-shard* count — and
+`trial_offset` positions those trials within the global budget. If you want
+100 trials in total and split them across four array tasks, each task gets
+`num_trials=25`:
 
 - task 0: trials 0–24, offset 0
 - task 1: trials 25–49, offset 25

--- a/interfaces/python/source/working-with-infomap/inputs.md
+++ b/interfaces/python/source/working-with-infomap/inputs.md
@@ -51,8 +51,10 @@ read* belong to the ``Network.from_*`` constructors; passing one to
 {func}`infomap.run` raises with a pointer to the right constructor rather than
 silently building a different graph. For a NetworkX or igraph graph the
 directedness is read from the graph object itself, so no ``directed`` argument
-is needed; for a SciPy matrix or edge index, pass ``directed=`` to the matching
-``from_*`` constructor.
+is needed. For a SciPy matrix or edge index, pass ``directed=`` to the matching
+``from_*`` constructor — and note that the two routes default differently:
+a SciPy matrix is read as *undirected* unless you say otherwise, while a
+``(2, E)`` edge index follows the PyG convention and is read as *directed*.
 
 Two library-idiomatic one-shot helpers return native types instead of a
 {class}`~infomap.Result`: {func}`infomap.find_communities` (a NetworkX-style
@@ -215,8 +217,11 @@ iterable of tuples: ``infomap.run([(0, 1, 1.0), (1, 2, 1.0), ...])``.
 ```{admonition} Edge index vs link rows
 :class: note
 A two-row *integer* array is read as a ``(2, E)`` edge index (the PyG / GNN
-convention). Rows of ``(source, target, weight)`` have a float column and are
-read as weighted links. For an explicit edge index with its own options, use
+convention) and, following that convention, defaults to a **directed** flow
+model — pass ``directed=False`` to `Network.from_edge_index` if your edge
+index lists an undirected graph. Rows of ``(source, target, weight)`` have a
+float column and are read as weighted links. For an explicit edge index with
+its own options, use
 `Network.from_edge_index(edge_index, edge_weight=..., directed=...)`.
 ```
 

--- a/interfaces/python/source/working-with-infomap/running-and-options.md
+++ b/interfaces/python/source/working-with-infomap/running-and-options.md
@@ -21,7 +21,8 @@ hard Infomap looks.
 ```
 
 Most runs need only three choices: a `seed`, how many `num_trials` to run, and
-either `two_level` or `directed` for the flow model. The shortest useful run:
+whether the flow is `directed`; add `two_level` if you want a flat partition
+instead of the multilevel default. The shortest useful run:
 
 ```python
 import networkx as nx
@@ -32,6 +33,7 @@ result = infomap.run(
     seed=123,        # reproducible
     num_trials=10,   # keep the best of 10 restarts
     two_level=True,  # flat partition; omit for the multilevel default
+    silent=True,     # skip the engine's console log
 )
 print(result.num_top_modules, result.codelength)
 ```
@@ -257,8 +259,8 @@ your domain says walkers teleport much more or less often.
 
 The map equation operates at the natural timescale of one random-walk step.
 `markov_time` shifts this timescale: values below 1 encode the walk more
-frequently (favoring more, smaller modules) and values above 1 encode it less
-frequently (favoring fewer, larger modules). This is the principled way to
+frequently (favouring more, smaller modules) and values above 1 encode it less
+frequently (favouring fewer, larger modules). This is the principled way to
 examine structure at a specific resolution when the data does not have a natural
 scale {cite:p}`kheirkhahzadeh2016markov`.
 
@@ -287,21 +289,27 @@ specifically want to study structure at a given scale, or when reviewers ask
 ### `regularized` for sparse data
 
 ```{code-cell} python
-# On the karate club, regularization merges weakly supported modules
-# into fewer, larger communities.
+# On the small karate club the regularization prior competes with the data:
+# at half strength the three modules survive, and at the default strength
+# the prior already outweighs the data and collapses them into one.
 G_karate = nx.karate_club_graph()
 
 for label, kwargs in [
-    ("baseline",                       {}),
-    ("regularized",                    {"regularized": True}),
-    ("regularized, strength=2",        {"regularized": True, "regularization_strength": 2.0}),
+    ("baseline",                  {}),
+    ("regularized, strength=0.5", {"regularized": True, "regularization_strength": 0.5}),
+    ("regularized (default 1.0)", {"regularized": True}),
 ]:
     result = infomap.run(G_karate, two_level=True, seed=123, num_trials=10, silent=True, **kwargs)
     print(f"{label}: modules={result.num_top_modules}, L={result.codelength:.4f}")
 ```
 
-Higher `regularization_strength` merges more modules. Use this when you have
-prior reason to believe that small modules in your result reflect sampling noise
+Higher `regularization_strength` merges more modules — on a network this small
+the default strength already merges everything, which is why the option is
+meant for large, sparse, or incompletely sampled data rather than well-sampled
+toy graphs. For a gradual version of the same sweep, where a planted partition
+goes from 14 modules through 7 to 1 as the strength grows, see
+{doc}`/robustness/incomplete-data`. Use regularization when you have prior
+reason to believe that small modules in your result reflect sampling noise
 rather than real structure. The Bayesian derivation is in
 {cite:t}`smiljanic2020missing`.
 

--- a/interfaces/python/source/working-with-infomap/visualizing-and-exporting.md
+++ b/interfaces/python/source/working-with-infomap/visualizing-and-exporting.md
@@ -117,8 +117,10 @@ For production figures, copy
 ### Export to GraphML and GEXF
 
 For a single file bundling the network topology and the Infomap result,
-{func}`infomap.to_networkx` returns a copy of the graph annotated with the
-partition, which NetworkX then writes:
+{func}`infomap.to_networkx` builds a *new* NetworkX graph from the result:
+nodes are the result's (state) nodes, keyed by `state_id` and carrying the
+Infomap node `name` plus the partition attributes, and edges come from the
+partitioned network. NetworkX then writes it:
 
 ```{code-cell} python
 import os
@@ -127,7 +129,7 @@ from infomap import to_networkx
 
 tmp = tempfile.mkdtemp()
 
-annotated = to_networkx(result)   # adds infomap_module, infomap_path, flow, ...
+annotated = to_networkx(result)   # new graph with infomap_module, infomap_path, flow, ...
 graphml_path = os.path.join(tmp, "karate.graphml")
 gexf_path = os.path.join(tmp, "karate.gexf")
 nx.write_graphml(annotated, graphml_path)
@@ -137,14 +139,20 @@ print(f"GraphML: {os.path.getsize(graphml_path):,} bytes")
 print(f"GEXF:    {os.path.getsize(gexf_path):,} bytes")
 ```
 
-The annotated graph carries these Infomap node attributes:
+The exported graph carries these Infomap node attributes, all stored as
+strings for GraphML/GEXF compatibility:
 
 | Attribute | Value |
 |---|---|
-| `infomap_module` | Top-level module id (string) |
-| `infomap_path` | Colon-separated path, e.g. `"1"` or `"2:3"` |
-| `infomap_level_1`, `infomap_level_2`, … | One attribute per hierarchy level |
+| `infomap_module` | Top-level module id |
+| `infomap_path` | Colon-separated tree path ending in the node's position within its module, e.g. `"1:1"` or `"2:3:4"` |
+| `infomap_level_1`, `infomap_level_2`, … | One attribute per path component (the last is the node's position within its final module) |
 | `flow` | Stationary visit frequency |
+
+Because the graph is rebuilt from the result, your original graph's node
+attributes are *not* carried over. To keep them, annotate your own graph in
+place with {func}`infomap.find_communities` (see below) or
+{func}`infomap.io.export.annotate_networkx_graph`.
 
 Open the GraphML file in Gephi, select **Appearance → Nodes → Partition**, and
 choose `infomap_module` to colour the graph by community.
@@ -245,8 +253,12 @@ print("Temp directory removed.")
   module-coloured layouts only.
 - **`.clu` records the top level.** Pass `depth_level` to `write_clu` for a
   deeper level; `.tree` / `.ftree` carry the full hierarchy.
-- **`to_networkx` returns a copy.** It annotates a new graph and leaves your
-  original untouched.
+- **`to_networkx` builds a new graph, not a copy of yours.** Its nodes are the
+  result's (state) nodes keyed by `state_id`, so your original graph — and any
+  attributes on it — is left untouched and *not* carried into the export. Use
+  {func}`infomap.find_communities` or
+  {func}`infomap.io.export.annotate_networkx_graph` to annotate your own graph
+  instead.
 
 ## API pointers
 
@@ -258,10 +270,10 @@ print("Temp directory removed.")
 
 **In-memory graph export**
 
-- {func}`infomap.to_networkx` returns a NetworkX copy annotated with
-  `infomap_module`, `infomap_path`, per-level ids, and `flow`; write it with
-  `nx.write_graphml` / `nx.write_gexf`.
-- {func}`infomap.to_igraph` returns the same annotation on an `igraph.Graph`.
+- {func}`infomap.to_networkx` builds a NetworkX graph from the result's (state)
+  nodes, annotated with `infomap_module`, `infomap_path`, per-level ids, and
+  `flow` (all strings); write it with `nx.write_graphml` / `nx.write_gexf`.
+- {func}`infomap.to_igraph` builds the same graph as an `igraph.Graph`.
 - {func}`infomap.io.export.write_graphml`, {func}`infomap.io.export.write_gexf`,
   and {func}`infomap.io.export.annotate_networkx_graph` are convenience wrappers
   around that pattern. They take a post-run stateful {class}`~infomap.Infomap`,

--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 
 from ._core import Core
 from ._core import apply_initial_partition
-from ._core import build_info
+from ._core import build_info as _engine_build_info
 from ._core import run as _cli_run
 
 # Documented tree-walking iterator/node types returned by ``Infomap.tree`` /
@@ -1488,6 +1488,14 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         )
 
     def remove_multilayer_link(self):
+        """Unsupported operation kept for interface parity.
+
+        Raises
+        ------
+        NotImplementedError
+            Always; removing multilayer links is not supported by the
+            Python API. Rebuild the network without the link instead.
+        """
         return self._network.remove_multilayer_link()
 
     def set_meta_data(self, node_id, meta_category):
@@ -2119,7 +2127,33 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         return self._core.elapsedTime()
 
 
+def build_info():
+    """Report how the compiled Infomap extension was built.
+
+    Returns
+    -------
+    dict
+        A dict with an ``enabled_features`` tuple naming the optional
+        features the native engine was compiled with (empty for a standard
+        build).
+
+    Examples
+    --------
+    >>> import infomap
+    >>> sorted(infomap.build_info())
+    ['enabled_features']
+    """
+    return _engine_build_info()
+
+
 def main():
+    """Run the ``infomap`` command-line interface.
+
+    This is the console-script entry point behind the ``infomap`` command
+    (and ``python -m infomap``): it joins ``sys.argv[1:]`` into a native CLI
+    invocation and returns the process exit code, suitable for
+    ``sys.exit``. A keyboard interrupt exits cleanly with code 130.
+    """
     args = " ".join(sys.argv[1:])
     try:
         return _cli_run(args)

--- a/interfaces/python/src/infomap/io/networkx.py
+++ b/interfaces/python/src/infomap/io/networkx.py
@@ -5,6 +5,10 @@ from typing import Any
 
 from ._arrays import apply_node_meta_data, community_node_data
 
+# run_networkx and add_networkx_graph are internal plumbing shared with the
+# facade and the docs notebooks; only find_communities is public API.
+__all__ = ["find_communities"]
+
 
 def _label_to_internal_id(labels):
     if not labels:

--- a/interfaces/python/src/infomap/network.py
+++ b/interfaces/python/src/infomap/network.py
@@ -622,6 +622,14 @@ class Network:
         return self
 
     def remove_multilayer_link(self):
+        """Unsupported operation kept for interface parity.
+
+        Raises
+        ------
+        NotImplementedError
+            Always; removing multilayer links is not supported by the
+            Python API. Rebuild the network without the link instead.
+        """
         raise NotImplementedError(
             "Removing multilayer links is not supported by the Python API."
         )

--- a/interfaces/python/src/infomap/result.py
+++ b/interfaces/python/src/infomap/result.py
@@ -32,6 +32,9 @@ from ._results import _to_dataframe_sort_columns, perplexity
 if TYPE_CHECKING:
     from ._facade import Infomap
 
+# build_result is internal plumbing shared by Infomap.run and Network.run;
+# only the result types are public API.
+__all__ = ["Result", "TreeNode"]
 
 _DEFAULT_TO_DATAFRAME_COLUMNS = ("node_id", "module_id", "flow", "path", "name")
 _DATAFRAME_COLUMN_ALIASES = {"community": "module_id"}


### PR DESCRIPTION
## Summary

A full review of the Python docs (every code example executed against the built package, math recomputed, every API claim checked against the Python and C++ sources) surfaced a handful of factual errors and inconsistencies. This PR fixes all of them.

Correctness:
- **flow-and-random-walks**: default (unrecorded) teleportation lands at the *source* of a weight-proportional link, i.e. proportional to out-strength — not in-strength, which applies only with `recorded_teleportation=True` (`FlowCalculator.cpp:384-388`).
- **visualizing-and-exporting**: `to_networkx` builds a *new* graph from the result's (state) nodes and does not copy the input graph or its attributes; the attribute table now matches the actual output (full leaf path, string values), and attribute-preserving workflows are pointed to `find_communities` / `annotate_networkx_graph`.
- **bipartite**: `hide_bipartite_nodes` only filters written output files, not the in-memory `Result`.
- **metadata**: both mentions of Bassolas et al. (2022) now consistently describe metadata-dependent *encoding* of random walks, per the paper.
- **temporal/multilayer**: uniform relaxation is strength-weighted per layer (not "equal weight"), and a relaxed step is not the same as a layer switch.
- **running-and-options**: the regularized example now demonstrates its own lesson (3 → 3 → 1 modules across strengths, with prose explaining why karate collapses at the default), and `two_level` is no longer labelled a flow-model option.
- **inputs**: the `(2, E)` edge-index route defaults to *directed* flow while the SciPy route defaults to undirected — now stated in both places.
- **hpc**: `num_trials` is the per-shard trial count, not the total budget.
- **the-infomap-class**: the migration table maps `im.nodes` to `result.nodes(states=True)`.
- **references**: Aslak et al. was published in 2018, not 2017 (key renamed, notebook citation updated).
- **faq**: `num_threads` defaults to `None` (the engine's `auto` mode), not the string `"auto"`.

Coverage and polish:
- `infomap.main` and `infomap.build_info` were public exports documented nowhere; both got docstrings (with a doctest for `build_info`) and a new section in `api/functions.rst`.
- The `remove_multilayer_link` stubs got docstrings; `infomap.result` and `infomap.io.networkx` declare `__all__` to mark `build_result` / `run_networkx` as internal plumbing (no renames, so no breakage).
- Smaller prose fixes: proper `{doc}` link instead of "chapter 1", a note that the karate example runs weighted, a garbled list on the Concepts index, `directed=True` in memory-and-state step 2 to match step 1, `silent=True` on the first running-and-options example, and a British-spelling inconsistency.

## Verification

- `sphinx-build` completes cleanly; the only warnings are sandbox-proxy intersphinx fetch failures. All notebook pages re-executed during the build, and the reworked regularized example renders exactly the numbers the prose claims (3 → 3 → 1 modules).
- `make test-python-unit`: 477 passed, 2 skipped.
- `make test-python-doctest`: ruff clean, 38 doctests passed (including the new `build_info` example).
- The memory-and-state change (`directed=True`) was verified to produce identical modules and codelength before committing.

## Notes

- `run_networkx` / `build_result` were deliberately *not* underscore-renamed — `examples/notebooks/_support.py` imports `run_networkx`, and a rename risks breaking external users. `__all__` now marks them internal; a hard rename can be a follow-up decision.
- The Bassolas et al. rewrite follows the paper's title/abstract framing; worth a quick sanity check from an author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJ5Z21bH9cT3UGjmK9ZSYn

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJ5Z21bH9cT3UGjmK9ZSYn)_