### PR TITLE
docs(python): voice pass across the documentation prose

### DIFF
--- a/interfaces/python/source/concepts/flow-and-random-walks.md
+++ b/interfaces/python/source/concepts/flow-and-random-walks.md
@@ -30,8 +30,8 @@ random walker entering a dense cluster tends to stay there for many steps before
 it escapes. That persistence is what defines a community in flow-based clustering: a module
 is a part of the network where flow **lingers** {cite:p}`rosvall2008maps`.
 
-The map equation, Infomap's objective function, measures how far a description
-of the walker's trajectory compresses. To do that it needs to know how often the
+The map equation, Infomap's objective function, measures how compactly the
+walker's trajectory can be described. To do that it needs to know how often the
 walker visits each node and how often it crosses module boundaries. Both
 come from **flow**.
 

--- a/interfaces/python/source/concepts/hierarchy-and-the-multilevel-map.md
+++ b/interfaces/python/source/concepts/hierarchy-and-the-multilevel-map.md
@@ -26,12 +26,13 @@ neighbourhoods that hold blocks. A plain two-level partition, one
 index codebook over one set of leaf modules, sees only one cross-section of that
 structure at a time.
 
-The two-level map equation has a *resolution limit* {cite:p}`kawamoto2015resolution`: modules with too
-few internal links go missing (the threshold grows with the logarithm of the
-total boundary-crossing traffic; the toggle below gives the exact bound),
-because merging them into a larger module shortens the two-level description. In
-a nested network the two-level method must choose between resolving the
-fine-grained modules and capturing the coarse super-groups.
+The two-level map equation has a *resolution limit*
+{cite:p}`kawamoto2015resolution`: modules with too few internal links go
+missing, because merging them into a larger module shortens the two-level
+description. The threshold grows with the logarithm of the total
+boundary-crossing traffic; the toggle below gives the exact bound. In a nested
+network the two-level method must choose between resolving the fine-grained
+modules and capturing the coarse super-groups.
 
 The multilevel map equation lifts the limit by allowing nested index codebooks
 to any depth. It adds a level only when that level shortens the total

--- a/interfaces/python/source/concepts/index.md
+++ b/interfaces/python/source/concepts/index.md
@@ -6,8 +6,8 @@ it does before running it on your own data.
 
 - {doc}`Flow and random walks <flow-and-random-walks>`: what "flow" means and why
   Infomap models a random walker.
-- {doc}`The map equation <the-map-equation>`: the objective Infomap minimises —
-  the codelength, i.e. the bits needed to describe that walk — and the partition
+- {doc}`The map equation <the-map-equation>`: the objective Infomap minimises
+  (the codelength, the bits needed to describe that walk) and the partition
   that makes it shortest.
 - {doc}`Hierarchy and the multilevel map equation <hierarchy-and-the-multilevel-map>`:
   how Infomap discovers nested structure to any depth, with no resolution

