### PR TITLE
fix(python): make the Python API silent by default

### DIFF
--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -196,7 +196,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         trial_results=None,
         no_final_output=False,
         verbosity_level=1,
-        silent=False,
+        silent=True,
         pretty=False,
         two_level=False,
         flow_model=None,
@@ -336,7 +336,8 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             Verbosity level on the console. 1 keeps the default output level, 2 renders
             -vv and so on.
         silent : bool, optional
-            Suppress console output.
+            Suppress console output. The Python API is quiet by default; construct with
+            silent=False for the engine log. The command-line interface is unaffected.
         pretty : bool, optional
             Deprecated. Accepted for backward compatibility; has no effect.
         two_level : bool, optional
@@ -643,7 +644,8 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             Verbosity level on the console. 1 keeps the default output level, 2 renders
             -vv and so on.
         silent : bool, optional
-            Suppress console output.
+            Suppress console output. The Python API is quiet by default; construct with
+            silent=False for the engine log. The command-line interface is unaffected.
         pretty : bool, optional
             Deprecated. Accepted for backward compatibility; has no effect.
         two_level : bool, optional

--- a/interfaces/python/src/infomap/_options.py
+++ b/interfaces/python/src/infomap/_options.py
@@ -203,7 +203,8 @@ class Options:
         Verbosity level on the console. 1 keeps the default output level, 2 renders -vv
         and so on.
     silent : bool, optional
-        Suppress console output.
+        Suppress console output. The Python API is quiet by default; construct with
+        silent=False for the engine log. The command-line interface is unaffected.
     two_level : bool, optional
         Optimize a two-level partition instead of the default multi-level hierarchy.
     flow_model : str, optional
@@ -361,7 +362,7 @@ class Options:
     trial_results: str | None = None
     no_final_output: bool = False
     verbosity_level: int = 1
-    silent: bool = False
+    silent: bool = True
     # algorithm
     two_level: bool = False
     flow_model: str | None = None
