### PR TITLE
feat(python): Result.to_networkx/to_igraph methods and native attribute types

### DIFF
--- a/interfaces/python/source/the-infomap-class.md
+++ b/interfaces/python/source/the-infomap-class.md
@@ -64,7 +64,7 @@ Each stateful pattern has a direct functional or `Network` equivalent:
 | Per-node flow | `for n in im.nodes: n.data.flow` | `for n in result.nodes(states=True): n.flow` (`im.nodes` iterates state nodes; plain `result.nodes()` gives physical nodes, identical for first-order networks) |
 | DataFrame | `im.to_dataframe([...])` | `result.to_dataframe([...])` |
 | Scalar metrics | `im.codelength`, `im.num_top_modules` | `result.codelength`, `result.num_top_modules` |
-| Graph-file export | `infomap.io.export.write_graphml(graph, im, path)` | `nx.write_graphml(infomap.to_networkx(result), path)` |
+| Graph-file export | `infomap.io.export.write_graphml(graph, im, path)` | `nx.write_graphml(result.to_networkx(), path)` |
 
 The two consistent shifts: building a network is a {class}`~infomap.Network`
 (or a direct {func}`infomap.run` call) rather than the stateful instance, and

--- a/interfaces/python/source/working-with-infomap/visualizing-and-exporting.md
+++ b/interfaces/python/source/working-with-infomap/visualizing-and-exporting.md
@@ -119,10 +119,11 @@ For production figures, copy
 ### Export to GraphML and GEXF
 
 For a single file bundling the network topology and the Infomap result,
-{func}`infomap.to_networkx` builds a *new* NetworkX graph from the result:
-nodes are the result's (state) nodes, keyed by `state_id` and carrying the
-Infomap node `name` plus the partition attributes, and edges come from the
-partitioned network. NetworkX then writes it:
+{func}`infomap.to_networkx` (also available as
+{meth}`result.to_networkx() <infomap.Result.to_networkx>`) builds a *new*
+NetworkX graph from the result: nodes are the result's (state) nodes, keyed by
+`state_id` and carrying the Infomap node `name` plus the partition attributes,
+and edges come from the partitioned network. NetworkX then writes it:
 
 ```{code-cell} python
 import os

--- a/interfaces/python/source/working-with-infomap/visualizing-and-exporting.md
+++ b/interfaces/python/source/working-with-infomap/visualizing-and-exporting.md
@@ -141,15 +141,18 @@ print(f"GraphML: {os.path.getsize(graphml_path):,} bytes")
 print(f"GEXF:    {os.path.getsize(gexf_path):,} bytes")
 ```
 
-The exported graph carries these Infomap node attributes, all stored as
-strings for GraphML/GEXF compatibility:
+The exported graph carries these Infomap node attributes:
 
 | Attribute | Value |
 |---|---|
