### PR TITLE
refactor: drop C++14 static-constexpr ODR workarounds

### DIFF
--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -240,8 +240,7 @@ public:
     Console console;
     console.section(fmt::format(FMT_STRING("Summary after {}{}"), m_trialsRun, m_trialsRun > 1 ? " trials" : " trial"));
     if (m_autoStopped) {
-      const unsigned int patience = Config::convergePatience;
-      Console::detail(0, "auto: stopped after {} trials (no improvement in last {})", m_trialsRun, patience);
+      Console::detail(0, "auto: stopped after {} trials (no improvement in last {})", m_trialsRun, Config::convergePatience);
     }
     std::string codelengthRange;
     std::string topModulesRange;

--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -27,13 +27,6 @@
 
 namespace infomap {
 
-constexpr int FlowModel::undirected;
-constexpr int FlowModel::directed;
-constexpr int FlowModel::undirdir;
-constexpr int FlowModel::outdirdir;
-constexpr int FlowModel::rawdir;
-constexpr int FlowModel::precomputed;
-
 namespace {
 
   const std::vector<std::pair<std::string, FlowModel>>& flowModelMappings()


### PR DESCRIPTION
## What

Follow-up to #708 (C++17 bump). Now that `static constexpr` data members are implicitly `inline`, the C++14 crutches for ODR-using them are unnecessary:

- **`Config.cpp`** — removed the six out-of-line `constexpr int FlowModel::…;` definitions. The flow-model constants are ODR-used (stored into `flowModelMappings()`), which is why C++14 required them; in C++17 they are redundant and deprecated.
- **`InfomapBase.cpp`** — inlined the `patience` local back into the `Console::detail()` call. It existed only to avoid binding `Config::convergePatience` to a reference through `fmt::make_format_args`; that ODR-use is fine in C++17.

## Why

Pure cleanup enabled by C++17 — removes dead scaffolding and silences the C++17 deprecation of redundant out-of-line `constexpr` redeclarations.

## Verification

- Links clean under `-std=c++17` (Apple clang) — the removed definitions left no undefined symbols
- `-Wall -Wextra -pedantic -Wshadow`: no new warnings
- `make test-native`: ctest 22/22
- `--converge` still prints `no improvement in last 5`

No behavior change.

First in a small C++17 feature-adoption series (this = Fas 1; Fas 2 = attributes, stacked on top).