@@ -518,7 +519,7 @@ def _construct_args(
     trial_results=None,
     no_final_output=False,
     verbosity_level=1,
-    silent=False,
+    silent=True,
     # algorithm
     two_level=False,
     flow_model=None,

--- a/interfaces/python/src/infomap/_run.py
+++ b/interfaces/python/src/infomap/_run.py
@@ -185,6 +185,12 @@ def run(
 
     Notes
     -----
+    ``run`` is quiet by default: unless ``silent`` is given, it runs with
+    ``silent=True``. Pass ``silent=False`` (as a keyword or in a mapping) for
+    the engine log. An :class:`Options` instance is a total configuration and
+    always carries an explicit ``silent`` (``False`` unless set), which is
+    respected as-is. The stateful :class:`Infomap` keeps its verbose default.
+
     Keyword arguments go to the engine; the input adapters always build with
     their defaults (e.g. networkx reads the ``"weight"`` edge attribute, a
     SciPy matrix is treated as undirected). For non-default input building -- a
@@ -209,10 +215,7 @@ def run(
     One call from an iterable of ``(u, v[, w])`` links to a :class:`Result`:
 
     >>> from infomap import run
-    >>> result = run(
-    ...     [(1, 2), (1, 3), (2, 3), (4, 5), (4, 6), (5, 6), (3, 4)],
-    ...     silent=True,
-    ... )
+    >>> result = run([(1, 2), (1, 3), (2, 3), (4, 5), (4, 6), (5, 6), (3, 4)])
     >>> result.num_top_modules
     2
     >>> for node_id, module_id in sorted(result.modules().items()):
@@ -230,6 +233,12 @@ def run(
     from .network import Network
 
     resolved = _resolve_options(options, overrides)
+    # The functional front door defaults to a quiet engine. Absent (or an
+    # explicit None) means the user made no choice; an Options instance always
+    # carries an explicit silent bool (it is a total configuration), so its
+    # value is respected like any user-supplied one.
+    if resolved.get("silent") is None:
+        resolved["silent"] = True
     # Keys the user actually supplied (kwargs + a mapping `options`), used to
     # reject adapter-only arguments below. An Options *instance* is excluded on
     # purpose: its to_kwargs() carries every field (e.g. directed=None) the user

--- a/interfaces/python/src/infomap/_run.py
+++ b/interfaces/python/src/infomap/_run.py
@@ -185,11 +185,12 @@ def run(
 
     Notes
     -----
-    ``run`` is quiet by default: unless ``silent`` is given, it runs with
-    ``silent=True``. Pass ``silent=False`` (as a keyword or in a mapping) for
-    the engine log. An :class:`Options` instance is a total configuration and
-    always carries an explicit ``silent`` (``False`` unless set), which is
-    respected as-is. The stateful :class:`Infomap` keeps its verbose default.
+    The Python API is quiet by default (``silent=True``, here and on
+    :class:`Infomap`, :class:`Network`, and :class:`Options`). Pass
+    ``silent=False`` for the engine log — except for :class:`Network` input,
+    whose engine is silent for its whole lifetime (``silent=False`` warns
+    there; see :meth:`Network.run`). The ``infomap`` command-line interface
+    keeps its verbose default.
 
     Keyword arguments go to the engine; the input adapters always build with
     their defaults (e.g. networkx reads the ``"weight"`` edge attribute, a
@@ -233,12 +234,6 @@ def run(
     from .network import Network
 
     resolved = _resolve_options(options, overrides)
-    # The functional front door defaults to a quiet engine. Absent (or an
-    # explicit None) means the user made no choice; an Options instance always
-    # carries an explicit silent bool (it is a total configuration), so its
-    # value is respected like any user-supplied one.
-    if resolved.get("silent") is None:
-        resolved["silent"] = True
     # Keys the user actually supplied (kwargs + a mapping `options`), used to
     # reject adapter-only arguments below. An Options *instance* is excluded on
     # purpose: its to_kwargs() carries every field (e.g. directed=None) the user

--- a/interfaces/python/src/infomap/network.py
+++ b/interfaces/python/src/infomap/network.py
@@ -25,6 +25,7 @@ an :class:`Infomap`.
 
 from __future__ import annotations
 
+import warnings
 from typing import Any
 
 from ._core import Core, apply_initial_partition
@@ -273,6 +274,13 @@ class Network:
         -------
         Result
             An immutable snapshot of the run, bound to this ``Network``.
+
+        Notes
+        -----
+        A ``Network`` engine is silent for its whole lifetime; ``silent=False``
+        cannot re-enable the engine log here and warns instead. For the log,
+        run through the stateful :class:`~infomap.Infomap` (constructed with
+        ``silent=False``) or pass the input directly to :func:`infomap.run`.
         """
         from ._options import Options, _construct_args
         from .result import build_result
@@ -283,6 +291,16 @@ class Network:
             resolved = options
         else:
             resolved = Options(**dict(options))
+
+        if resolved.silent is False:
+            warnings.warn(
+                "A Network engine is silent for its whole lifetime; "
+                "silent=False has no effect here. For the engine log, run "
+                "through Infomap(silent=False) or pass the input directly "
+                "to infomap.run().",
+                UserWarning,
+                stacklevel=2,
+            )
 
         rendered_args = _construct_args(args, **resolved.to_kwargs())
         if initial_partition is None:

--- a/scripts/generate_binding_options.py
+++ b/scripts/generate_binding_options.py
@@ -99,6 +99,7 @@ def _facade_params(catalog: ParameterCatalog):
     index["include_self_links"] = {
         "type": include_self_links.type,
         "default": include_self_links.default,
+        "run_default": include_self_links.default,
         "doc_type": "bool, optional",
         "doc": (
             "Deprecated. Self-links are included by default; use "
@@ -122,6 +123,18 @@ def _facade_params(catalog: ParameterCatalog):
             index[name] = {
                 "type": param.python_type(),
                 "default": param.python_default_expr(),
+                # ``Infomap.run`` re-renders its keywords on top of the
+                # constructed state, and a rendered flag can only switch on. A
+                # generic boolean flag whose binding default is truthy
+                # (silent=True) would re-render every run and override the
+                # constructor's choice, so the run signature keeps the flag's
+                # no-op default. Other policies (repeated_short etc.) render
+                # nothing at their binding default already.
+                "run_default": (
+                    "False"
+                    if param.render_policy == "flag"
+                    else param.python_default_expr()
+                ),
                 "doc_type": param.python_doc_type(),
                 "doc": param.python_doc_description(),
             }
@@ -647,11 +660,13 @@ def generate_ts(catalog: ParameterCatalog) -> str:
     return "\n".join(lines)
 
 
-def _render_facade_signature(names, index, indent="        "):
+def _render_facade_signature(names, index, indent="        ", context="init"):
     lines = []
     for name in names:
         if name in _FACADE_ONLY_PARAMS:
             default = _FACADE_ONLY_PARAMS[name]["default"]
+        elif context == "run":
+            default = index[name]["run_default"]
         else:
             default = index[name]["default"]
         lines.append(f"{indent}{name}={default},")
@@ -704,7 +719,7 @@ def generate_facade(catalog: ParameterCatalog) -> str:
     lines.append("        self,")
     lines.append("        args=None,")
     lines.append("        initial_partition=None,")
-    lines.extend(_render_facade_signature(names, index))
+    lines.extend(_render_facade_signature(names, index, context="run"))
     lines.append("    ):")
     lines.append('        """Run Infomap.')
     lines.append("")

--- a/src/io/ParameterCatalog.cpp
+++ b/src/io/ParameterCatalog.cpp
@@ -976,6 +976,8 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .longName("silent")
         .description("Suppress console output.")
         .group("Output")
+        .bindingDefaults("True", "FALSE")
+        .pythonDoc("Suppress console output. The Python API is quiet by default; construct with silent=False for the engine log. The command-line interface is unaffected.")
         .configTarget(&Config::silent),
     param()
         .longName("pretty")

--- a/test/python/test_run_functional.py
+++ b/test/python/test_run_functional.py
@@ -9,6 +9,8 @@ honours the same run-generation guard as the ``Infomap``-backed one.
 
 from __future__ import annotations
 
+import sys
+
 import networkx as nx
 import pytest
 
@@ -37,6 +39,60 @@ def test_run_edgelist_matches_oo():
 
     expected = _oo_codelength(lambda im: im.add_links(_LINKS), **_SETTINGS)
     assert result.codelength == pytest.approx(expected)
+
+
+def _engine_log(capfd) -> str:
+    """Read the engine log from the fd-level capture.
+
+    The engine writes via ``std::cout``; under pytest's fd-level capture
+    stdout is a pipe, so the C runtime fully buffers the log and it must be
+    flushed before reading (silence assertions would otherwise pass vacuously).
+    """
+    import ctypes
+
+    if sys.platform == "win32":
+        ctypes.cdll.msvcrt.fflush(None)
+    else:
+        ctypes.CDLL(None).fflush(None)
+    return capfd.readouterr().out
+
+
+def test_run_is_silent_by_default(capfd):
+    _engine_log(capfd)  # drain log buffered by earlier (unflushed) tests
+    infomap.run(_LINKS, num_trials=1, seed=1)
+    assert _engine_log(capfd) == ""
+
+
+def test_run_network_input_is_silent_by_default(capfd):
+    _engine_log(capfd)  # drain log buffered by earlier (unflushed) tests
+    net = Network().add_links(_LINKS)
+    infomap.run(net, num_trials=1, seed=1)
+    assert _engine_log(capfd) == ""
+
+
+def test_run_silent_false_override_prints_engine_log(capfd):
+    _engine_log(capfd)
+    infomap.run(_LINKS, silent=False, num_trials=1, seed=1)
+    assert _engine_log(capfd) != ""
+
+
+def test_run_options_mapping_silent_false_prints_engine_log(capfd):
+    _engine_log(capfd)
+    infomap.run(_LINKS, options={"silent": False, "num_trials": 1, "seed": 1})
+    assert _engine_log(capfd) != ""
+
+
+def test_run_options_instance_silent_is_respected(capfd):
+    # An Options instance is a total configuration: to_kwargs() always carries
+    # an explicit silent (False unless set), which run() respects as-is.
+    from infomap import Options
+
+    _engine_log(capfd)
+    infomap.run(_LINKS, options=Options(num_trials=1, seed=1))
+    assert _engine_log(capfd) != ""
+
+    infomap.run(_LINKS, options=Options(num_trials=1, seed=1, silent=True))
+    assert _engine_log(capfd) == ""
 
 
 def test_run_networkx_matches_oo():

--- a/test/python/test_run_functional.py
+++ b/test/python/test_run_functional.py
@@ -83,16 +83,56 @@ def test_run_options_mapping_silent_false_prints_engine_log(capfd):
 
 
 def test_run_options_instance_silent_is_respected(capfd):
-    # An Options instance is a total configuration: to_kwargs() always carries
-    # an explicit silent (False unless set), which run() respects as-is.
     from infomap import Options
 
     _engine_log(capfd)
     infomap.run(_LINKS, options=Options(num_trials=1, seed=1))
+    assert _engine_log(capfd) == ""
+
+    infomap.run(_LINKS, options=Options(num_trials=1, seed=1, silent=False))
     assert _engine_log(capfd) != ""
 
-    infomap.run(_LINKS, options=Options(num_trials=1, seed=1, silent=True))
+
+def test_options_default_is_silent():
+    from infomap import Options
+
+    assert Options().silent is True
+    assert Options(silent=False).silent is False
+
+
+def test_stateful_infomap_is_silent_by_default(capfd):
+    _engine_log(capfd)  # drain log buffered by earlier (unflushed) tests
+    im = Infomap(num_trials=1, seed=1, no_file_output=True)
+    im.add_links(_LINKS)
+    im.run()
     assert _engine_log(capfd) == ""
+
+
+def test_stateful_infomap_silent_false_prints_engine_log(capfd):
+    _engine_log(capfd)
+    im = Infomap(silent=False, num_trials=1, seed=1, no_file_output=True)
+    im.add_links(_LINKS)
+    im.run()
+    assert _engine_log(capfd) != ""
+
+
+def test_network_run_is_silent_by_default(capfd):
+    _engine_log(capfd)
+    net = Network().add_links(_LINKS)
+    net.run(options={"num_trials": 1, "seed": 1})
+    assert _engine_log(capfd) == ""
+
+
+def test_network_run_silent_false_warns():
+    # A Network engine is constructed silent for its whole lifetime (a flag
+    # cannot be switched off per run), so an explicit silent=False warns
+    # instead of being silently ignored.
+    net = Network().add_links(_LINKS)
+    with pytest.warns(UserWarning, match="silent for its whole lifetime"):
+        net.run(options={"silent": False, "num_trials": 1, "seed": 1})
+
+    with pytest.warns(UserWarning, match="silent for its whole lifetime"):
+        infomap.run(net, silent=False, num_trials=1, seed=1)
 
 
 def test_run_networkx_matches_oo():

--- a/test/python/test_wrapper_args.py
+++ b/test/python/test_wrapper_args.py
@@ -28,6 +28,7 @@ def test_construct_args_renders_expected_cli_flags():
         "--existing",
         "--no-infomap",
         "--no-file-output",
+        "--silent",
         "-vvv",
         "--output",
         "json,tree",
@@ -80,7 +81,7 @@ def test_run_forwards_variable_markov_options(monkeypatch):
 def test_construct_args_renders_variable_markov_min_scale():
     args = infomap_module._construct_args(variable_markov_min_scale=0.5)
 
-    assert shlex.split(args) == ["--variable-markov-min-scale", "0.5"]
+    assert shlex.split(args) == ["--silent", "--variable-markov-min-scale", "0.5"]
 
 
 def test_infomap_facade_signatures_match_options():


### PR DESCRIPTION
The Python API printed the full engine log unless every call passed `silent=True` — which every docs example, test, and even `run()`'s own docstring example did. The whole Python package now defaults to a quiet engine. Two commits:

## 1. `infomap.run()` silent by default (run()-local)

First cut: an overridable injection in the functional front door.

## 2. Package-wide default via the parameter catalog

The real mechanism: `--silent` gets `bindingDefaults("True", "FALSE")` in `ParameterCatalog.cpp`, so the *generated* `Infomap` constructor, `Options` dataclass, and `_construct_args` all default to silent from one source of truth (the run()-local injection from commit 1 is removed again). `find_communities` / `find_igraph_communities` already defaulted to silent.

| Entry point | Default | `silent=False` |
|---|---|---|
| `infomap.run(...)` | silent | engine log |
| `Infomap(...)` (stateful) | silent | engine log |
| `Options()` | `silent=True` field | engine log |
| `Network.run(...)` | silent (pre-existing) | **warns** — see below |
| `find_*communities` | silent (pre-existing) | engine log |
| `infomap` CLI / `python -m infomap` | **verbose** (unchanged) | n/a |
| R / JS bindings | unchanged | n/a |

## Two subtleties the tests caught

- **`Infomap.run()` re-renders its keywords on top of the constructed state, and a rendered flag can only switch on.** A truthy flag default in the run signature re-silenced every run and overrode a `silent=False` constructor (and double-rendered `--silent` into output-file headers). The generator now keeps no-op defaults for generic boolean flags in the `run()` signature; construction keeps the binding default.
- **A `Network` engine is constructed silent for its whole lifetime** (hardcoded since #694) and a per-run flag cannot switch it off. An explicit `silent=False` on `Network.run` / `infomap.run(net, ...)` now warns instead of being silently ignored, with a pointer to `Infomap(silent=False)`.

Engine-output tests flush the C-level stdout buffer before reading — `std::cout` is fully buffered under pytest's fd capture, so silence assertions would otherwise pass vacuously.

## Verification

- Python: 514 passed ×3 (stable), ruff + doctests + pyright clean, binding-options freshness green.
- Native: `make test-native` green (catalog change is metadata-only).
- CLI: `python -m infomap` verbose, `--silent` works.
- R (`options.R`) and JS (`arguments.ts`, metadata) regenerated with zero diff.
- Docs examples' explicit `silent=True` stays correct; notebooks all pass `silent` explicitly.

## Note

Behaviour change of a released API (v2.14.0): bare `run(g)` / `Infomap()` no longer print the log; the fix is `silent=False`.