### PR TITLE
docs(python): deprecate advanced-tier kwargs on the Infomap signatures

### DIFF
--- a/interfaces/parameters/overrides.json
+++ b/interfaces/parameters/overrides.json
@@ -74,5 +74,21 @@
         "--markov-time"
       ]
     }
+  },
+  "apiNotes": {
+    "python": {
+      "inertWithoutOutputDir": [
+        "--output",
+        "--tree",
+        "--ftree",
+        "--clu",
+        "--clu-level",
+        "--out-name",
+        "--no-file-output",
+        "--hide-bipartite-nodes",
+        "--print-all-trials",
+        "--no-overwrite"
+      ]
+    }
   }
 }

--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -259,90 +259,258 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             exclude them.
         skip_adjust_bipartite_flow : bool, optional
             Keep flow on bipartite nodes instead of distributing it to primary nodes.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         bipartite_teleportation : bool, optional
             Use bipartite teleportation instead of the default two-step unipartite
             teleportation.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         weight_threshold : float, optional
             Ignore input links with weight below this threshold.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         no_self_links : bool, optional
             Exclude self-links from the input network.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         node_limit : int, optional
             Read only nodes up to this node id and ignore links connected to higher node
             ids.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         matchable_multilayer_ids : int, optional
             Construct state ids from node ids and layer ids that stay comparable across
             networks. Set at least to the largest layer id among networks to match.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         cluster_data : str, optional
             Read an initial partition from a clu file or a hierarchy from a tree/ftree
             file. Tree input may use physical or state nodes for higher-order networks.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         assign_to_neighbouring_module : bool, optional
             With --cluster-data, assign nodes missing module ids to a neighboring node's
             module when possible.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         meta_data : str, optional
             Read metadata to encode from a clu-format file.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         meta_data_rate : float, optional
             With --meta-data, set the metadata encoding rate. The default encodes
             metadata at each step.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         meta_data_unweighted : bool, optional
             With --meta-data, encode metadata without weighting by node flow.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         no_infomap : bool, optional
             Skip optimization. Use this to calculate codelength for --cluster-data or to
             print non-modular statistics.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         out_name : str, optional
             Base name for output files, for example [out_directory]/[out-name].tree.
+
+            Has no effect in the Python API unless an output directory is passed via
+            ``args`` (library mode disables file output otherwise; use the ``write_*``
+            methods to write results).
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         no_file_output : bool, optional
             Do not write output files.
+
+            Has no effect in the Python API unless an output directory is passed via
+            ``args`` (library mode disables file output otherwise; use the ``write_*``
+            methods to write results).
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         tree : bool, optional
             Write the modular hierarchy to a tree file. Enabled by default when no other
             output format is selected.
+
+            Has no effect in the Python API unless an output directory is passed via
+            ``args`` (library mode disables file output otherwise; use the ``write_*``
+            methods to write results).
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         ftree : bool, optional
             Write the modular hierarchy and aggregated links between nested modules to
             an ftree file. Used by Network Navigator.
+
+            Has no effect in the Python API unless an output directory is passed via
+            ``args`` (library mode disables file output otherwise; use the ``write_*``
+            methods to write results).
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         clu : bool, optional
             Write top-level module ids for each node to a clu file.
+
+            Has no effect in the Python API unless an output directory is passed via
+            ``args`` (library mode disables file output otherwise; use the ``write_*``
+            methods to write results).
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         clu_level : int, optional
             With --clu or --output clu, write module ids at this depth from the root.
             Use -1 for bottom-level modules.
+
+            Has no effect in the Python API unless an output directory is passed via
+            ``args`` (library mode disables file output otherwise; use the ``write_*``
+            methods to write results).
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         output : sequence of str, optional
             Write selected output formats as a comma-separated list without spaces, e.g.
             -o clu,tree,ftree. Options: clu, tree, ftree, newick, json, csv, network,
             states, flow.
+
+            Has no effect in the Python API unless an output directory is passed via
+            ``args`` (library mode disables file output otherwise; use the ``write_*``
+            methods to write results).
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         hide_bipartite_nodes : bool, optional
             Hide bipartite nodes in output by projecting the solution to primary nodes.
