### PR TITLE
docs(python): fix review findings and redesign flow-model figures

### DIFF
--- a/interfaces/python/source/_ext/docs_viz.py
+++ b/interfaces/python/source/_ext/docs_viz.py
@@ -42,6 +42,7 @@ def draw_partition(
     weight="weight",
     module_colors=None,
     flow=None,
+    pos=None,
 ):
     """Draw ``graph`` with nodes colored by their module.
 
@@ -80,6 +81,11 @@ def draw_partition(
         each marker's *area* is set proportional to the node's flow, so its
         *radius* grows as the square root of the flow; the average-flow node
         keeps ``node_size``. Without it every node draws at ``node_size``.
+    pos : dict, optional
+        Precomputed ``{node -> (x, y)}`` layout, used as-is. Lets a caller pass
+        a bipartite two-column layout, or share one layout across the panels of
+        a multi-panel figure so a node keeps its position. Without it a
+        reproducible spring layout is computed from ``seed``.
 
     Returns
     -------
@@ -96,7 +102,8 @@ def draw_partition(
     color_of = module_colors or module_palette(modules[n] for n in ordered)
     node_colors = [color_of[modules[n]] for n in ordered]
 
-    pos = nx.spring_layout(graph, seed=seed)
+    if pos is None:
+        pos = nx.spring_layout(graph, seed=seed)
 
     # Node marker area is proportional to flow, so the radius grows as the
     # square root of the flow; the average-flow node keeps ``node_size``.

--- a/interfaces/python/source/concepts/choosing-a-method.md
+++ b/interfaces/python/source/concepts/choosing-a-method.md
@@ -29,8 +29,7 @@ The main difference is the objective. Louvain and Leiden
 score a partition by **modularity**: whether more edges fall inside groups than a
 random graph with the same degrees would predict. Infomap scores it by the **map
 equation**: how few bits describe a random walk on the network under that
-partition (see {doc}`/concepts/the-map-equation`). Modularity asks how the network
-is wired; the map equation asks how it is used.
+partition (see {doc}`/concepts/the-map-equation`).
 
 Running both is a useful sanity check. Where the two agree, the grouping is
 robust to the choice of objective; where they differ, the grouping depends on

--- a/interfaces/python/source/concepts/flow-and-random-walks.md
+++ b/interfaces/python/source/concepts/flow-and-random-walks.md
@@ -20,10 +20,10 @@ walker's stationary visit frequency, and modules are the regions that trap it.
 
 ## What flow captures
 
-Every network encodes a pattern of movement. Hyperlinks carry web surfers from
-page to page, and citations pull readers toward influential papers. Revealing
-the large-scale structure of such a system takes a currency that respects
-direction, weight, and how paths chain together.
+Networks describe movement. Hyperlinks route web surfers between pages; readers
+follow citations to the papers that shape a field. To see the large-scale
+structure of that movement you need a currency that respects direction, weight,
+and how paths chain together.
 
 Counting edges inside and outside groups misses something dynamic: the way a
 random walker entering a dense cluster tends to stay there for many steps before

--- a/interfaces/python/source/concepts/hierarchy-and-the-multilevel-map.md
+++ b/interfaces/python/source/concepts/hierarchy-and-the-multilevel-map.md
@@ -122,9 +122,10 @@ $$
 \frac{4^{l_c}}{l_c + 1} \lesssim C.
 $$
 
-Contrast this with modularity, where the limit scales as $\sqrt{m}$ with
-total link count $m$. The map equation's dependence on the cut size $C$
-rather than $m$ is already much less restrictive, but it does not vanish.
+Contrast this with modularity, whose resolution limit scales as roughly
+$\sqrt{L}$ in the total link count $L$ (see {doc}`/concepts/choosing-a-method`).
+The map equation's dependence on the cut size $C$ rather than $L$ is already much
+less restrictive, but it does not vanish.
 
 The *hierarchical* map equation evaluates the analogous update with the effective
 network size equal to the super-module plus its boundary links, not the full

--- a/interfaces/python/source/concepts/state-nodes-and-higher-order-flow.md
+++ b/interfaces/python/source/concepts/state-nodes-and-higher-order-flow.md
@@ -27,9 +27,9 @@ a traveller flies next depends on where they came *from*, and which colleagues a
 person interacts with depends on the setting (work, home, a conference).
 Collapsing that context into a plain network averages it away.
 
-The fix is to stop treating a node as a single thing. Memory, multilayer and
-multiplex, and temporal networks all rest on the same construction, the
-**state node**, with different notions of "context."
+The fix is to stop treating a node as a single thing. Memory, multilayer, and
+temporal networks all rest on the same construction, the **state node**, with
+different notions of "context."
 
 ## Physical nodes vs state nodes
 

--- a/interfaces/python/source/concepts/the-map-equation.md
+++ b/interfaces/python/source/concepts/the-map-equation.md
@@ -25,10 +25,9 @@ When you split a network into communities, how do you know the split is *good*?
 You need a quality function: a single number that scores any candidate partition.
 
 Many methods use modularity, which counts whether more edges fall inside modules
-than a random baseline would predict. Modularity asks a question about how the
-network was wired.
+than a random baseline would predict. Modularity asks how the network was wired.
 
-The map equation asks a question about how it is *used*. Given that flow moves
+The map equation asks how it is *used*. Given that flow moves
 through the network, say passengers through airports or clicks across the web,
 which partition best compresses a description of that movement? The answer is
 the partition with the shortest **codelength**: the fewest bits per step needed

--- a/interfaces/python/source/faq.md
+++ b/interfaces/python/source/faq.md
@@ -1,7 +1,7 @@
 # FAQ & common pitfalls
 
-Short answers to the questions that trip people up most often. Each answer
-links to the chapter that explains it properly.
+Short answers to the questions that trip people up most often, each linking to
+the chapter that covers it in full.
 
 ## Getting data in
 
@@ -52,7 +52,7 @@ Infomap found. See {doc}`The map equation <concepts/the-map-equation>`.
 
 Infomap minimises a flow-based description length, not a target count or a
 sociological ground truth. Boundary nodes where the random walker mixes can form
-their own module if naming it shortens the overall description, so an unexpected
+their own module when doing so shortens the overall description, so an unexpected
 module count is not necessarily an error. See
 {doc}`The map equation <concepts/the-map-equation>`.
 
@@ -121,8 +121,9 @@ relax rate is ignored. See {doc}`Multilayer networks <flow-models/multilayer>`.
 ### How do I model a network with memory (higher-order flow)?
 
 Declare state nodes on a `Network` with `add_state_node(state_id, node_id)`,
-where `node_id` is the physical node, and link them with `add_link`. Memory lets a physical node appear in overlapping
-modules. See {doc}`Memory and state networks <flow-models/memory-and-state>`.
+where `node_id` is the physical node, and link them with `add_link`. Memory lets a
+physical node appear in overlapping modules, so read the partition with
+`result.modules(states=True)`. See {doc}`Memory and state networks <flow-models/memory-and-state>`.
 
 ### How do I cluster a time-varying (temporal) network?
 
@@ -199,8 +200,9 @@ hardware. Set `num_threads=` to a positive integer to override. See {doc}`Runnin
 
 ### How do I run many trials across cluster jobs and combine them?
 
-Give each job a non-overlapping range with `trial_offset=` / `trial_results=`, then merge
-the shard files with `python -m infomap.merge` (it keeps the best codelength). See
+Give each job a non-overlapping range with `trial_offset=` and write its shard
+with `trial_results=`, then merge the shard files with `python -m infomap.merge`
+(it keeps the best codelength). See
 {doc}`Running at scale (HPC) <workflows/hpc>`.
 
 ## Method and citation

--- a/interfaces/python/source/flow-models/bipartite.md
+++ b/interfaces/python/source/flow-models/bipartite.md
@@ -150,6 +150,9 @@ each node carries and can move module boundaries.
 
 ### Visualise
 
+Lay the two node types out as two columns, users on the left and items on the
+right, so the community structure reads as horizontal bands.
+
 ```{code-cell} python
 import matplotlib.pyplot as plt
 from myst_nb import glue
@@ -159,8 +162,7 @@ from docs_viz import draw_partition
 
 # Build a NetworkX graph matching the Infomap network above
 G = nx.Graph()
-G.add_nodes_from(range(4))              # users
-G.add_nodes_from(range(4, 8))           # items
+G.add_nodes_from(range(8))
 for u, v, w in [
     (0, 4, 3.0), (0, 5, 2.0), (1, 4, 2.0), (1, 5, 3.0),
     (2, 6, 3.0), (2, 7, 2.0), (3, 6, 2.0), (3, 7, 3.0),
@@ -168,16 +170,28 @@ for u, v, w in [
 ]:
     G.add_edge(u, v, weight=w)
 
-flow = {n.node_id: n.flow for n in result.nodes()}
-fig = draw_partition(G, modules, flow=flow)
+# Two columns: users left, items right. The default bipartite run folds item
+# flow onto the users, so items would draw as near-invisible dots if sized by
+# flow; size every node the same and let colour carry the module structure.
+pos = {u: (0.0, 3 - u) for u in range(4)}
+pos.update({v: (2.2, 3 - (v - 4)) for v in range(4, 8)})
+
+fig, ax = plt.subplots(figsize=(5.4, 4.2))
+draw_partition(G, modules, ax=ax, pos=pos, with_labels=True, node_size=620)
+ax.text(0.0, 3.7, "users", ha="center", color="0.35", weight="bold")
+ax.text(2.2, 3.7, "items", ha="center", color="0.35", weight="bold")
+ax.set_xlim(-0.6, 2.8)
+ax.set_ylim(-0.6, 4.0)
+fig.tight_layout()
 glue("fig-bipartite", fig, display=False)
 plt.close(fig)
 ```
 
 ```{glue:figure} fig-bipartite
-A small weighted bipartite network (users 0-3, items 4-7) coloured by
-module. Each user groups with the items it interacts with most, so every
-module spans both node types.
+The bipartite network as two columns, users on the left and items on the right,
+coloured by module. Each module is a band spanning both types: users {0, 1} with
+items {4, 5}, users {2, 3} with items {6, 7}. The thin diagonals are the two
+weak cross-cluster links.
 ```
 
 ## API pointers

--- a/interfaces/python/source/flow-models/memory-and-state.md
+++ b/interfaces/python/source/flow-models/memory-and-state.md
@@ -139,160 +139,155 @@ These expressions reduce to the standard first-order map equation when each
 physical node has exactly one state node {cite:p}`rosvall2008maps`.
 :::
 
-## A junction shared by two flows
+## Node i, visited in two contexts
 
-The example below constructs a small four-node network where two independent
-streams of flow pass through a shared junction node **B**:
+The bundled `states()` network makes the memory effect concrete. Five physical
+nodes *i*, *j*, *k*, *l*, *m* carry the flow, and node *i* is visited in two
+different contexts:
 
-- **Stream 1:** $A \to B \to C \to A$ (a tight triangle)
-- **Stream 2:** $D \to B \to D$ (an out-and-back trip)
+- arriving from the *j*–*k* side, flow tends to continue back into *j* and *k*;
+- arriving from the *l*–*m* side, it tends to continue back into *l* and *m*.
 
-In a first-order view, node B sits at the intersection and ends up lumped with
-whichever stream has more traffic. In a second-order view, the two streams
-through B travel on different state nodes, so Infomap assigns B to *both*
-modules at once.
+A memoryless walker cannot tell the two apart: at *i* it mixes both streams and
+the distinction is lost. A memory model splits *i* into two **state nodes**, one
+per context, so each keeps its own onward flow, and *i* ends up in *both*
+communities at once. This is the same bridging role node *i* plays in the
+{doc}`multilayer example </flow-models/multilayer>`, reached through memory
+rather than layers.
 
-### Step 1: First-order baseline
+### First order: one blurred community
 
-Build the aggregated physical network and run Infomap with first-order flow.
+Start with the memoryless baseline. Aggregate the two contexts of *i* into a
+single node and run standard, first-order flow.
 
 ```{code-cell} python
-import networkx as nx
 import infomap
-from infomap import Network, run
+import networkx as nx
+from infomap import run
 from docs_viz import draw_partition
 
-# Directed graph: two streams share junction B (node 1)
-# Stream 1: A(0)→B(1)→C(2)→A(0)
-# Stream 2: D(3)→B(1)→D(3)
+# Physical network: i links to both pairs; {j,k} and {l,m} are the two groups.
 g = nx.DiGraph()
-g.add_nodes_from([0, 1, 2, 3])
-g.add_edges_from([(0, 1), (1, 2), (2, 0),   # stream 1
-                  (3, 1), (1, 3)])            # stream 2
+g.add_weighted_edges_from([
+    ("i", "j", 1.0), ("i", "k", 1.0), ("i", "l", 1.0), ("i", "m", 1.0),
+    ("j", "i", 1.0), ("j", "k", 1.0), ("k", "i", 1.0), ("k", "j", 1.0),
+    ("l", "i", 1.0), ("l", "m", 1.0), ("m", "i", 1.0), ("m", "l", 1.0),
+])
 
-node_name = {0: "A", 1: "B", 2: "C", 3: "D"}
+result_first = run(g, two_level=True, directed=True, seed=123, num_trials=20, silent=True)
+print(f"First-order modules: {result_first.num_top_modules}")
+print(f"Codelength         : {result_first.codelength:.4f} bits")
 
-result1 = infomap.run(g, two_level=True, silent=True)
-modules1 = result1.modules()   # {node_id: module_id}
-
-print("First-order: node → module")
-for nid, mod in sorted(modules1.items()):
-    print(f"  {node_name[nid]} → module {mod}")
-print(f"Distinct modules: {len(set(modules1.values()))}")
+assert result_first.num_top_modules == 1
 ```
 
-With first-order flow the walker mixes the two streams at B, and all four
-nodes collapse into a single module.
+With no memory the walker at *i* continues to *j*, *k*, *l*, *m* with equal
+probability, so flow leaks freely between the two pairs. Infomap finds a single
+module: the structure is in the wiring, but not in the memoryless flow.
 
-### Step 2: Second-order state-node network
+### Second order: i splits, communities overlap
 
-Now build the same network as a state-node graph. Each physical node gets one
-state node per incoming stream. Node B gets **two** state nodes:
-
-- state 10 (physical 1): flow that arrived from stream 1
-- state 11 (physical 1): flow that arrived from stream 2
+Now the state network. The bundled `states()` loader carries the two contexts of
+*i* as two state nodes, with directed, weighted links (it comes pre-configured
+for directed flow).
 
 ```{code-cell} python
-net = Network()
+result = run(infomap.datasets.states(), num_trials=20, seed=123, silent=True)
 
-# Declare state nodes: add_state_node(state_id, node_id) — node_id is physical
-net.add_state_node(0,  0)   # phys A, state 0
-net.add_state_node(2,  2)   # phys C, state 2
-net.add_state_node(3,  3)   # phys D, state 3
-net.add_state_node(10, 1)   # phys B, state 10 (stream 1 context)
-net.add_state_node(11, 1)   # phys B, state 11 (stream 2 context)
+print(f"State nodes  : {len(list(result.nodes(states=True)))}")
+print(f"Modules found: {result.num_top_modules}")
+print(f"Codelength   : {result.codelength:.4f} bits")
 
-# Add directed links between STATE nodes
-# Stream 1: A(0) → B_s1(10) → C(2) → A(0)
-net.add_link(0,  10, 1.0)
-net.add_link(10, 2,  1.0)
-net.add_link(2,  0,  1.0)
-
-# Stream 2: D(3) → B_s2(11) → D(3)
-net.add_link(3,  11, 1.0)
-net.add_link(11, 3,  1.0)
-
-# directed=True matches step 1 (a bare Network defaults to undirected flow,
-# unlike the DiGraph route, which enables it automatically)
-result2 = run(net, two_level=True, silent=True, directed=True)
-
-n_physical = len({node.node_id for node in result2.nodes(states=True)})
-print(f"have_memory: {result2.have_memory}")
-print(f"physical nodes: {n_physical}")
-print()
-
-# For memory networks, modules() requires states=True
-state_modules = result2.modules(states=True)   # {state_id: module_id}
-
-print("State node assignments:")
-phys_label = {0: "A", 2: "C", 3: "D", 10: "B (stream-1 ctx)", 11: "B (stream-2 ctx)"}
-for sid, mod in sorted(state_modules.items()):
-    print(f"  state {sid:>2} ({phys_label.get(sid, '?')}) → module {mod}")
+# Two communities, at a lower codelength than the first-order run.
+assert result.num_top_modules == 2
 ```
 
-### Step 3: Read overlapping physical-node membership
+Two modules, and a lower codelength than the first-order run: the memory model
+describes the flow more efficiently *and* recovers the two groups the aggregate
+hid.
 
-Iterate `result.nodes(states=True)` to see which physical node appears in more
-than one module. Each state node exposes `.node_id` (the physical node it
-belongs to), `.state_id`, and `.module_id`.
+### Read the overlap
+
+Each physical node has one entry per state node in `result.nodes(states=True)`.
+Group by `node_id` to find the physical node that lands in more than one module.
+Each state node exposes `.node_id` (the physical node it belongs to),
+`.state_id`, and `.module_id`.
 
 ```{code-cell} python
 from collections import defaultdict
 
-phys_to_modules = defaultdict(list)
-for node in result2.nodes(states=True):
-    phys_to_modules[node.node_id].append(node.module_id)
+name = {1: "i", 2: "j", 3: "k", 4: "l", 5: "m"}
+phys_to_modules = defaultdict(set)
+for node in result.nodes(states=True):
+    phys_to_modules[node.node_id].add(node.module_id)
 
-print("Physical node membership after second-order analysis:")
-for phys_id, mods in sorted(phys_to_modules.items()):
-    overlap = " ← OVERLAP" if len(mods) > 1 else ""
-    print(f"  {node_name[phys_id]} (phys {phys_id}): modules {mods}{overlap}")
+for pid, mods in sorted(phys_to_modules.items()):
+    tag = "  ← overlap" if len(mods) > 1 else ""
+    print(f"  {name[pid]}: modules {sorted(mods)}{tag}")
 ```
 
-### Step 4: Visualise
+Physical node *i* carries two state nodes that land in different modules, so it
+belongs to both communities; *j*, *k*, *l*, *m* each sit in one. Overlapping
+membership falls straight out of the state-node formalism.
 
-Colour the physical graph by each node's *primary* module (the first module it
-belongs to).
+### Visualise
+
+Draw the state network directly. The two state nodes of *i* sit side by side in
+the centre, ringed together as the one physical node they share; each takes the
+colour of its own module, so the overlap is visible at a glance.
 
 ```{code-cell} python
 import matplotlib.pyplot as plt
+from matplotlib.patches import Ellipse
 from myst_nb import glue
 
-# Primary module per physical node (first listed)
-primary = {pid: mods[0] for pid, mods in phys_to_modules.items()}
+# State-level links keyed by state id (the *States file); states 1 and 4 are
+# both physical node i.
+state_links = [
+    (1, 2, 0.8), (1, 3, 0.8), (1, 5, 0.2), (1, 6, 0.2),
+    (2, 1, 1.0), (2, 3, 1.0), (3, 1, 1.0), (3, 2, 1.0),
+    (4, 5, 0.8), (4, 6, 0.8), (4, 2, 0.2), (4, 3, 0.2),
+    (5, 4, 1.0), (5, 6, 1.0), (6, 4, 1.0), (6, 5, 1.0),
+]
+state_phys = {1: "i", 2: "j", 3: "k", 4: "i", 5: "l", 6: "m"}
+state_module = {n.state_id: n.module_id for n in result.nodes(states=True)}
 
-# Physical-node flow: sum the flow of every state node sharing that physical id.
-flow = {}
-for node in result2.nodes(states=True):
-    flow[node.node_id] = flow.get(node.node_id, 0.0) + node.flow
+G = nx.DiGraph()
+G.add_weighted_edges_from(state_links)
 
-fig = draw_partition(g, primary, flow=flow)
-fig.axes[0].set_title(
-    "Second-order: B overlaps modules 1 and 2\n"
-    "(colour shows primary assignment)",
-    fontsize=9,
-)
+# Two triangles, with i's two state nodes centred so the split reads clearly.
+pos = {2: (-1.7, 0.9), 3: (-1.7, -0.9), 1: (-0.5, 0.0),
+       5: (1.7, 0.9), 6: (1.7, -0.9), 4: (0.5, 0.0)}
+
+fig, ax = plt.subplots(figsize=(6.0, 4.4))
+draw_partition(G, state_module, ax=ax, pos=pos, node_size=650)
+nx.draw_networkx_labels(G, pos, labels=state_phys, ax=ax, font_size=11, font_color="white")
+ax.add_patch(Ellipse((0.0, 0.0), 2.0, 1.15, fill=False, ls=(0, (4, 3)), ec="0.35", lw=1.3))
+ax.annotate("one physical node i,\ntwo state nodes", (0.0, -0.72),
+            ha="center", va="top", fontsize=8.5, color="0.35")
+ax.set_xlim(-2.4, 2.4)
+ax.set_ylim(-1.7, 1.4)
 glue("fig-memory-and-state", fig, display=False)
 plt.close(fig)
 ```
 
 ```{glue:figure} fig-memory-and-state
-The physical nodes coloured by their primary module. Node B sits on the
-boundary: with second-order (state-node) flow it belongs to both
-communities, so a single colour can show only one of its two memberships.
+The state network of the `states()` example. Physical node *i* appears as two
+state nodes (centre), one in each community; *j*, *k* join *i*'s first context
+and *l*, *m* its second. Colour shows the module; the dashed ring marks the two
+state nodes that are the same physical node.
 ```
 
 ### Contrast
 
-| Node | First-order | Second-order |
+| Node | First order | Second order |
 |------|-------------|--------------|
-| A    | one shared module | stream 1 |
-| B    | one shared module | streams 1 **and** 2 (overlap) |
-| C    | one shared module | stream 1 |
-| D    | one shared module | stream 2 |
+| *i*  | one merged module | **both** communities (overlap) |
+| *j*, *k* | one merged module | with *i*'s first context |
+| *l*, *m* | one merged module | with *i*'s second context |
 
-The first-order model sees one community of four nodes. The second-order model
-finds two communities (A–B–C and B–D) that overlap at junction B.
+The first-order model blurs the two streams through *i* into a single community.
+The second-order model keeps them apart and lets *i* belong to both.
 
 ## Options
 

--- a/interfaces/python/source/flow-models/multilayer.md
+++ b/interfaces/python/source/flow-models/multilayer.md
@@ -223,8 +223,9 @@ for pid, assignments in sorted(phys_memberships.items()):
 Physical node *i* has two assignments; all others have one.
 
 Now draw both layers side by side, colouring each node by the module it lands
-in. A shared palette keeps a module the same colour across panels, so physical
-node *i* shows up in a different colour in each layer.
+in. A shared palette and a shared layout fix each module's colour and node *i*'s
+position across panels, so *i* sits in the same spot in a different colour in
+each layer.
 
 ```{code-cell} python
 from myst_nb import glue
@@ -233,10 +234,16 @@ import matplotlib.pyplot as plt
 import networkx as nx
 from docs_viz import draw_partition, module_palette
 
-layers = {
-    1: ([("i", "l"), ("l", "m"), ("i", "m")], "Layer 1"),
-    2: ([("i", "j"), ("j", "k"), ("i", "k")], "Layer 2"),
+# Layer triangles, and one shared layout: node i sits at the same spot (bottom
+# centre) in both panels, and each layer's two partners take the same upper
+# corners, so only colour and labels change between the panels.
+layer_edges = {
+    1: [("i", "l"), ("l", "m"), ("i", "m")],
+    2: [("i", "j"), ("j", "k"), ("i", "k")],
 }
+pos = {"i": (0.0, -0.75),
+       "l": (-0.95, 0.6), "m": (0.95, 0.6),
+       "j": (-0.95, 0.6), "k": (0.95, 0.6)}
 
 # Module assignment and flow per physical node, recorded separately per layer.
 state_nodes = list(result.nodes(states=True))
@@ -253,24 +260,30 @@ colours = module_palette(
 )
 
 fig, axes = plt.subplots(1, 2, figsize=(8, 4), layout="constrained")
-for ax, (layer, (edges, title)) in zip(axes, layers.items()):
+for ax, layer in zip(axes, (1, 2)):
     G = nx.Graph()
-    G.add_edges_from(edges)
+    G.add_edges_from(layer_edges[layer])
     draw_partition(
         G, module_in_layer[layer], ax=ax, module_colors=colours,
-        with_labels=True, node_size=600, flow=flow_in_layer[layer],
+        with_labels=True, node_size=650, flow=flow_in_layer[layer],
+        pos={n: pos[n] for n in G},
     )
-    ax.set_title(title, fontsize=11)
+    ax.set_title(f"Layer {layer}", fontsize=11)
+    ax.set_xlim(-1.4, 1.4)
+    ax.set_ylim(-1.15, 1.0)
 
-fig.suptitle("Physical node i is bi-modular: one colour per layer", fontsize=12)
+fig.suptitle(
+    "Physical node i is the bridge: the same node, a different module per layer",
+    fontsize=12,
+)
 glue("fig-multilayer", fig, display=False)
 plt.close(fig)
 ```
 
 ```{glue:figure} fig-multilayer
-The two layers drawn separately, coloured by module with a shared palette.
-Physical node *i* appears in both layers in a different colour: the bi-modular
-overlap that state nodes make possible.
+The two layers drawn with one shared layout, coloured by module. Physical node
+*i* holds the same position in both panels but takes a different colour: the
+bi-modular overlap that state nodes make possible.
 ```
 
 ### Relax rate sensitivity
@@ -378,8 +391,10 @@ pick one form per network.
 
 Back in the relax-rate model, `multilayer_relax_to_self=True` links a relaxing
 state node to its *own physical node* in the target layer instead of spreading
-directly to its out-neighbours there. The flow is the same; the state network
-is smaller, which matters on large networks:
+directly to its out-neighbours there. It shrinks the state network, which
+matters on large networks. For a coherent partition the flow is unchanged; it
+can differ slightly only when a node's target-layer neighbours split across
+modules:
 
 ```{code-cell} python
 net_self = Network()
@@ -442,7 +457,7 @@ out-neighbours in the target layer:
 | `multilayer_relax_limit_up` | `-1` | The same cap, counting only towards higher layer ids |
 | `multilayer_relax_limit_down` | `-1` | The same cap, counting only towards lower layer ids |
 | `multilayer_relax_by_jsd` | `False` | Weight relaxation by neighbourhood similarity; see {doc}`/flow-models/temporal` |
-| `multilayer_relax_to_self` | `False` | Relax to the node's own copy in the target layer instead of spreading to its out-neighbours; smaller state network, same flow |
+| `multilayer_relax_to_self` | `False` | Relax to the node's own copy in the target layer instead of spreading to its out-neighbours; smaller state network, identical flow for coherent partitions |
 
 ## Going deeper
 

--- a/interfaces/python/source/flow-models/temporal.md
+++ b/interfaces/python/source/flow-models/temporal.md
@@ -208,7 +208,7 @@ community identity persists. Raising it toward 1 pushes Infomap toward the
 aggregate static solution. The default is `0.15`; values in the 0.15–0.25 range
 are usually a good choice for networks where communities evolve smoothly, and
 neighbourhood flow coupling stays robust across a broad range of relax rates
-(0.15 to 0.7) on benchmark networks {cite:p}`aslak2018temporal`.
+(about 0.15 to 0.7) on their synthetic benchmarks {cite:p}`aslak2018temporal`.
 
 For long time series, `multilayer_relax_limit` caps how far the random walker
 may jump between layers, so coupling stays between temporally nearby windows

--- a/interfaces/python/source/index.rst
+++ b/interfaces/python/source/index.rst
@@ -5,9 +5,9 @@ Infomap is a network community-detection method: it finds the modules that best
 compress the flow of a random walk on your network. Three properties follow from
 that flow-based view, the `map equation`_:
 
-- **It models how a system is used, not only how it is wired.** Link direction
-  and weight steer the walk, so citation, transport, and information networks
-  cluster by their real dynamics.
+- **It models how a system is used, not just how it is wired.** Link direction
+  and weight steer the walk, so a citation or transport network clusters by where
+  flow actually goes.
 - **It finds hierarchy with no resolution parameter to tune.** The number of
   nested levels is inferred directly from the data.
 - **It spans a broad range of flow models:** multilayer, memory,

--- a/interfaces/python/source/robustness/incomplete-data.md
+++ b/interfaces/python/source/robustness/incomplete-data.md
@@ -36,9 +36,10 @@ the module codebooks look cheap to shrink, so the optimiser splits nodes into
 smaller and smaller groups, down to groups of two or three nodes with no
 principled support. Those modules are an artefact of noise.
 
-This problem is not about the search algorithm or the number of trials; it is a
-bias in how the objective function responds to sparse data. The fix is a
-regularization mechanism baked into the objective itself.
+The search algorithm and the number of trials are not the cause. The bias is in
+the objective itself: on sparse data it rewards splitting communities that the
+evidence does not support. The fix is a regularization mechanism built into the
+objective.
 
 ## Regularization as a Bayesian prior
 

--- a/interfaces/python/source/workflows/graphrag.md
+++ b/interfaces/python/source/workflows/graphrag.md
@@ -35,10 +35,9 @@ with a modularity objective. Infomap optimises a different quality function: it
 finds the partition that minimises the description length of a random walk over
 the weighted graph (see {doc}`/concepts/the-map-equation`). Whether that flow
 view groups your entities more usefully than modularity depends on the graph;
-running both and comparing is reasonable. What this page provides is the
-plumbing: the adapter in `infomap.tl.graphrag` handles the column mapping,
-node-id translation, hierarchy extraction, and Parquet output, so an Infomap
-partition drops into GraphRAG's own table schema and the downstream
+running both and comparing is reasonable. The `infomap.tl.graphrag` adapter maps
+the columns, translates node ids, extracts the hierarchy, and writes Parquet, so
+an Infomap partition drops into GraphRAG's table schema and the downstream
 summarisation and retrieval steps run unchanged.
 
 ## What Infomap optimises here

--- a/interfaces/python/source/workflows/hpc.md
+++ b/interfaces/python/source/workflows/hpc.md
@@ -91,9 +91,9 @@ common mistake of allocating 8 cores but Infomap running with 64 threads
 and fighting every other job on the node.
 
 `parallel_trials=True` runs independent trials concurrently using OpenMP.
-The number of concurrent workers is clamped to `min(num_threads,
-num_trials)`. Peak memory scales with the worker count, so check your
-memory allocation if you raise thread counts significantly. (The
+The number of concurrent workers is clamped to `min(num_trials, OpenMP
+thread count)`, which `num_threads` sets. Peak memory scales with the worker
+count, so check your memory allocation if you raise thread counts significantly. (The
 {doc}`benchmark-performance <../examples/benchmark-performance>`
 notebook has run-time and memory scaling curves to help plan allocations.)
 

--- a/interfaces/python/source/workflows/scanpy.md
+++ b/interfaces/python/source/workflows/scanpy.md
@@ -24,9 +24,9 @@ cluster labels, and compare with Leiden in a few lines.
 Single-cell RNA-seq pipelines, Scanpy chief among them, cluster cells by
 building a $k$-nearest-neighbour graph in PCA-reduced space and then running a
 graph-partitioning algorithm. Leiden is the standard default; it
-optimises a modularity-style objective with a tunable resolution parameter. Infomap optimises
-the map equation instead: it asks where a random walker on the connectivity graph
-spends its time, and names those flow-trapping regions as modules.
+optimises a modularity-style objective with a tunable resolution parameter.
+Infomap optimises the map equation instead: it finds where a random walker on the
+connectivity graph gets trapped and treats those flow-trapping regions as modules.
 
 Both algorithms take the same weighted neighbour graph as input and produce a
 partition of observations as output, so swapping in Infomap means calling a

--- a/interfaces/python/source/working-with-infomap/inputs.md
+++ b/interfaces/python/source/working-with-infomap/inputs.md
@@ -56,7 +56,7 @@ is needed. For a SciPy matrix or edge index, pass ``directed=`` to the matching
 a SciPy matrix is read as *undirected* unless you say otherwise, while a
 ``(2, E)`` edge index follows the PyG convention and is read as *directed*.
 
-Two library-idiomatic one-shot helpers return native types instead of a
+Two one-shot helpers return native types instead of a
 {class}`~infomap.Result`: {func}`infomap.find_communities` (a NetworkX-style
 ``list[set]``) and {func}`infomap.find_igraph_communities` (an
 ``igraph.VertexClustering``).
@@ -79,7 +79,7 @@ result = infomap.run(g, two_level=True, seed=123, num_trials=5, silent=True)
 
 print(f"Modules:    {result.num_top_modules}")
 print(f"Codelength: {result.codelength:.4f} bits/step")
-print(f"Modules:    {result.modules()}")     # {node_id: module_id}
+print(f"Assignment: {result.modules()}")     # {node_id: module_id}
 ```
 
 **Non-integer node labels** (strings, compound keys) work out of the box. The

--- a/interfaces/python/source/working-with-infomap/results-and-iteration.md
+++ b/interfaces/python/source/working-with-infomap/results-and-iteration.md
@@ -21,10 +21,9 @@ tabular output through `to_dataframe()`.
 
 ## What the Result holds
 
-The partition is more than a list of labels: every node carries a flow value
-that quantifies how much of the random walk visits it, and the full hierarchical
-tree encodes nested module structure that a flat assignment vector cannot
-represent.
+A {class}`~infomap.Result` holds more than labels. Each node carries a flow
+value, the share of the random walk that visits it, and the hierarchical tree
+records nested modules that a flat assignment vector cannot.
 
 This chapter covers the summary statistics, the assignment dict, the per-node
 view with flow, and the DataFrame export. It also explains why a single run may
@@ -45,8 +44,7 @@ Anything that expects a node-colouring can consume it directly.
 The **inner layer** is per-node flow. Each node's `flow` records the stationary
 probability of a random walk visiting it under the best partition. High-flow
 nodes are influential hubs; low-flow nodes are peripheral. This layer lets you
-rank nodes within a module, build flow-weighted summaries, and flag nodes near
-module boundaries.
+rank nodes within a module or build flow-weighted summaries.
 
 `result.to_dataframe()` materialises all three layers into one tabular object you
 can filter, group, merge, and export.
@@ -181,8 +179,8 @@ print(f"Sub-modules      (depth 2): {sorted(set(sub_mods.values()))}")
 When you need flow alongside module membership, iterate over `result.nodes()`.
 Each node is an immutable view; the attributes you reach for most are `node_id`,
 `module_id`, and `flow`, alongside `path`, `name`, and `layer_id`. See
-{class}`~infomap.TreeNode` for the full set (including `state_id`, `depth`, and
-`modular_centrality`):
+{class}`~infomap.TreeNode` for the full set (including `state_id`, `state_name`,
+`depth`, `child_index`, and `modular_centrality`):
 
 ```{code-cell} python
 print(f"{'node_id':>8}  {'module_id':>10}  {'flow':>10}")


### PR DESCRIPTION
Docs-only changes on top of the recent audit passes (#711, #713–#716). Two parts, both verified.

## Review round 3 — correctness & voice

**Correctness / consistency**
- `working-with-infomap/inputs`: the two `print` lines were both labelled `Modules:` — the second (the `{node_id: module_id}` dict) is now `Assignment:`. Dropped "library-idiomatic".
- `concepts/hierarchy-and-the-multilevel-map` & `concepts/choosing-a-method`: the modularity resolution limit used `m` for link count, colliding with `m` = module count elsewhere. Now `L`, with a cross-reference.
- `flow-models/multilayer`: "the flow is the same" for `multilayer_relax_to_self` is exact only for coherent partitions — softened.
- `workflows/hpc`: the parallel-worker clamp is `min(num_trials, OpenMP thread count)`, not `num_threads`.
- `flow-models/temporal`: scoped the 0.15–0.7 relax-rate robustness range to Aslak et al.'s synthetic benchmarks.
- `working-with-infomap/results-and-iteration`: the `TreeNode` "full set" now lists `state_name` and `child_index`.
- `faq`: fixed `trial_offset`/`trial_results` wording; the memory answer now points at `modules(states=True)`.

**Voice** — trimmed AI-cadence tells (the repeated "wired vs used" antithesis, rule-of-three padding, throat-clearing openers, light anthropomorphism) across concepts / workflows / index / faq.

## Flow-model example figures
- `docs_viz.draw_partition`: new optional `pos=` for a precomputed layout (backward compatible).
- **bipartite**: two-column layout (users | items) with uniform node size. The default bipartite run folds item flow onto the users, so flow-sized item nodes were shrinking to invisible dots; colour now carries the module structure.
- **memory-and-state**: example rebuilt on `datasets.states()`. Node *i* is bi-modular (a state node in each community); first-order finds 1 module, the state network 2. New state-network figure, mirroring the multilayer example.
- **multilayer**: node *i* is pinned to the same position in both layer panels, so "same node, different module per layer" reads at a glance.

Note: the multilayer *network* stays hand-built. The bundled `datasets.multilayer_intra()` (Fig 5) uses uniform weight 1, while this chapter's example uses asymmetric 0.8/1.0 weights, so they are different networks; the later `*Intra`/`*Inter` and fully-explicit sections already load `datasets.multilayer_intra_inter()` / `datasets.multilayer()`.

## Verification
- All executed code cells on the three figure pages run cleanly (matching the build's `nb_execution_raise_on_error=True`).
- Structural docs build passes with no broken cross-references.

Two other review findings (the `regularized=True` "composes freely" wording and graphrag's use of the deprecated `Infomap.codelength` accessors) were considered and intentionally left as-is.