-| `infomap_module` | Top-level module id |
-| `infomap_path` | Colon-separated tree path ending in the node's position within its module, e.g. `"1:1"` or `"2:3:4"` |
-| `infomap_level_1`, `infomap_level_2`, … | One attribute per path component (the last is the node's position within its final module) |
-| `flow` | Stationary visit frequency |
+| `infomap_module` | Top-level module id (`int`) |
+| `infomap_path` | Colon-separated tree path ending in the node's position within its module, e.g. `"1:1"` or `"2:3:4"` (`str`) |
+| `infomap_level_1`, `infomap_level_2`, … | One attribute per path component (the last is the node's position within its final module) (`int`) |
+| `flow` | Stationary visit frequency (`float`) |
+
+GraphML and GEXF store the types alongside the values, so module ids and flows
+come back as numbers when the file is read — Gephi's numeric colour scales and
+sorting work directly.
 
 Because the graph is rebuilt from the result, your original graph's node
 attributes are *not* carried over. To keep them, annotate your own graph in

--- a/interfaces/python/src/infomap/io/export.py
+++ b/interfaces/python/src/infomap/io/export.py
@@ -34,7 +34,7 @@ def _import_igraph() -> Any:
     return ig
 
 
-def _string_attributes(
+def _node_attributes(
     path: tuple[int, ...],
     *,
     module_attribute: str | None,
@@ -42,17 +42,22 @@ def _string_attributes(
     include_hierarchy: bool,
     flow: Any = None,
     flow_attribute: str | None = None,
-) -> dict[str, str]:
-    attributes = {}
+    stringify: bool = False,
+) -> dict[str, Any]:
+    # The annotate family stringifies every value (its documented contract);
+    # the to_* builders keep native ints and floats. The path is a string
+    # either way.
+    coerce = str if stringify else (lambda value: value)
+    attributes: dict[str, Any] = {}
     if module_attribute is not None:
-        attributes[module_attribute] = str(path[0])
+        attributes[module_attribute] = coerce(path[0])
     if include_hierarchy:
         if path_attribute is not None:
             attributes[path_attribute] = ":".join(str(module_id) for module_id in path)
         for level, module_id in enumerate(path, start=1):
-            attributes[f"infomap_level_{level}"] = str(module_id)
+            attributes[f"infomap_level_{level}"] = coerce(module_id)
     if flow_attribute is not None and flow is not None:
-        attributes[flow_attribute] = str(flow)
+        attributes[flow_attribute] = coerce(flow)
     return attributes
 
 
@@ -156,13 +161,14 @@ def _annotate_networkx_graph(
 
     for node in matching_nodes:
         output_graph.nodes[node].update(
-            _string_attributes(
+            _node_attributes(
                 assignments[node],
                 module_attribute=module_attribute,
                 path_attribute=path_attribute,
                 include_hierarchy=include_hierarchy,
                 flow=flows.get(node),
                 flow_attribute=flow_attribute,
+                stringify=True,
             )
         )
 
@@ -268,13 +274,14 @@ def _annotate_igraph_graph(
 
     values_by_attribute: dict[str, list[str | None]] = {}
     for vertex_id in matching_nodes:
-        attributes = _string_attributes(
+        attributes = _node_attributes(
             assignments[vertex_id],
             module_attribute=module_attribute,
             path_attribute=path_attribute,
             include_hierarchy=include_hierarchy,
             flow=flows.get(vertex_id),
             flow_attribute=flow_attribute,
+            stringify=True,
         )
         for attribute, value in attributes.items():
             values_by_attribute.setdefault(attribute, [None] * n_vertices)
@@ -373,9 +380,11 @@ def to_networkx(
     """Build a NetworkX graph from a :class:`~infomap.Result`.
 
     Nodes are the result's (state) nodes, keyed by ``state_id``, carrying the
-    Infomap node ``name`` plus the module/path/flow attributes (the same
-    attribute scheme as :func:`~infomap.io.export.annotate_networkx_graph`). Edges come from the
-    partitioned network.
+    Infomap node ``name`` plus the module/path/flow attributes. Edges come
+    from the partitioned network, with their weights as ``weight``. The
+    attribute values keep their native types: module ids are :class:`int`,
+    flows and weights are :class:`float`, and the tree path is a
+    colon-joined :class:`str` such as ``"1:3"``.
 
     Parameters
     ----------
@@ -398,6 +407,11 @@ def to_networkx(
     -------
     networkx.Graph or networkx.DiGraph
         ``DiGraph`` when the partitioned network is directed, else ``Graph``.
+
+    See Also
+    --------
+    annotate_networkx_graph : Annotate an existing graph in place instead
+        (string-valued attributes).
     """
     nx = _import_networkx()
     result._check_generation()
@@ -408,7 +422,7 @@ def to_networkx(
     for node in _result_nodes(result):
         attributes = {"name": node.name}
         attributes.update(
-            _string_attributes(
+            _node_attributes(
                 node.path,
                 module_attribute=module_attribute,
                 path_attribute=path_attribute,
@@ -436,9 +450,9 @@ def to_igraph(
     """Build a python-igraph graph from a :class:`~infomap.Result`.
 
     Vertices are the result's (state) nodes in ``state_id`` order, carrying the
-    Infomap node ``name`` plus the module/path/flow attributes (the same
-    attribute scheme as :func:`~infomap.io.export.annotate_igraph_graph`). Edges come from the
-    partitioned network.
+    Infomap node ``name`` plus the module/path/flow attributes. Edges come
+    from the partitioned network, with their weights as ``weight``. The
+    attribute values keep their native types, as in :func:`to_networkx`.
 
     Parameters
     ----------
@@ -451,6 +465,11 @@ def to_igraph(
     -------
     igraph.Graph
         Directed when the partitioned network is directed, else undirected.
+
+    See Also
+    --------
+    annotate_igraph_graph : Annotate an existing graph in place instead
+        (string-valued attributes).
     """
     ig = _import_igraph()
 
@@ -466,7 +485,7 @@ def to_igraph(
     values_by_attribute: dict[str, list[Any]] = {"name": [None] * n_vertices}
     for index, node in enumerate(nodes):
         values_by_attribute["name"][index] = node.name
-        attributes = _string_attributes(
+        attributes = _node_attributes(
             node.path,
             module_attribute=module_attribute,
             path_attribute=path_attribute,

--- a/interfaces/python/src/infomap/io/export.py
+++ b/interfaces/python/src/infomap/io/export.py
@@ -410,6 +410,7 @@ def to_networkx(
 
     See Also
     --------
+    infomap.Result.to_networkx : The same conversion as a ``Result`` method.
     annotate_networkx_graph : Annotate an existing graph in place instead
         (string-valued attributes).
     """
@@ -468,6 +469,7 @@ def to_igraph(
 
     See Also
     --------
+    infomap.Result.to_igraph : The same conversion as a ``Result`` method.
     annotate_igraph_graph : Annotate an existing graph in place instead
         (string-valued attributes).
     """

--- a/interfaces/python/src/infomap/result.py
+++ b/interfaces/python/src/infomap/result.py
@@ -741,6 +741,64 @@ class Result:
 
         return dataframe
 
+    def to_networkx(
+        self,
+        *,
+        module_attribute: str | None = "infomap_module",
+        path_attribute: str | None = "infomap_path",
+        include_hierarchy: bool = True,
+        flow_attribute: str | None = "flow",
+    ) -> Any:
+        """Build a NetworkX graph of the partitioned network.
+
+        Equivalent to :func:`infomap.to_networkx`; see it for the parameters
+        and the attribute scheme.
+
+        Returns
+        -------
+        networkx.Graph or networkx.DiGraph
+            ``DiGraph`` when the partitioned network is directed, else
+            ``Graph``.
+        """
+        from .io.export import to_networkx
+
+        return to_networkx(
+            self,
+            module_attribute=module_attribute,
+            path_attribute=path_attribute,
+            include_hierarchy=include_hierarchy,
+            flow_attribute=flow_attribute,
+        )
+
+    def to_igraph(
+        self,
+        *,
+        module_attribute: str | None = "infomap_module",
+        path_attribute: str | None = "infomap_path",
+        include_hierarchy: bool = True,
+        flow_attribute: str | None = "flow",
+    ) -> Any:
+        """Build a python-igraph graph of the partitioned network.
+
+        Equivalent to :func:`infomap.to_igraph`; see it for the parameters
+        and the attribute scheme.
+
+        Returns
+        -------
+        igraph.Graph
+            Directed when the partitioned network is directed, else
+            undirected.
+        """
+        from .io.export import to_igraph
+
+        return to_igraph(
+            self,
+            module_attribute=module_attribute,
+            path_attribute=path_attribute,
+            include_hierarchy=include_hierarchy,
+            flow_attribute=flow_attribute,
+        )
+
     def _column(
         self, resolved: str, requested: str, snapshot: _Snapshot, names: dict
     ) -> list:

--- a/test/python/test_export.py
+++ b/test/python/test_export.py
@@ -57,12 +57,18 @@ def test_networkx_export_supports_custom_module_attribute():
         im,
         node_mapping=mapping,
         module_attribute="community",
+        flow_attribute="flow",
     )
 
+    # The annotate family keeps its documented all-strings contract.
     assert set(nx.get_node_attributes(annotated, "community")) == set(graph.nodes)
     assert all(
         isinstance(value, str)
         for value in nx.get_node_attributes(annotated, "community").values()
+    )
+    assert all(
+        isinstance(value, str)
+        for value in nx.get_node_attributes(annotated, "flow").values()
     )
 
 

--- a/test/python/test_run_functional.py
+++ b/test/python/test_run_functional.py
@@ -156,6 +156,15 @@ def test_to_networkx_graph_survives_graphml_and_gexf(tmp_path):
     nx.write_gexf(exported, tmp_path / "karate.gexf")
 
 
+def test_result_to_networkx_method_matches_function():
+    graph = nx.karate_club_graph()
+    result = infomap.run(graph, **_SETTINGS)
+
+    from_method = result.to_networkx(flow_attribute="f")
+    from_function = infomap.to_networkx(result, flow_attribute="f")
+    assert nx.utils.graphs_equal(from_method, from_function)
+
+
 def test_to_networkx_directed_flow_model_exports_digraph():
     # Result directedness derives from the effective flow model, so an
     # explicit flow_model="directed" exports a DiGraph exactly like
@@ -269,6 +278,19 @@ def test_to_igraph_graph_survives_graphml(tmp_path):
     exported.write_graphml(str(path))
     read_back = ig.Graph.Read_GraphML(str(path))
     assert all(value is not None for value in read_back.vs["infomap_module"])
+
+
+def test_result_to_igraph_method_matches_function():
+    ig = pytest.importorskip("igraph")
+    graph = ig.Graph.Famous("Zachary")
+    result = infomap.run(graph, **_SETTINGS)
+
+    from_method = result.to_igraph(flow_attribute="f")
+    from_function = infomap.to_igraph(result, flow_attribute="f")
+    assert from_method.vcount() == from_function.vcount()
+    assert from_method.get_edgelist() == from_function.get_edgelist()
+    for attribute in from_function.vs.attributes():
+        assert from_method.vs[attribute] == from_function.vs[attribute]
 
 
 def test_run_rejects_unsupported_input():

--- a/test/python/test_run_functional.py
+++ b/test/python/test_run_functional.py
@@ -121,12 +121,39 @@ def test_to_networkx_round_trip():
     assert all("flow" in data for _, data in exported.nodes(data=True))
 
     # The exported partition matches the result's module assignment.
-    result_modules = result.modules()
     exported_modules = {
-        node: int(data["infomap_module"])
-        for node, data in exported.nodes(data=True)
+        node: data["infomap_module"] for node, data in exported.nodes(data=True)
     }
-    assert exported_modules == result_modules
+    assert exported_modules == result.modules()
+
+
+def test_to_networkx_attributes_have_native_types():
+    graph = nx.karate_club_graph()
+    result = infomap.run(graph, **_SETTINGS)
+
+    exported = infomap.to_networkx(result)
+    for _, data in exported.nodes(data=True):
+        assert isinstance(data["infomap_module"], int)
+        assert isinstance(data["infomap_path"], str)
+        assert isinstance(data["infomap_level_1"], int)
+        assert isinstance(data["flow"], float)
+    for _, _, data in exported.edges(data=True):
+        assert isinstance(data["weight"], float)
+
+
+def test_to_networkx_graph_survives_graphml_and_gexf(tmp_path):
+    graph = nx.karate_club_graph()
+    result = infomap.run(graph, **_SETTINGS)
+    exported = infomap.to_networkx(result)
+
+    graphml_path = tmp_path / "karate.graphml"
+    nx.write_graphml(exported, graphml_path)
+    read_back = nx.read_graphml(graphml_path)
+    node = next(iter(read_back.nodes))
+    assert isinstance(read_back.nodes[node]["infomap_module"], int)
+    assert isinstance(read_back.nodes[node]["flow"], float)
+
+    nx.write_gexf(exported, tmp_path / "karate.gexf")
 
 
 def test_to_networkx_directed_flow_model_exports_digraph():
@@ -227,6 +254,21 @@ def test_to_igraph_round_trip():
     assert exported.ecount() == graph.ecount()
     assert "infomap_module" in exported.vs.attributes()
     assert "flow" in exported.vs.attributes()
+    assert all(isinstance(value, int) for value in exported.vs["infomap_module"])
+    assert all(isinstance(value, str) for value in exported.vs["infomap_path"])
+    assert all(isinstance(value, float) for value in exported.vs["flow"])
+
+
+def test_to_igraph_graph_survives_graphml(tmp_path):
+    ig = pytest.importorskip("igraph")
+    graph = ig.Graph.Famous("Zachary")
+    result = infomap.run(graph, **_SETTINGS)
+    exported = infomap.to_igraph(result)
+
+    path = tmp_path / "karate.graphml"
+    exported.write_graphml(str(path))
+    read_back = ig.Graph.Read_GraphML(str(path))
+    assert all(value is not None for value in read_back.vs["infomap_module"])
 
 
 def test_run_rejects_unsupported_input():


### PR DESCRIPTION
Two related fixes to the `Result` graph exports, from user feedback that tripped over both.

## fix: native attribute types in `to_networkx` / `to_igraph`

The builders stringified every node attribute (`infomap_module` was `'1'`, `flow` was `'0.21...'`), inherited from the annotate helpers whose all-strings contract targets GraphML/GEXF files. The rationale doesn't hold for the built graphs:

- they already carry `float` edge weights and original-typed `name`s,
- NetworkX and igraph write and read numeric attributes natively (`attr.type` long/double round-trips, and Gephi's numeric colour scales work directly),
- the `find_communities` / `find_igraph_communities` write-backs already use native types,
- our own test cast with `int(...)` to compare.

Now: module ids and `infomap_level_*` are `int`, `flow` is `float`, the colon-joined path stays `str`. `annotate_networkx_graph` / `annotate_igraph_graph` keep their documented string contract (guarded by a test).

Note: this changes behaviour of an API released in v2.14.0. String comparisons like `data["infomap_module"] == "1"` break; `int(...)`/`float(...)` casts keep working.

## feat: `Result.to_networkx()` / `Result.to_igraph()`

`Result` already exposes `to_dataframe`, so the graph conversions were the odd ones out as module-level-only functions — `result.to_networkx()` raised `AttributeError`. Both are now thin methods delegating to the `io.export` functions, which stay the documented primary form.

## Tests

- Native-type assertions for both builders, GraphML/GEXF file round-trips, method/function parity, and a string-contract regression guard for the annotate family.
- Full suite: 482 passed, ruff + doctests + pyright clean.