+
+            Has no effect in the Python API unless an output directory is passed via
+            ``args`` (library mode disables file output otherwise; use the ``write_*``
+            methods to write results).
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         print_all_trials : bool, optional
             Write each trial to separate output files. Has effect only when --num-trials
             is greater than 1.
+
+            Has no effect in the Python API unless an output directory is passed via
+            ``args`` (library mode disables file output otherwise; use the ``write_*``
+            methods to write results).
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         no_overwrite : bool, optional
             Fail with an output error if any target output file already exists. By
             default existing files are replaced.
+
+            Has no effect in the Python API unless an output directory is passed via
+            ``args`` (library mode disables file output otherwise; use the ``write_*``
+            methods to write results).
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         print_config_fingerprint : bool, optional
             Print the canonical configuration fingerprint and exit.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         timing_json : str, optional
             Write machine-readable run timing JSON to this path. Use - for stdout.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         summary_json : str, optional
             Write machine-readable final run summary JSON to this path. Use - for
             stdout.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         manifest_json : str, optional
             Write a machine-readable run manifest JSON to this path. Use - for stdout.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         memory_report : bool, optional
             Include peak RSS and best-effort bytes per node/link estimates in timing
             JSON. Requires --timing-json.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         trial_offset : int, optional
             Global index of the first trial this process runs; trial i uses seed =
             base_seed + (trial_offset + i). Default 0 (single-process behavior).
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         trial_results : str, optional
             Write this shard's per-trial results (codelengths, seeds, best-tree
             reference, fingerprints) as JSON to this path, for deterministic merging of
             distributed shard runs into a final solution.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         no_final_output : bool, optional
             Skip writing this process's aggregate best result. Per-trial outputs and
             --trial-results are still written.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         verbosity_level : int, optional
             Verbosity level on the console. 1 keeps the default output level, 2 renders
             -vv and so on.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         silent : bool, optional
             Suppress console output. The Python API is quiet by default; construct with
             silent=False for the engine log. The command-line interface is unaffected.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         pretty : bool | None, optional
             Deprecated. Accepted for backward compatibility; has no effect. Passing it
             explicitly emits a DeprecationWarning.
