### PR TITLE
refactor: C++17 follow-ups — lookups, ODR, filesystem, nodiscard, readability

### DIFF
--- a/interfaces/R/generated/infomap_wrap.cpp
+++ b/interfaces/R/generated/infomap_wrap.cpp
@@ -40648,12 +40648,12 @@ R_swig_InfomapBase_getMaxEntropy ( SEXP self, SEXP s_swig_copy)
     
     res1 = SWIG_R_ConvertPtr(self, &argp1, SWIGTYPE_p_infomap__InfomapBase, 0 |  0 );
     if (!SWIG_IsOK(res1)) {
-      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapBase_getMaxEntropy" "', argument " "1"" of type '" "infomap::InfomapBase *""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapBase_getMaxEntropy" "', argument " "1"" of type '" "infomap::InfomapBase const *""'"); 
     }
     arg1 = reinterpret_cast< infomap::InfomapBase * >(argp1);
     {
       try {
-        result = (double)(arg1)->getMaxEntropy();
+        result = (double)((infomap::InfomapBase const *)arg1)->getMaxEntropy();
       } catch (const std::exception& e) {
         SWIG_exception(SWIG_RuntimeError, e.what());
       }
@@ -40684,12 +40684,12 @@ R_swig_InfomapBase_getMaxFlow ( SEXP self, SEXP s_swig_copy)
     
     res1 = SWIG_R_ConvertPtr(self, &argp1, SWIGTYPE_p_infomap__InfomapBase, 0 |  0 );
     if (!SWIG_IsOK(res1)) {
-      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapBase_getMaxFlow" "', argument " "1"" of type '" "infomap::InfomapBase *""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapBase_getMaxFlow" "', argument " "1"" of type '" "infomap::InfomapBase const *""'"); 
     }
     arg1 = reinterpret_cast< infomap::InfomapBase * >(argp1);
     {
       try {
-        result = (double)(arg1)->getMaxFlow();
+        result = (double)((infomap::InfomapBase const *)arg1)->getMaxFlow();
       } catch (const std::exception& e) {
         SWIG_exception(SWIG_RuntimeError, e.what());
       }

--- a/interfaces/python/generated/infomap_wrap.cpp
+++ b/interfaces/python/generated/infomap_wrap.cpp
@@ -47810,12 +47810,12 @@ SWIGINTERN PyObject *_wrap_InfomapBase_getMaxEntropy(PyObject *self, PyObject *a
   swig_obj[0] = args;
   res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__InfomapBase, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapBase_getMaxEntropy" "', argument " "1"" of type '" "infomap::InfomapBase *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapBase_getMaxEntropy" "', argument " "1"" of type '" "infomap::InfomapBase const *""'"); 
   }
   arg1 = reinterpret_cast< infomap::InfomapBase * >(argp1);
   {
     try {
-      result = (double)(arg1)->getMaxEntropy();
+      result = (double)((infomap::InfomapBase const *)arg1)->getMaxEntropy();
     } catch (const std::exception& e) {
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
@@ -47840,12 +47840,12 @@ SWIGINTERN PyObject *_wrap_InfomapBase_getMaxFlow(PyObject *self, PyObject *args
   swig_obj[0] = args;
   res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__InfomapBase, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapBase_getMaxFlow" "', argument " "1"" of type '" "infomap::InfomapBase *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapBase_getMaxFlow" "', argument " "1"" of type '" "infomap::InfomapBase const *""'"); 
   }
   arg1 = reinterpret_cast< infomap::InfomapBase * >(argp1);
   {
     try {
-      result = (double)(arg1)->getMaxFlow();
+      result = (double)((infomap::InfomapBase const *)arg1)->getMaxFlow();
     } catch (const std::exception& e) {
       SWIG_exception(SWIG_RuntimeError, e.what());
     }

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -415,12 +415,12 @@ private:
           m_timing.recordTrial(trialIndex, threadNumber, trialSeed, trialTime, trialCodelength, trialTopModules, trialNumLevels);
 
           if (worker.printAllTrials && m_numTrials > 1) {
-            std::lock_guard<std::mutex> lock(outputMutex);
+            std::scoped_lock lock(outputMutex);
             auto outputTimer = m_timing.scope("output_s");
             worker.writeResult(static_cast<int>(globalIndex + 1));
           }
 
-          std::lock_guard<std::mutex> lock(bestResultMutex);
+          std::scoped_lock lock(bestResultMutex);
           const auto bestIndexMissing = result.bestTrialIndex >= m_numTrials;
           const auto isBetter = trialCodelength < result.bestHierarchicalCodelength - 1e-10;
           const auto isEarlierTie = std::abs(trialCodelength - result.bestHierarchicalCodelength) < 1e-10 && trialIndex < result.bestTrialIndex;
@@ -433,14 +433,14 @@ private:
             result.bestTree = std::move(trialTree);
           }
         } catch (const std::exception& e) {
-          std::lock_guard<std::mutex> lock(errorMutex);
+          std::scoped_lock lock(errorMutex);
           if (!hasError || trialIndex < firstErrorTrial) {
             hasError = true;
             firstErrorTrial = trialIndex;
             firstError = e.what();
           }
         } catch (...) {
-          std::lock_guard<std::mutex> lock(errorMutex);
+          std::scoped_lock lock(errorMutex);
           if (!hasError || trialIndex < firstErrorTrial) {
             hasError = true;
             firstErrorTrial = trialIndex;

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -109,11 +109,11 @@ public:
 
   [[nodiscard]] unsigned int numLeafNodes() const { return m_leafNodes.size(); }
 
-  const std::vector<InfoNode*>& leafNodes() const { return m_leafNodes; }
+  [[nodiscard]] const std::vector<InfoNode*>& leafNodes() const { return m_leafNodes; }
 
   [[nodiscard]] unsigned int numTopModules() const { return m_root.childDegree(); }
 
-  unsigned int numActiveModules() const { return m_optimizer->numActiveModules(); }
+  [[nodiscard]] unsigned int numActiveModules() const { return m_optimizer->numActiveModules(); }
 
   [[nodiscard]] unsigned int numNonTrivialTopModules() const { return m_numNonTrivialTopModules; }
 
@@ -182,10 +182,10 @@ public:
   [[nodiscard]] double getLossyDistortion() const { return m_optimizer->getLossyDistortion(); }
   [[nodiscard]] double getLossyOneLevelLossless() const { return m_optimizer->getLossyOneLevelLossless(); }
   // 1-based indices of the top modules that are noise modules (l_i > lambda * H_i).
-  std::vector<unsigned int> noiseTopModules() const;
+  [[nodiscard]] std::vector<unsigned int> noiseTopModules() const;
 #endif
-  double getMaxEntropy() { return m_maxEntropy; }
-  double getMaxFlow() { return m_maxFlow; }
+  [[nodiscard]] double getMaxEntropy() const { return m_maxEntropy; }
+  [[nodiscard]] double getMaxFlow() const { return m_maxFlow; }
 
   const Date& getStartDate() const { return m_startDate; }
   const Stopwatch& getElapsedTime() const { return m_elapsedTime; }

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -654,7 +654,7 @@ protected:
   // resolved to state ids in initTrialPartition once the network is built.
   std::vector<std::array<unsigned int, 3>> m_multilayerInitialPartition;
 
-  const unsigned int SUPER_LEVEL_ADDITION = 1 << 20;
+  static constexpr unsigned int SUPER_LEVEL_ADDITION = 1 << 20;
   bool m_isMain = true;
   unsigned int m_subLevel = 0;
 

--- a/src/core/LossyMapEquation.h
+++ b/src/core/LossyMapEquation.h
@@ -38,19 +38,19 @@ public:
   // Getters
   // ===================================================
 
-  double getIndexCodelength() const { return indexCodelength; }
+  [[nodiscard]] double getIndexCodelength() const { return indexCodelength; }
 
-  double getModuleCodelength() const { return moduleCodelength - m_sumCorrection; }
+  [[nodiscard]] double getModuleCodelength() const { return moduleCodelength - m_sumCorrection; }
 
-  double getCodelength() const { return codelength - m_sumCorrection; } // J_lambda
+  [[nodiscard]] double getCodelength() const { return codelength - m_sumCorrection; } // J_lambda
 
-  double getLossyRate() const { return codelength - m_sumNoiseLoss; } // L_lossy
+  [[nodiscard]] double getLossyRate() const { return codelength - m_sumNoiseLoss; } // L_lossy
 
-  double getLossyDistortion() const { return m_sumNoiseEntropy; } // D
+  [[nodiscard]] double getLossyDistortion() const { return m_sumNoiseEntropy; } // D
 
   // L_1 = H(p_alpha): the lossless one-level reference, captured in calcCodelength
   // of the root. Independent of lambda; used for reporting and relative savings.
-  double getOneLevelLossless() const { return m_oneLevelLossless; }
+  [[nodiscard]] double getOneLevelLossless() const { return m_oneLevelLossless; }
 
   // ===================================================
   // IO

--- a/src/core/MapEquation.h
+++ b/src/core/MapEquation.h
@@ -76,11 +76,11 @@ public:
   // Getters
   // ===================================================
 
-  double getIndexCodelength() const { return indexCodelength; }
+  [[nodiscard]] double getIndexCodelength() const { return indexCodelength; }
 
-  double getModuleCodelength() const { return moduleCodelength; }
+  [[nodiscard]] double getModuleCodelength() const { return moduleCodelength; }
 
-  double getCodelength() const { return codelength; }
+  [[nodiscard]] double getCodelength() const { return codelength; }
 
   // ===================================================
   // IO

--- a/src/core/MetaMapEquation.cpp
+++ b/src/core/MetaMapEquation.cpp
@@ -175,20 +175,24 @@ INFOMAP_HOT double MetaMapEquation::getDeltaCodelengthOnMovingNode(InfoNode& cur
   unsigned int oldModuleIndex = oldModuleDelta.module;
   unsigned int newModuleIndex = newModuleDelta.module;
 
+  // Hoist the two module lookups: the four codelength queries below only touch
+  // these two modules, so a single map traversal each suffices.
+  auto& oldModuleMeta = m_moduleToMetaCollection[oldModuleIndex];
+  auto& newModuleMeta = m_moduleToMetaCollection[newModuleIndex];
+
   // Remove codelength of old and new module before changes
-  deltaMetaL -= getCurrentModuleMetaCodelength(oldModuleIndex, current, 0);
-  deltaMetaL -= getCurrentModuleMetaCodelength(newModuleIndex, current, 0);
+  deltaMetaL -= getCurrentModuleMetaCodelength(oldModuleMeta, current, 0);
+  deltaMetaL -= getCurrentModuleMetaCodelength(newModuleMeta, current, 0);
   // Add codelength of old module with current node removed
-  deltaMetaL += getCurrentModuleMetaCodelength(oldModuleIndex, current, -1);
+  deltaMetaL += getCurrentModuleMetaCodelength(oldModuleMeta, current, -1);
   // Add codelength of old module with current node added
-  deltaMetaL += getCurrentModuleMetaCodelength(newModuleIndex, current, 1);
+  deltaMetaL += getCurrentModuleMetaCodelength(newModuleMeta, current, 1);
 
   return deltaL + deltaMetaL * metaDataRate;
 }
 
-double MetaMapEquation::getCurrentModuleMetaCodelength(unsigned int module, InfoNode& current, int addRemoveOrNothing)
+double MetaMapEquation::getCurrentModuleMetaCodelength(MetaCollection& currentMetaCollection, InfoNode& current, int addRemoveOrNothing)
 {
-  auto& currentMetaCollection = m_moduleToMetaCollection[module];
   const MetaCollection* nodeMeta = current.metaCollectionPtr();
 
   double moduleMetaCodelength = 0.0;
@@ -227,16 +231,21 @@ void MetaMapEquation::updateCodelengthOnMovingNode(InfoNode& current,
   unsigned int oldModuleIndex = oldModuleDelta.module;
   unsigned int newModuleIndex = newModuleDelta.module;
 
+  // Hoist the two module lookups; the references stay valid across
+  // updateMetaData, which mutates these collections in place.
+  auto& oldModuleMeta = m_moduleToMetaCollection[oldModuleIndex];
+  auto& newModuleMeta = m_moduleToMetaCollection[newModuleIndex];
+
   // Remove codelength of old and new module before changes
-  deltaMetaL -= getCurrentModuleMetaCodelength(oldModuleIndex, current, 0);
-  deltaMetaL -= getCurrentModuleMetaCodelength(newModuleIndex, current, 0);
+  deltaMetaL -= getCurrentModuleMetaCodelength(oldModuleMeta, current, 0);
+  deltaMetaL -= getCurrentModuleMetaCodelength(newModuleMeta, current, 0);
 
   // Update meta data from moving node
   updateMetaData(current, oldModuleIndex, newModuleIndex);
 
   // Add codelength of old and new module after changes
-  deltaMetaL += getCurrentModuleMetaCodelength(oldModuleIndex, current, 0);
-  deltaMetaL += getCurrentModuleMetaCodelength(newModuleIndex, current, 0);
+  deltaMetaL += getCurrentModuleMetaCodelength(oldModuleMeta, current, 0);
+  deltaMetaL += getCurrentModuleMetaCodelength(newModuleMeta, current, 0);
 
   metaCodelength += deltaMetaL;
 }

--- a/src/core/MetaMapEquation.h
+++ b/src/core/MetaMapEquation.h
@@ -151,7 +151,7 @@ private:
    * @param addRemoveOrNothing +1, -1 or 0 to calculate codelength
    * as if current node was added, removed or untouched in current module
    */
-  double getCurrentModuleMetaCodelength(unsigned int module, InfoNode& current, int addRemoveOrNothing);
+  double getCurrentModuleMetaCodelength(MetaCollection& metaCollection, InfoNode& current, int addRemoveOrNothing);
 
   // ===================================================
   // Private member variables

--- a/src/core/StateNetwork.h
+++ b/src/core/StateNetwork.h
@@ -194,15 +194,15 @@ public:
   virtual void clearLinks();
 
   // Getters
-  const NodeMap& nodes() const { return m_nodes; }
-  unsigned int numNodes() const { return m_nodes.size(); }
-  unsigned int numPhysicalNodes() const { return m_numPhysicalNodesFound; }
-  double sumNodeWeight() const { return m_sumNodeWeight; }
+  [[nodiscard]] const NodeMap& nodes() const { return m_nodes; }
+  [[nodiscard]] unsigned int numNodes() const { return m_nodes.size(); }
+  [[nodiscard]] unsigned int numPhysicalNodes() const { return m_numPhysicalNodesFound; }
+  [[nodiscard]] double sumNodeWeight() const { return m_sumNodeWeight; }
 #ifndef SWIG
   // Mode B (multilayer) build representation, consumed only by the multilayer
   // expansion in Network. Hidden from the bindings: external callers read links
   // through getLinks()/getLinkResults(), which now serve the consumed CSR store.
-  const NodeLinkMap& nodeLinkMap() const { return m_nodeLinkMap; }
+  [[nodiscard]] const NodeLinkMap& nodeLinkMap() const { return m_nodeLinkMap; }
   NodeLinkMap& nodeLinkMap() { return m_nodeLinkMap; }
 #endif
 
@@ -215,10 +215,10 @@ public:
   {
     if (!m_linksFinalized) const_cast<StateNetwork*>(this)->finalizeLinks();
   }
-  unsigned int nodeId(unsigned int index) const { return m_nodeIds[index]; }
-  unsigned int indexOfId(unsigned int id) const;
-  unsigned int outDegree(unsigned int index) const { return m_linkOffsets[index + 1] - m_linkOffsets[index]; }
-  bool isDangling(unsigned int index) const { return outDegree(index) == 0; }
+  [[nodiscard]] unsigned int nodeId(unsigned int index) const { return m_nodeIds[index]; }
+  [[nodiscard]] unsigned int indexOfId(unsigned int id) const;
+  [[nodiscard]] unsigned int outDegree(unsigned int index) const { return m_linkOffsets[index + 1] - m_linkOffsets[index]; }
+  [[nodiscard]] bool isDangling(unsigned int index) const { return outDegree(index) == 0; }
   // fn(srcIndex, targetIndex, weight, double& flow) in (src,tgt) order. flow is
   // writable (CSR arrays are mutable) so FlowCalculator can write flow back.
   template <typename Fn>
@@ -241,26 +241,26 @@ public:
   // never consumed as CSR. The ensureFinalized() call is guarded so SWIG never
   // parses a reference to the hidden method (the compiled library the wrapper
   // calls still lazy-finalizes).
-  unsigned int numAggregatedLinks() const
+  [[nodiscard]] unsigned int numAggregatedLinks() const
   {
 #ifndef SWIG
     if (!m_useMapBuild) ensureFinalized();
 #endif
     return m_numAggregatedLinks;
   }
-  unsigned int numLinks() const
+  [[nodiscard]] unsigned int numLinks() const
   {
 #ifndef SWIG
     if (!m_useMapBuild) ensureFinalized();
 #endif
     return m_numLinks;
   }
-  double sumLinkWeight() const { return m_sumLinkWeight; }
-  unsigned int numSelfLinks() const { return m_numSelfLinks; }
-  double sumSelfLinkWeight() const { return m_sumSelfLinkWeight; }
+  [[nodiscard]] double sumLinkWeight() const { return m_sumLinkWeight; }
+  [[nodiscard]] unsigned int numSelfLinks() const { return m_numSelfLinks; }
+  [[nodiscard]] double sumSelfLinkWeight() const { return m_sumSelfLinkWeight; }
   // Use convention of counting self-links only once, treating them as directed
-  double sumWeightedDegree() const { return 2 * sumLinkWeight() - sumSelfLinkWeight(); }
-  unsigned int sumDegree() const { return 2 * numLinks() - numSelfLinks(); }
+  [[nodiscard]] double sumWeightedDegree() const { return 2 * sumLinkWeight() - sumSelfLinkWeight(); }
+  [[nodiscard]] unsigned int sumDegree() const { return 2 * numLinks() - numSelfLinks(); }
   std::map<unsigned int, double>& outWeights()
   {
 #ifndef SWIG
@@ -269,24 +269,24 @@ public:
     return m_outWeights;
   }
   std::map<unsigned int, std::string>& names() { return m_names; }
-  const std::map<unsigned int, std::string>& names() const { return m_names; }
-  bool haveNodeWeights() const { return m_haveNodeWeights; }
-  bool haveStateNodeWeights() const { return m_haveStateNodeWeights; }
-  bool haveFileInput() const { return m_haveFileInput; }
+  [[nodiscard]] const std::map<unsigned int, std::string>& names() const { return m_names; }
+  [[nodiscard]] bool haveNodeWeights() const { return m_haveNodeWeights; }
+  [[nodiscard]] bool haveStateNodeWeights() const { return m_haveStateNodeWeights; }
+  [[nodiscard]] bool haveFileInput() const { return m_haveFileInput; }
 
-  virtual const std::map<unsigned int, std::vector<int>>& metaData() const = 0;
+  [[nodiscard]] virtual const std::map<unsigned int, std::vector<int>>& metaData() const = 0;
 
-  bool haveDirectedInput() const { return m_haveDirectedInput; }
-  bool haveMemoryInput() const { return m_haveMemoryInput; }
-  bool higherOrderInputMethodCalled() const { return m_higherOrderInputMethodCalled; }
+  [[nodiscard]] bool haveDirectedInput() const { return m_haveDirectedInput; }
+  [[nodiscard]] bool haveMemoryInput() const { return m_haveMemoryInput; }
+  [[nodiscard]] bool higherOrderInputMethodCalled() const { return m_higherOrderInputMethodCalled; }
   // Bipartite
-  bool isBipartite() const { return m_bipartiteStartId > 0; }
-  unsigned int bipartiteStartId() const { return m_bipartiteStartId; }
+  [[nodiscard]] bool isBipartite() const { return m_bipartiteStartId > 0; }
+  [[nodiscard]] unsigned int bipartiteStartId() const { return m_bipartiteStartId; }
   void setBipartiteStartId(unsigned int value) { m_bipartiteStartId = value; }
   // Multilayer
 #ifndef SWIG
-  unsigned int numLayers() const { return m_layers.size(); }
-  const std::set<unsigned int>& layers() const { return m_layers; }
+  [[nodiscard]] unsigned int numLayers() const { return m_layers.size(); }
+  [[nodiscard]] const std::set<unsigned int>& layers() const { return m_layers; }
 #endif
 
   /**

--- a/src/io/ClusterMap.cpp
+++ b/src/io/ClusterMap.cpp
@@ -126,10 +126,8 @@ void ClusterMap::readTree(const std::string& filename, bool includeFlow, const s
 
     if (isMultilayer && m_treeLeafIdType == TreeLeafIdType::state) {
       // Re-map state id from layer/node ids in case the multilayer state ids differ
-      auto it = layerNodeToStateId->find(layerId);
-      if (it != layerNodeToStateId->end()) {
-        auto nodeIdToStateId = it->second.find(nodeId);
-        if (nodeIdToStateId != it->second.end()) {
+      if (auto it = layerNodeToStateId->find(layerId); it != layerNodeToStateId->end()) {
+        if (auto nodeIdToStateId = it->second.find(nodeId); nodeIdToStateId != it->second.end()) {
           stateId = nodeIdToStateId->second;
           multilayerNodeFound = true;
         }
@@ -167,7 +165,6 @@ void ClusterMap::readClu(const std::string& filename, bool includeFlow, const st
   SafeInFile input(filename);
   std::string line;
   std::istringstream lineStream;
-  std::map<unsigned int, unsigned int> clusterData;
 
   while (!std::getline(input, line).fail()) {
     if (line.empty() || line[0] == '#' || line[0] == '*')
@@ -200,11 +197,8 @@ void ClusterMap::readClu(const std::string& filename, bool includeFlow, const st
         throw std::runtime_error(fmt::format(FMT_STRING("Couldn't parse layer id from line '{}'"), line));
 
       // get new state id from map
-      auto it = layerNodeToStateId->find(layerId);
-
-      if (it != layerNodeToStateId->end()) {
-        auto nodeIdToStateId = it->second.find(nodeId);
-        if (nodeIdToStateId != it->second.end()) {
+      if (auto it = layerNodeToStateId->find(layerId); it != layerNodeToStateId->end()) {
+        if (auto nodeIdToStateId = it->second.find(nodeId); nodeIdToStateId != it->second.end()) {
           stateId = nodeIdToStateId->second;
           multilayerNodeFound = true;
         }

--- a/src/io/ClusterMap.h
+++ b/src/io/ClusterMap.h
@@ -40,16 +40,16 @@ class ClusterMap {
 public:
   void readClusterData(const std::string& filename, bool includeFlow = false, const std::map<unsigned int, std::map<unsigned int, unsigned int>>* layerNodeToStateId = nullptr);
 
-  const std::map<unsigned int, unsigned int>& clusterIds() const noexcept
+  [[nodiscard]] const std::map<unsigned int, unsigned int>& clusterIds() const noexcept
   {
     return m_clusterIds;
   }
 
-  const TreePaths& treePaths() const noexcept { return m_treePaths; }
+  [[nodiscard]] const TreePaths& treePaths() const noexcept { return m_treePaths; }
 
-  const std::string& extension() const noexcept { return m_extension; }
+  [[nodiscard]] const std::string& extension() const noexcept { return m_extension; }
 
-  TreeLeafIdType treeLeafIdType() const noexcept { return m_treeLeafIdType; }
+  [[nodiscard]] TreeLeafIdType treeLeafIdType() const noexcept { return m_treeLeafIdType; }
 
 private:
   void readTree(const std::string& filename, bool includeFlow, const std::map<unsigned int, std::map<unsigned int, unsigned int>>* layerNodeToStateId = nullptr);

--- a/src/io/Config.h
+++ b/src/io/Config.h
@@ -311,18 +311,18 @@ struct Config {
   [[nodiscard]] bool isRegularizedMultilayerFlow() const { return isMultilayerNetwork() && regularized; }
 #endif
 
-  bool haveMemory() const { return stateInput; }
+  [[nodiscard]] bool haveMemory() const { return stateInput; }
   [[nodiscard]] bool printStates() const { return stateOutput; }
 
-  bool haveMetaData() const { return !metaDataFile.empty() || numMetaDataDimensions != 0; }
+  [[nodiscard]] bool haveMetaData() const { return !metaDataFile.empty() || numMetaDataDimensions != 0; }
 
-  bool haveOutput() const { return !noFileOutput; }
+  [[nodiscard]] bool haveOutput() const { return !noFileOutput; }
 
 #ifndef SWIG
-  bool overwriteOutput() const { return !noOverwriteOutput; }
+  [[nodiscard]] bool overwriteOutput() const { return !noOverwriteOutput; }
 #endif
 
-  bool haveModularResultOutput() const
+  [[nodiscard]] bool haveModularResultOutput() const
   {
     return printTree || printFlowTree || printNewick || printJson || printCsv || printClu;
   }

--- a/src/io/InfomapError.h
+++ b/src/io/InfomapError.h
@@ -37,13 +37,13 @@ public:
       : std::runtime_error(message),
         m_code(code) {}
 
-  ExitCode code() const { return m_code; }
+  [[nodiscard]] ExitCode code() const { return m_code; }
 
 private:
   ExitCode m_code;
 };
 
-inline int exitCodeValue(ExitCode code)
+[[nodiscard]] constexpr int exitCodeValue(ExitCode code)
 {
   return static_cast<int>(code);
 }

--- a/src/io/Network.cpp
+++ b/src/io/Network.cpp
@@ -828,9 +828,7 @@ unsigned int Network::addMultilayerNode(unsigned int layerId, unsigned int physi
 
   // Create state node if not already exist, return state node id
   auto& layerIt = m_layerNodeToStateId[layerId];
-  auto it = layerIt.find(physicalId);
-
-  if (it != layerIt.end()) {
+  if (auto it = layerIt.find(physicalId); it != layerIt.end()) {
     return it->second;
   }
 
@@ -846,7 +844,7 @@ unsigned int Network::addMultilayerNode(unsigned int layerId, unsigned int physi
   auto& stateNode = ret.first->second;
   stateNode.layerId = layerId;
   stateNode.weight = weight;
-  m_layerNodeToStateId[layerId][physicalId] = stateNode.id;
+  layerIt[physicalId] = stateNode.id;
   m_layers.insert(layerId);
   return stateNode.id;
 }
@@ -857,9 +855,7 @@ unsigned int Network::addMultilayerNode(unsigned int stateId, unsigned int layer
 
   // Create state node if not already exist, return state node id
   auto& layerIt = m_layerNodeToStateId[layerId];
-  auto it = layerIt.find(physicalId);
-
-  if (it != layerIt.end()) {
+  if (auto it = layerIt.find(physicalId); it != layerIt.end()) {
     return it->second;
   }
 
@@ -867,7 +863,7 @@ unsigned int Network::addMultilayerNode(unsigned int stateId, unsigned int layer
   auto& stateNode = ret.first->second;
   stateNode.layerId = layerId;
   stateNode.weight = weight;
-  m_layerNodeToStateId[layerId][physicalId] = stateNode.id;
+  layerIt[physicalId] = stateNode.id;
   m_layers.insert(layerId);
   return stateNode.id;
 }

--- a/src/io/Network.cpp
+++ b/src/io/Network.cpp
@@ -800,12 +800,12 @@ void Network::addMultilayerInterLink(unsigned int layer1, unsigned int n, unsign
   // numLinks() read; an in-memory numLinks() read before expansion just finalizes
   // an empty buffer, which the first expansion addLink re-opens via definalize().)
   auto& interLinks = m_interLinks[LayerNode(layer1, n)];
-  auto it = interLinks.find(layer2);
+  auto [it, inserted] = interLinks.try_emplace(layer2, 0.0);
 
-  if (it == interLinks.end()) {
+  if (inserted) {
     ++m_numInterLayerLinks;
   }
-  interLinks[layer2] += interWeight;
+  it->second += interWeight;
 }
 
 void Network::addMultilayerInterLinks(const std::vector<unsigned int>& sourceLayerIds,

--- a/src/io/Network.h
+++ b/src/io/Network.h
@@ -83,11 +83,11 @@ public:
    */
   virtual void readMetaData(const std::string& filename);
 
-  unsigned int numMetaDataColumns() const { return m_numMetaDataColumns; }
-  const std::map<unsigned int, std::vector<int>>& metaData() const override { return m_metaData; }
+  [[nodiscard]] unsigned int numMetaDataColumns() const { return m_numMetaDataColumns; }
+  [[nodiscard]] const std::map<unsigned int, std::vector<int>>& metaData() const override { return m_metaData; }
 
-  bool isMultilayerNetwork() const { return !m_layerNodeToStateId.empty(); }
-  const std::map<unsigned int, std::map<unsigned int, unsigned int>>& layerNodeToStateId() const { return m_layerNodeToStateId; }
+  [[nodiscard]] bool isMultilayerNetwork() const { return !m_layerNodeToStateId.empty(); }
+  [[nodiscard]] const std::map<unsigned int, std::map<unsigned int, unsigned int>>& layerNodeToStateId() const { return m_layerNodeToStateId; }
 
   void postProcessInputData();
   void generateStateNetworkFromMultilayer();

--- a/src/io/NetworkInputParser.h
+++ b/src/io/NetworkInputParser.h
@@ -28,8 +28,7 @@
 #include <string>
 #include <vector>
 
-namespace infomap {
-namespace input {
+namespace infomap::input {
 
   struct NetworkInputOptions {
     bool undirectedFlow = true;
@@ -529,7 +528,6 @@ namespace input {
     Console::detail(1, "parsed {} columns of meta data for {} nodes", numMetaDataColumns, numMetaDataRows);
   }
 
-} // namespace input
-} // namespace infomap
+} // namespace infomap::input
 
 #endif // NETWORK_INPUT_PARSER_H_

--- a/src/io/Output.cpp
+++ b/src/io/Output.cpp
@@ -75,7 +75,8 @@ namespace {
   void writeJsonObjectPrefix(std::ostream& outStream, const Json& json)
   {
     const auto dumped = json.dump();
-    outStream << dumped.substr(0, dumped.size() - 1);
+    // Drop the trailing '}' without copying the whole dump into a substr.
+    outStream.write(dumped.data(), static_cast<std::streamsize>(dumped.size() - 1));
   }
 
 } // namespace

--- a/src/io/ProgramInterface.cpp
+++ b/src/io/ProgramInterface.cpp
@@ -19,24 +19,6 @@
 
 namespace infomap {
 
-const std::string ArgType::integer = "integer";
-const std::string ArgType::number = "number";
-const std::string ArgType::string = "string";
-const std::string ArgType::path = "path";
-const std::string ArgType::probability = "probability";
-const std::string ArgType::option = "option";
-const std::string ArgType::list = "list";
-
-const std::unordered_map<std::string, char> ArgType::toShort = {
-  { "integer", 'n' },
-  { "number", 'f' },
-  { "string", 's' },
-  { "path", 'p' },
-  { "probability", 'P' },
-  { "option", 'o' },
-  { "list", 'l' },
-};
-
 namespace {
 
   using ShortOptionMap = std::map<char, Option*>;

--- a/src/io/ProgramInterface.h
+++ b/src/io/ProgramInterface.h
@@ -33,14 +33,22 @@ namespace infomap {
 struct CleanExit {};
 
 struct ArgType {
-  static const std::string integer;
-  static const std::string number;
-  static const std::string string;
-  static const std::string path;
-  static const std::string probability;
-  static const std::string option;
-  static const std::string list;
-  static const std::unordered_map<std::string, char> toShort;
+  inline static const std::string integer = "integer";
+  inline static const std::string number = "number";
+  inline static const std::string string = "string";
+  inline static const std::string path = "path";
+  inline static const std::string probability = "probability";
+  inline static const std::string option = "option";
+  inline static const std::string list = "list";
+  inline static const std::unordered_map<std::string, char> toShort = {
+    { "integer", 'n' },
+    { "number", 'f' },
+    { "string", 's' },
+    { "path", 'p' },
+    { "probability", 'P' },
+    { "option", 'o' },
+    { "list", 'l' },
+  };
 };
 
 struct Option {

--- a/src/io/SafeFile.h
+++ b/src/io/SafeFile.h
@@ -14,15 +14,15 @@
 #include "../utils/format.h"
 #include <atomic>
 #include <ctime>
+#include <filesystem>
 #include <fstream>
 #include <ios>
 #include <cstdio>
 #include <stdexcept>
 #include <string>
-#include <sys/stat.h>
+#include <system_error>
 
 #ifdef _WIN32
-#include <direct.h>
 #include <process.h>
 #else
 #include <unistd.h>
@@ -65,69 +65,24 @@ public:
 
 inline bool pathExists(const std::string& path)
 {
-  struct stat info;
-  return stat(path.c_str(), &info) == 0;
+  std::error_code ec;
+  return std::filesystem::exists(path, ec);
 }
-
-inline bool isDirectory(const std::string& path)
-{
-  struct stat info;
-  if (stat(path.c_str(), &info) != 0)
-    return false;
-  return (info.st_mode & S_IFDIR) != 0;
-}
-
-inline std::string stripTrailingPathSeparators(std::string path)
-{
-  while (path.size() > 1 && (path.back() == '/' || path.back() == '\\'))
-    path.pop_back();
-  return path;
-}
-
-#ifdef _WIN32
-inline bool isWindowsPathRoot(const std::string& path)
-{
-  // Drive root, e.g. "C:".
-  if (path.size() == 2 && path[1] == ':')
-    return true;
-  // UNC root, e.g. "\\server" or "\\server\share": leading "\\" with at most one
-  // path separator after it. Recursing/creating above this point is invalid.
-  if (path.size() >= 2 && (path[0] == '\\' || path[0] == '/') && (path[1] == '\\' || path[1] == '/')) {
-    const auto rest = path.substr(2);
-    const auto firstSep = rest.find_first_of("/\\");
-    if (firstSep == std::string::npos)
-      return true;
-    return rest.find_first_of("/\\", firstSep + 1) == std::string::npos;
-  }
-  return false;
-}
-#endif
 
 inline void ensureDirectoryExists(const std::string& directory)
 {
-  if (directory.empty() || isDirectory(directory))
+  if (directory.empty())
     return;
 
-  const auto normalized = stripTrailingPathSeparators(directory);
-#ifdef _WIN32
-  // Never try to create a drive or UNC share root; assume it exists. If it truly
-  // does not, creating a child below will fail with a clear error instead.
-  if (isWindowsPathRoot(normalized))
-    return;
-#endif
-  const auto separator = normalized.find_last_of("/\\");
-  if (separator != std::string::npos) {
-    const auto parent = normalized.substr(0, separator);
-    if (!parent.empty())
-      ensureDirectoryExists(parent);
-  }
-
-#ifdef _WIN32
-  const auto created = _mkdir(normalized.c_str());
-#else
-  const auto created = mkdir(normalized.c_str(), 0777);
-#endif
-  if (created != 0 && !isDirectory(normalized)) {
+  // create_directories creates any missing parents and handles trailing
+  // separators and drive/UNC roots, so the previous manual recursion plus the
+  // Windows-root special case collapse into this single call. It returns false
+  // (with ec unset) when the directory already existed, so only a real error
+  // that also left the path a non-directory is fatal.
+  std::error_code ec;
+  std::filesystem::create_directories(directory, ec);
+  std::error_code statusEc;
+  if (ec && !std::filesystem::is_directory(directory, statusEc)) {
     throw InfomapError(ExitCode::OutputError, fmt::format(FMT_STRING("Can't create output directory '{}'."), directory));
   }
 }

--- a/src/utils/Log.cpp
+++ b/src/utils/Log.cpp
@@ -33,11 +33,6 @@ std::ostream& Log::defaultStream()
 }
 #endif
 
-std::ostream* Log::s_ostream = nullptr;
-unsigned int Log::s_verboseLevel = 0;
-bool Log::s_silent = false;
-thread_local unsigned int Log::s_threadMuteDepth = 0;
-
 void Log::setNoOutput()
 {
   static NullStreambuf nullBuf;

--- a/src/utils/Log.h
+++ b/src/utils/Log.h
@@ -164,10 +164,10 @@ private:
 #ifndef INFOMAP_R
   static std::ostream& defaultStream();
 #endif
-  static std::ostream* s_ostream;
-  static unsigned int s_verboseLevel;
-  static bool s_silent;
-  static thread_local unsigned int s_threadMuteDepth;
+  inline static std::ostream* s_ostream = nullptr;
+  inline static unsigned int s_verboseLevel = 0;
+  inline static bool s_silent = false;
+  inline static thread_local unsigned int s_threadMuteDepth = 0;
 };
 
 struct hideIf {

--- a/src/utils/TimingRegistry.h
+++ b/src/utils/TimingRegistry.h
@@ -75,7 +75,7 @@ public:
 
   void addPhase(const std::string& phase, double seconds)
   {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::scoped_lock lock(m_mutex);
     for (auto& entry : m_phases) {
       if (entry.first == phase) {
         entry.second += seconds;
@@ -87,7 +87,7 @@ public:
 
   void setPhase(const std::string& phase, double seconds)
   {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::scoped_lock lock(m_mutex);
     for (auto& entry : m_phases) {
       if (entry.first == phase) {
         entry.second = seconds;
@@ -99,13 +99,13 @@ public:
 
   void resetTrials(unsigned int numTrials)
   {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::scoped_lock lock(m_mutex);
     m_trials.assign(numTrials, TrialTimingRecord());
   }
 
   void recordTrial(unsigned int trialIndex, int thread, unsigned long seed, double timeSec, double codelength, unsigned int topModules, unsigned int numLevels)
   {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::scoped_lock lock(m_mutex);
     if (trialIndex >= m_trials.size()) {
       m_trials.resize(trialIndex + 1);
     }
@@ -123,13 +123,13 @@ public:
 
   std::vector<std::pair<std::string, double>> phases() const
   {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::scoped_lock lock(m_mutex);
     return m_phases;
   }
 
   std::vector<TrialTimingRecord> trials() const
   {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::scoped_lock lock(m_mutex);
     return m_trials;
   }
 

--- a/src/utils/convert.cpp
+++ b/src/utils/convert.cpp
@@ -10,8 +10,7 @@
 #include "convert.h"
 #include "format.h"
 
-namespace infomap {
-namespace io {
+namespace infomap::io {
 
   std::string toPrecision(double value, unsigned int precision, bool fixed)
   {
@@ -24,5 +23,4 @@ namespace io {
                  : fmt::format(FMT_STRING("{:.{}g}"), value, precision);
   }
 
-} // namespace io
-} // namespace infomap
+} // namespace infomap::io

--- a/src/utils/infomath.h
+++ b/src/utils/infomath.h
@@ -35,8 +35,7 @@
 #define INFOMAP_AVX2_LOG 1
 #endif
 
-namespace infomap {
-namespace infomath {
+namespace infomap::infomath {
 
   using std::log2;
 
@@ -215,7 +214,6 @@ namespace infomath {
     return tsallisEntropyUniform(k, q) * baseCorrection + offsetCorrection;
   }
 
-} // namespace infomath
-} // namespace infomap
+} // namespace infomap::infomath
 
 #endif // INFOMATH_H_

--- a/test/cpp/test_utils_io.cpp
+++ b/test/cpp/test_utils_io.cpp
@@ -11,6 +11,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+#include <filesystem>
 #include <iomanip>
 #include <iostream>
 #include <limits>
@@ -329,7 +330,7 @@ TEST_CASE("ensureDirectoryExists creates a deep directory chain [fast][core][uti
 
   infomap::ensureDirectoryExists(leaf);
 
-  CHECK(infomap::isDirectory(leaf));
+  CHECK(std::filesystem::is_directory(leaf));
   // Idempotent: a second call on an existing chain is a no-op, not an error.
   CHECK_NOTHROW(infomap::ensureDirectoryExists(leaf));
 }


### PR DESCRIPTION
## Summary

Follow-ups to the C++14 → C++17 migration, from a sweep for missed wins.

**Hot-path lookup elision (perf):**
- `MetaMapEquation`: `getDeltaCodelengthOnMovingNode` / `updateCodelengthOnMovingNode` touch only two modules but did **four** `std::map::operator[]` traversals each. Hoist the two `MetaCollection` references once and pass them into `getCurrentModuleMetaCodelength`, halving the red-black-tree walks on the innermost `--meta-data` optimizer loop.
- `Network::addMultilayerInterLink`: fold the `find` + `operator[]` double lookup into a single `try_emplace`; `addMultilayerNode` reuses its already-bound `layerIt` reference instead of re-indexing the outer map.

**ODR / code-size cleanup (spirit of #725):**
- `ArgType`'s string/map constants and `Log`'s four static members become C++17 `inline` variables, deleting their out-of-line definitions. `InfomapBase::SUPER_LEVEL_ADDITION` becomes `static constexpr`. (This exhausts the remaining out-of-line static-definition sites — verified none are left.)

**std::filesystem:**
- `SafeFile.h` hand-rolled recursive directory creation over `stat`/`mkdir`/`_mkdir` plus Windows drive/UNC-root helpers. `std::filesystem::create_directories` does it all natively, so `ensureDirectoryExists` collapses to one call, `pathExists` wraps `std::filesystem::exists`, and the helpers plus every `#ifdef _WIN32` branch here are gone (−60 lines). `InfomapError` wrapping preserved.

**[[nodiscard]] sweep (finishes #727):**
- The attribute on the pure getters #727 left unmarked, across `Config`, `InfomapError` (`code()`; `exitCodeValue` now `constexpr`), `InfomapBase` (+ missing `const` on `getMaxEntropy`/`getMaxFlow`), `StateNetwork`, `Network`, `MapEquation`/`LossyMapEquation`, `ClusterMap`. Mutating accessors/setters left alone.

**Readability (Tier 3):**
- `std::lock_guard<std::mutex>` → `std::scoped_lock` (CTAD) in `TimingRegistry` and the trial loop.
- Nested namespaces collapsed to `namespace infomap::infomath` / `infomap::io` / `infomap::input`.
- `find` + `if` folded into `if`-init where the handle is branch-local (`addMultilayerNode`, the two `ClusterMap` multilayer remaps).
- `writeJsonObjectPrefix` writes `size()-1` bytes instead of copying via `substr`; dead `clusterData` local removed.

**SWIG:** the added `const` on `getMaxEntropy`/`getMaxFlow` changes SWIG dispatch, so the tracked R and Python wrappers are regenerated (SWIG 4.4.1); the rest of the changes produce no wrapper churn.

## Verification

- `cmake --build` clean (Release), no new warnings; `ctest` full suite **22/22 pass**.
- R and Python SWIG freshness checks pass locally.
- Meta path unchanged (codelength 3.106223636); multilayer auto-detect and states→`.clu`→re-read round-trips run clean; deep-directory output (`out/a/b/c/`, none pre-existing) works and is idempotent.

## Notes

An `InfomapIterator` `insert(make_pair(...))` → `try_emplace` change was investigated and **rejected**: `InfoNode` has a shallow copy constructor and a destructor that rewires sibling/parent pointers, so the two forms are not equivalent (temporary-copy destructors are load-bearing). It regressed the states-network round-trip test, so that call site is left as-is.

Deliberately **not** included: `strtod`→`from_chars` on the link-weight path. Floating-point `from_chars` only landed recently in libc++ (~LLVM 20), the real portability risk given macOS builds — GCC/MSVC are fine, libc++ is not guaranteed. The `if`-init folds in `Config::adaptDefaults` / the `Output` metadata lambda were skipped (the handle is used after the `if`), as were the `std::optional` conversions of the bool-out-param helpers (bool + out-param is the right idiom there — `parse()` writes through a reference to a config member).