### PR TITLE
ci(python): promote full-scope pyright to the full-suite CI leg

### DIFF
--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -265,11 +265,12 @@ jobs:
         if: matrix.run-full-suite
         run: make test-python-doctest
 
-      # Deterministic core-scope gate (io/ and tl/ excluded); mirrors the
-      # pre-push hook.
-      - name: Type check Python core surface
+      # Full scope including the io/ and tl/ integration adapters. The
+      # [test]+[examples] extras installed above pin the optional-dep set and
+      # pyright is version-pinned, so the diagnostics are reproducible here.
+      - name: Type check Python package
         if: matrix.run-full-suite
-        run: make test-python-typecheck-core
+        run: make test-python-typecheck
 
       - name: Run Python example smoke tests
         if: matrix.run-full-suite

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -111,8 +111,8 @@ repos:
       # pyright runs at PUSH time, not on every commit: it is slower and its
       # results depend on installed deps. Scoped to the core surface (io/, tl/
       # excluded) so it stays deterministic across dev machines -- see the
-      # test-python-typecheck-core target. Full-scope pyright stays a manual /
-      # future-CI check.
+      # test-python-typecheck-core target. Full-scope pyright runs in CI's
+      # full-suite Python leg, where the extras pin the optional-dep set.
       - id: pyright-core
         name: pyright (core, pre-push)
         language: system

--- a/interfaces/python/src/infomap/io/networkx.py
+++ b/interfaces/python/src/infomap/io/networkx.py
@@ -85,7 +85,9 @@ def run_networkx(
 ) -> tuple[Any, dict[int, Any]]:
     from .._facade import Infomap
 
-    options = {"silent": True, "no_file_output": True}
+    # dict[str, Any]: the caller's infomap_options carry arbitrary option
+    # value types, not just the bools of the two seeds.
+    options: dict[str, Any] = {"silent": True, "no_file_output": True}
     options.update(infomap_options)
 
     infomap = Infomap(**options)

--- a/interfaces/python/src/infomap/tl/__init__.py
+++ b/interfaces/python/src/infomap/tl/__init__.py
@@ -208,7 +208,9 @@ def infomap(
     )
     _validate_adjacency_shape(matrix, n_obs=n_obs)
 
-    options = {"silent": True, "no_file_output": True}
+    # dict[str, Any]: the caller's infomap_options carry arbitrary option
+    # value types, not just the bools of the two seeds.
+    options: dict[str, Any] = {"silent": True, "no_file_output": True}
     options.update(infomap_options)
     im = Infomap(args=args, **options)
     obs_names = list(adata.obs_names)

--- a/mk/python.mk
+++ b/mk/python.mk
@@ -109,17 +109,20 @@ test-python-examples:
 
 # Static type check of the hand-written package. Config + scope (include the
 # package, exclude the SWIG-generated _swig.py) live in [tool.pyright] in
-# pyproject.toml. Not part of the default `test-python` aggregate -- run it
-# explicitly or in a dedicated CI job.
+# pyproject.toml. Not part of the default `test-python` aggregate -- gated in
+# CI's full-suite Python leg, where the [test]+[examples] extras pin the
+# optional-dep set and pyright itself is version-pinned, so the diagnostics
+# are reproducible there. Optional-dep upgrades that surface new diagnostics
+# show up in the corresponding dependabot PR, which is where they belong.
 test-python-typecheck:
 	@$(PYRIGHT)
 
 # Type check only the core API/algorithm surface, excluding the optional
 # third-party integration adapters (io/, tl/) whose pyright diagnostics vary
 # with which optional deps + stub packages are installed. Used by the pre-push
-# hook so the gate is deterministic across dev machines; the full-scope check
-# above (and pyproject's [tool.pyright]) still covers everything. Scope lives in
-# interfaces/python/pyrightconfig-core.json.
+# hook (and CI quick mode) so the gate is deterministic across dev machines;
+# the full-scope check above covers everything in CI's full-suite leg. Scope
+# lives in interfaces/python/pyrightconfig-core.json.
 test-python-typecheck-core:
 	@$(PYRIGHT) -p interfaces/python/pyrightconfig-core.json
 


### PR DESCRIPTION
## Summary

Implements #746: the full-suite Python CI job now runs `make test-python-typecheck` (full scope, `io/` and `tl/` included) instead of the core-scope subset; quick mode and the pre-push hook keep the deterministic core gate.

- Reproducibility in CI comes from the pinned pyright version (#736) plus the `[test]`+`[examples]` extras the job already installs. Optional-dep upgrades that surface new diagnostics land in the corresponding dependabot PR's CI — exactly where they belong.
- Fixes the 23 full-scope errors that the `Literal`-typed signatures from #752 exposed: the option seed dicts in `io/networkx.find_communities` and `tl.infomap` inferred as `dict[str, bool]` and failed every non-bool kwarg expansion; they now carry `dict[str, Any]`.
- Updates the `mk/python.mk` and `.pre-commit-config.yaml` comments that called full scope "manual / future-CI".

## Verification

- `make test-python-typecheck`: 0 errors (full scope)
- `make test-python-typecheck-core`: 0 errors
- Full suite: 551 passed, 2 skipped; ruff clean

## Notes

- Closes #746. Fifth completed item on the #737 roadmap's 2.x track (#738–#741, #746).
- The two pandas-stubs `Axes` errors originally noted on the issue resolved themselves: the `require_pandas` consolidation in #736 makes graphrag's `pd` handle type as `Any`, so pandas constructor calls are no longer argument-checked there. Intentional guard behavior, noted for awareness.

---
_Generated by [Claude Code](https://claude.ai/code/session_017XjuZM32ZUn1AbeWJVXuyi)_