@@ -351,123 +519,263 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         flow_model : str, optional
             Choose how Infomap derives flow from the input links. Options: undirected,
             directed, undirdir, outdirdir, rawdir, precomputed.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         directed : bool, optional
             Treat input links as directed. Shorthand for --flow-model directed.
         recorded_teleportation : bool, optional
             When teleportation is used to calculate flow, also record teleportation
             steps in the codelength.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         use_node_weights_as_flow : bool, optional
             Use node weights from the API or Pajek node records as normalized node flow.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         to_nodes : bool, optional
             Teleport to nodes instead of links. Uses uniform node weights unless node
             weights are provided.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         teleportation_probability : float, optional
             Set the probability of teleporting to a random node or link when calculating
             flow.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         regularized : bool, optional
             Add a fully connected Bayesian prior network to reduce overfitting to
             missing links. Activates --recorded-teleportation.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         regularization_strength : float, optional
             Scale the relative strength of the Bayesian prior network used by
             --regularized.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         entropy_corrected : bool, optional
             Correct for negative entropy bias in small samples, especially solutions
             with many modules.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         entropy_correction_strength : float, optional
             Scale the default correction used by --entropy-corrected.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         markov_time : float, optional
             Scale link flow to change the cost of moving between modules. Higher values
             result in fewer modules.
         variable_markov_time : bool, optional
             Vary Markov time locally to reduce overpartitioning in sparse areas while
             keeping higher resolution in dense areas.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         variable_markov_damping : float, optional
             With --variable-markov-time, set damping between local effective degree (0)
             and local entropy (1).
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         variable_markov_min_scale : float, optional
             With --variable-markov-time, set the minimum local scale for zero-entropy
             nodes. Local Markov time is max scale divided by local scale.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         preferred_number_of_modules : int, optional
             Penalize solutions by how far their number of modules differs from this
             value.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         preferred_number_of_levels : int, optional
             Soft preference for the depth of the hierarchy. Steering to a shallower
             depth is reliable at a small codelength cost; deeper is best-effort, bounded
             by what the optimizer proposes. No-op with --two-level or strength 0.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         preferred_number_of_levels_strength : float, optional
             Scale the strength of --preferred-number-of-levels. 0 disables the
             preference; larger values increase the cost of deviating from the preferred
             depth.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         multilayer_relax_rate : float, optional
             Set the probability of relaxing from a state node to neighboring layers
             instead of staying in the current layer.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         multilayer_relax_limit : int, optional
             Limit relaxation to this many neighboring layer ids in each direction. Use a
             negative value to allow relaxation to any layer.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         multilayer_relax_limit_up : int, optional
             Limit relaxation upward to this many higher neighboring layer ids. Use a
             negative value to allow relaxation to any higher layer.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         multilayer_relax_limit_down : int, optional
             Limit relaxation downward to this many lower neighboring layer ids. Use a
             negative value to allow relaxation to any lower layer.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         multilayer_relax_by_jsd : bool, optional
             Weight multilayer relaxation by out-link similarity measured with
             Jensen-Shannon divergence.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         multilayer_relax_to_self : bool, optional
             On relaxation, link a state node to its own physical node in the target
             layer instead of spreading to its out-neighbors. Builds a smaller state
             network with the same flow as the default.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         seed : int, optional
             Set the random number generator seed for reproducible results.
         num_trials : int, optional
             Run this many independent trials and keep the best solution.
         core_loop_limit : int, optional
             Limit how many core loops try to move each node to the best module.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         core_level_limit : int, optional
             Limit how many times core loops are reapplied to the aggregated modular
             network to find larger structures. 0 means no limit.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         tune_iteration_limit : int, optional
             Limit the main iterations in the two-level partition algorithm. 0 means no
             limit.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         core_loop_codelength_threshold : float, optional
             Require at least this codelength improvement to accept a new solution in a
             core loop.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         tune_iteration_relative_threshold : float, optional
             Require each tune iteration to improve codelength by this fraction of the
             initial two-level codelength.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         fast_hierarchical_solution : int, optional
             Find top modules fast. Use 2 to keep all fast levels and 3 to skip the
             recursive part.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         inner_parallelization : bool, optional
             Experimental: use batched parallel node moves for coarse optimization.
             Performance gains are workload-dependent, often require a relaxed
             core-loop-codelength-threshold and low tune-iteration-limit, and may produce
             a different partition than serial optimization.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         parallel_trials : bool, optional
             Run independent trials in parallel with OpenMP. --num-trials remains the
             total number of trials; the number of parallel workers follows the OpenMP
             thread count (e.g. OMP_NUM_THREADS), clamped to --num-trials. Peak memory
             scales with the worker count. Nested OpenMP and --inner-parallelization are
             disabled inside workers.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         converge : bool, optional
             Treat the trial count as a cap and stop early once the best codelength has
             plateaued (no meaningful improvement over several consecutive trials). Runs
             trials serially; cannot be combined with parallel trials or distributed
             sharding. With no explicit trial count, a default cap is used.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         num_threads : str, optional
             Effective thread budget: 'auto' (resolve from --num-threads >
             INFOMAP_NUM_THREADS > SLURM_CPUS_PER_TASK > OMP_NUM_THREADS > cpuset >
             hardware), or a positive integer. 1 forces fully serial. Governs the
             recursive partition, parallel trials, and inner parallelization.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         threads : str, optional
             Alias for --num-threads.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         prefer_modular_solution : bool, optional
             Prefer a modular solution even when one module gives a lower codelength.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         num_random_moves : int, optional
             Try this many random moves in each core loop to merge weakly connected
             nodes.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         max_degree_for_random_moves : int, optional
             Try random moves only for nodes with degree at most this value.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         """
         if pretty is not None:
             warnings.warn(
@@ -577,90 +885,258 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             exclude them.
         skip_adjust_bipartite_flow : bool, optional
             Keep flow on bipartite nodes instead of distributing it to primary nodes.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         bipartite_teleportation : bool, optional
             Use bipartite teleportation instead of the default two-step unipartite
             teleportation.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         weight_threshold : float, optional
             Ignore input links with weight below this threshold.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         no_self_links : bool, optional
             Exclude self-links from the input network.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         node_limit : int, optional
             Read only nodes up to this node id and ignore links connected to higher node
             ids.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         matchable_multilayer_ids : int, optional
             Construct state ids from node ids and layer ids that stay comparable across
             networks. Set at least to the largest layer id among networks to match.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         cluster_data : str, optional
             Read an initial partition from a clu file or a hierarchy from a tree/ftree
             file. Tree input may use physical or state nodes for higher-order networks.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         assign_to_neighbouring_module : bool, optional
             With --cluster-data, assign nodes missing module ids to a neighboring node's
             module when possible.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         meta_data : str, optional
             Read metadata to encode from a clu-format file.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         meta_data_rate : float, optional
             With --meta-data, set the metadata encoding rate. The default encodes
             metadata at each step.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         meta_data_unweighted : bool, optional
             With --meta-data, encode metadata without weighting by node flow.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         no_infomap : bool, optional
             Skip optimization. Use this to calculate codelength for --cluster-data or to
             print non-modular statistics.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         out_name : str, optional
             Base name for output files, for example [out_directory]/[out-name].tree.
+
+            Has no effect in the Python API unless an output directory is passed via
+            ``args`` (library mode disables file output otherwise; use the ``write_*``
+            methods to write results).
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         no_file_output : bool, optional
             Do not write output files.
+
+            Has no effect in the Python API unless an output directory is passed via
+            ``args`` (library mode disables file output otherwise; use the ``write_*``
+            methods to write results).
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         tree : bool, optional
             Write the modular hierarchy to a tree file. Enabled by default when no other
             output format is selected.
+
+            Has no effect in the Python API unless an output directory is passed via
+            ``args`` (library mode disables file output otherwise; use the ``write_*``
+            methods to write results).
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         ftree : bool, optional
             Write the modular hierarchy and aggregated links between nested modules to
             an ftree file. Used by Network Navigator.
+
+            Has no effect in the Python API unless an output directory is passed via
+            ``args`` (library mode disables file output otherwise; use the ``write_*``
+            methods to write results).
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         clu : bool, optional
             Write top-level module ids for each node to a clu file.
+
+            Has no effect in the Python API unless an output directory is passed via
+            ``args`` (library mode disables file output otherwise; use the ``write_*``
+            methods to write results).
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         clu_level : int, optional
             With --clu or --output clu, write module ids at this depth from the root.
             Use -1 for bottom-level modules.
+
+            Has no effect in the Python API unless an output directory is passed via
+            ``args`` (library mode disables file output otherwise; use the ``write_*``
+            methods to write results).
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         output : sequence of str, optional
             Write selected output formats as a comma-separated list without spaces, e.g.
             -o clu,tree,ftree. Options: clu, tree, ftree, newick, json, csv, network,
             states, flow.
+
+            Has no effect in the Python API unless an output directory is passed via
+            ``args`` (library mode disables file output otherwise; use the ``write_*``
+            methods to write results).
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         hide_bipartite_nodes : bool, optional
             Hide bipartite nodes in output by projecting the solution to primary nodes.
+
+            Has no effect in the Python API unless an output directory is passed via
+            ``args`` (library mode disables file output otherwise; use the ``write_*``
+            methods to write results).
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         print_all_trials : bool, optional
             Write each trial to separate output files. Has effect only when --num-trials
             is greater than 1.
+
+            Has no effect in the Python API unless an output directory is passed via
+            ``args`` (library mode disables file output otherwise; use the ``write_*``
+            methods to write results).
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         no_overwrite : bool, optional
             Fail with an output error if any target output file already exists. By
             default existing files are replaced.
+
+            Has no effect in the Python API unless an output directory is passed via
+            ``args`` (library mode disables file output otherwise; use the ``write_*``
+            methods to write results).
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         print_config_fingerprint : bool, optional
             Print the canonical configuration fingerprint and exit.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         timing_json : str, optional
             Write machine-readable run timing JSON to this path. Use - for stdout.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         summary_json : str, optional
             Write machine-readable final run summary JSON to this path. Use - for
             stdout.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         manifest_json : str, optional
             Write a machine-readable run manifest JSON to this path. Use - for stdout.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         memory_report : bool, optional
             Include peak RSS and best-effort bytes per node/link estimates in timing
             JSON. Requires --timing-json.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         trial_offset : int, optional
             Global index of the first trial this process runs; trial i uses seed =
             base_seed + (trial_offset + i). Default 0 (single-process behavior).
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         trial_results : str, optional
             Write this shard's per-trial results (codelengths, seeds, best-tree
             reference, fingerprints) as JSON to this path, for deterministic merging of
             distributed shard runs into a final solution.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         no_final_output : bool, optional
             Skip writing this process's aggregate best result. Per-trial outputs and
             --trial-results are still written.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         verbosity_level : int, optional
             Verbosity level on the console. 1 keeps the default output level, 2 renders
             -vv and so on.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         silent : bool, optional
             Suppress console output. The Python API is quiet by default; construct with
             silent=False for the engine log. The command-line interface is unaffected.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         pretty : bool | None, optional
             Deprecated. Accepted for backward compatibility; has no effect. Passing it
             explicitly emits a DeprecationWarning.
@@ -669,123 +1145,263 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         flow_model : str, optional
             Choose how Infomap derives flow from the input links. Options: undirected,
             directed, undirdir, outdirdir, rawdir, precomputed.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         directed : bool, optional
             Treat input links as directed. Shorthand for --flow-model directed.
         recorded_teleportation : bool, optional
             When teleportation is used to calculate flow, also record teleportation
             steps in the codelength.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         use_node_weights_as_flow : bool, optional
             Use node weights from the API or Pajek node records as normalized node flow.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         to_nodes : bool, optional
             Teleport to nodes instead of links. Uses uniform node weights unless node
             weights are provided.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         teleportation_probability : float, optional
             Set the probability of teleporting to a random node or link when calculating
             flow.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         regularized : bool, optional
             Add a fully connected Bayesian prior network to reduce overfitting to
             missing links. Activates --recorded-teleportation.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         regularization_strength : float, optional
             Scale the relative strength of the Bayesian prior network used by
             --regularized.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         entropy_corrected : bool, optional
             Correct for negative entropy bias in small samples, especially solutions
             with many modules.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         entropy_correction_strength : float, optional
             Scale the default correction used by --entropy-corrected.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         markov_time : float, optional
             Scale link flow to change the cost of moving between modules. Higher values
             result in fewer modules.
         variable_markov_time : bool, optional
             Vary Markov time locally to reduce overpartitioning in sparse areas while
             keeping higher resolution in dense areas.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         variable_markov_damping : float, optional
             With --variable-markov-time, set damping between local effective degree (0)
             and local entropy (1).
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         variable_markov_min_scale : float, optional
             With --variable-markov-time, set the minimum local scale for zero-entropy
             nodes. Local Markov time is max scale divided by local scale.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         preferred_number_of_modules : int, optional
             Penalize solutions by how far their number of modules differs from this
             value.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         preferred_number_of_levels : int, optional
             Soft preference for the depth of the hierarchy. Steering to a shallower
             depth is reliable at a small codelength cost; deeper is best-effort, bounded
             by what the optimizer proposes. No-op with --two-level or strength 0.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         preferred_number_of_levels_strength : float, optional
             Scale the strength of --preferred-number-of-levels. 0 disables the
             preference; larger values increase the cost of deviating from the preferred
             depth.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         multilayer_relax_rate : float, optional
             Set the probability of relaxing from a state node to neighboring layers
             instead of staying in the current layer.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         multilayer_relax_limit : int, optional
             Limit relaxation to this many neighboring layer ids in each direction. Use a
             negative value to allow relaxation to any layer.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         multilayer_relax_limit_up : int, optional
             Limit relaxation upward to this many higher neighboring layer ids. Use a
             negative value to allow relaxation to any higher layer.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         multilayer_relax_limit_down : int, optional
             Limit relaxation downward to this many lower neighboring layer ids. Use a
             negative value to allow relaxation to any lower layer.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         multilayer_relax_by_jsd : bool, optional
             Weight multilayer relaxation by out-link similarity measured with
             Jensen-Shannon divergence.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         multilayer_relax_to_self : bool, optional
             On relaxation, link a state node to its own physical node in the target
             layer instead of spreading to its out-neighbors. Builds a smaller state
             network with the same flow as the default.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         seed : int, optional
             Set the random number generator seed for reproducible results.
         num_trials : int, optional
             Run this many independent trials and keep the best solution.
         core_loop_limit : int, optional
             Limit how many core loops try to move each node to the best module.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         core_level_limit : int, optional
             Limit how many times core loops are reapplied to the aggregated modular
             network to find larger structures. 0 means no limit.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         tune_iteration_limit : int, optional
             Limit the main iterations in the two-level partition algorithm. 0 means no
             limit.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         core_loop_codelength_threshold : float, optional
             Require at least this codelength improvement to accept a new solution in a
             core loop.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         tune_iteration_relative_threshold : float, optional
             Require each tune iteration to improve codelength by this fraction of the
             initial two-level codelength.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         fast_hierarchical_solution : int, optional
             Find top modules fast. Use 2 to keep all fast levels and 3 to skip the
             recursive part.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         inner_parallelization : bool, optional
             Experimental: use batched parallel node moves for coarse optimization.
             Performance gains are workload-dependent, often require a relaxed
             core-loop-codelength-threshold and low tune-iteration-limit, and may produce
             a different partition than serial optimization.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         parallel_trials : bool, optional
             Run independent trials in parallel with OpenMP. --num-trials remains the
             total number of trials; the number of parallel workers follows the OpenMP
             thread count (e.g. OMP_NUM_THREADS), clamped to --num-trials. Peak memory
             scales with the worker count. Nested OpenMP and --inner-parallelization are
             disabled inside workers.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         converge : bool, optional
             Treat the trial count as a cap and stop early once the best codelength has
             plateaued (no meaningful improvement over several consecutive trials). Runs
             trials serially; cannot be combined with parallel trials or distributed
             sharding. With no explicit trial count, a default cap is used.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         num_threads : str, optional
             Effective thread budget: 'auto' (resolve from --num-threads >
             INFOMAP_NUM_THREADS > SLURM_CPUS_PER_TASK > OMP_NUM_THREADS > cpuset >
             hardware), or a positive integer. 1 forces fully serial. Governs the
             recursive partition, parallel trials, and inner parallelization.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         threads : str, optional
             Alias for --num-threads.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         prefer_modular_solution : bool, optional
             Prefer a modular solution even when one module gives a lower codelength.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         num_random_moves : int, optional
             Try this many random moves in each core loop to merge weakly connected
             nodes.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
         max_degree_for_random_moves : int, optional
             Try random moves only for nodes with degree at most this value.
+
+            .. deprecated:: 2.15
+                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
+                instead; this keyword leaves the ``Infomap`` signature in 3.0.
 
         Returns
         -------

--- a/scripts/generate_binding_options.py
+++ b/scripts/generate_binding_options.py
@@ -147,10 +147,12 @@ def _facade_params(catalog: ParameterCatalog):
                 "default": param.python_default_expr(),
                 # Signature-tier metadata (issue #738/#739): "common" params
                 # stay as real keyword parameters in the 3.0 signatures;
-                # "advanced" params move to Options. Not yet consumed by the
-                # emitters -- the deprecation pass (#741) and the 3.0
-                # signature cut (#748) read it from here.
+                # "advanced" params are docs-only deprecated on the facade
+                # (#741) and move to Options in 3.0 (#748).
                 "tier": param.tier("python"),
+                # Output-artifact params are inert through kwargs (library
+                # mode forces noFileOutput without an output directory).
+                "inert_without_outdir": param.python_inert_without_outdir(),
                 # ``Infomap.run`` re-renders its keywords on top of the
                 # constructed state, and a rendered flag can only switch on. A
                 # generic boolean flag whose binding default is truthy
@@ -749,6 +751,26 @@ def _render_facade_signature(names, index, indent="        ", context="init"):
     return lines
 
 
+# The release in which the advanced-tier facade kwargs were docs-only
+# deprecated (issue #741). Bump alongside the next such pass, if any.
+_ADVANCED_TIER_DEPRECATED_IN = "2.15"
+
+# Parameters whose docstrings already carry their own deprecation text and
+# migration path; the generic advanced-tier directive would be noise on top.
+_SELF_DEPRECATED_PARAMS = {"include_self_links", "pretty"}
+
+_INERT_WITHOUT_OUTDIR_NOTE = (
+    "Has no effect in the Python API unless an output directory is passed "
+    "via `args` (library mode disables file output otherwise; use the "
+    "`write_*` methods to write results)."
+)
+
+_ADVANCED_TIER_NOTE = (
+    "Pass it via `Options` to `infomap.run()` or `Network.run()` instead; "
+    "this keyword leaves the `Infomap` signature in 3.0."
+)
+
+
 def _render_facade_docstring_params(names, index):
     lines = []
     for name in names:
@@ -757,6 +779,15 @@ def _render_facade_docstring_params(names, index):
             continue
         lines.append(f"        {name} : {info['doc_type']}")
         lines.extend(wrap_doc(info["doc"], "            "))
+        if info.get("inert_without_outdir"):
+            lines.append("")
+            lines.extend(wrap_doc(_INERT_WITHOUT_OUTDIR_NOTE, "            "))
+        if info.get("tier") == "advanced" and name not in _SELF_DEPRECATED_PARAMS:
+            lines.append("")
+            lines.append(
+                f"            .. deprecated:: {_ADVANCED_TIER_DEPRECATED_IN}"
+            )
+            lines.extend(wrap_doc(_ADVANCED_TIER_NOTE, "                "))
     return lines
 
 

--- a/scripts/parameter_catalog.py
+++ b/scripts/parameter_catalog.py
@@ -122,6 +122,22 @@ class Parameter:
         common = self.overrides.get("tiers", {}).get(language, {}).get("common", [])
         return "common" if self.flag in common else "advanced"
 
+    def python_inert_without_outdir(self) -> bool:
+        """True for output-artifact parameters that are inert via kwargs.
+
+        In library mode (``isCLI=false``, the only mode the Python API uses)
+        the engine forces ``noFileOutput`` on when no output directory is
+        given (``src/io/Config.cpp``), and the directory can only arrive via
+        the positional ``args`` argument. The flags are declared in the
+        overrides file (``apiNotes.python.inertWithoutOutputDir``).
+        """
+        inert = (
+            self.overrides.get("apiNotes", {})
+            .get("python", {})
+            .get("inertWithoutOutputDir", [])
+        )
+        return self.flag in inert
+
     def uses_generic_spec(self) -> bool:
         return self.render_policy in {"flag", "value"}
 
@@ -277,6 +293,13 @@ class ParameterCatalog:
                 raise RuntimeError(
                     f"tiers.{language}.common lists flag(s) not in the "
                     f"parameter catalog: {missing}"
+                )
+        for language, notes in self.overrides.get("apiNotes", {}).items():
+            missing = sorted(set(notes.get("inertWithoutOutputDir", [])) - known_flags)
+            if missing:
+                raise RuntimeError(
+                    f"apiNotes.{language}.inertWithoutOutputDir lists flag(s) "
+                    f"not in the parameter catalog: {missing}"
                 )
 
     def grouped(self) -> dict[str, list[Parameter]]:

--- a/test/python/test_deprecations.py
+++ b/test/python/test_deprecations.py
@@ -145,3 +145,17 @@ def test_from_options_silent():
 def test_deprecated_member_still_documents_deprecation():
     """The docs-only policy: deprecated members keep their ``.. deprecated::`` note."""
     assert ".. deprecated::" in Infomap.codelength.__doc__
+
+
+# -- advanced-tier keyword parameters (docs-only deprecated, #741) -----------
+
+
+@pytest.mark.fast
+def test_advanced_tier_kwargs_stay_silent_and_functional():
+    """Advanced-tier kwargs are deprecated by documentation only: passing
+    them explicitly emits no DeprecationWarning and keeps working."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        im = _two_triangles(core_loop_limit=5, flow_model="undirected")
+        result = im.run(markov_time=1.0, core_loop_limit=5)
+    assert result.num_top_modules >= 1

