### PR TITLE
docs(python): fix remaining factual errors and broken xrefs from docs review

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ For contributing, security reporting, and maintainer workflows, see
    :target: https://github.com/mapequation/infomap/actions/workflows/ci.yml
    :alt: CI
 
-.. _Map equation: https://www.mapequation.org/publications.html#Rosvall-Axelsson-Bergstrom-2009-Map-equation?utm_source=infomap&utm_medium=readme&utm_campaign=infomap
+.. _Map equation: https://www.mapequation.org/publications.html?utm_source=infomap&utm_medium=readme&utm_campaign=infomap#Rosvall-Axelsson-Bergstrom-2009-Map-equation
 .. _`mapequation.org/infomap/`: https://www.mapequation.org/infomap/?utm_source=infomap&utm_medium=readme&utm_campaign=infomap
 .. _`CHANGELOG.md`: https://github.com/mapequation/infomap/blob/master/CHANGELOG.md
 .. _`CONTRIBUTING.md`: https://github.com/mapequation/infomap/blob/master/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Install optional integrations for common Python graph and analysis workflows:
     pip install "infomap[igraph]"
     pip install "infomap[pandas]"
 
-Upgrades use the usual `pip` flow:
+Upgrades use the usual ``pip`` flow:
 
 .. code-block:: bash
 
@@ -84,9 +84,9 @@ For direct control over Infomap-specific options and result access:
 
 .. code-block:: python
 
-    from infomap import Infomap, InfomapOptions
+    from infomap import Infomap, Options
 
-    options = InfomapOptions(two_level=True, silent=True, num_trials=20, seed=123)
+    options = Options(two_level=True, silent=True, num_trials=20, seed=123)
     im = Infomap.from_options(options)
     im.add_link(0, 1)
     im.add_link(1, 2)
@@ -324,7 +324,7 @@ For contact information, see `mapequation.org/about.html`_.
 Terms of use
 ------------
 
-Infomap is released under a dual licence.
+Infomap is released under a dual license.
 
 The code is available under the GNU General Public License version 3 or any
 later version; see `LICENSE_GPLv3.txt`_.

--- a/interfaces/python/source/api/infomap.rst
+++ b/interfaces/python/source/api/infomap.rst
@@ -9,10 +9,10 @@ four calls.
 
 .. code-block:: python
 
-   im = infomap.Infomap(num_trials=10, seed=42)   # 1. configure
-   im.add_networkx_graph(graph)                    # 2. build
-   result = im.run()                                # 3. search
-   result.modules()                                 # 4. read
+   im = infomap.Infomap(num_trials=10, seed=42)  # 1. configure
+   im.add_networkx_graph(graph)                  # 2. build
+   result = im.run()                             # 3. search
+   result.modules()                              # 4. read
 
 Everything else on this page refines one of those four steps. The tables below
 group the members by purpose; the full reference, with signatures and

--- a/interfaces/python/source/api/iterators.rst
+++ b/interfaces/python/source/api/iterators.rst
@@ -4,7 +4,8 @@ Tree nodes and iterators
 .. currentmodule:: infomap
 
 Walking an :class:`Infomap` partition yields nodes via these iterator types.
-:class:`InfoNode` is the node wrapper returned by each step.
+Each step yields an iterator positioned at the current node, proxying the
+attributes of the underlying :class:`InfoNode` (available via ``current()``).
 
 .. autoclass:: InfoNode
    :members:

--- a/interfaces/python/source/api/options.rst
+++ b/interfaces/python/source/api/options.rst
@@ -10,5 +10,8 @@ Options and multilayer inputs
 .. autoclass:: Options
    :members:
 
+.. autodata:: InfomapOptions
+   :no-value:
+
 .. autoclass:: MultilayerNode
    :members:

--- a/interfaces/python/source/concepts/choosing-a-method.md
+++ b/interfaces/python/source/concepts/choosing-a-method.md
@@ -39,8 +39,9 @@ what you mean by "community".
 ## What each objective optimises
 
 **Modularity (Louvain, Leiden).** Both are usually run to maximise modularity, a
