### PR TITLE
refactor: structured bindings + try_emplace in the map code

### DIFF
--- a/src/Infomap.h
+++ b/src/Infomap.h
@@ -79,21 +79,21 @@ public:
   void addNode(unsigned int id, std::string name, double weight) { m_network.addNode(id, std::move(name), weight); }
 
   void addName(unsigned int id, const std::string& name) { m_network.addName(id, name); }
-  std::string getName(unsigned int id) const
+  [[nodiscard]] std::string getName(unsigned int id) const
   {
     auto& names = m_network.names();
     auto it = names.find(id);
     return it != names.end() ? it->second : "";
   }
 
-  const std::map<unsigned int, std::string>& getNames() const { return m_network.names(); }
+  [[nodiscard]] const std::map<unsigned int, std::string>& getNames() const { return m_network.names(); }
 
   // State-id -> name for higher-order (state/memory) networks. Physical names
   // live in getNames(), keyed by physical id; state nodes carry their own
   // optional name parsed from the *States section (StateNode::name). Only
   // non-empty names are returned, so a first-order network (no per-state names)
   // yields an empty map and callers fall back to the physical name.
-  std::map<unsigned int, std::string> getStateNames() const
+  [[nodiscard]] std::map<unsigned int, std::string> getStateNames() const
   {
     std::map<unsigned int, std::string> stateNames;
     for (const auto& entry : m_network.nodes()) {
@@ -106,7 +106,7 @@ public:
   // Name of a single state node, or "" if the id is unknown or unnamed. The
   // scalar counterpart of getStateNames(), mirroring getName(); the R binding
   // walks state nodes calling this since SWIG-R exposes std::map opaquely.
-  std::string getStateName(unsigned int stateId) const
+  [[nodiscard]] std::string getStateName(unsigned int stateId) const
   {
     const auto& nodes = m_network.nodes();
     auto it = nodes.find(stateId);
@@ -150,7 +150,7 @@ public:
   // add_multilayer_* / setMultilayerInitialPartition APIs. The network must be
   // built first (state nodes are created on the fly). Throws std::out_of_range
   // if the combination is not present (issue #616).
-  unsigned int getMultilayerStateId(unsigned int layerId, unsigned int nodeId) const
+  [[nodiscard]] unsigned int getMultilayerStateId(unsigned int layerId, unsigned int nodeId) const
   {
     const auto& map = m_network.layerNodeToStateId();
     auto layerIt = map.find(layerId);
@@ -164,7 +164,7 @@ public:
 
   void setBipartiteStartId(unsigned int startId) { m_network.setBipartiteStartId(startId); }
 
-  std::map<std::pair<unsigned int, unsigned int>, double> getLinks(bool flow) const
+  [[nodiscard]] std::map<std::pair<unsigned int, unsigned int>, double> getLinks(bool flow) const
   {
     std::map<std::pair<unsigned int, unsigned int>, double> links;
 
@@ -176,7 +176,7 @@ public:
   }
 
 #ifndef SWIGPYTHON
-  std::vector<LinkResult> getLinkResults() const
+  [[nodiscard]] std::vector<LinkResult> getLinkResults() const
   {
     std::vector<LinkResult> links;
     links.reserve(m_network.numLinks());
@@ -189,7 +189,7 @@ public:
   }
 #endif
 
-  std::map<unsigned int, unsigned int> getModules(int level = 1, bool states = false)
+  [[nodiscard]] std::map<unsigned int, unsigned int> getModules(int level = 1, bool states = false)
   {
     if (haveMemory() && !states) {
       throw std::runtime_error("Cannot get modules on higher-order network without states.");
@@ -208,7 +208,7 @@ public:
   // (above) so SWIG wraps its parallel-vector members for Python. Excluded from
   // the R binding together with NodeData (see the struct's #ifndef SWIGR note).
 #ifndef SWIGR
-  NodeData getNodeData(int level = 1, bool states = false)
+  [[nodiscard]] NodeData getNodeData(int level = 1, bool states = false)
   {
     // Mirror _results.get_nodes: physical iterator for higher-order networks
     // unless state-level data is requested.

--- a/src/core/InfoNode.cpp
+++ b/src/core/InfoNode.cpp
@@ -355,8 +355,7 @@ void InfoNode::calcChildDegree() noexcept
     m_childDegree = 1;
   else {
     m_childDegree = 0;
-    for (auto& child : children()) {
-      (void)child;
+    for ([[maybe_unused]] auto& child : children()) {
       ++m_childDegree;
     }
   }

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -240,8 +240,7 @@ public:
     Console console;
     console.section(fmt::format(FMT_STRING("Summary after {}{}"), m_trialsRun, m_trialsRun > 1 ? " trials" : " trial"));
     if (m_autoStopped) {
-      const unsigned int patience = Config::convergePatience;
-      Console::detail(0, "auto: stopped after {} trials (no improvement in last {})", m_trialsRun, patience);
+      Console::detail(0, "auto: stopped after {} trials (no improvement in last {})", m_trialsRun, Config::convergePatience);
     }
     std::string codelengthRange;
     std::string topModulesRange;

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1216,13 +1216,13 @@ InfomapBase& InfomapBase::initTree(const NodePaths& tree)
     Path prefix;
     for (size_t i = 0; i + 1 < path.size(); ++i) {
       prefix.push_back(path[i]);
-      auto inserted = moduleByPathPrefix.emplace(prefix, nullptr);
-      if (inserted.second) {
+      auto [it, inserted] = moduleByPathPrefix.emplace(prefix, nullptr);
+      if (inserted) {
         auto* module = &allocNode();
         parent->addChild(module);
-        inserted.first->second = module;
+        it->second = module;
       }
-      parent = inserted.first->second;
+      parent = it->second;
     }
 
     parent->addChild(leafNode);

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -102,57 +102,57 @@ public:
   // ===================================================
 
   Network& network() { return m_network; }
-  const Network& network() const { return m_network; }
+  [[nodiscard]] const Network& network() const { return m_network; }
 
   InfoNode& root() { return m_root; }
-  const InfoNode& root() const { return m_root; }
+  [[nodiscard]] const InfoNode& root() const { return m_root; }
 
-  unsigned int numLeafNodes() const { return m_leafNodes.size(); }
+  [[nodiscard]] unsigned int numLeafNodes() const { return m_leafNodes.size(); }
 
   const std::vector<InfoNode*>& leafNodes() const { return m_leafNodes; }
 
-  unsigned int numTopModules() const { return m_root.childDegree(); }
+  [[nodiscard]] unsigned int numTopModules() const { return m_root.childDegree(); }
 
   unsigned int numActiveModules() const { return m_optimizer->numActiveModules(); }
 
-  unsigned int numNonTrivialTopModules() const { return m_numNonTrivialTopModules; }
+  [[nodiscard]] unsigned int numNonTrivialTopModules() const { return m_numNonTrivialTopModules; }
 
-  bool haveModules() const { return !m_root.isLeaf() && !m_root.firstChild->isLeaf(); }
+  [[nodiscard]] bool haveModules() const { return !m_root.isLeaf() && !m_root.firstChild->isLeaf(); }
 
-  bool haveNonTrivialModules() const { return numNonTrivialTopModules() > 0; }
+  [[nodiscard]] bool haveNonTrivialModules() const { return numNonTrivialTopModules() > 0; }
 
   /**
    * Number of node levels below the root in current Infomap instance, 1 if no modules
    */
-  unsigned int numLevels() const;
+  [[nodiscard]] unsigned int numLevels() const;
 
   /**
    * Get maximum depth of any child in the tree, following possible sub Infomap instances
    */
-  unsigned int maxTreeDepth() const;
+  [[nodiscard]] unsigned int maxTreeDepth() const;
 
-  double getCodelength() const { return m_optimizer->getCodelength(); }
+  [[nodiscard]] double getCodelength() const { return m_optimizer->getCodelength(); }
 
-  double getMetaCodelength(bool unweighted = false) const { return m_optimizer->getMetaCodelength(unweighted); }
+  [[nodiscard]] double getMetaCodelength(bool unweighted = false) const { return m_optimizer->getMetaCodelength(unweighted); }
 
-  double codelength() const { return m_hierarchicalCodelength; }
+  [[nodiscard]] double codelength() const { return m_hierarchicalCodelength; }
 
-  const std::vector<double>& codelengths() const { return m_codelengths; }
+  [[nodiscard]] const std::vector<double>& codelengths() const { return m_codelengths; }
 
-  double getIndexCodelength() const { return m_optimizer->getIndexCodelength(); }
+  [[nodiscard]] double getIndexCodelength() const { return m_optimizer->getIndexCodelength(); }
 
-  double getModuleCodelength() const { return m_hierarchicalCodelength - m_optimizer->getIndexCodelength(); }
+  [[nodiscard]] double getModuleCodelength() const { return m_hierarchicalCodelength - m_optimizer->getIndexCodelength(); }
 
-  double getHierarchicalCodelength() const { return m_hierarchicalCodelength; }
+  [[nodiscard]] double getHierarchicalCodelength() const { return m_hierarchicalCodelength; }
 
-  double getOneLevelCodelength() const { return m_oneLevelCodelength; }
+  [[nodiscard]] double getOneLevelCodelength() const { return m_oneLevelCodelength; }
 
 #ifndef SWIG
   // One-level reference reported to the user. In lossy mode this is the lossless
   // L_1 = H(p_alpha) (a lambda-independent upper bound), not the lambda-dependent
   // corrected one-module objective that m_oneLevelCodelength holds for the optimizer.
   // Guarded from SWIG so it is not exposed as a new binding; callers below use it.
-  double getReferenceOneLevelCodelength() const
+  [[nodiscard]] double getReferenceOneLevelCodelength() const
   {
 #if INFOMAP_FEATURE_LOSSY_MAP_EQUATION
     if (lossy)
@@ -162,25 +162,25 @@ public:
   }
 #endif
 
-  double getRelativeCodelengthSavings() const
+  [[nodiscard]] double getRelativeCodelengthSavings() const
   {
     auto oneLevelCodelength = getReferenceOneLevelCodelength();
     return oneLevelCodelength < 1e-16 ? 0 : 1.0 - codelength() / oneLevelCodelength;
   }
 
 #ifndef SWIG
-  double getRelativeCodelengthSavings(double codelength) const
+  [[nodiscard]] double getRelativeCodelengthSavings(double codelength) const
   {
     auto oneLevelCodelength = getReferenceOneLevelCodelength();
     return oneLevelCodelength < 1e-16 ? 0 : 1.0 - codelength / oneLevelCodelength;
   }
 #endif
 
-  double getEntropyRate() { return m_entropyRate; }
+  [[nodiscard]] double getEntropyRate() { return m_entropyRate; }
 #if INFOMAP_FEATURE_LOSSY_MAP_EQUATION
-  double getLossyRate() const { return m_optimizer->getLossyRate(); }
-  double getLossyDistortion() const { return m_optimizer->getLossyDistortion(); }
-  double getLossyOneLevelLossless() const { return m_optimizer->getLossyOneLevelLossless(); }
+  [[nodiscard]] double getLossyRate() const { return m_optimizer->getLossyRate(); }
+  [[nodiscard]] double getLossyDistortion() const { return m_optimizer->getLossyDistortion(); }
+  [[nodiscard]] double getLossyOneLevelLossless() const { return m_optimizer->getLossyOneLevelLossless(); }
   // 1-based indices of the top modules that are noise modules (l_i > lambda * H_i).
   std::vector<unsigned int> noiseTopModules() const;
 #endif
@@ -192,7 +192,7 @@ public:
 
   std::vector<InfoNode*>& activeNetwork() const { return *m_activeNetwork; }
 
-  std::map<unsigned int, std::vector<unsigned int>> getMultilevelModules(bool states = false);
+  [[nodiscard]] std::map<unsigned int, std::vector<unsigned int>> getMultilevelModules(bool states = false);
 
   // ===================================================
   // IO

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -1000,18 +1000,17 @@ inline void InfomapOptimizer<Objective>::consolidateModules(bool replaceExisting
         // If undirected, the order may be swapped to aggregate the edge on an opposite one
         if (m_infomap->isUndirectedClustering() && m1 > m2)
           std::swap(m1, m2);
-        auto ret = moduleLinks.insert(std::make_pair(NodePair(m1, m2), edge.data.flow));
-        if (!ret.second) {
-          ret.first->second += edge.data.flow;
+        auto [it, inserted] = moduleLinks.try_emplace(NodePair(m1, m2), edge.data.flow);
+        if (!inserted) {
+          it->second += edge.data.flow;
         }
       }
     }
   }
 
   // Add the aggregated edge flow structure to the new modules
-  for (auto& e : moduleLinks) {
-    const auto& nodePair = e.first;
-    modules[nodePair.first]->addOutEdge(*modules[nodePair.second], 0.0, e.second);
+  for (const auto& [nodePair, flow] : moduleLinks) {
+    modules[nodePair.first]->addOutEdge(*modules[nodePair.second], 0.0, flow);
   }
 
   if (replaceExistingModules) {

--- a/src/core/ObjectPool.h
+++ b/src/core/ObjectPool.h
@@ -102,7 +102,7 @@ public:
   }
 
   template <typename... Args>
-  T* alloc(Args&&... args)
+  [[nodiscard]] T* alloc(Args&&... args)
   {
     T* slot;
     if (!m_free.empty()) {
@@ -144,8 +144,8 @@ public:
     m_chunks.emplace_back(n - m_free.size());
   }
 
-  std::size_t liveCount() const noexcept { return m_liveCount; }
-  std::size_t chunkCount() const noexcept { return m_chunks.size(); }
+  [[nodiscard]] std::size_t liveCount() const noexcept { return m_liveCount; }
+  [[nodiscard]] std::size_t chunkCount() const noexcept { return m_chunks.size(); }
 };
 
 } // namespace infomap

--- a/src/core/StateNetwork.cpp
+++ b/src/core/StateNetwork.cpp
@@ -66,11 +66,11 @@ std::pair<StateNetwork::NodeMap::iterator, bool> StateNetwork::addNode(unsigned 
 
 StateNetwork::PhysNode& StateNetwork::addPhysicalNode(unsigned int physId)
 {
-  auto result = m_physNodes.emplace(physId, PhysNode(physId));
-  if (result.second) {
+  auto [it, inserted] = m_physNodes.emplace(physId, PhysNode(physId));
+  if (inserted) {
     ++m_numPhysicalNodesFound; // count uniques so numPhysicalNodes() survives a freed map
   }
-  auto& physNode = result.first->second;
+  auto& physNode = it->second;
   physNode.physId = physId;
   m_sumNodeWeight += 1.0;
   return physNode;
@@ -103,7 +103,7 @@ StateNetwork::PhysNode& StateNetwork::addPhysicalNode(unsigned int physId, doubl
 
 std::pair<std::map<unsigned int, std::string>::iterator, bool> StateNetwork::addName(unsigned int id, const std::string& name)
 {
-  return m_names.insert(std::make_pair(id, name));
+  return m_names.try_emplace(id, name);
 }
 
 bool StateNetwork::addLink(unsigned int sourceId, unsigned int targetId, double weight)

--- a/src/core/iterators/InfomapIterator.cpp
+++ b/src/core/iterators/InfomapIterator.cpp
@@ -160,9 +160,9 @@ InfomapIterator& InfomapIteratorPhysical::operator++() noexcept
       auto firstLeafIt = *this;
       // If on a leaf node, loop through and aggregate to physical nodes
       while (!isEnd() && m_current->isLeaf()) {
-        auto ret = m_physNodes.insert(std::make_pair(m_current->physicalId, InfoNode(*m_current)));
-        auto& physNode = ret.first->second;
-        if (ret.second) {
+        auto [it, inserted] = m_physNodes.insert(std::make_pair(m_current->physicalId, InfoNode(*m_current)));
+        auto& physNode = it->second;
+        if (inserted) {
           // New physical node, use same parent as the state leaf node
           physNode.parent = m_current->parent;
         } else {

--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -27,13 +27,6 @@
 
 namespace infomap {
 
-constexpr int FlowModel::undirected;
-constexpr int FlowModel::directed;
-constexpr int FlowModel::undirdir;
-constexpr int FlowModel::outdirdir;
-constexpr int FlowModel::rawdir;
-constexpr int FlowModel::precomputed;
-
 namespace {
 
   const std::vector<std::pair<std::string, FlowModel>>& flowModelMappings()

--- a/src/io/Config.h
+++ b/src/io/Config.h
@@ -299,20 +299,20 @@ struct Config {
     flowModelIsSet = true;
   }
 
-  bool isUndirectedClustering() const { return flowModel == FlowModel::undirected; }
+  [[nodiscard]] bool isUndirectedClustering() const { return flowModel == FlowModel::undirected; }
 
-  bool isUndirectedFlow() const { return flowModel == FlowModel::undirected || flowModel == FlowModel::undirdir; }
+  [[nodiscard]] bool isUndirectedFlow() const { return flowModel == FlowModel::undirected || flowModel == FlowModel::undirdir; }
 
-  bool printAsUndirected() const { return isUndirectedClustering(); }
+  [[nodiscard]] bool printAsUndirected() const { return isUndirectedClustering(); }
 
-  bool isMultilayerNetwork() const { return multilayerInput || !additionalInput.empty(); }
-  bool isBipartite() const { return bipartite; }
+  [[nodiscard]] bool isMultilayerNetwork() const { return multilayerInput || !additionalInput.empty(); }
+  [[nodiscard]] bool isBipartite() const { return bipartite; }
 #ifndef SWIG
-  bool isRegularizedMultilayerFlow() const { return isMultilayerNetwork() && regularized; }
+  [[nodiscard]] bool isRegularizedMultilayerFlow() const { return isMultilayerNetwork() && regularized; }
 #endif
 
   bool haveMemory() const { return stateInput; }
-  bool printStates() const { return stateOutput; }
+  [[nodiscard]] bool printStates() const { return stateOutput; }
 
   bool haveMetaData() const { return !metaDataFile.empty() || numMetaDataDimensions != 0; }
 

--- a/src/io/ProgramInterface.cpp
+++ b/src/io/ProgramInterface.cpp
@@ -54,13 +54,11 @@ namespace {
     for (auto& optionArgument : options) {
       auto& opt = *optionArgument;
       if (opt.shortName != '\0') {
-        auto inserted = lookup.shortOptions.insert(std::make_pair(opt.shortName, &opt));
-        if (!inserted.second)
+        if (!lookup.shortOptions.try_emplace(opt.shortName, &opt).second)
           throw std::runtime_error(fmt::format(FMT_STRING("Duplication of option '{}'"), opt.shortName));
       }
 
-      auto inserted = lookup.longOptions.insert(std::make_pair(opt.longName, &opt));
-      if (!inserted.second)
+      if (!lookup.longOptions.try_emplace(opt.longName, &opt).second)
         throw std::runtime_error(fmt::format(FMT_STRING("Duplication of option \"{}\""), opt.longName));
     }
     return lookup;

--- a/src/utils/FlowCalculator.cpp
+++ b/src/utils/FlowCalculator.cpp
@@ -1125,10 +1125,8 @@ void FlowCalculator::calcUndirectedRegularizedFlow(const StateNetwork& network, 
 }
 
 #if INFOMAP_FEATURE_REGULARIZED_MULTILAYER
-void FlowCalculator::calcUndirectedRegularizedMultilayerFlow(const StateNetwork& network, const Config& config)
+void FlowCalculator::calcUndirectedRegularizedMultilayerFlow([[maybe_unused]] const StateNetwork& network, [[maybe_unused]] const Config& config)
 {
-  (void)network;
-  (void)config;
   throw std::runtime_error("Undirected regularized multilayer flow is not implemented.");
 }
 #endif // INFOMAP_FEATURE_REGULARIZED_MULTILAYER


### PR DESCRIPTION
Stacked on #727. **Merge order: #725 → #726 → #727 → this.** Base is `refactor/cxx17-nodiscard-public-api`, so the diff here is only the Fas 3 changes.

Behavior-preserving readability + minor efficiency in the map-heavy core, enabled by C++17.

## Structured bindings

Where the insert/emplace result is consumed locally (never returned whole), `auto [it, inserted] = …` replaces the `.first`/`.second` dance:

- `StateNetwork::addPhysicalNode` — `m_physNodes.emplace`
- `InfomapOptimizer::consolidateModules` — `moduleLinks` insert **and** the aggregation loop (`for (const auto& [nodePair, flow] : moduleLinks)`)
- `InfomapBase::initTree` — `moduleByPathPrefix`
- `InfomapIteratorPhysical::operator++` — `m_physNodes` (kept `insert` here — hot path — structured binding only)

## `try_emplace`

Over `insert(std::make_pair(...))` where it avoids a throwaway construct when the key already exists and reads clearer:

- `StateNetwork::addName` — skips the `std::string` copy on a duplicate id
- `InfomapOptimizer` module-link aggregation — insert-or-accumulate
- `ProgramInterface` option lookup — both duplicate checks (also drops the local)

## Left alone on purpose

- `addStateNode` / `addNode(id, weight)` — they return the pair whole, so bindings don't help.
- `toZeroBasedIndex.insert(std::make_pair(k, id++))` (MemMapEquation / RegularizedMultilayer) — the `id++` side effect makes `try_emplace` *read* as if the increment were conditional (it isn't; the argument is always evaluated), so the swap would be a readability trap for no gain (`unsigned` value).

## Verification

- Default + `lossy-map-equation` + `regularized-multilayer` builds clean under `-std=c++17` (`-Wall -Wextra -pedantic -Wshadow`)
- `make test-native`: ctest 22/22 — includes the golden-file output/flow/partition tests, so **output is byte-identical**
- SWIG wrappers still fresh (`InfomapOptimizer.h` change was a method body, not a signature)
- CLI sanity: states, multilayer (higher-order), and multilevel (ninetriangles → 3 levels, codelength 3.38583082) runs all match

No behavior change.