--- a/test/python/test_facade_generated_block.py
+++ b/test/python/test_facade_generated_block.py
@@ -68,3 +68,28 @@ def test_generated_signatures_are_annotated():
     assert "Literal" in str(run_signature.parameters["flow_model"].annotation)
     assert "Literal" in str(run_signature.parameters["output"].annotation)
     assert run_signature.parameters["num_trials"].annotation is int
+
+
+def test_docstring_deprecation_follows_the_signature_tier():
+    from infomap import Infomap
+
+    for doc in (Infomap.__init__.__doc__, Infomap.run.__doc__):
+        assert doc is not None
+        # Advanced-tier parameters carry the docs-only deprecation directive.
+        assert ".. deprecated:: 2.15" in doc
+        # Common-tier parameters (#738) do not: no directive may appear
+        # between a common param's entry and the next parameter entry.
+        for common, following in [
+            ("seed : ", "num_trials : "),
+            ("num_trials : ", "core_loop_limit : "),
+            ("two_level : ", "flow_model : "),
+            ("directed : ", "recorded_teleportation : "),
+            ("markov_time : ", "variable_markov_time : "),
+        ]:
+            start = doc.index(common)
+            end = doc.index(following, start)
+            assert ".. deprecated::" not in doc[start:end], common
+        # Output-artifact params carry the inertness note from #748.
+        start = doc.index("output : ")
+        end = doc.index("hide_bipartite_nodes : ", start)
+        assert "Has no effect in the Python API" in doc[start:end]