-static-density score against a degree-preserving null model. That null model is
-undirected, so by default both ignore edge direction. Leiden is a general
+static-density score against a degree-preserving null model. Standard
+modularity's null model is undirected, so edge direction is ignored unless you
+switch to a directed-modularity variant. Leiden is a general
 optimiser: it maximises whichever quality function you give it, adds a refinement
 step that guarantees internally connected communities, and reaches better optima
 than Louvain's greedy moves {cite:p}`traag2019leiden`. This page uses the

--- a/interfaces/python/source/concepts/state-nodes-and-higher-order-flow.md
+++ b/interfaces/python/source/concepts/state-nodes-and-higher-order-flow.md
@@ -51,9 +51,9 @@ hub airport can belong to several regional systems.
 
 ## The map equation on state nodes
 
-A higher-order network is a set of state nodes $\{\alpha_i\}$ (state node
-$\alpha$ of physical node $i$) with transitions between them. The map equation is
-unchanged in form,
+A higher-order network is a set of state nodes, each attached to a physical
+node, with transitions between them. The map equation is unchanged in form
+(the sum still runs over the $m$ modules),
 
 $$
 L(\mathsf{M}) =
@@ -75,7 +75,8 @@ nodes: from state $\alpha_i$ the walker mostly continues to *j* and *k*, from
 state $\delta_i$ mostly to *l* and *m*. The weak 0.2-links let it occasionally
 switch sides, so the two contexts are coupled but distinct.
 
-Build state nodes directly with `add_state_node(state_id, physical_id)` and
+Build state nodes directly with `add_state_node(state_id, node_id)`, where
+`node_id` is the physical node, and
 link them, then read the partition back with `result.nodes(states=True)`:
 
 ```{code-cell} python
@@ -177,8 +178,8 @@ directly, but the partition you read back is always over state nodes.
 
 ## API pointers
 
-- `Network().add_state_node(state_id, physical_id)` declares a state node;
-  `add_link` then links state nodes.
+- `Network().add_state_node(state_id, node_id)` declares a state node on the
+  physical node `node_id`; `add_link` then links state nodes.
 - You need `result.modules(states=True)` to read a higher-order partition;
   `result.nodes(states=True)` exposes each node's `.node_id` (physical),
   `.state_id`, `.module_id`, and `.flow`.

--- a/interfaces/python/source/concepts/the-map-equation.md
+++ b/interfaces/python/source/concepts/the-map-equation.md
@@ -90,7 +90,8 @@ two partitions of the same network, the one with smaller $L$ compresses the flow
 better and captures more of its community structure.
 
 For undirected networks, a node's visit frequency equals its normalised strength
-(its total incident link weight divided by the network total), so Infomap needs
+(its total incident link weight divided by twice the total link weight, the sum
+of all node strengths), so Infomap needs
 no teleportation. For directed networks Infomap uses a random-surfer
 model with teleportation probability $\tau = 0.15$ (the conventional choice, one
 minus PageRank's 0.85 damping factor) to guarantee an ergodic stationary
@@ -110,8 +111,8 @@ $$
 
 and module $i$'s codebook (one codeword per node plus an exit symbol, with
 $p_{\circlearrowright}^i = q_{i\curvearrowright} + \sum_{\alpha\in i} p_\alpha$,
-where $p_\alpha$ is node $\alpha$'s visit frequency from
-{doc}`flow-and-random-walks`) has entropy
+where $p_\alpha$ is node $\alpha$'s visit frequency, the stationary flow
+$\pi_\alpha$ of {doc}`flow-and-random-walks`) has entropy
 
 $$
 H(\mathcal{P}^i)

--- a/interfaces/python/source/conf.py
+++ b/interfaces/python/source/conf.py
@@ -15,7 +15,7 @@ os.environ["PYTHONPATH"] = os.pathsep.join(
 # -- Project information -----------------------------------------------------
 
 project = "Infomap"
-copyright = "2020, Daniel Edler, Anton Holmgren, Martin Rosvall"
+copyright = "2020-2026, Daniel Edler, Anton Holmgren, Martin Rosvall"
 author = "Daniel Edler, Anton Holmgren, Martin Rosvall"
 
 version_module_path = (

--- a/interfaces/python/source/faq.md
+++ b/interfaces/python/source/faq.md
@@ -119,8 +119,8 @@ relax rate is ignored. See {doc}`Multilayer networks <flow-models/multilayer>`.
 
 ### How do I model a network with memory (higher-order flow)?
 
-Declare state nodes on a `Network` with `add_state_node(state_id, physical_id)`
-and link them with `add_link`. Memory lets a physical node appear in overlapping
+Declare state nodes on a `Network` with `add_state_node(state_id, node_id)`,
+where `node_id` is the physical node, and link them with `add_link`. Memory lets a physical node appear in overlapping
 modules. See {doc}`Memory and state networks <flow-models/memory-and-state>`.
 
 ### How do I cluster a time-varying (temporal) network?

--- a/interfaces/python/source/flow-models/bipartite.md
+++ b/interfaces/python/source/flow-models/bipartite.md
@@ -22,7 +22,7 @@ random walk directly, returning modules that mix both node types.
 ## Two node types, links between them
 
 Many networks connect two distinct kinds of entities: users rating movies,
-species visiting flowers, papers citing authors. Links go exclusively
+species visiting flowers, authors writing papers. Links go exclusively
 *between* the two types, never within them. This is a bipartite network.
 
 A common workaround is to project one type onto the other, replacing
@@ -201,7 +201,7 @@ module spans both node types.
 | Option | Where | Effect |
 |---|---|---|
 | `bipartite_start_id` | {class}`~infomap.Network` attribute | First node id of the second type; declares the network bipartite |
-| `hide_bipartite_nodes` | {func}`infomap.run` | Omit the second-type nodes from written output files (the in-memory result keeps both types) |
+| `hide_bipartite_nodes` | {class}`~infomap.Infomap` (file-writing runs) | Omit the second-type nodes from written output files (the in-memory result keeps both types) |
 | `skip_adjust_bipartite_flow` | {func}`infomap.run` | Keep flow on the second-type nodes instead of folding it onto the first type |
 | `bipartite_teleportation` | {func}`infomap.run` | On directed runs, teleport with bipartite-aware jumps instead of the two-step unipartite scheme |
 

--- a/interfaces/python/source/flow-models/memory-and-state.md
+++ b/interfaces/python/source/flow-models/memory-and-state.md
@@ -195,7 +195,7 @@ state node per incoming stream. Node B gets **two** state nodes:
 ```{code-cell} python
 net = Network()
 