--- a/interfaces/python/source/concepts/state-nodes-and-higher-order-flow.md
+++ b/interfaces/python/source/concepts/state-nodes-and-higher-order-flow.md
@@ -70,14 +70,14 @@ codebook entropy.
 The classic illustration is the network that documents the
 [states input format](https://www.mapequation.org/infomap/#InputStates) on
 mapequation.org (it ships with Infomap as `examples/networks/states.net`).
-Five physical nodes *i*, *j*, *k*, *l*, *m*, where *i* carries two state
+It has five physical nodes *i*, *j*, *k*, *l*, *m*, where *i* carries two state
 nodes: from state $\alpha_i$ the walker mostly continues to *j* and *k*, from
 state $\delta_i$ mostly to *l* and *m*. The weak 0.2-links let it occasionally
 switch sides, so the two contexts are coupled but distinct.
 
 Build state nodes directly with `add_state_node(state_id, node_id)`, where
-`node_id` is the physical node, and
-link them, then read the partition back with `result.nodes(states=True)`:
+`node_id` is the physical node, link them with `add_link`, then read the
+partition back with `result.nodes(states=True)`:
 
 ```{code-cell} python
 import infomap

--- a/interfaces/python/source/concepts/the-map-equation.md
+++ b/interfaces/python/source/concepts/the-map-equation.md
@@ -30,16 +30,14 @@ network was wired.
 
 The map equation asks a question about how it is *used*. Given that flow moves
 through the network, say passengers through airports or clicks across the web,
-which partition best compresses a description of that movement? The answer is
-the partition with the shortest **codelength**: the fewest bits per step needed
-to describe a random walk. Both questions are legitimate and often give the
-same answer. They can disagree when links carry real movement, because only the
-map equation models that movement.
+which partition best compresses a description of that movement? Both questions
+are legitimate and often give the same answer. They can disagree when links
+carry real movement, because only the map equation models that movement.
 
 ## Reusing street names
 
 Picture narrating a random walker's journey to a friend, one step at a time, in
-as few words as possible. The trick is the one paper maps already use: reuse
+as few words as possible. The trick is what paper maps have always done: reuse
 names.
 
 Street names repeat across cities. Almost every town has a Main Street. Within
@@ -133,10 +131,12 @@ $q_{i\curvearrowright}$ and $\sum_{\alpha\in i} p_\alpha$ per module; see
 
 Zachary's karate club is a classic benchmark: 34 people, 78 friendships, and a
 known split into two factions. It is small enough to explore interactively and
-has real structure Infomap reliably recovers. Note that the NetworkX graph
-carries integer edge weights (interaction counts), and the adapter reads them
-by default, so the walk — and the codelengths below — are weighted; recomputing
-them by hand from the bare topology gives slightly different values.
+has real structure that Infomap recovers.
+
+The NetworkX version carries integer edge weights (interaction counts), and the
+adapter uses them by default, so the walk and the codelengths below are
+weighted. Computing them by hand from the unweighted topology gives slightly
+different values.
 
 ```{code-cell} python
 import networkx as nx
@@ -170,7 +170,8 @@ length of the flow, not a sociological label. Nodes on the boundary between the
 factions can form their own transitional cluster where the walker's affiliation
 is split, and naming it shortens the code, so Infomap often reports more than two
 modules here. To steer the search toward two modules, pass
-`preferred_number_of_modules=2` — a soft preference, not a hard constraint.
+`preferred_number_of_modules=2`, a soft preference rather than a hard
+constraint.
 ```
 
 ```{code-cell} python

--- a/interfaces/python/source/flow-models/temporal.md
+++ b/interfaces/python/source/flow-models/temporal.md
@@ -79,8 +79,8 @@ probabilities and how state nodes of one physical node share a codeword within a
 module. What is specific to *time* is how the windows should be coupled.
 
 **Uniform relaxation** (the default) lets the walker relax to any window,
-weighted only by the node's link strength there — no window is privileged over
-another. It is the simplest choice and works well when communities change
+weighted only by the node's link strength there, and no window is privileged
+over another. It is the simplest choice and works well when communities change
 gradually.
 
 **Neighbourhood flow coupling** (`multilayer_relax_by_jsd`) makes the coupling

--- a/interfaces/python/source/index.rst
+++ b/interfaces/python/source/index.rst
@@ -67,7 +67,7 @@ Where to go
       :link-type: doc
 
       Multilayer, memory, temporal, metadata, bipartite, and higher-order
-      networks: Infomap's deeper modelling surface.
+      networks: the representations beyond a plain graph.
 
    .. grid-item-card:: Workflows & integrations
       :link: workflows/index

--- a/interfaces/python/source/quickstart.rst
+++ b/interfaces/python/source/quickstart.rst
@@ -55,9 +55,8 @@ directly:
 
     print(result.codelength)
 
-For non-default loading from a graph library, the ``from_*`` constructors take
-the adapter options that :func:`infomap.run` does not, such as a different edge
-weight attribute or explicit directedness:
+The ``from_*`` constructors take the adapter options that :func:`infomap.run`
+does not, such as a different edge-weight attribute or explicit directedness:
 
 .. code-block:: python
 

--- a/interfaces/python/source/workflows/hpc.md
+++ b/interfaces/python/source/workflows/hpc.md
@@ -50,7 +50,7 @@ seed, total trial count, and algorithm settings.
 
 ## Trials as independent work units
 
-Each task runs `num_trials` trials of its own — the *per-shard* count — and
+Each task runs `num_trials` trials of its own (the *per-shard* count), and
 `trial_offset` positions those trials within the global budget. If you want
 100 trials in total and split them across four array tasks, each task gets
 `num_trials=25`:

--- a/interfaces/python/source/working-with-infomap/inputs.md
+++ b/interfaces/python/source/working-with-infomap/inputs.md
@@ -52,9 +52,9 @@ read* belong to the ``Network.from_*`` constructors; passing one to
 silently building a different graph. For a NetworkX or igraph graph the
 directedness is read from the graph object itself, so no ``directed`` argument
 is needed. For a SciPy matrix or edge index, pass ``directed=`` to the matching
-``from_*`` constructor — and note that the two routes default differently:
-a SciPy matrix is read as *undirected* unless you say otherwise, while a
-``(2, E)`` edge index follows the PyG convention and is read as *directed*.
+``from_*`` constructor. Note that the two routes default differently: a SciPy
+matrix is read as *undirected* unless you say otherwise, while a ``(2, E)`` edge
+index follows the PyG convention and is read as *directed*.
 
 Two library-idiomatic one-shot helpers return native types instead of a
 {class}`~infomap.Result`: {func}`infomap.find_communities` (a NetworkX-style
@@ -213,7 +213,7 @@ print(f"pandas route: {result.num_top_modules} modules, {result.codelength:.4f} 
 
 Source and target columns must hold integers. Convert string labels to integer
 codes first (``pandas.factorize``) and keep the ``uniques`` array it returns as
-your reverse mapping — this route registers no node names, so the result
+your reverse mapping. This route registers no node names, so the result
 DataFrame's ``"name"`` column cannot recover the labels. An equally valid one-call form is an
 iterable of tuples: ``infomap.run([(0, 1, 1.0), (1, 2, 1.0), ...])``.
 
@@ -221,8 +221,8 @@ iterable of tuples: ``infomap.run([(0, 1, 1.0), (1, 2, 1.0), ...])``.
 :class: note
 A two-row *integer* array is read as a ``(2, E)`` edge index (the PyG / GNN
 convention) and, following that convention, defaults to a **directed** flow
-model — pass ``directed=False`` to `Network.from_edge_index` if your edge
-index lists an undirected graph. Rows of ``(source, target, weight)`` have a
+model. Pass ``directed=False`` to `Network.from_edge_index` if your edge index
+lists an undirected graph. Rows of ``(source, target, weight)`` have a
 float column and are read as weighted links. For an explicit edge index with
 its own options, use
 `Network.from_edge_index(edge_index, edge_weight=..., directed=...)`.

--- a/interfaces/python/source/working-with-infomap/running-and-options.md
+++ b/interfaces/python/source/working-with-infomap/running-and-options.md
@@ -304,7 +304,7 @@ for label, kwargs in [
     print(f"{label}: modules={result.num_top_modules}, L={result.codelength:.4f}")
 ```
 
-Higher `regularization_strength` merges more modules — on a network this small
+Higher `regularization_strength` merges more modules. On a network this small
 the default strength already merges everything, which is why the option is
 meant for large, sparse, or incompletely sampled data rather than well-sampled
 toy graphs. For a gradual version of the same sweep, where a planted partition

--- a/interfaces/python/source/working-with-infomap/visualizing-and-exporting.md
+++ b/interfaces/python/source/working-with-infomap/visualizing-and-exporting.md
@@ -256,8 +256,8 @@ print("Temp directory removed.")
 - **`.clu` records the top level.** Pass `depth_level` to `write_clu` for a
   deeper level; `.tree` / `.ftree` carry the full hierarchy.
 - **`to_networkx` builds a new graph, not a copy of yours.** Its nodes are the
-  result's (state) nodes keyed by `state_id`, so your original graph — and any
-  attributes on it — is left untouched and *not* carried into the export. Use
+  result's (state) nodes keyed by `state_id`, so your original graph is left
+  untouched: its attributes are *not* carried into the export. Use
   {func}`infomap.find_communities` or
   {func}`infomap.io.export.annotate_networkx_graph` to annotate your own graph
   instead.


### PR DESCRIPTION
## What

A voice and readability pass over the Python docs prose, applying a consistent
editorial bar page by page. Prose only: no code cells, math, or citations
changed.

## Substantive edits (where warranted)

- **concepts/the-map-equation**: cut a codelength definition that was
  re-derived a third time (already given in "At a glance" and earned in the
  street-names section), tightening the opening arc; split the dense
  karate-club weighting caveat.
- **concepts/state-nodes-and-higher-order-flow**: fix a sentence fragment in
  the example intro and a clumsy chained instruction.
- **concepts/flow-and-random-walks**, **hierarchy-and-the-multilevel-map**:
  sharpen the two sentences that state what the map equation measures and how
  the resolution limit works.
- **index**, **quickstart**, **working-with-infomap/inputs**: replace the
  "deeper modelling surface" flow-models card blurb with a concrete one, drop a
  nominal throat-clearing opener, and split three long sentences.

## Hygiene (folded in silently)

- Remove every prose em dash across the site (one code-comment dash left as
  code).

The mature tiers (flow-models, robustness, workflows, FAQ, reference,
installation, citing) were already at the bar and were left alone beyond
hygiene.

## Verification

The full executing myst-nb build (`nb_execution_raise_on_error`) is green with
zero warnings; every in-cell assertion still holds.