### PR DESCRIPTION
## Summary

Implements #741 — the last 2.x preparation step before the 3.0 signature cut (#748). Docs-only deprecation per the policy in RELEASING.md; no runtime warnings, no behavior change.

- Every advanced-tier parameter (tier metadata from #751) gets a `.. deprecated:: 2.15` directive in the generated `Infomap.__init__`/`run` docstrings, pointing at `Options` via `infomap.run()`/`Network.run()` — the migration paths that exist today (`options=` on `Infomap` itself arrives with #748's sentinel machinery). The five common-tier parameters decided on #738 (`seed`, `num_trials`, `two_level`, `directed`, `markov_time`) are untouched, as are `include_self_links`/`pretty` (own deprecation texts) and the `Options` class docstring (it is the destination).
- The ten output-artifact parameters (`output`, `tree`, `ftree`, `clu`, `clu_level`, `out_name`, `no_file_output`, `hide_bipartite_nodes`, `print_all_trials`, `no_overwrite`) additionally document that they have no effect through kwargs — library mode disables file output without an output directory (verified on #748) — and point at the `write_*` methods.
- The inert-flag list lives in `overrides.json` (`apiNotes.python.inertWithoutOutputDir`) with fail-loud catalog validation, mirroring the `tiers` section from #751.
- Tests: `test_deprecations.py` pins that explicitly passed advanced-tier kwargs stay silent and functional; `test_facade_generated_block.py` pins the docstring structure (directive present on advanced params, absent between each common-tier entry and its successor, inertness note on the output params).

## Verification

- Full suite: 551 passed, 2 skipped; doctests 38 passed (includes ruff)
- `make test-python-typecheck-core`: 0 errors
- `make test-binding-options-freshness`: fresh; R/TS outputs and `_options.py` byte-identical (facade docstrings only, ~616 added lines)

## Notes

- Closes #741. With this merged, the 2.x preparation chain #738→#739→#740→#741 is complete; remaining 2.x-track work (#742–#746) and the 3.0 cut (#748) build on it.
- `docs(python)` prefix: docs-only deprecation is not a behavior change, so this triggers no version bump on its own.
- `silent`/`verbosity_level` get the generic Options migration text even though their 3.0 story is Python `logging` (#745) — the Options path works throughout 2.x, and the directive can be retargeted when #745 lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_017XjuZM32ZUn1AbeWJVXuyi)_