### PR TITLE
feat(python): add signature-tier metadata to the parameter catalog

### DIFF
--- a/interfaces/parameters/overrides.json
+++ b/interfaces/parameters/overrides.json
@@ -63,5 +63,16 @@
         "reason": "Existing TypeScript argument helper exposes CLI about flags."
       }
     ]
+  },
+  "tiers": {
+    "python": {
+      "common": [
+        "--seed",
+        "--num-trials",
+        "--two-level",
+        "--directed",
+        "--markov-time"
+      ]
+    }
   }
 }

--- a/scripts/generate_binding_options.py
+++ b/scripts/generate_binding_options.py
@@ -39,6 +39,8 @@ _FACADE_ONLY_PARAMS = {
             "Deprecated. Accepted for backward compatibility; has no effect. "
             "Passing it explicitly emits a DeprecationWarning."
         ),
+        # Deprecated no-op; never part of the common signature tier.
+        "tier": "advanced",
     },
 }
 
@@ -122,6 +124,8 @@ def _facade_params(catalog: ParameterCatalog):
             "Deprecated. Self-links are included by default; use "
             "no_self_links=True to exclude them."
         ),
+        # Deprecated alias; never part of the common signature tier.
+        "tier": "advanced",
     }
     # Map each anchor catalog name to the facade-only params that follow it.
     after = {}
@@ -140,6 +144,12 @@ def _facade_params(catalog: ParameterCatalog):
             index[name] = {
                 "type": param.python_type(),
                 "default": param.python_default_expr(),
+                # Signature-tier metadata (issue #738/#739): "common" params
+                # stay as real keyword parameters in the 3.0 signatures;
+                # "advanced" params move to Options. Not yet consumed by the
+                # emitters -- the deprecation pass (#741) and the 3.0
+                # signature cut (#748) read it from here.
+                "tier": param.tier("python"),
                 # ``Infomap.run`` re-renders its keywords on top of the
                 # constructed state, and a rendered flag can only switch on. A
                 # generic boolean flag whose binding default is truthy

--- a/scripts/parameter_catalog.py
+++ b/scripts/parameter_catalog.py
@@ -110,6 +110,18 @@ class Parameter:
             return camel_name(self.flag)
         return snake_name(self.flag)
 
+    def tier(self, language: str) -> str:
+        """The binding-surface tier of this parameter: ``common`` or ``advanced``.
+
+        Tier membership is declared per language in the overrides file
+        (``tiers.<language>.common``, keyed by CLI flag); every parameter not
+        listed there is ``advanced``. The tier decides which parameters stay
+        as real keyword parameters in the 3.0 signatures (see issue #738) —
+        everything else is carried by the options object.
+        """
+        common = self.overrides.get("tiers", {}).get(language, {}).get("common", [])
+        return "common" if self.flag in common else "advanced"
+
     def uses_generic_spec(self) -> bool:
         return self.render_policy in {"flag", "value"}
 
@@ -227,6 +239,26 @@ class ParameterCatalog:
             language: {entry["flag"] for entry in entries}
             for language, entries in overrides.get("hiddenBindings", {}).items()
         }
+        self._validate_tiers()
+
+    def _validate_tiers(self) -> None:
+        # Fail loud on typos: every tier entry must name a real catalog flag,
+        # and only the known tier names are accepted. A silently dropped tier
+        # entry would put a parameter in the wrong 3.0 signature.
+        known_flags = {param.flag for param in self.parameters}
+        for language, tiers in self.overrides.get("tiers", {}).items():
+            unknown_tiers = set(tiers) - {"common"}
+            if unknown_tiers:
+                raise RuntimeError(
+                    f"Unknown tier name(s) for {language}: {sorted(unknown_tiers)}; "
+                    "only 'common' is declared (everything else is advanced)"
+                )
+            missing = sorted(set(tiers.get("common", [])) - known_flags)
+            if missing:
+                raise RuntimeError(
+                    f"tiers.{language}.common lists flag(s) not in the "
+                    f"parameter catalog: {missing}"
+                )
 
     def grouped(self) -> dict[str, list[Parameter]]:
         return {

--- a/test/python/test_parameter_catalog.py
+++ b/test/python/test_parameter_catalog.py
@@ -117,3 +117,75 @@ def test_parameter_catalog_classifies_binding_render_policies():
         == "deprecated_alias"
     )
     assert catalog.binding_only_entry("ts", "help").render_policy == "binding_only"
