### PR TITLE
refactor: mark pure public-API getters [[nodiscard]]

### DIFF
--- a/src/Infomap.h
+++ b/src/Infomap.h
@@ -79,21 +79,21 @@ public:
   void addNode(unsigned int id, std::string name, double weight) { m_network.addNode(id, std::move(name), weight); }
 
   void addName(unsigned int id, const std::string& name) { m_network.addName(id, name); }
-  std::string getName(unsigned int id) const
+  [[nodiscard]] std::string getName(unsigned int id) const
   {
     auto& names = m_network.names();
     auto it = names.find(id);
     return it != names.end() ? it->second : "";
   }
 
-  const std::map<unsigned int, std::string>& getNames() const { return m_network.names(); }
+  [[nodiscard]] const std::map<unsigned int, std::string>& getNames() const { return m_network.names(); }
 
   // State-id -> name for higher-order (state/memory) networks. Physical names
   // live in getNames(), keyed by physical id; state nodes carry their own
   // optional name parsed from the *States section (StateNode::name). Only
   // non-empty names are returned, so a first-order network (no per-state names)
   // yields an empty map and callers fall back to the physical name.
-  std::map<unsigned int, std::string> getStateNames() const
+  [[nodiscard]] std::map<unsigned int, std::string> getStateNames() const
   {
     std::map<unsigned int, std::string> stateNames;
     for (const auto& entry : m_network.nodes()) {
@@ -106,7 +106,7 @@ public:
   // Name of a single state node, or "" if the id is unknown or unnamed. The
   // scalar counterpart of getStateNames(), mirroring getName(); the R binding
   // walks state nodes calling this since SWIG-R exposes std::map opaquely.
-  std::string getStateName(unsigned int stateId) const
+  [[nodiscard]] std::string getStateName(unsigned int stateId) const
   {
     const auto& nodes = m_network.nodes();
     auto it = nodes.find(stateId);
@@ -150,7 +150,7 @@ public:
   // add_multilayer_* / setMultilayerInitialPartition APIs. The network must be
   // built first (state nodes are created on the fly). Throws std::out_of_range
   // if the combination is not present (issue #616).
-  unsigned int getMultilayerStateId(unsigned int layerId, unsigned int nodeId) const
+  [[nodiscard]] unsigned int getMultilayerStateId(unsigned int layerId, unsigned int nodeId) const
   {
     const auto& map = m_network.layerNodeToStateId();
     auto layerIt = map.find(layerId);
@@ -164,7 +164,7 @@ public:
 
   void setBipartiteStartId(unsigned int startId) { m_network.setBipartiteStartId(startId); }
 
-  std::map<std::pair<unsigned int, unsigned int>, double> getLinks(bool flow) const
+  [[nodiscard]] std::map<std::pair<unsigned int, unsigned int>, double> getLinks(bool flow) const
   {
     std::map<std::pair<unsigned int, unsigned int>, double> links;
 
@@ -176,7 +176,7 @@ public:
   }
 
 #ifndef SWIGPYTHON
-  std::vector<LinkResult> getLinkResults() const
+  [[nodiscard]] std::vector<LinkResult> getLinkResults() const
   {
     std::vector<LinkResult> links;
     links.reserve(m_network.numLinks());
@@ -189,7 +189,7 @@ public:
   }
 #endif
 
-  std::map<unsigned int, unsigned int> getModules(int level = 1, bool states = false)
+  [[nodiscard]] std::map<unsigned int, unsigned int> getModules(int level = 1, bool states = false)
   {
     if (haveMemory() && !states) {
       throw std::runtime_error("Cannot get modules on higher-order network without states.");
@@ -208,7 +208,7 @@ public:
   // (above) so SWIG wraps its parallel-vector members for Python. Excluded from
   // the R binding together with NodeData (see the struct's #ifndef SWIGR note).
 #ifndef SWIGR
-  NodeData getNodeData(int level = 1, bool states = false)
+  [[nodiscard]] NodeData getNodeData(int level = 1, bool states = false)
   {
     // Mirror _results.get_nodes: physical iterator for higher-order networks
     // unless state-level data is requested.

--- a/src/core/InfoNode.cpp
+++ b/src/core/InfoNode.cpp
@@ -355,8 +355,7 @@ void InfoNode::calcChildDegree() noexcept
     m_childDegree = 1;
   else {
     m_childDegree = 0;
-    for (auto& child : children()) {
-      (void)child;
+    for ([[maybe_unused]] auto& child : children()) {
       ++m_childDegree;
     }
   }

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -240,8 +240,7 @@ public:
     Console console;
     console.section(fmt::format(FMT_STRING("Summary after {}{}"), m_trialsRun, m_trialsRun > 1 ? " trials" : " trial"));
     if (m_autoStopped) {
-      const unsigned int patience = Config::convergePatience;
-      Console::detail(0, "auto: stopped after {} trials (no improvement in last {})", m_trialsRun, patience);
+      Console::detail(0, "auto: stopped after {} trials (no improvement in last {})", m_trialsRun, Config::convergePatience);
     }
     std::string codelengthRange;
     std::string topModulesRange;

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -102,57 +102,57 @@ public:
   // ===================================================
 
   Network& network() { return m_network; }
-  const Network& network() const { return m_network; }
+  [[nodiscard]] const Network& network() const { return m_network; }
 
   InfoNode& root() { return m_root; }
-  const InfoNode& root() const { return m_root; }
+  [[nodiscard]] const InfoNode& root() const { return m_root; }
 
-  unsigned int numLeafNodes() const { return m_leafNodes.size(); }
+  [[nodiscard]] unsigned int numLeafNodes() const { return m_leafNodes.size(); }
 
   const std::vector<InfoNode*>& leafNodes() const { return m_leafNodes; }
 
-  unsigned int numTopModules() const { return m_root.childDegree(); }
+  [[nodiscard]] unsigned int numTopModules() const { return m_root.childDegree(); }
 
   unsigned int numActiveModules() const { return m_optimizer->numActiveModules(); }
 
-  unsigned int numNonTrivialTopModules() const { return m_numNonTrivialTopModules; }
+  [[nodiscard]] unsigned int numNonTrivialTopModules() const { return m_numNonTrivialTopModules; }
 
-  bool haveModules() const { return !m_root.isLeaf() && !m_root.firstChild->isLeaf(); }
+  [[nodiscard]] bool haveModules() const { return !m_root.isLeaf() && !m_root.firstChild->isLeaf(); }
 
-  bool haveNonTrivialModules() const { return numNonTrivialTopModules() > 0; }
+  [[nodiscard]] bool haveNonTrivialModules() const { return numNonTrivialTopModules() > 0; }
 
   /**
    * Number of node levels below the root in current Infomap instance, 1 if no modules
    */
-  unsigned int numLevels() const;
+  [[nodiscard]] unsigned int numLevels() const;
 
   /**
    * Get maximum depth of any child in the tree, following possible sub Infomap instances
    */
-  unsigned int maxTreeDepth() const;
+  [[nodiscard]] unsigned int maxTreeDepth() const;
 
-  double getCodelength() const { return m_optimizer->getCodelength(); }
+  [[nodiscard]] double getCodelength() const { return m_optimizer->getCodelength(); }
 
-  double getMetaCodelength(bool unweighted = false) const { return m_optimizer->getMetaCodelength(unweighted); }
+  [[nodiscard]] double getMetaCodelength(bool unweighted = false) const { return m_optimizer->getMetaCodelength(unweighted); }
 
-  double codelength() const { return m_hierarchicalCodelength; }
+  [[nodiscard]] double codelength() const { return m_hierarchicalCodelength; }
 
-  const std::vector<double>& codelengths() const { return m_codelengths; }
+  [[nodiscard]] const std::vector<double>& codelengths() const { return m_codelengths; }
 
-  double getIndexCodelength() const { return m_optimizer->getIndexCodelength(); }
+  [[nodiscard]] double getIndexCodelength() const { return m_optimizer->getIndexCodelength(); }
 
-  double getModuleCodelength() const { return m_hierarchicalCodelength - m_optimizer->getIndexCodelength(); }
+  [[nodiscard]] double getModuleCodelength() const { return m_hierarchicalCodelength - m_optimizer->getIndexCodelength(); }
 
-  double getHierarchicalCodelength() const { return m_hierarchicalCodelength; }
+  [[nodiscard]] double getHierarchicalCodelength() const { return m_hierarchicalCodelength; }
 
-  double getOneLevelCodelength() const { return m_oneLevelCodelength; }
+  [[nodiscard]] double getOneLevelCodelength() const { return m_oneLevelCodelength; }
 
 #ifndef SWIG
   // One-level reference reported to the user. In lossy mode this is the lossless
   // L_1 = H(p_alpha) (a lambda-independent upper bound), not the lambda-dependent
   // corrected one-module objective that m_oneLevelCodelength holds for the optimizer.
   // Guarded from SWIG so it is not exposed as a new binding; callers below use it.
-  double getReferenceOneLevelCodelength() const
+  [[nodiscard]] double getReferenceOneLevelCodelength() const
   {
 #if INFOMAP_FEATURE_LOSSY_MAP_EQUATION
     if (lossy)
@@ -162,25 +162,25 @@ public:
   }
 #endif
 
-  double getRelativeCodelengthSavings() const
+  [[nodiscard]] double getRelativeCodelengthSavings() const
   {
     auto oneLevelCodelength = getReferenceOneLevelCodelength();
     return oneLevelCodelength < 1e-16 ? 0 : 1.0 - codelength() / oneLevelCodelength;
   }
 
 #ifndef SWIG
-  double getRelativeCodelengthSavings(double codelength) const
+  [[nodiscard]] double getRelativeCodelengthSavings(double codelength) const
   {
     auto oneLevelCodelength = getReferenceOneLevelCodelength();
     return oneLevelCodelength < 1e-16 ? 0 : 1.0 - codelength / oneLevelCodelength;
   }
 #endif
 
-  double getEntropyRate() { return m_entropyRate; }
+  [[nodiscard]] double getEntropyRate() { return m_entropyRate; }
 #if INFOMAP_FEATURE_LOSSY_MAP_EQUATION
-  double getLossyRate() const { return m_optimizer->getLossyRate(); }
-  double getLossyDistortion() const { return m_optimizer->getLossyDistortion(); }
-  double getLossyOneLevelLossless() const { return m_optimizer->getLossyOneLevelLossless(); }
+  [[nodiscard]] double getLossyRate() const { return m_optimizer->getLossyRate(); }
+  [[nodiscard]] double getLossyDistortion() const { return m_optimizer->getLossyDistortion(); }
+  [[nodiscard]] double getLossyOneLevelLossless() const { return m_optimizer->getLossyOneLevelLossless(); }
   // 1-based indices of the top modules that are noise modules (l_i > lambda * H_i).
   std::vector<unsigned int> noiseTopModules() const;
 #endif
@@ -192,7 +192,7 @@ public:
 
   std::vector<InfoNode*>& activeNetwork() const { return *m_activeNetwork; }
 
-  std::map<unsigned int, std::vector<unsigned int>> getMultilevelModules(bool states = false);
+  [[nodiscard]] std::map<unsigned int, std::vector<unsigned int>> getMultilevelModules(bool states = false);
 
   // ===================================================
   // IO

--- a/src/core/ObjectPool.h
+++ b/src/core/ObjectPool.h
@@ -102,7 +102,7 @@ public:
   }
 
   template <typename... Args>
-  T* alloc(Args&&... args)
+  [[nodiscard]] T* alloc(Args&&... args)
   {
     T* slot;
     if (!m_free.empty()) {
@@ -144,8 +144,8 @@ public:
     m_chunks.emplace_back(n - m_free.size());
   }
 
-  std::size_t liveCount() const noexcept { return m_liveCount; }
-  std::size_t chunkCount() const noexcept { return m_chunks.size(); }
+  [[nodiscard]] std::size_t liveCount() const noexcept { return m_liveCount; }
+  [[nodiscard]] std::size_t chunkCount() const noexcept { return m_chunks.size(); }
 };
 
 } // namespace infomap

--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -27,13 +27,6 @@
 
 namespace infomap {
 
-constexpr int FlowModel::undirected;
-constexpr int FlowModel::directed;
-constexpr int FlowModel::undirdir;
-constexpr int FlowModel::outdirdir;
-constexpr int FlowModel::rawdir;
-constexpr int FlowModel::precomputed;
-
 namespace {
 
   const std::vector<std::pair<std::string, FlowModel>>& flowModelMappings()

--- a/src/io/Config.h
+++ b/src/io/Config.h
@@ -299,20 +299,20 @@ struct Config {
     flowModelIsSet = true;
   }
 
-  bool isUndirectedClustering() const { return flowModel == FlowModel::undirected; }
+  [[nodiscard]] bool isUndirectedClustering() const { return flowModel == FlowModel::undirected; }
 
-  bool isUndirectedFlow() const { return flowModel == FlowModel::undirected || flowModel == FlowModel::undirdir; }
+  [[nodiscard]] bool isUndirectedFlow() const { return flowModel == FlowModel::undirected || flowModel == FlowModel::undirdir; }
 
-  bool printAsUndirected() const { return isUndirectedClustering(); }
+  [[nodiscard]] bool printAsUndirected() const { return isUndirectedClustering(); }
 
-  bool isMultilayerNetwork() const { return multilayerInput || !additionalInput.empty(); }
-  bool isBipartite() const { return bipartite; }
+  [[nodiscard]] bool isMultilayerNetwork() const { return multilayerInput || !additionalInput.empty(); }
+  [[nodiscard]] bool isBipartite() const { return bipartite; }
 #ifndef SWIG
-  bool isRegularizedMultilayerFlow() const { return isMultilayerNetwork() && regularized; }
+  [[nodiscard]] bool isRegularizedMultilayerFlow() const { return isMultilayerNetwork() && regularized; }
 #endif
 
   bool haveMemory() const { return stateInput; }
-  bool printStates() const { return stateOutput; }
+  [[nodiscard]] bool printStates() const { return stateOutput; }
 
   bool haveMetaData() const { return !metaDataFile.empty() || numMetaDataDimensions != 0; }
 

--- a/src/utils/FlowCalculator.cpp
+++ b/src/utils/FlowCalculator.cpp
@@ -1125,10 +1125,8 @@ void FlowCalculator::calcUndirectedRegularizedFlow(const StateNetwork& network, 
 }
 
 #if INFOMAP_FEATURE_REGULARIZED_MULTILAYER
-void FlowCalculator::calcUndirectedRegularizedMultilayerFlow(const StateNetwork& network, const Config& config)
+void FlowCalculator::calcUndirectedRegularizedMultilayerFlow([[maybe_unused]] const StateNetwork& network, [[maybe_unused]] const Config& config)
 {
-  (void)network;
-  (void)config;
   throw std::runtime_error("Undirected regularized multilayer flow is not implemented.");
 }
 #endif // INFOMAP_FEATURE_REGULARIZED_MULTILAYER


### PR DESCRIPTION
Stacked on #726 (attributes). **Merge order: #725 → #726 → this.** Base is `refactor/cxx17-attributes`, so the diff here is only the `[[nodiscard]]` additions.

Completes the item deferred in #726: `[[nodiscard]]` on the public API. Previously skipped because these headers are SWIG-`%include`d — but **SWIG 4.4.1 parses and ignores the attribute**, so the regenerated R/Python wrappers come out byte-identical and no generated files change.

## What

`[[nodiscard]]` on 41 pure query/observer methods, so discarding a result (e.g. `im.get_modules();` with no assignment, or an ignored `codelength()`) warns:

- **`Infomap.h`** — `InfomapWrapper` getters: `getName`, `getNames`, `getStateNames`, `getStateName`, `getMultilayerStateId`, `getLinks`, `getLinkResults`, `getModules`, `getNodeData`.
- **`InfomapBase.h`** — result getters: the codelength family (`codelength`, `getIndexCodelength`, `getModuleCodelength`, `getHierarchicalCodelength`, `getOneLevelCodelength`, `getMetaCodelength`, `getReferenceOneLevelCodelength`, `getRelativeCodelengthSavings`×2, `codelengths`), counts (`numLeafNodes`, `numTopModules`, `numNonTrivialTopModules`, `numLevels`, `maxTreeDepth`), `haveModules`/`haveNonTrivialModules`, `getEntropyRate`, `getMultilevelModules`, `getLossy*`, `network()`/`root()`.
- **`Config.h`** — predicates: `isUndirectedClustering`, `isUndirectedFlow`, `printAsUndirected`, `isMultilayerNetwork`, `isBipartite`, `isRegularizedMultilayerFlow`, `printStates`.

## Excluded on purpose

Fluent setters (`Infomap& setX(...)` — return `*this` for chaining), `void` mutators, and internal state predicates (`isTopLevel`/`isFirstLoop`/…).

## Verification

- Native builds **default + `lossy-map-equation` + `regularized-multilayer`** clean under `-std=c++17` (`-Wall -Wextra -pedantic -Wshadow`) — **no discarded-result warnings**, i.e. no internal call site discards any annotated getter
- `make test-python-swig-freshness` / `test-r-swig-freshness`: **fresh** (wrappers unchanged)
- `make test-native`: ctest 22/22
- Python extension rebuilds; `codelength` / `num_top_modules` / `get_modules()` verified through the binding

No behavior change.