-# Declare state nodes: add_state_node(state_id, physical_id)
+# Declare state nodes: add_state_node(state_id, node_id) — node_id is physical
 net.add_state_node(0,  0)   # phys A, state 0
 net.add_state_node(2,  2)   # phys C, state 2
 net.add_state_node(3,  3)   # phys D, state 3
@@ -300,22 +300,23 @@ finds two communities (A–B–C and B–D) that overlap at junction B.
 
 ```python
 net = Network()
-net.add_state_node(state_id, physical_id)
+net.add_state_node(state_id, node_id)
 ```
 
-Creates a state node with a unique integer `state_id` mapped to `physical_id`.
+Creates a state node with a unique integer `state_id` mapped to the physical
+node `node_id`.
 If the physical node does not yet exist, `add_state_node` creates it. Use
 {meth}`infomap.Network.set_name` afterwards for a human-readable label.
 
 **Adding state-level links**
 
 ```python
-net.add_link(source_state_id, target_state_id, weight=1.0)
+net.add_link(source_id, target_id, weight=1.0)
 ```
 
 Links connect *state nodes*, not physical nodes. The same `add_link` serves both
-first-order and higher-order networks; in a state-node network the integer ids
-refer to state node ids.
+first-order and higher-order networks; in a state-node network `source_id` and
+`target_id` refer to state node ids.
 
 **Querying results**
 
@@ -345,5 +346,5 @@ grouping by `node_id`, as shown in the worked example.
   implementation of higher-order flows {cite:p}`edler2017higher`.
 - The survey (§5.1) covers higher-order and memory flows
   {cite:p}`smiljanic2026survey`. Its companion notebook,