+
+
+def _minimal_param(flag, group="Accuracy", **extra):
+    param = {
+        "long": flag,
+        "short": "",
+        "description": f"Test parameter {flag}.",
+        "group": group,
+        "required": False,
+        "advanced": False,
+        "incremental": False,
+        "default": False,
+    }
+    param.update(extra)
+    return param
+
+
+def test_parameter_tier_defaults_to_advanced_and_reads_overrides():
+    parameters = [
+        _minimal_param("--seed", required=True, longType="integer"),
+        _minimal_param("--two-level"),
+        _minimal_param("--core-loop-limit", required=True, longType="integer"),
+    ]
+    overrides = {"tiers": {"python": {"common": ["--seed", "--two-level"]}}}
+
+    catalog = ParameterCatalog(parameters, overrides)
+    tiers = {param.flag: param.tier("python") for param in catalog.parameters}
+
+    assert tiers == {
+        "--seed": "common",
+        "--two-level": "common",
+        "--core-loop-limit": "advanced",
+    }
+    # Tier declarations are per language; an undeclared language is all-advanced.
+    assert all(param.tier("r") == "advanced" for param in catalog.parameters)
+
+
+def test_parameter_catalog_rejects_unknown_tier_flag():
+    import pytest
+
+    parameters = [_minimal_param("--seed", required=True, longType="integer")]
+    overrides = {"tiers": {"python": {"common": ["--seeed"]}}}
+
+    with pytest.raises(RuntimeError, match=r"--seeed"):
+        ParameterCatalog(parameters, overrides)
+
+
+def test_parameter_catalog_rejects_unknown_tier_name():
+    import pytest
+
+    parameters = [_minimal_param("--seed", required=True, longType="integer")]
+    overrides = {"tiers": {"python": {"comon": ["--seed"]}}}
+
+    with pytest.raises(RuntimeError, match="comon"):
+        ParameterCatalog(parameters, overrides)
+
+
+def test_python_common_tier_matches_issue_738_decision(test_paths):
+    import json
+
+    overrides = json.loads(
+        (test_paths.repo_root / "interfaces" / "parameters" / "overrides.json")
+        .read_text(encoding="utf-8")
+    )
+
+    assert overrides["tiers"]["python"]["common"] == [
+        "--seed",
+        "--num-trials",
+        "--two-level",
+        "--directed",
+        "--markov-time",
+    ]


### PR DESCRIPTION
## Summary

Implements #739: declare the Python "common tier" decided on #738 as catalog metadata and thread it through the generator, without changing any generated output.

- `interfaces/parameters/overrides.json`: new `tiers.python.common` section listing the five decided flags (`--seed`, `--num-trials`, `--two-level`, `--directed`, `--markov-time`), keyed by CLI flag like the existing `bindingOnly`/`hiddenBindings` sections.
- `scripts/parameter_catalog.py`: `Parameter.tier(language)` returns `"common"`/`"advanced"` (an undeclared language is all-advanced), and the catalog constructor validates the tiers section fail-loud — unknown tier names or flags not in the catalog raise, so a typo cannot silently put a parameter in the wrong 3.0 signature.
- `scripts/generate_binding_options.py`: the tier is exposed in the generator's parameter index, with the deprecated `include_self_links` and `pretty` explicitly marked `advanced`. The emitters do not read it yet — the deprecation pass (#741) and the 3.0 signature cut (#748) consume it from here.
- Four new tests in `test/python/test_parameter_catalog.py`, including one pinning `overrides.json` to the exact #738 decision.

Plumbing only, per the issue: `make build-binding-options` regenerates all four tracked outputs byte-identically.

## Verification

- `make build-binding-options && make test-binding-options-freshness`: outputs byte-identical (only the four source files show in `git status`)
- `pytest test/python -m fast`: 372 passed
- `test_signature_catalog.py` + `test_facade_generated_block.py`: green
- `ruff check scripts/ test/python/test_parameter_catalog.py`: clean

## Notes

- Closes #739 (commit message carries the `Closes` footer).
- The branch was restarted from `master` after #736 merged; it contains this single commit.
- Tier membership is a Python-surface policy decision, so it lives in `overrides.json` rather than `ParameterCatalog.cpp` — no C++ rebuild coupling, and R/JS are unaffected until they opt in with their own `tiers.<language>` sections.

---
_Generated by [Claude Code](https://claude.ai/code/session_017XjuZM32ZUn1AbeWJVXuyi)_