### PR TITLE
ci(python): add non-blocking Python 3.15 prerelease wheel check

### DIFF
--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -31,9 +31,19 @@ on:
         required: false
         type: string
         default: ""
+      prerelease-python-check:
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
+
+env:
+  # Single source of truth for the cibuildwheel pin used by the wheel jobs
+  # in this workflow. Keep in sync with the `release` extra in pyproject.toml
+  # (bumped there by dependabot).
+  CIBW_VERSION: "4.1.0"
 
 jobs:
   swig-freshness:
@@ -363,7 +373,7 @@ jobs:
           python-version: "3.14"
 
       - name: Install Python release tooling
-        run: python -m pip install build cibuildwheel==4.1.0 twine wheel
+        run: python -m pip install build "cibuildwheel==${{ env.CIBW_VERSION }}" twine wheel
 
       - name: Install macOS OpenMP runtime
         if: startsWith(matrix.os, 'macos')
@@ -406,6 +416,58 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-wheels-${{ matrix.os }}
+          path: wheelhouse/*.whl
+          retention-days: 7
+
+  prerelease-wheels:
+    # Non-blocking early warning: test-build wheels against prerelease CPython
+    # (3.15) so C-API / build breakage surfaces before the final release. Does
+    # not publish and is not part of the release path.
+    if: inputs.prerelease-python-check
+    name: Python prerelease wheel ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, windows-2025-vs2026, macos-15]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Set up Python
+        uses: ./.github/actions/setup-python-build
+        with:
+          python-version: "3.14"
+
+      - name: Install cibuildwheel
+        run: python -m pip install "cibuildwheel==${{ env.CIBW_VERSION }}"
+
+      - name: Install macOS OpenMP runtime
+        if: startsWith(matrix.os, 'macos')
+        run: brew install libomp
+
+      - name: Build prerelease wheels
+        run: python -m cibuildwheel . --output-dir wheelhouse
+        env:
+          CIBW_BUILD: "cp315-*"
+          CIBW_ENABLE: cpython-prerelease
+          CIBW_SKIP: "*-musllinux*"
+          CIBW_TEST_COMMAND: >-
+            python -c "from infomap import Infomap; print(Infomap(silent=True).num_top_modules)"
+          CIBW_ENVIRONMENT_MACOS: >-
+            CXX=/usr/bin/clang++
+            MACOSX_DEPLOYMENT_TARGET=15.0
+            CPPFLAGS="-I$(brew --prefix libomp)/include"
+            LDFLAGS="-L$(brew --prefix libomp)/lib"
+
+      - name: Upload prerelease wheels
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: python-prerelease-wheels-${{ matrix.os }}
           path: wheelhouse/*.whl
           retention-days: 7
 

--- a/.github/workflows/python-prerelease-check.yml
+++ b/.github/workflows/python-prerelease-check.yml
@@ -1,0 +1,22 @@
+name: Python prerelease check
+
+# Weekly (and on-demand) test-build of the Python wheels against prerelease
+# CPython (3.15) so C-API or build breakage surfaces well before the final
+# release. Non-blocking: this workflow builds nothing that ships and never
+# gates PRs or merges. Schedules only run on the default branch.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  prerelease-wheels:
+    uses: ./.github/workflows/_python-package.yml
+    with:
+      run-tests: false
+      build-release-artifacts: false
+      prerelease-python-check: true


### PR DESCRIPTION
## What

Adds a weekly (and manually dispatchable) workflow that test-builds the Python wheels against **prerelease CPython 3.15** (currently 3.15.0b2) on Linux, macOS, and Windows, so C-API or build breakage surfaces well before the final 3.15 release in October 2026.

## Why

`requires-python = ">=3.11"` has no upper cap, so 3.15 users already fall back to an sdist build. This gives us early warning that infomap's C++/SWIG extension still compiles and imports against 3.15's C API, ahead of shipping real cp315 wheels at rc1.

Verified viable ahead of this PR: a throwaway spike built cp315 wheels green on all three OS against 3.15.0b2 (extension compiles + imports).

## How

- New `prerelease-python-check` input on the reusable `_python-package.yml` drives a dedicated `prerelease-wheels` job: `CIBW_BUILD: "cp315-*"`, `CIBW_ENABLE: cpython-prerelease`, import smoke test via `CIBW_TEST_COMMAND`. It publishes nothing and is not part of the release path. Gated off by default, so existing callers (`ci.yml`, `prerelease.yml`, `release.yml`) are unaffected.
- New `python-prerelease-check.yml` caller runs it on a weekly cron + `workflow_dispatch`. A **separate** workflow keeps it non-blocking (no PR or merge depends on it) while still going **red on breakage** so we get notified.
- Hoisted the cibuildwheel pin to a workflow-level `CIBW_VERSION` env so the release wheel job and the prerelease job share one source of truth (still manually synced with the `release` extra in `pyproject.toml`, which dependabot bumps).

## Follow-up (not in this PR)

At 3.15 rc1 (ABI frozen, ~a month out), add `cp315-*` to the real release `CIBW_BUILD` so 3.15 wheels ship day one in October.

## Note on verification

`workflow_dispatch` only lists workflows present on the default branch, so this new workflow can't be dispatch-tested until it's merged. The cp315 build itself is already proven (spike above); the residual is YAML wiring, which `actionlint` validates clean (including the reusable-workflow input plumbing). Recommend a one-off manual dispatch right after merge to confirm end-to-end.