-  `examples/notebooks/5.1 Memory Networks.ipynb`, works a full-size example
-  with empirical pathway data and sparse-Markov-chain model selection.
+  `examples/notebooks/5.1 Memory Networks.ipynb`, works the `*States` file
+  format and the `add_state_node` API on a small journal-citation example.

--- a/interfaces/python/source/flow-models/multilayer.md
+++ b/interfaces/python/source/flow-models/multilayer.md
@@ -51,7 +51,7 @@ current layer most of the time and crosses to another at rate $r$, the **relax
 rate**. When it rarely crosses ($r$ small), each layer behaves on its own and
 Alice lands in a different module in each of her layers. When it crosses freely
 ($r = 1$), the layers fuse and Alice gets one module. The default $r = 0.15$
-relaxes the layer constraint about once in six steps (the relaxed step can
+relaxes the layer constraint about once in seven steps (the relaxed step can
 land back in the current layer, so actual switches are rarer), enough coupling
 to respect the multiplex structure without washing out the per-layer signal.
 
@@ -112,7 +112,7 @@ out-strength of node $i$ from layer $\alpha$.
 When no empirical inter-layer data are available, setting
 $D_i^{\alpha\beta} = (1-r)\delta_{\alpha\beta}S_i + r\,s_i^\beta$ recovers the
 relax-rate formula above {cite:p}`domenico2015multilayer`. At $r = 0.15$ the
-walker takes a relaxed step about once every $1/r \approx 6$ steps (and
+walker takes a relaxed step about once every $1/r \approx 7$ steps (and
 switches layers less often still, since the relaxed step is strength-weighted
 over all layers including the current one), enough coupling for layers to
 inform each other without fusing.

--- a/interfaces/python/source/the-infomap-class.md
+++ b/interfaces/python/source/the-infomap-class.md
@@ -17,7 +17,8 @@ The {class}`infomap.Infomap` class is the stateful entry point: build a network
 with the `add_*` verbs, then call `run()` for an immutable
 {class}`~infomap.Result`. New code should prefer {func}`infomap.run` for one-shot
 use and {class}`~infomap.Network` for incremental construction; existing
-`Infomap` code keeps working unchanged.
+`Infomap` code keeps working essentially unchanged (see
+[Removed accessors](#removed-accessors) for the few exceptions).
 ```
 
 ## When to use it

--- a/interfaces/python/source/workflows/hpc.md
+++ b/interfaces/python/source/workflows/hpc.md
@@ -131,7 +131,8 @@ edges = [
 
 ```{code-cell} python
 # On a cluster each entry below would be a separate job-array task.
-# Each shard uses a distinct base seed so their trial seeds never overlap.
+# Each shard uses a distinct base seed so their trial seeds never overlap;
+# the SLURM recipe below instead shares one seed and offsets with trial_offset.
 shard_specs = [
     {"shard_id": 0, "seed": 10, "num_trials": 4},
     {"shard_id": 1, "seed": 20, "num_trials": 4},

--- a/interfaces/python/source/workflows/scanpy.md
+++ b/interfaces/python/source/workflows/scanpy.md
@@ -244,8 +244,8 @@ Key `infomap.tl.infomap` keyword arguments:
 | `adjacency` | `None` | Pass a sparse matrix directly |
 | `directed` | `False` | Treat graph as directed |
 | `use_weights` | `True` | Use edge weights; `False` for unweighted |
-| `seed` | (none) | Random seed forwarded to Infomap |
-| `num_trials` | (none) | Independent restarts; more trials give a more stable partition |
+| `seed` | Infomap's `123` | Random seed forwarded to Infomap |
+| `num_trials` | Infomap's `1` | Independent restarts; more trials give a more stable partition |
 
 ## Going deeper
 

--- a/interfaces/python/source/working-with-infomap/inputs.md
+++ b/interfaces/python/source/working-with-infomap/inputs.md
@@ -83,8 +83,10 @@ print(f"Modules:    {result.modules()}")     # {node_id: module_id}
 ```
 
 **Non-integer node labels** (strings, compound keys) work out of the box. The
-loader maps them to internal integers; the cleanest way to read assignments back
-in your own labels is the ``"name"`` column of the result DataFrame:
+loader maps them to internal integers. For string labels, the cleanest way to
+read assignments back in your own labels is the ``"name"`` column of the result
+DataFrame; for other label types (tuples, frozensets), use
+{class}`~infomap.Network` and its label mapping as shown below:
 
 ```{code-cell} python
 g_str = nx.Graph([("alice", "bob"), ("bob", "carol"), ("dave", "eve")])
@@ -210,8 +212,9 @@ print(f"pandas route: {result.num_top_modules} modules, {result.codelength:.4f} 
 ```
 
 Source and target columns must hold integers. Convert string labels to integer
-codes first (``pandas.factorize``), then read names back through the result
-DataFrame or your own reverse mapping. An equally valid one-call form is an
+codes first (``pandas.factorize``) and keep the ``uniques`` array it returns as
+your reverse mapping — this route registers no node names, so the result
+DataFrame's ``"name"`` column cannot recover the labels. An equally valid one-call form is an
 iterable of tuples: ``infomap.run([(0, 1, 1.0), (1, 2, 1.0), ...])``.
 
 ```{admonition} Edge index vs link rows
@@ -342,8 +345,8 @@ To draw the partition or write it to disk, see
   are one-shot helpers returning a NetworkX ``list[set]`` and an
   ``igraph.VertexClustering`` respectively.
 - {meth}`infomap.Result.modules` returns `{node_id: module_id}`;
-  {meth}`infomap.Result.to_dataframe` returns node id, module id, flow, and name
-  as a DataFrame.
+  {meth}`infomap.Result.to_dataframe` returns node id, module id, flow, path,
+  and name as a DataFrame.
 
 ## Going deeper
 

--- a/interfaces/python/source/working-with-infomap/results-and-iteration.md
+++ b/interfaces/python/source/working-with-infomap/results-and-iteration.md
@@ -109,8 +109,9 @@ lazily on first access and then cached. The surface follows one convention:
   `result.nodes()`, `result.to_dataframe()`.
 
 A `Result` from an earlier run of a reused stateful {class}`~infomap.Infomap`
-raises if you read its node data after a later `run()`. The scalar properties
-stay readable.
+raises if you read its node data after a later `run()`. The eagerly captured
+scalar properties stay readable (the lazily computed `effective_num_*`
+properties must have been read at least once before the re-run).
 
 ### Summary statistics
 
@@ -284,7 +285,8 @@ codelength; large noisy networks spread wider.
 
 - **A `Result` goes stale if its network runs again.** Reading `nodes()` or
   `modules()` on a `Result` after a later `run()` on the same network raises;
-  finish reading a result before you re-run. The scalar properties stay readable.
+  finish reading a result before you re-run. The eagerly captured scalar
+  properties stay readable.
 - **Module ids carry no order or meaning.** They are stable within one run but
   arbitrary across runs; compare partitions with a metric, not id equality.
 - **`modules()` returns the top level by default.** Pass `depth=-1` for the

--- a/interfaces/python/source/working-with-infomap/visualizing-and-exporting.md
+++ b/interfaces/python/source/working-with-infomap/visualizing-and-exporting.md
@@ -172,7 +172,9 @@ For igraph users, {func}`infomap.to_igraph` returns the same annotation on an
 
 The stateful {class}`~infomap.Infomap` writes the engine's native text formats:
 build one, run it, and call its `write_*` methods.
-These formats feed the mapequation.org Network Navigator and alluvial diagrams.
+These formats feed the mapequation.org tools: `.ftree` opens in the Network
+Navigator, and `.tree`/`.clu` load in the alluvial diagram generator and other
+scripts.
 
 ```{code-cell} python
 im = infomap.Infomap(two_level=True, seed=123, num_trials=10, silent=True)
@@ -275,9 +277,10 @@ print("Temp directory removed.")
   `flow` (all strings); write it with `nx.write_graphml` / `nx.write_gexf`.
 - {func}`infomap.to_igraph` builds the same graph as an `igraph.Graph`.
 - {func}`infomap.io.export.write_graphml`, {func}`infomap.io.export.write_gexf`,
-  and {func}`infomap.io.export.annotate_networkx_graph` are convenience wrappers
-  around that pattern. They take a post-run stateful {class}`~infomap.Infomap`,
-  not a {class}`~infomap.Result`. (`write_gexf` supports NetworkX only.)
+  and {func}`infomap.io.export.annotate_networkx_graph` instead annotate *your
+  own* graph with the partition. They take a post-run stateful
+  {class}`~infomap.Infomap`, not a {class}`~infomap.Result`. (`write_gexf`
+  supports NetworkX only.)
 
 **Native engine formats** (written by the stateful {class}`~infomap.Infomap`)
 

--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -120,7 +120,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
     >>> im = Infomap(silent=True, num_trials=10)
     >>> im.read_file("ninetriangles.net")
     >>> result = im.run()
-    >>> round(result.codelength, 4)
+    >>> result.codelength
     3.3858
     >>> result.num_top_modules
     3
@@ -1935,7 +1935,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         >>> im.add_link(1, 4)
         >>> im.add_link(2, 4)
         >>> result = im.run()
-        >>> round(result.codelength, 4)
+        >>> result.codelength
         0.9183
 
 
@@ -1982,7 +1982,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         ...     4: 1
         ... }
         >>> result = im.run(no_infomap=True)
-        >>> round(result.codelength, 4)
+        >>> result.codelength
         3.4056
 
 

--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -120,7 +120,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
     >>> im = Infomap(silent=True, num_trials=10)
     >>> im.read_file("ninetriangles.net")
     >>> result = im.run()
-    >>> result.codelength
+    >>> round(result.codelength, 4)
     3.3858
     >>> result.num_top_modules
     3
@@ -1935,7 +1935,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         >>> im.add_link(1, 4)
         >>> im.add_link(2, 4)
         >>> result = im.run()
-        >>> result.codelength
+        >>> round(result.codelength, 4)
         0.9183
 
 
@@ -1982,7 +1982,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         ...     4: 1
         ... }
         >>> result = im.run(no_infomap=True)
-        >>> result.codelength
+        >>> round(result.codelength, 4)
         3.4056
 
 

--- a/interfaces/python/src/infomap/_results.py
+++ b/interfaces/python/src/infomap/_results.py
@@ -592,9 +592,10 @@ class _InfomapResultsMixin:
 
         Returns
         -------
-        InfomapIteratorPhysical
+        iterator
             An iterator over each physical node in the tree, depth first from
-            the root
+            the root (:class:`InfomapIteratorPhysical` for memory networks,
+            :class:`InfomapIterator` for first-order networks)
 
         .. deprecated::
             Use ``result = im.run(); result.tree(states=False)``.
@@ -655,13 +656,13 @@ class _InfomapResultsMixin:
         See Also
         --------
         get_nodes
-        InfomapLeafIteratorPhysical
 
         Returns
         -------
-        InfomapLeafIteratorPhysical
+        iterator
             An iterator over each physical leaf node in the tree, depth first
-            from the root
+            from the root (the concrete iterator type depends on whether the
+            network has memory)
 
         .. deprecated::
             Use ``result = im.run(); result.nodes(states=False)``.

--- a/interfaces/python/src/infomap/_swig.py
+++ b/interfaces/python/src/infomap/_swig.py
@@ -515,9 +515,10 @@ class InfoNode(object):
     r"""
     A node in the hierarchical partition tree.
 
-    Yielded by the tree-walking iterators on :class:`Infomap`
-    (:meth:`Infomap.tree`, :meth:`Infomap.nodes`, and friends). Exposes the
-    node's ids, flow, and position in the tree as properties.
+    The underlying node type of the tree-walking iterators on :class:`Infomap`
+    (:meth:`Infomap.tree`, :meth:`Infomap.nodes`, and friends); the iterators
+    proxy its attributes and expose it directly via their ``current()`` method.
+    Exposes the node's ids, flow, and position in the tree as properties.
     """
 
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
@@ -1534,7 +1535,7 @@ class InfomapIteratorPhysical(InfomapIterator):
     r"""
     Like :class:`InfomapIterator`, but aggregates state nodes belonging to the
     same physical node within each leaf module. Returned by
-    :meth:`Infomap.physical_tree`.
+    :meth:`Infomap.physical_tree` for memory networks.
     """
 
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
@@ -1646,8 +1647,7 @@ _infomap.InfomapIteratorPhysical_swigregister(InfomapIteratorPhysical)
 class InfomapLeafIteratorPhysical(InfomapIteratorPhysical):
     r"""
     Iterator over the leaf nodes of the partition tree, aggregating state nodes
-    belonging to the same physical node within each leaf module. Returned by
-    :meth:`Infomap.physical_nodes`.
+    belonging to the same physical node within each leaf module.
     """
 
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")

--- a/interfaces/python/src/infomap/io/export.py
+++ b/interfaces/python/src/infomap/io/export.py
@@ -302,7 +302,7 @@ def annotate_igraph_graph(
     Writes each vertex's module assignment (and optionally its tree path,
     per-level module ids, and flow) as string-valued vertex attributes,
     suitable for GraphML export. Vertices are matched to Infomap state ids by
-    igraph vertex index, as assigned by :meth:`Infomap.add_igraph_graph`.
+    igraph vertex index, as assigned by :meth:`infomap.Infomap.add_igraph_graph`.
 
     Parameters
     ----------
@@ -370,11 +370,11 @@ def to_networkx(
     include_hierarchy: bool = True,
     flow_attribute: str | None = "flow",
 ) -> Any:
-    """Build a NetworkX graph from a :class:`~infomap.result.Result`.
+    """Build a NetworkX graph from a :class:`~infomap.Result`.
 
     Nodes are the result's (state) nodes, keyed by ``state_id``, carrying the
     Infomap node ``name`` plus the module/path/flow attributes (the same
-    attribute scheme as :func:`~infomap.export.annotate_networkx_graph`). Edges come from the
+    attribute scheme as :func:`~infomap.io.export.annotate_networkx_graph`). Edges come from the
     partitioned network.
 
     Parameters
@@ -433,11 +433,11 @@ def to_igraph(
     include_hierarchy: bool = True,
     flow_attribute: str | None = "flow",
 ) -> Any:
-    """Build a python-igraph graph from a :class:`~infomap.result.Result`.
+    """Build a python-igraph graph from a :class:`~infomap.Result`.
 
     Vertices are the result's (state) nodes in ``state_id`` order, carrying the
     Infomap node ``name`` plus the module/path/flow attributes (the same
-    attribute scheme as :func:`~infomap.export.annotate_igraph_graph`). Edges come from the
+    attribute scheme as :func:`~infomap.io.export.annotate_igraph_graph`). Edges come from the
     partitioned network.
 
     Parameters

--- a/interfaces/python/src/infomap/network.py
+++ b/interfaces/python/src/infomap/network.py
@@ -83,15 +83,15 @@ class Network:
 
     Parameters
     ----------
-    core : infomap._core.Core, optional
-        The engine boundary to build onto. If ``None``, a default silent,
+    core : optional
+        Internal engine handle to build onto. If ``None``, a default silent,
         no-file-output ``Core`` is created and owned by this ``Network``. When
         composed by :class:`infomap.Infomap`, the shared, options-configured
         ``Core`` is passed in.
     """
 
     #: ``{internal_id: label}`` mapping set by the library constructors
-    #: (``from_networkx``/``from_igraph``/``from_scipy_sparse``/``from_edge_index``).
+    #: (``from_networkx``/``from_igraph``/``from_scipy_sparse_matrix``/``from_edge_index``).
     #: Bare annotation: declares the instance attribute for type-checkers without
     #: creating it at runtime (no behaviour change).
     node_id_to_label: dict[int, Any]

--- a/interfaces/python/src/infomap/tl/graphrag.py
+++ b/interfaces/python/src/infomap/tl/graphrag.py
@@ -157,7 +157,7 @@ def read_graphrag(
     Assigns a 1-based Infomap node id to every entity (and to any relationship
     endpoint that does not appear in the entity table) and converts the
     relationships to source/target/weight arrays ready for
-    :meth:`Infomap.add_links`.
+    :meth:`infomap.Infomap.add_links`.
 
     Parameters
     ----------

--- a/interfaces/swig/InfoNode.i
+++ b/interfaces/swig/InfoNode.i
@@ -18,9 +18,10 @@ namespace std {
 %feature("docstring") infomap::InfoNode
 "A node in the hierarchical partition tree.
 
-Yielded by the tree-walking iterators on :class:`Infomap`
-(:meth:`Infomap.tree`, :meth:`Infomap.nodes`, and friends). Exposes the
-node's ids, flow, and position in the tree as properties.";
+The underlying node type of the tree-walking iterators on :class:`Infomap`
+(:meth:`Infomap.tree`, :meth:`Infomap.nodes`, and friends); the iterators
+proxy its attributes and expose it directly via their ``current()`` method.
+Exposes the node's ids, flow, and position in the tree as properties.";
 #endif
 
 /* Parse the header file to generate wrappers */

--- a/interfaces/swig/InfomapIterator.i
+++ b/interfaces/swig/InfomapIterator.i
@@ -35,12 +35,11 @@ are leaf nodes). Returned by :meth:`Infomap.leaf_modules`.";
 %feature("docstring") infomap::InfomapIteratorPhysical
 "Like :class:`InfomapIterator`, but aggregates state nodes belonging to the
 same physical node within each leaf module. Returned by
-:meth:`Infomap.physical_tree`.";
+:meth:`Infomap.physical_tree` for memory networks.";
 
 %feature("docstring") infomap::InfomapLeafIteratorPhysical
 "Iterator over the leaf nodes of the partition tree, aggregating state nodes
-belonging to the same physical node within each leaf module. Returned by
-:meth:`Infomap.physical_nodes`.";
+belonging to the same physical node within each leaf module.";
 
 %feature("docstring") infomap::InfomapParentIterator
 "Iterator that walks upward from a node, parent by parent, until the root.";


### PR DESCRIPTION
## Summary

A full review of the published Python docs (every page verified against the package source, with all code examples executed against the built package). No broken examples or dead links were found; this PR fixes the remaining factual errors and inconsistencies:

- **Prose fixes**: Network Navigator needs `.ftree`, not `.tree`/`.clu`; name-column readback only works for string labels (and not at all via the integer edge-list route); scope the undirected-null-model claim to standard modularity (NetworkX Louvain uses directed modularity on `DiGraph`); `1/0.15` is about seven steps, not six; correct the description of the 5.1 companion notebook; `hide_bipartite_nodes` needs the file-writing `Infomap` class; qualify which scalar properties survive a re-run; add `path` to the `to_dataframe` column list.
- **Signature errors**: `add_state_node(state_id, physical_id)` shown in five places — the parameter is `node_id`, so keyword calls copied from the docs would raise `TypeError`; same for `add_link(source_state_id, ...)`.
- **API reference / docstrings**: iteration yields iterator proxies, not `InfoNode`; `InfomapLeafIteratorPhysical` is never returned by the public API; correct the `physical_tree`/`physical_nodes` Returns sections; fully qualify four cross-references in `io.export`/`tl.graphrag` that failed to resolve under the pages' `currentmodule`; document the `InfomapOptions` alias on the options page.
- **Polish**: malformed utm link in README (query params after the `#` fragment), `InfomapOptions` → `Options` in the README example, licence/license spelling, copyright range 2020–2026, forwarded `seed`/`num_trials` defaults on the Scanpy page.

Docstring changes were made in the SWIG sources (`interfaces/swig/*.i`) and the tracked `_swig.py` was regenerated with SWIG 4.4.1 (`infomap_wrap.cpp` unchanged).

## Verification

- `make test-python-swig-freshness` passes
- `make test-python-doctest` passes (38 doctest modules, ruff clean)
- Full Sphinx site build succeeds with no new warnings (the 6 remaining are intersphinx inventory fetches blocked by the sandbox network proxy)

## Notes

- The facade doctest floats stay at display precision (`3.3858`) — the pytest `NUMBER` optionflag in `pyproject.toml` covers matching against full-precision output, so no `round()` is needed in the examples.
- Follow-ups from the review that were intentionally *not* changed: the HPC "three shards" demo keeps distinct per-shard seeds (labeled simplification; a comment now points at the `trial_offset` SLURM recipe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019atXJaeLukp6qLySFmEpRt