### PR TITLE
Revert C++17 follow-up refactors (#725–#730)

### DIFF
--- a/interfaces/R/generated/infomap_wrap.cpp
+++ b/interfaces/R/generated/infomap_wrap.cpp
@@ -40648,12 +40648,12 @@ R_swig_InfomapBase_getMaxEntropy ( SEXP self, SEXP s_swig_copy)
     
     res1 = SWIG_R_ConvertPtr(self, &argp1, SWIGTYPE_p_infomap__InfomapBase, 0 |  0 );
     if (!SWIG_IsOK(res1)) {
-      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapBase_getMaxEntropy" "', argument " "1"" of type '" "infomap::InfomapBase const *""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapBase_getMaxEntropy" "', argument " "1"" of type '" "infomap::InfomapBase *""'"); 
     }
     arg1 = reinterpret_cast< infomap::InfomapBase * >(argp1);
     {
       try {
-        result = (double)((infomap::InfomapBase const *)arg1)->getMaxEntropy();
+        result = (double)(arg1)->getMaxEntropy();
       } catch (const std::exception& e) {
         SWIG_exception(SWIG_RuntimeError, e.what());
       }
@@ -40684,12 +40684,12 @@ R_swig_InfomapBase_getMaxFlow ( SEXP self, SEXP s_swig_copy)
     
     res1 = SWIG_R_ConvertPtr(self, &argp1, SWIGTYPE_p_infomap__InfomapBase, 0 |  0 );
     if (!SWIG_IsOK(res1)) {
-      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapBase_getMaxFlow" "', argument " "1"" of type '" "infomap::InfomapBase const *""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapBase_getMaxFlow" "', argument " "1"" of type '" "infomap::InfomapBase *""'"); 
     }
     arg1 = reinterpret_cast< infomap::InfomapBase * >(argp1);
     {
       try {
-        result = (double)((infomap::InfomapBase const *)arg1)->getMaxFlow();
+        result = (double)(arg1)->getMaxFlow();
       } catch (const std::exception& e) {
         SWIG_exception(SWIG_RuntimeError, e.what());
       }

--- a/interfaces/python/generated/infomap_wrap.cpp
+++ b/interfaces/python/generated/infomap_wrap.cpp
@@ -47810,12 +47810,12 @@ SWIGINTERN PyObject *_wrap_InfomapBase_getMaxEntropy(PyObject *self, PyObject *a
   swig_obj[0] = args;
   res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__InfomapBase, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapBase_getMaxEntropy" "', argument " "1"" of type '" "infomap::InfomapBase const *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapBase_getMaxEntropy" "', argument " "1"" of type '" "infomap::InfomapBase *""'"); 
   }
   arg1 = reinterpret_cast< infomap::InfomapBase * >(argp1);
   {
     try {
-      result = (double)((infomap::InfomapBase const *)arg1)->getMaxEntropy();
+      result = (double)(arg1)->getMaxEntropy();
     } catch (const std::exception& e) {
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
@@ -47840,12 +47840,12 @@ SWIGINTERN PyObject *_wrap_InfomapBase_getMaxFlow(PyObject *self, PyObject *args
   swig_obj[0] = args;
   res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__InfomapBase, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapBase_getMaxFlow" "', argument " "1"" of type '" "infomap::InfomapBase const *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapBase_getMaxFlow" "', argument " "1"" of type '" "infomap::InfomapBase *""'"); 
   }
   arg1 = reinterpret_cast< infomap::InfomapBase * >(argp1);
   {
     try {
-      result = (double)((infomap::InfomapBase const *)arg1)->getMaxFlow();
+      result = (double)(arg1)->getMaxFlow();
     } catch (const std::exception& e) {
       SWIG_exception(SWIG_RuntimeError, e.what());
     }

--- a/src/Infomap.h
+++ b/src/Infomap.h
@@ -79,21 +79,21 @@ public:
   void addNode(unsigned int id, std::string name, double weight) { m_network.addNode(id, std::move(name), weight); }
 
   void addName(unsigned int id, const std::string& name) { m_network.addName(id, name); }
-  [[nodiscard]] std::string getName(unsigned int id) const
+  std::string getName(unsigned int id) const
   {
     auto& names = m_network.names();
     auto it = names.find(id);
     return it != names.end() ? it->second : "";
   }
 
-  [[nodiscard]] const std::map<unsigned int, std::string>& getNames() const { return m_network.names(); }
+  const std::map<unsigned int, std::string>& getNames() const { return m_network.names(); }
 
   // State-id -> name for higher-order (state/memory) networks. Physical names
   // live in getNames(), keyed by physical id; state nodes carry their own
   // optional name parsed from the *States section (StateNode::name). Only
   // non-empty names are returned, so a first-order network (no per-state names)
   // yields an empty map and callers fall back to the physical name.
-  [[nodiscard]] std::map<unsigned int, std::string> getStateNames() const
+  std::map<unsigned int, std::string> getStateNames() const
   {
     std::map<unsigned int, std::string> stateNames;
     for (const auto& entry : m_network.nodes()) {
@@ -106,7 +106,7 @@ public:
   // Name of a single state node, or "" if the id is unknown or unnamed. The
   // scalar counterpart of getStateNames(), mirroring getName(); the R binding
   // walks state nodes calling this since SWIG-R exposes std::map opaquely.
-  [[nodiscard]] std::string getStateName(unsigned int stateId) const
+  std::string getStateName(unsigned int stateId) const
   {
     const auto& nodes = m_network.nodes();
     auto it = nodes.find(stateId);
@@ -150,7 +150,7 @@ public:
   // add_multilayer_* / setMultilayerInitialPartition APIs. The network must be
   // built first (state nodes are created on the fly). Throws std::out_of_range
   // if the combination is not present (issue #616).
-  [[nodiscard]] unsigned int getMultilayerStateId(unsigned int layerId, unsigned int nodeId) const
+  unsigned int getMultilayerStateId(unsigned int layerId, unsigned int nodeId) const
   {
     const auto& map = m_network.layerNodeToStateId();
     auto layerIt = map.find(layerId);
@@ -164,7 +164,7 @@ public:
 
   void setBipartiteStartId(unsigned int startId) { m_network.setBipartiteStartId(startId); }
 
-  [[nodiscard]] std::map<std::pair<unsigned int, unsigned int>, double> getLinks(bool flow) const
+  std::map<std::pair<unsigned int, unsigned int>, double> getLinks(bool flow) const
   {
     std::map<std::pair<unsigned int, unsigned int>, double> links;
 
@@ -176,7 +176,7 @@ public:
   }
 
 #ifndef SWIGPYTHON
-  [[nodiscard]] std::vector<LinkResult> getLinkResults() const
+  std::vector<LinkResult> getLinkResults() const
   {
     std::vector<LinkResult> links;
     links.reserve(m_network.numLinks());
@@ -189,7 +189,7 @@ public:
   }
 #endif
 
-  [[nodiscard]] std::map<unsigned int, unsigned int> getModules(int level = 1, bool states = false)
+  std::map<unsigned int, unsigned int> getModules(int level = 1, bool states = false)
   {
     if (haveMemory() && !states) {
       throw std::runtime_error("Cannot get modules on higher-order network without states.");
@@ -208,7 +208,7 @@ public:
   // (above) so SWIG wraps its parallel-vector members for Python. Excluded from
   // the R binding together with NodeData (see the struct's #ifndef SWIGR note).
 #ifndef SWIGR
-  [[nodiscard]] NodeData getNodeData(int level = 1, bool states = false)
+  NodeData getNodeData(int level = 1, bool states = false)
   {
     // Mirror _results.get_nodes: physical iterator for higher-order networks
     // unless state-level data is requested.

--- a/src/core/InfoNode.cpp
+++ b/src/core/InfoNode.cpp
@@ -355,7 +355,8 @@ void InfoNode::calcChildDegree() noexcept
     m_childDegree = 1;
   else {
     m_childDegree = 0;
-    for ([[maybe_unused]] auto& child : children()) {
+    for (auto& child : children()) {
+      (void)child;
       ++m_childDegree;
     }
   }

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -415,12 +415,12 @@ private:
           m_timing.recordTrial(trialIndex, threadNumber, trialSeed, trialTime, trialCodelength, trialTopModules, trialNumLevels);
 
           if (worker.printAllTrials && m_numTrials > 1) {
-            std::scoped_lock lock(outputMutex);
+            std::lock_guard<std::mutex> lock(outputMutex);
             auto outputTimer = m_timing.scope("output_s");
             worker.writeResult(static_cast<int>(globalIndex + 1));
           }
 
-          std::scoped_lock lock(bestResultMutex);
+          std::lock_guard<std::mutex> lock(bestResultMutex);
           const auto bestIndexMissing = result.bestTrialIndex >= m_numTrials;
           const auto isBetter = trialCodelength < result.bestHierarchicalCodelength - 1e-10;
           const auto isEarlierTie = std::abs(trialCodelength - result.bestHierarchicalCodelength) < 1e-10 && trialIndex < result.bestTrialIndex;
@@ -433,14 +433,14 @@ private:
             result.bestTree = std::move(trialTree);
           }
         } catch (const std::exception& e) {
-          std::scoped_lock lock(errorMutex);
+          std::lock_guard<std::mutex> lock(errorMutex);
           if (!hasError || trialIndex < firstErrorTrial) {
             hasError = true;
             firstErrorTrial = trialIndex;
             firstError = e.what();
           }
         } catch (...) {
-          std::scoped_lock lock(errorMutex);
+          std::lock_guard<std::mutex> lock(errorMutex);
           if (!hasError || trialIndex < firstErrorTrial) {
             hasError = true;
             firstErrorTrial = trialIndex;

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -240,7 +240,8 @@ public:
     Console console;
     console.section(fmt::format(FMT_STRING("Summary after {}{}"), m_trialsRun, m_trialsRun > 1 ? " trials" : " trial"));
     if (m_autoStopped) {
-      Console::detail(0, "auto: stopped after {} trials (no improvement in last {})", m_trialsRun, Config::convergePatience);
+      const unsigned int patience = Config::convergePatience;
+      Console::detail(0, "auto: stopped after {} trials (no improvement in last {})", m_trialsRun, patience);
     }
     std::string codelengthRange;
     std::string topModulesRange;

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1216,13 +1216,13 @@ InfomapBase& InfomapBase::initTree(const NodePaths& tree)
     Path prefix;
     for (size_t i = 0; i + 1 < path.size(); ++i) {
       prefix.push_back(path[i]);
-      auto [it, inserted] = moduleByPathPrefix.emplace(prefix, nullptr);
-      if (inserted) {
+      auto inserted = moduleByPathPrefix.emplace(prefix, nullptr);
+      if (inserted.second) {
         auto* module = &allocNode();
         parent->addChild(module);
-        it->second = module;
+        inserted.first->second = module;
       }
-      parent = it->second;
+      parent = inserted.first->second;
     }
 
     parent->addChild(leafNode);

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -102,57 +102,57 @@ public:
   // ===================================================
 
   Network& network() { return m_network; }
-  [[nodiscard]] const Network& network() const { return m_network; }
+  const Network& network() const { return m_network; }
 
   InfoNode& root() { return m_root; }
-  [[nodiscard]] const InfoNode& root() const { return m_root; }
+  const InfoNode& root() const { return m_root; }
 
-  [[nodiscard]] unsigned int numLeafNodes() const { return m_leafNodes.size(); }
+  unsigned int numLeafNodes() const { return m_leafNodes.size(); }
 
   const std::vector<InfoNode*>& leafNodes() const { return m_leafNodes; }
 
-  [[nodiscard]] unsigned int numTopModules() const { return m_root.childDegree(); }
+  unsigned int numTopModules() const { return m_root.childDegree(); }
 
   unsigned int numActiveModules() const { return m_optimizer->numActiveModules(); }
 
-  [[nodiscard]] unsigned int numNonTrivialTopModules() const { return m_numNonTrivialTopModules; }
+  unsigned int numNonTrivialTopModules() const { return m_numNonTrivialTopModules; }
 
-  [[nodiscard]] bool haveModules() const { return !m_root.isLeaf() && !m_root.firstChild->isLeaf(); }
+  bool haveModules() const { return !m_root.isLeaf() && !m_root.firstChild->isLeaf(); }
 
-  [[nodiscard]] bool haveNonTrivialModules() const { return numNonTrivialTopModules() > 0; }
+  bool haveNonTrivialModules() const { return numNonTrivialTopModules() > 0; }
 
   /**
    * Number of node levels below the root in current Infomap instance, 1 if no modules
    */
-  [[nodiscard]] unsigned int numLevels() const;
+  unsigned int numLevels() const;
 
   /**
    * Get maximum depth of any child in the tree, following possible sub Infomap instances
    */
-  [[nodiscard]] unsigned int maxTreeDepth() const;
+  unsigned int maxTreeDepth() const;
 
-  [[nodiscard]] double getCodelength() const { return m_optimizer->getCodelength(); }
+  double getCodelength() const { return m_optimizer->getCodelength(); }
 
-  [[nodiscard]] double getMetaCodelength(bool unweighted = false) const { return m_optimizer->getMetaCodelength(unweighted); }
+  double getMetaCodelength(bool unweighted = false) const { return m_optimizer->getMetaCodelength(unweighted); }
 
-  [[nodiscard]] double codelength() const { return m_hierarchicalCodelength; }
+  double codelength() const { return m_hierarchicalCodelength; }
 
-  [[nodiscard]] const std::vector<double>& codelengths() const { return m_codelengths; }
+  const std::vector<double>& codelengths() const { return m_codelengths; }
 
-  [[nodiscard]] double getIndexCodelength() const { return m_optimizer->getIndexCodelength(); }
+  double getIndexCodelength() const { return m_optimizer->getIndexCodelength(); }
 
-  [[nodiscard]] double getModuleCodelength() const { return m_hierarchicalCodelength - m_optimizer->getIndexCodelength(); }
+  double getModuleCodelength() const { return m_hierarchicalCodelength - m_optimizer->getIndexCodelength(); }
 
-  [[nodiscard]] double getHierarchicalCodelength() const { return m_hierarchicalCodelength; }
+  double getHierarchicalCodelength() const { return m_hierarchicalCodelength; }
 
-  [[nodiscard]] double getOneLevelCodelength() const { return m_oneLevelCodelength; }
+  double getOneLevelCodelength() const { return m_oneLevelCodelength; }
 
 #ifndef SWIG
   // One-level reference reported to the user. In lossy mode this is the lossless
   // L_1 = H(p_alpha) (a lambda-independent upper bound), not the lambda-dependent
   // corrected one-module objective that m_oneLevelCodelength holds for the optimizer.
   // Guarded from SWIG so it is not exposed as a new binding; callers below use it.
-  [[nodiscard]] double getReferenceOneLevelCodelength() const
+  double getReferenceOneLevelCodelength() const
   {
 #if INFOMAP_FEATURE_LOSSY_MAP_EQUATION
     if (lossy)
@@ -162,25 +162,25 @@ public:
   }
 #endif
 
-  [[nodiscard]] double getRelativeCodelengthSavings() const
+  double getRelativeCodelengthSavings() const
   {
     auto oneLevelCodelength = getReferenceOneLevelCodelength();
     return oneLevelCodelength < 1e-16 ? 0 : 1.0 - codelength() / oneLevelCodelength;
   }
 
 #ifndef SWIG
-  [[nodiscard]] double getRelativeCodelengthSavings(double codelength) const
+  double getRelativeCodelengthSavings(double codelength) const
   {
     auto oneLevelCodelength = getReferenceOneLevelCodelength();
     return oneLevelCodelength < 1e-16 ? 0 : 1.0 - codelength / oneLevelCodelength;
   }
 #endif
 
-  [[nodiscard]] double getEntropyRate() { return m_entropyRate; }
+  double getEntropyRate() { return m_entropyRate; }
 #if INFOMAP_FEATURE_LOSSY_MAP_EQUATION
-  [[nodiscard]] double getLossyRate() const { return m_optimizer->getLossyRate(); }
-  [[nodiscard]] double getLossyDistortion() const { return m_optimizer->getLossyDistortion(); }
-  [[nodiscard]] double getLossyOneLevelLossless() const { return m_optimizer->getLossyOneLevelLossless(); }
+  double getLossyRate() const { return m_optimizer->getLossyRate(); }
+  double getLossyDistortion() const { return m_optimizer->getLossyDistortion(); }
+  double getLossyOneLevelLossless() const { return m_optimizer->getLossyOneLevelLossless(); }
   // 1-based indices of the top modules that are noise modules (l_i > lambda * H_i).
   std::vector<unsigned int> noiseTopModules() const;
 #endif
@@ -192,7 +192,7 @@ public:
 
   std::vector<InfoNode*>& activeNetwork() const { return *m_activeNetwork; }
 
-  [[nodiscard]] std::map<unsigned int, std::vector<unsigned int>> getMultilevelModules(bool states = false);
+  std::map<unsigned int, std::vector<unsigned int>> getMultilevelModules(bool states = false);
 
   // ===================================================
   // IO

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -109,11 +109,11 @@ public:
 
   [[nodiscard]] unsigned int numLeafNodes() const { return m_leafNodes.size(); }
 
-  [[nodiscard]] const std::vector<InfoNode*>& leafNodes() const { return m_leafNodes; }
+  const std::vector<InfoNode*>& leafNodes() const { return m_leafNodes; }
 
   [[nodiscard]] unsigned int numTopModules() const { return m_root.childDegree(); }
 
-  [[nodiscard]] unsigned int numActiveModules() const { return m_optimizer->numActiveModules(); }
+  unsigned int numActiveModules() const { return m_optimizer->numActiveModules(); }
 
   [[nodiscard]] unsigned int numNonTrivialTopModules() const { return m_numNonTrivialTopModules; }
 
@@ -182,10 +182,10 @@ public:
   [[nodiscard]] double getLossyDistortion() const { return m_optimizer->getLossyDistortion(); }
   [[nodiscard]] double getLossyOneLevelLossless() const { return m_optimizer->getLossyOneLevelLossless(); }
   // 1-based indices of the top modules that are noise modules (l_i > lambda * H_i).
-  [[nodiscard]] std::vector<unsigned int> noiseTopModules() const;
+  std::vector<unsigned int> noiseTopModules() const;
 #endif
-  [[nodiscard]] double getMaxEntropy() const { return m_maxEntropy; }
-  [[nodiscard]] double getMaxFlow() const { return m_maxFlow; }
+  double getMaxEntropy() { return m_maxEntropy; }
+  double getMaxFlow() { return m_maxFlow; }
 
   const Date& getStartDate() const { return m_startDate; }
   const Stopwatch& getElapsedTime() const { return m_elapsedTime; }
@@ -654,7 +654,7 @@ protected:
   // resolved to state ids in initTrialPartition once the network is built.
   std::vector<std::array<unsigned int, 3>> m_multilayerInitialPartition;
 
-  static constexpr unsigned int SUPER_LEVEL_ADDITION = 1 << 20;
+  const unsigned int SUPER_LEVEL_ADDITION = 1 << 20;
   bool m_isMain = true;
   unsigned int m_subLevel = 0;
 

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -1000,17 +1000,18 @@ inline void InfomapOptimizer<Objective>::consolidateModules(bool replaceExisting
         // If undirected, the order may be swapped to aggregate the edge on an opposite one
         if (m_infomap->isUndirectedClustering() && m1 > m2)
           std::swap(m1, m2);
-        auto [it, inserted] = moduleLinks.try_emplace(NodePair(m1, m2), edge.data.flow);
-        if (!inserted) {
-          it->second += edge.data.flow;
+        auto ret = moduleLinks.insert(std::make_pair(NodePair(m1, m2), edge.data.flow));
+        if (!ret.second) {
+          ret.first->second += edge.data.flow;
         }
       }
     }
   }
 
   // Add the aggregated edge flow structure to the new modules
-  for (const auto& [nodePair, flow] : moduleLinks) {
-    modules[nodePair.first]->addOutEdge(*modules[nodePair.second], 0.0, flow);
+  for (auto& e : moduleLinks) {
+    const auto& nodePair = e.first;
+    modules[nodePair.first]->addOutEdge(*modules[nodePair.second], 0.0, e.second);
   }
 
   if (replaceExistingModules) {

--- a/src/core/LossyMapEquation.h
+++ b/src/core/LossyMapEquation.h
@@ -38,19 +38,19 @@ public:
   // Getters
   // ===================================================
 
-  [[nodiscard]] double getIndexCodelength() const { return indexCodelength; }
+  double getIndexCodelength() const { return indexCodelength; }
 
-  [[nodiscard]] double getModuleCodelength() const { return moduleCodelength - m_sumCorrection; }
+  double getModuleCodelength() const { return moduleCodelength - m_sumCorrection; }
 
-  [[nodiscard]] double getCodelength() const { return codelength - m_sumCorrection; } // J_lambda
+  double getCodelength() const { return codelength - m_sumCorrection; } // J_lambda
 
-  [[nodiscard]] double getLossyRate() const { return codelength - m_sumNoiseLoss; } // L_lossy
+  double getLossyRate() const { return codelength - m_sumNoiseLoss; } // L_lossy
 
-  [[nodiscard]] double getLossyDistortion() const { return m_sumNoiseEntropy; } // D
+  double getLossyDistortion() const { return m_sumNoiseEntropy; } // D
 
   // L_1 = H(p_alpha): the lossless one-level reference, captured in calcCodelength
   // of the root. Independent of lambda; used for reporting and relative savings.
-  [[nodiscard]] double getOneLevelLossless() const { return m_oneLevelLossless; }
+  double getOneLevelLossless() const { return m_oneLevelLossless; }
 
   // ===================================================
   // IO

--- a/src/core/MapEquation.h
+++ b/src/core/MapEquation.h
@@ -76,11 +76,11 @@ public:
   // Getters
   // ===================================================
 
-  [[nodiscard]] double getIndexCodelength() const { return indexCodelength; }
+  double getIndexCodelength() const { return indexCodelength; }
 
-  [[nodiscard]] double getModuleCodelength() const { return moduleCodelength; }
+  double getModuleCodelength() const { return moduleCodelength; }
 
-  [[nodiscard]] double getCodelength() const { return codelength; }
+  double getCodelength() const { return codelength; }
 
   // ===================================================
   // IO

--- a/src/core/MetaMapEquation.cpp
+++ b/src/core/MetaMapEquation.cpp
@@ -175,24 +175,20 @@ INFOMAP_HOT double MetaMapEquation::getDeltaCodelengthOnMovingNode(InfoNode& cur
   unsigned int oldModuleIndex = oldModuleDelta.module;
   unsigned int newModuleIndex = newModuleDelta.module;
 
-  // Hoist the two module lookups: the four codelength queries below only touch
-  // these two modules, so a single map traversal each suffices.
-  auto& oldModuleMeta = m_moduleToMetaCollection[oldModuleIndex];
-  auto& newModuleMeta = m_moduleToMetaCollection[newModuleIndex];
-
   // Remove codelength of old and new module before changes
-  deltaMetaL -= getCurrentModuleMetaCodelength(oldModuleMeta, current, 0);
-  deltaMetaL -= getCurrentModuleMetaCodelength(newModuleMeta, current, 0);
+  deltaMetaL -= getCurrentModuleMetaCodelength(oldModuleIndex, current, 0);
+  deltaMetaL -= getCurrentModuleMetaCodelength(newModuleIndex, current, 0);
   // Add codelength of old module with current node removed
-  deltaMetaL += getCurrentModuleMetaCodelength(oldModuleMeta, current, -1);
+  deltaMetaL += getCurrentModuleMetaCodelength(oldModuleIndex, current, -1);
   // Add codelength of old module with current node added
-  deltaMetaL += getCurrentModuleMetaCodelength(newModuleMeta, current, 1);
+  deltaMetaL += getCurrentModuleMetaCodelength(newModuleIndex, current, 1);
 
   return deltaL + deltaMetaL * metaDataRate;
 }
 
-double MetaMapEquation::getCurrentModuleMetaCodelength(MetaCollection& currentMetaCollection, InfoNode& current, int addRemoveOrNothing)
+double MetaMapEquation::getCurrentModuleMetaCodelength(unsigned int module, InfoNode& current, int addRemoveOrNothing)
 {
+  auto& currentMetaCollection = m_moduleToMetaCollection[module];
   const MetaCollection* nodeMeta = current.metaCollectionPtr();
 
   double moduleMetaCodelength = 0.0;
@@ -231,21 +227,16 @@ void MetaMapEquation::updateCodelengthOnMovingNode(InfoNode& current,
   unsigned int oldModuleIndex = oldModuleDelta.module;
   unsigned int newModuleIndex = newModuleDelta.module;
 
-  // Hoist the two module lookups; the references stay valid across
-  // updateMetaData, which mutates these collections in place.
-  auto& oldModuleMeta = m_moduleToMetaCollection[oldModuleIndex];
-  auto& newModuleMeta = m_moduleToMetaCollection[newModuleIndex];
-
   // Remove codelength of old and new module before changes
-  deltaMetaL -= getCurrentModuleMetaCodelength(oldModuleMeta, current, 0);
-  deltaMetaL -= getCurrentModuleMetaCodelength(newModuleMeta, current, 0);
+  deltaMetaL -= getCurrentModuleMetaCodelength(oldModuleIndex, current, 0);
+  deltaMetaL -= getCurrentModuleMetaCodelength(newModuleIndex, current, 0);
 
   // Update meta data from moving node
   updateMetaData(current, oldModuleIndex, newModuleIndex);
 
   // Add codelength of old and new module after changes
-  deltaMetaL += getCurrentModuleMetaCodelength(oldModuleMeta, current, 0);
-  deltaMetaL += getCurrentModuleMetaCodelength(newModuleMeta, current, 0);
+  deltaMetaL += getCurrentModuleMetaCodelength(oldModuleIndex, current, 0);
+  deltaMetaL += getCurrentModuleMetaCodelength(newModuleIndex, current, 0);
 
   metaCodelength += deltaMetaL;
 }

--- a/src/core/MetaMapEquation.h
+++ b/src/core/MetaMapEquation.h
@@ -151,7 +151,7 @@ private:
    * @param addRemoveOrNothing +1, -1 or 0 to calculate codelength
    * as if current node was added, removed or untouched in current module
    */
-  double getCurrentModuleMetaCodelength(MetaCollection& metaCollection, InfoNode& current, int addRemoveOrNothing);
+  double getCurrentModuleMetaCodelength(unsigned int module, InfoNode& current, int addRemoveOrNothing);
 
   // ===================================================
   // Private member variables

--- a/src/core/ObjectPool.h
+++ b/src/core/ObjectPool.h
@@ -102,7 +102,7 @@ public:
   }
 
   template <typename... Args>
-  [[nodiscard]] T* alloc(Args&&... args)
+  T* alloc(Args&&... args)
   {
     T* slot;
     if (!m_free.empty()) {
@@ -144,8 +144,8 @@ public:
     m_chunks.emplace_back(n - m_free.size());
   }
 
-  [[nodiscard]] std::size_t liveCount() const noexcept { return m_liveCount; }
-  [[nodiscard]] std::size_t chunkCount() const noexcept { return m_chunks.size(); }
+  std::size_t liveCount() const noexcept { return m_liveCount; }
+  std::size_t chunkCount() const noexcept { return m_chunks.size(); }
 };
 
 } // namespace infomap

--- a/src/core/StateNetwork.cpp
+++ b/src/core/StateNetwork.cpp
@@ -66,11 +66,11 @@ std::pair<StateNetwork::NodeMap::iterator, bool> StateNetwork::addNode(unsigned 
 
 StateNetwork::PhysNode& StateNetwork::addPhysicalNode(unsigned int physId)
 {
-  auto [it, inserted] = m_physNodes.emplace(physId, PhysNode(physId));
-  if (inserted) {
+  auto result = m_physNodes.emplace(physId, PhysNode(physId));
+  if (result.second) {
     ++m_numPhysicalNodesFound; // count uniques so numPhysicalNodes() survives a freed map
   }
-  auto& physNode = it->second;
+  auto& physNode = result.first->second;
   physNode.physId = physId;
   m_sumNodeWeight += 1.0;
   return physNode;
@@ -103,7 +103,7 @@ StateNetwork::PhysNode& StateNetwork::addPhysicalNode(unsigned int physId, doubl
 
 std::pair<std::map<unsigned int, std::string>::iterator, bool> StateNetwork::addName(unsigned int id, const std::string& name)
 {
-  return m_names.try_emplace(id, name);
+  return m_names.insert(std::make_pair(id, name));
 }
 
 bool StateNetwork::addLink(unsigned int sourceId, unsigned int targetId, double weight)

--- a/src/core/StateNetwork.h
+++ b/src/core/StateNetwork.h
@@ -194,15 +194,15 @@ public:
   virtual void clearLinks();
 
   // Getters
-  [[nodiscard]] const NodeMap& nodes() const { return m_nodes; }
-  [[nodiscard]] unsigned int numNodes() const { return m_nodes.size(); }
-  [[nodiscard]] unsigned int numPhysicalNodes() const { return m_numPhysicalNodesFound; }
-  [[nodiscard]] double sumNodeWeight() const { return m_sumNodeWeight; }
+  const NodeMap& nodes() const { return m_nodes; }
+  unsigned int numNodes() const { return m_nodes.size(); }
+  unsigned int numPhysicalNodes() const { return m_numPhysicalNodesFound; }
+  double sumNodeWeight() const { return m_sumNodeWeight; }
 #ifndef SWIG
   // Mode B (multilayer) build representation, consumed only by the multilayer
   // expansion in Network. Hidden from the bindings: external callers read links
   // through getLinks()/getLinkResults(), which now serve the consumed CSR store.
-  [[nodiscard]] const NodeLinkMap& nodeLinkMap() const { return m_nodeLinkMap; }
+  const NodeLinkMap& nodeLinkMap() const { return m_nodeLinkMap; }
   NodeLinkMap& nodeLinkMap() { return m_nodeLinkMap; }
 #endif
 
@@ -215,10 +215,10 @@ public:
   {
     if (!m_linksFinalized) const_cast<StateNetwork*>(this)->finalizeLinks();
   }
-  [[nodiscard]] unsigned int nodeId(unsigned int index) const { return m_nodeIds[index]; }
-  [[nodiscard]] unsigned int indexOfId(unsigned int id) const;
-  [[nodiscard]] unsigned int outDegree(unsigned int index) const { return m_linkOffsets[index + 1] - m_linkOffsets[index]; }
-  [[nodiscard]] bool isDangling(unsigned int index) const { return outDegree(index) == 0; }
+  unsigned int nodeId(unsigned int index) const { return m_nodeIds[index]; }
+  unsigned int indexOfId(unsigned int id) const;
+  unsigned int outDegree(unsigned int index) const { return m_linkOffsets[index + 1] - m_linkOffsets[index]; }
+  bool isDangling(unsigned int index) const { return outDegree(index) == 0; }
   // fn(srcIndex, targetIndex, weight, double& flow) in (src,tgt) order. flow is
   // writable (CSR arrays are mutable) so FlowCalculator can write flow back.
   template <typename Fn>
@@ -241,26 +241,26 @@ public:
   // never consumed as CSR. The ensureFinalized() call is guarded so SWIG never
   // parses a reference to the hidden method (the compiled library the wrapper
   // calls still lazy-finalizes).
-  [[nodiscard]] unsigned int numAggregatedLinks() const
+  unsigned int numAggregatedLinks() const
   {
 #ifndef SWIG
     if (!m_useMapBuild) ensureFinalized();
 #endif
     return m_numAggregatedLinks;
   }
-  [[nodiscard]] unsigned int numLinks() const
+  unsigned int numLinks() const
   {
 #ifndef SWIG
     if (!m_useMapBuild) ensureFinalized();
 #endif
     return m_numLinks;
   }
-  [[nodiscard]] double sumLinkWeight() const { return m_sumLinkWeight; }
-  [[nodiscard]] unsigned int numSelfLinks() const { return m_numSelfLinks; }
-  [[nodiscard]] double sumSelfLinkWeight() const { return m_sumSelfLinkWeight; }
+  double sumLinkWeight() const { return m_sumLinkWeight; }
+  unsigned int numSelfLinks() const { return m_numSelfLinks; }
+  double sumSelfLinkWeight() const { return m_sumSelfLinkWeight; }
   // Use convention of counting self-links only once, treating them as directed
-  [[nodiscard]] double sumWeightedDegree() const { return 2 * sumLinkWeight() - sumSelfLinkWeight(); }
-  [[nodiscard]] unsigned int sumDegree() const { return 2 * numLinks() - numSelfLinks(); }
+  double sumWeightedDegree() const { return 2 * sumLinkWeight() - sumSelfLinkWeight(); }
+  unsigned int sumDegree() const { return 2 * numLinks() - numSelfLinks(); }
   std::map<unsigned int, double>& outWeights()
   {
 #ifndef SWIG
@@ -269,24 +269,24 @@ public:
     return m_outWeights;
   }
   std::map<unsigned int, std::string>& names() { return m_names; }
-  [[nodiscard]] const std::map<unsigned int, std::string>& names() const { return m_names; }
-  [[nodiscard]] bool haveNodeWeights() const { return m_haveNodeWeights; }
-  [[nodiscard]] bool haveStateNodeWeights() const { return m_haveStateNodeWeights; }
-  [[nodiscard]] bool haveFileInput() const { return m_haveFileInput; }
+  const std::map<unsigned int, std::string>& names() const { return m_names; }
+  bool haveNodeWeights() const { return m_haveNodeWeights; }
+  bool haveStateNodeWeights() const { return m_haveStateNodeWeights; }
+  bool haveFileInput() const { return m_haveFileInput; }
 
-  [[nodiscard]] virtual const std::map<unsigned int, std::vector<int>>& metaData() const = 0;
+  virtual const std::map<unsigned int, std::vector<int>>& metaData() const = 0;
 
-  [[nodiscard]] bool haveDirectedInput() const { return m_haveDirectedInput; }
-  [[nodiscard]] bool haveMemoryInput() const { return m_haveMemoryInput; }
-  [[nodiscard]] bool higherOrderInputMethodCalled() const { return m_higherOrderInputMethodCalled; }
+  bool haveDirectedInput() const { return m_haveDirectedInput; }
+  bool haveMemoryInput() const { return m_haveMemoryInput; }
+  bool higherOrderInputMethodCalled() const { return m_higherOrderInputMethodCalled; }
   // Bipartite
-  [[nodiscard]] bool isBipartite() const { return m_bipartiteStartId > 0; }
-  [[nodiscard]] unsigned int bipartiteStartId() const { return m_bipartiteStartId; }
+  bool isBipartite() const { return m_bipartiteStartId > 0; }
+  unsigned int bipartiteStartId() const { return m_bipartiteStartId; }
   void setBipartiteStartId(unsigned int value) { m_bipartiteStartId = value; }
   // Multilayer
 #ifndef SWIG
-  [[nodiscard]] unsigned int numLayers() const { return m_layers.size(); }
-  [[nodiscard]] const std::set<unsigned int>& layers() const { return m_layers; }
+  unsigned int numLayers() const { return m_layers.size(); }
+  const std::set<unsigned int>& layers() const { return m_layers; }
 #endif
 
   /**

--- a/src/core/iterators/InfomapIterator.cpp
+++ b/src/core/iterators/InfomapIterator.cpp
@@ -160,9 +160,9 @@ InfomapIterator& InfomapIteratorPhysical::operator++() noexcept
       auto firstLeafIt = *this;
       // If on a leaf node, loop through and aggregate to physical nodes
       while (!isEnd() && m_current->isLeaf()) {
-        auto [it, inserted] = m_physNodes.insert(std::make_pair(m_current->physicalId, InfoNode(*m_current)));
-        auto& physNode = it->second;
-        if (inserted) {
+        auto ret = m_physNodes.insert(std::make_pair(m_current->physicalId, InfoNode(*m_current)));
+        auto& physNode = ret.first->second;
+        if (ret.second) {
           // New physical node, use same parent as the state leaf node
           physNode.parent = m_current->parent;
         } else {

--- a/src/io/ClusterMap.cpp
+++ b/src/io/ClusterMap.cpp
@@ -126,8 +126,10 @@ void ClusterMap::readTree(const std::string& filename, bool includeFlow, const s
 
     if (isMultilayer && m_treeLeafIdType == TreeLeafIdType::state) {
       // Re-map state id from layer/node ids in case the multilayer state ids differ
-      if (auto it = layerNodeToStateId->find(layerId); it != layerNodeToStateId->end()) {
-        if (auto nodeIdToStateId = it->second.find(nodeId); nodeIdToStateId != it->second.end()) {
+      auto it = layerNodeToStateId->find(layerId);
+      if (it != layerNodeToStateId->end()) {
+        auto nodeIdToStateId = it->second.find(nodeId);
+        if (nodeIdToStateId != it->second.end()) {
           stateId = nodeIdToStateId->second;
           multilayerNodeFound = true;
         }
@@ -165,6 +167,7 @@ void ClusterMap::readClu(const std::string& filename, bool includeFlow, const st
   SafeInFile input(filename);
   std::string line;
   std::istringstream lineStream;
+  std::map<unsigned int, unsigned int> clusterData;
 
   while (!std::getline(input, line).fail()) {
     if (line.empty() || line[0] == '#' || line[0] == '*')
@@ -197,8 +200,11 @@ void ClusterMap::readClu(const std::string& filename, bool includeFlow, const st
         throw std::runtime_error(fmt::format(FMT_STRING("Couldn't parse layer id from line '{}'"), line));
 
       // get new state id from map
-      if (auto it = layerNodeToStateId->find(layerId); it != layerNodeToStateId->end()) {
-        if (auto nodeIdToStateId = it->second.find(nodeId); nodeIdToStateId != it->second.end()) {
+      auto it = layerNodeToStateId->find(layerId);
+
+      if (it != layerNodeToStateId->end()) {
+        auto nodeIdToStateId = it->second.find(nodeId);
+        if (nodeIdToStateId != it->second.end()) {
           stateId = nodeIdToStateId->second;
           multilayerNodeFound = true;
         }

--- a/src/io/ClusterMap.h
+++ b/src/io/ClusterMap.h
@@ -40,16 +40,16 @@ class ClusterMap {
 public:
   void readClusterData(const std::string& filename, bool includeFlow = false, const std::map<unsigned int, std::map<unsigned int, unsigned int>>* layerNodeToStateId = nullptr);
 
-  [[nodiscard]] const std::map<unsigned int, unsigned int>& clusterIds() const noexcept
+  const std::map<unsigned int, unsigned int>& clusterIds() const noexcept
   {
     return m_clusterIds;
   }
 
-  [[nodiscard]] const TreePaths& treePaths() const noexcept { return m_treePaths; }
+  const TreePaths& treePaths() const noexcept { return m_treePaths; }
 
-  [[nodiscard]] const std::string& extension() const noexcept { return m_extension; }
+  const std::string& extension() const noexcept { return m_extension; }
 
-  [[nodiscard]] TreeLeafIdType treeLeafIdType() const noexcept { return m_treeLeafIdType; }
+  TreeLeafIdType treeLeafIdType() const noexcept { return m_treeLeafIdType; }
 
 private:
   void readTree(const std::string& filename, bool includeFlow, const std::map<unsigned int, std::map<unsigned int, unsigned int>>* layerNodeToStateId = nullptr);

--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -27,6 +27,13 @@
 
 namespace infomap {
 
+constexpr int FlowModel::undirected;
+constexpr int FlowModel::directed;
+constexpr int FlowModel::undirdir;
+constexpr int FlowModel::outdirdir;
+constexpr int FlowModel::rawdir;
+constexpr int FlowModel::precomputed;
+
 namespace {
 
   const std::vector<std::pair<std::string, FlowModel>>& flowModelMappings()

--- a/src/io/Config.h
+++ b/src/io/Config.h
@@ -299,20 +299,20 @@ struct Config {
     flowModelIsSet = true;
   }
 
-  [[nodiscard]] bool isUndirectedClustering() const { return flowModel == FlowModel::undirected; }
+  bool isUndirectedClustering() const { return flowModel == FlowModel::undirected; }
 
-  [[nodiscard]] bool isUndirectedFlow() const { return flowModel == FlowModel::undirected || flowModel == FlowModel::undirdir; }
+  bool isUndirectedFlow() const { return flowModel == FlowModel::undirected || flowModel == FlowModel::undirdir; }
 
-  [[nodiscard]] bool printAsUndirected() const { return isUndirectedClustering(); }
+  bool printAsUndirected() const { return isUndirectedClustering(); }
 
-  [[nodiscard]] bool isMultilayerNetwork() const { return multilayerInput || !additionalInput.empty(); }
-  [[nodiscard]] bool isBipartite() const { return bipartite; }
+  bool isMultilayerNetwork() const { return multilayerInput || !additionalInput.empty(); }
+  bool isBipartite() const { return bipartite; }
 #ifndef SWIG
-  [[nodiscard]] bool isRegularizedMultilayerFlow() const { return isMultilayerNetwork() && regularized; }
+  bool isRegularizedMultilayerFlow() const { return isMultilayerNetwork() && regularized; }
 #endif
 
   bool haveMemory() const { return stateInput; }
-  [[nodiscard]] bool printStates() const { return stateOutput; }
+  bool printStates() const { return stateOutput; }
 
   bool haveMetaData() const { return !metaDataFile.empty() || numMetaDataDimensions != 0; }
 

--- a/src/io/Config.h
+++ b/src/io/Config.h
@@ -311,18 +311,18 @@ struct Config {
   [[nodiscard]] bool isRegularizedMultilayerFlow() const { return isMultilayerNetwork() && regularized; }
 #endif
 
-  [[nodiscard]] bool haveMemory() const { return stateInput; }
+  bool haveMemory() const { return stateInput; }
   [[nodiscard]] bool printStates() const { return stateOutput; }
 
-  [[nodiscard]] bool haveMetaData() const { return !metaDataFile.empty() || numMetaDataDimensions != 0; }
+  bool haveMetaData() const { return !metaDataFile.empty() || numMetaDataDimensions != 0; }
 
-  [[nodiscard]] bool haveOutput() const { return !noFileOutput; }
+  bool haveOutput() const { return !noFileOutput; }
 
 #ifndef SWIG
-  [[nodiscard]] bool overwriteOutput() const { return !noOverwriteOutput; }
+  bool overwriteOutput() const { return !noOverwriteOutput; }
 #endif
 
-  [[nodiscard]] bool haveModularResultOutput() const
+  bool haveModularResultOutput() const
   {
     return printTree || printFlowTree || printNewick || printJson || printCsv || printClu;
   }

--- a/src/io/InfomapError.h
+++ b/src/io/InfomapError.h
@@ -37,13 +37,13 @@ public:
       : std::runtime_error(message),
         m_code(code) {}
 
-  [[nodiscard]] ExitCode code() const { return m_code; }
+  ExitCode code() const { return m_code; }
 
 private:
   ExitCode m_code;
 };
 
-[[nodiscard]] constexpr int exitCodeValue(ExitCode code)
+inline int exitCodeValue(ExitCode code)
 {
   return static_cast<int>(code);
 }

--- a/src/io/Network.cpp
+++ b/src/io/Network.cpp
@@ -800,12 +800,12 @@ void Network::addMultilayerInterLink(unsigned int layer1, unsigned int n, unsign
   // numLinks() read; an in-memory numLinks() read before expansion just finalizes
   // an empty buffer, which the first expansion addLink re-opens via definalize().)
   auto& interLinks = m_interLinks[LayerNode(layer1, n)];
-  auto [it, inserted] = interLinks.try_emplace(layer2, 0.0);
+  auto it = interLinks.find(layer2);
 
-  if (inserted) {
+  if (it == interLinks.end()) {
     ++m_numInterLayerLinks;
   }
-  it->second += interWeight;
+  interLinks[layer2] += interWeight;
 }
 
 void Network::addMultilayerInterLinks(const std::vector<unsigned int>& sourceLayerIds,
@@ -828,7 +828,9 @@ unsigned int Network::addMultilayerNode(unsigned int layerId, unsigned int physi
 
   // Create state node if not already exist, return state node id
   auto& layerIt = m_layerNodeToStateId[layerId];
-  if (auto it = layerIt.find(physicalId); it != layerIt.end()) {
+  auto it = layerIt.find(physicalId);
+
+  if (it != layerIt.end()) {
     return it->second;
   }
 
@@ -844,7 +846,7 @@ unsigned int Network::addMultilayerNode(unsigned int layerId, unsigned int physi
   auto& stateNode = ret.first->second;
   stateNode.layerId = layerId;
   stateNode.weight = weight;
-  layerIt[physicalId] = stateNode.id;
+  m_layerNodeToStateId[layerId][physicalId] = stateNode.id;
   m_layers.insert(layerId);
   return stateNode.id;
 }
@@ -855,7 +857,9 @@ unsigned int Network::addMultilayerNode(unsigned int stateId, unsigned int layer
 
   // Create state node if not already exist, return state node id
   auto& layerIt = m_layerNodeToStateId[layerId];
-  if (auto it = layerIt.find(physicalId); it != layerIt.end()) {
+  auto it = layerIt.find(physicalId);
+
+  if (it != layerIt.end()) {
     return it->second;
   }
 
@@ -863,7 +867,7 @@ unsigned int Network::addMultilayerNode(unsigned int stateId, unsigned int layer
   auto& stateNode = ret.first->second;
   stateNode.layerId = layerId;
   stateNode.weight = weight;
-  layerIt[physicalId] = stateNode.id;
+  m_layerNodeToStateId[layerId][physicalId] = stateNode.id;
   m_layers.insert(layerId);
   return stateNode.id;
 }

--- a/src/io/Network.h
+++ b/src/io/Network.h
@@ -83,11 +83,11 @@ public:
    */
   virtual void readMetaData(const std::string& filename);
 
-  [[nodiscard]] unsigned int numMetaDataColumns() const { return m_numMetaDataColumns; }
-  [[nodiscard]] const std::map<unsigned int, std::vector<int>>& metaData() const override { return m_metaData; }
+  unsigned int numMetaDataColumns() const { return m_numMetaDataColumns; }
+  const std::map<unsigned int, std::vector<int>>& metaData() const override { return m_metaData; }
 
-  [[nodiscard]] bool isMultilayerNetwork() const { return !m_layerNodeToStateId.empty(); }
-  [[nodiscard]] const std::map<unsigned int, std::map<unsigned int, unsigned int>>& layerNodeToStateId() const { return m_layerNodeToStateId; }
+  bool isMultilayerNetwork() const { return !m_layerNodeToStateId.empty(); }
+  const std::map<unsigned int, std::map<unsigned int, unsigned int>>& layerNodeToStateId() const { return m_layerNodeToStateId; }
 
   void postProcessInputData();
   void generateStateNetworkFromMultilayer();

--- a/src/io/NetworkInputParser.h
+++ b/src/io/NetworkInputParser.h
@@ -28,7 +28,8 @@
 #include <string>
 #include <vector>
 
-namespace infomap::input {
+namespace infomap {
+namespace input {
 
   struct NetworkInputOptions {
     bool undirectedFlow = true;
@@ -528,6 +529,7 @@ namespace infomap::input {
     Console::detail(1, "parsed {} columns of meta data for {} nodes", numMetaDataColumns, numMetaDataRows);
   }
 
-} // namespace infomap::input
+} // namespace input
+} // namespace infomap
 
 #endif // NETWORK_INPUT_PARSER_H_

--- a/src/io/Output.cpp
+++ b/src/io/Output.cpp
@@ -75,8 +75,7 @@ namespace {
   void writeJsonObjectPrefix(std::ostream& outStream, const Json& json)
   {
     const auto dumped = json.dump();
-    // Drop the trailing '}' without copying the whole dump into a substr.
-    outStream.write(dumped.data(), static_cast<std::streamsize>(dumped.size() - 1));
+    outStream << dumped.substr(0, dumped.size() - 1);
   }
 
 } // namespace

--- a/src/io/ProgramInterface.cpp
+++ b/src/io/ProgramInterface.cpp
@@ -54,11 +54,13 @@ namespace {
     for (auto& optionArgument : options) {
       auto& opt = *optionArgument;
       if (opt.shortName != '\0') {
-        if (!lookup.shortOptions.try_emplace(opt.shortName, &opt).second)
+        auto inserted = lookup.shortOptions.insert(std::make_pair(opt.shortName, &opt));
+        if (!inserted.second)
           throw std::runtime_error(fmt::format(FMT_STRING("Duplication of option '{}'"), opt.shortName));
       }
 
-      if (!lookup.longOptions.try_emplace(opt.longName, &opt).second)
+      auto inserted = lookup.longOptions.insert(std::make_pair(opt.longName, &opt));
+      if (!inserted.second)
         throw std::runtime_error(fmt::format(FMT_STRING("Duplication of option \"{}\""), opt.longName));
     }
     return lookup;

--- a/src/io/ProgramInterface.cpp
+++ b/src/io/ProgramInterface.cpp
@@ -19,6 +19,24 @@
 
 namespace infomap {
 
+const std::string ArgType::integer = "integer";
+const std::string ArgType::number = "number";
+const std::string ArgType::string = "string";
+const std::string ArgType::path = "path";
+const std::string ArgType::probability = "probability";
+const std::string ArgType::option = "option";
+const std::string ArgType::list = "list";
+
+const std::unordered_map<std::string, char> ArgType::toShort = {
+  { "integer", 'n' },
+  { "number", 'f' },
+  { "string", 's' },
+  { "path", 'p' },
+  { "probability", 'P' },
+  { "option", 'o' },
+  { "list", 'l' },
+};
+
 namespace {
 
   using ShortOptionMap = std::map<char, Option*>;

--- a/src/io/ProgramInterface.h
+++ b/src/io/ProgramInterface.h
@@ -33,22 +33,14 @@ namespace infomap {
 struct CleanExit {};
 
 struct ArgType {
-  inline static const std::string integer = "integer";
-  inline static const std::string number = "number";
-  inline static const std::string string = "string";
-  inline static const std::string path = "path";
-  inline static const std::string probability = "probability";
-  inline static const std::string option = "option";
-  inline static const std::string list = "list";
-  inline static const std::unordered_map<std::string, char> toShort = {
-    { "integer", 'n' },
-    { "number", 'f' },
-    { "string", 's' },
-    { "path", 'p' },
-    { "probability", 'P' },
-    { "option", 'o' },
-    { "list", 'l' },
-  };
+  static const std::string integer;
+  static const std::string number;
+  static const std::string string;
+  static const std::string path;
+  static const std::string probability;
+  static const std::string option;
+  static const std::string list;
+  static const std::unordered_map<std::string, char> toShort;
 };
 
 struct Option {

--- a/src/io/SafeFile.h
+++ b/src/io/SafeFile.h
@@ -14,15 +14,15 @@
 #include "../utils/format.h"
 #include <atomic>
 #include <ctime>
-#include <filesystem>
 #include <fstream>
 #include <ios>
 #include <cstdio>
 #include <stdexcept>
 #include <string>
-#include <system_error>
+#include <sys/stat.h>
 
 #ifdef _WIN32
+#include <direct.h>
 #include <process.h>
 #else
 #include <unistd.h>
@@ -65,24 +65,69 @@ public:
 
 inline bool pathExists(const std::string& path)
 {
-  std::error_code ec;
-  return std::filesystem::exists(path, ec);
+  struct stat info;
+  return stat(path.c_str(), &info) == 0;
 }
+
+inline bool isDirectory(const std::string& path)
+{
+  struct stat info;
+  if (stat(path.c_str(), &info) != 0)
+    return false;
+  return (info.st_mode & S_IFDIR) != 0;
+}
+
+inline std::string stripTrailingPathSeparators(std::string path)
+{
+  while (path.size() > 1 && (path.back() == '/' || path.back() == '\\'))
+    path.pop_back();
+  return path;
+}
+
+#ifdef _WIN32
+inline bool isWindowsPathRoot(const std::string& path)
+{
+  // Drive root, e.g. "C:".
+  if (path.size() == 2 && path[1] == ':')
+    return true;
+  // UNC root, e.g. "\\server" or "\\server\share": leading "\\" with at most one
+  // path separator after it. Recursing/creating above this point is invalid.
+  if (path.size() >= 2 && (path[0] == '\\' || path[0] == '/') && (path[1] == '\\' || path[1] == '/')) {
+    const auto rest = path.substr(2);
+    const auto firstSep = rest.find_first_of("/\\");
+    if (firstSep == std::string::npos)
+      return true;
+    return rest.find_first_of("/\\", firstSep + 1) == std::string::npos;
+  }
+  return false;
+}
+#endif
 
 inline void ensureDirectoryExists(const std::string& directory)
 {
-  if (directory.empty())
+  if (directory.empty() || isDirectory(directory))
     return;
 
-  // create_directories creates any missing parents and handles trailing
-  // separators and drive/UNC roots, so the previous manual recursion plus the
-  // Windows-root special case collapse into this single call. It returns false
-  // (with ec unset) when the directory already existed, so only a real error
-  // that also left the path a non-directory is fatal.
-  std::error_code ec;
-  std::filesystem::create_directories(directory, ec);
-  std::error_code statusEc;
-  if (ec && !std::filesystem::is_directory(directory, statusEc)) {
+  const auto normalized = stripTrailingPathSeparators(directory);
+#ifdef _WIN32
+  // Never try to create a drive or UNC share root; assume it exists. If it truly
+  // does not, creating a child below will fail with a clear error instead.
+  if (isWindowsPathRoot(normalized))
+    return;
+#endif
+  const auto separator = normalized.find_last_of("/\\");
+  if (separator != std::string::npos) {
+    const auto parent = normalized.substr(0, separator);
+    if (!parent.empty())
+      ensureDirectoryExists(parent);
+  }
+
+#ifdef _WIN32
+  const auto created = _mkdir(normalized.c_str());
+#else
+  const auto created = mkdir(normalized.c_str(), 0777);
+#endif
+  if (created != 0 && !isDirectory(normalized)) {
     throw InfomapError(ExitCode::OutputError, fmt::format(FMT_STRING("Can't create output directory '{}'."), directory));
   }
 }

--- a/src/utils/Console.cpp
+++ b/src/utils/Console.cpp
@@ -85,6 +85,12 @@ Console::Progress Console::progress(const std::string& label) const
 
 Console::Progress::Progress(std::string label) : m_label(std::move(label)) {}
 
+Console::Progress::Progress(Progress&& other) noexcept
+    : m_console(other.m_console), m_label(std::move(other.m_label)), m_live(other.m_live)
+{
+  other.m_live = false;
+}
+
 Console::Progress::~Progress()
 {
   // If updates were drawn but finish() was never reached (e.g. an early return

--- a/src/utils/Console.h
+++ b/src/utils/Console.h
@@ -138,12 +138,10 @@ private:
 class Console::Progress {
 public:
   explicit Progress(std::string label);
-  // Pinned RAII handle for the on-screen line: neither copyable nor movable.
-  // Console::progress() hands one back by value purely via C++17 guaranteed
-  // copy elision — the returned prvalue is constructed directly in the caller,
-  // so no move is needed. Forbidding moves also makes double-ownership of the
-  // live line (two instances each committing a newline) structurally impossible.
-  Progress(Progress&&) = delete;
+  // Movable so Console::progress() can return one by value; the moved-from
+  // instance relinquishes the on-screen line (m_live = false) so only the live
+  // owner commits a newline on destruction. Copying would duplicate ownership.
+  Progress(Progress&& other) noexcept;
   Progress(const Progress&) = delete;
   Progress& operator=(const Progress&) = delete;
   Progress& operator=(Progress&&) = delete;

--- a/src/utils/FlowCalculator.cpp
+++ b/src/utils/FlowCalculator.cpp
@@ -1125,8 +1125,10 @@ void FlowCalculator::calcUndirectedRegularizedFlow(const StateNetwork& network, 
 }
 
 #if INFOMAP_FEATURE_REGULARIZED_MULTILAYER
-void FlowCalculator::calcUndirectedRegularizedMultilayerFlow([[maybe_unused]] const StateNetwork& network, [[maybe_unused]] const Config& config)
+void FlowCalculator::calcUndirectedRegularizedMultilayerFlow(const StateNetwork& network, const Config& config)
 {
+  (void)network;
+  (void)config;
   throw std::runtime_error("Undirected regularized multilayer flow is not implemented.");
 }
 #endif // INFOMAP_FEATURE_REGULARIZED_MULTILAYER

--- a/src/utils/Log.cpp
+++ b/src/utils/Log.cpp
@@ -33,6 +33,11 @@ std::ostream& Log::defaultStream()
 }
 #endif
 
+std::ostream* Log::s_ostream = nullptr;
+unsigned int Log::s_verboseLevel = 0;
+bool Log::s_silent = false;
+thread_local unsigned int Log::s_threadMuteDepth = 0;
+
 void Log::setNoOutput()
 {
   static NullStreambuf nullBuf;

--- a/src/utils/Log.h
+++ b/src/utils/Log.h
@@ -164,10 +164,10 @@ private:
 #ifndef INFOMAP_R
   static std::ostream& defaultStream();
 #endif
-  inline static std::ostream* s_ostream = nullptr;
-  inline static unsigned int s_verboseLevel = 0;
-  inline static bool s_silent = false;
-  inline static thread_local unsigned int s_threadMuteDepth = 0;
+  static std::ostream* s_ostream;
+  static unsigned int s_verboseLevel;
+  static bool s_silent;
+  static thread_local unsigned int s_threadMuteDepth;
 };
 
 struct hideIf {

--- a/src/utils/TimingRegistry.h
+++ b/src/utils/TimingRegistry.h
@@ -75,7 +75,7 @@ public:
 
   void addPhase(const std::string& phase, double seconds)
   {
-    std::scoped_lock lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     for (auto& entry : m_phases) {
       if (entry.first == phase) {
         entry.second += seconds;
@@ -87,7 +87,7 @@ public:
 
   void setPhase(const std::string& phase, double seconds)
   {
-    std::scoped_lock lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     for (auto& entry : m_phases) {
       if (entry.first == phase) {
         entry.second = seconds;
@@ -99,13 +99,13 @@ public:
 
   void resetTrials(unsigned int numTrials)
   {
-    std::scoped_lock lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     m_trials.assign(numTrials, TrialTimingRecord());
   }
 
   void recordTrial(unsigned int trialIndex, int thread, unsigned long seed, double timeSec, double codelength, unsigned int topModules, unsigned int numLevels)
   {
-    std::scoped_lock lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     if (trialIndex >= m_trials.size()) {
       m_trials.resize(trialIndex + 1);
     }
@@ -123,13 +123,13 @@ public:
 
   std::vector<std::pair<std::string, double>> phases() const
   {
-    std::scoped_lock lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     return m_phases;
   }
 
   std::vector<TrialTimingRecord> trials() const
   {
-    std::scoped_lock lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     return m_trials;
   }
 

--- a/src/utils/convert.cpp
+++ b/src/utils/convert.cpp
@@ -10,7 +10,8 @@
 #include "convert.h"
 #include "format.h"
 
-namespace infomap::io {
+namespace infomap {
+namespace io {
 
   std::string toPrecision(double value, unsigned int precision, bool fixed)
   {
@@ -23,4 +24,5 @@ namespace infomap::io {
                  : fmt::format(FMT_STRING("{:.{}g}"), value, precision);
   }
 
-} // namespace infomap::io
+} // namespace io
+} // namespace infomap

--- a/src/utils/infomath.h
+++ b/src/utils/infomath.h
@@ -35,7 +35,8 @@
 #define INFOMAP_AVX2_LOG 1
 #endif
 
-namespace infomap::infomath {
+namespace infomap {
+namespace infomath {
 
   using std::log2;
 
@@ -214,6 +215,7 @@ namespace infomap::infomath {
     return tsallisEntropyUniform(k, q) * baseCorrection + offsetCorrection;
   }
 
-} // namespace infomap::infomath
+} // namespace infomath
+} // namespace infomap
 
 #endif // INFOMATH_H_

--- a/test/cpp/test_utils_io.cpp
+++ b/test/cpp/test_utils_io.cpp
@@ -11,7 +11,6 @@
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
-#include <filesystem>
 #include <iomanip>
 #include <iostream>
 #include <limits>
@@ -330,7 +329,7 @@ TEST_CASE("ensureDirectoryExists creates a deep directory chain [fast][core][uti
 
   infomap::ensureDirectoryExists(leaf);
 
-  CHECK(std::filesystem::is_directory(leaf));
+  CHECK(infomap::isDirectory(leaf));
   // Idempotent: a second call on an existing chain is a no-op, not an error.
   CHECK_NOTHROW(infomap::ensureDirectoryExists(leaf));
 }


### PR DESCRIPTION
Reverts the six C++17 follow-up refactors landed after the standard bump, restoring `master` to exactly the state right after #708 (the C++14→C++17 build bump).

## Why

igraph vendors the Infomap sources and pins the standard globally:

```cmake
set(CMAKE_CXX_STANDARD 14)
set(CMAKE_CXX_STANDARD_REQUIRED True)
```

Its `vendor/infomap/CMakeLists.txt` sets no per-target standard, so the vendored Infomap inherits C++14. The follow-up refactors adopted hard C++17-only constructs (`std::filesystem`, `std::optional`, inline variables, structured bindings, `map::try_emplace`) that do not compile under `-std=c++14`. igraph builds green today only because it still vendors 2.8.0; its next re-vendor would fail to build.

This revert backs those refactors out of `master` while we sort out the vendoring story. #708 itself is behavior-preserving and stays — only the follow-ups are reverted.

## Reverted PRs

- #730 — lookups, ODR, filesystem, nodiscard, readability
- #729 — pin `Console::Progress` via C++17 guaranteed elision
- #728 — structured bindings + `try_emplace` in the map code
- #727 — mark pure public-API getters `[[nodiscard]]`
- #726 — adopt C++17 attributes on the internal surface
- #725 — drop C++14 static-constexpr ODR workarounds

## Verification

The resulting tree is byte-identical to the tree at #708 (verified via `git rev-parse`), so this is a clean, conflict-free rollback of exactly the six follow-ups.

The reverted work is preserved on the `cpp17-followups` branch and will be re-proposed as a draft PR for re-landing once the vendoring approach is settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpZWGmx5bUi1wnDzpq3vrk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BpZWGmx5bUi1wnDzpq3vrk)_