### PR TITLE
docs(python): steer examples and docs to Options and the common tier

### DIFF
--- a/examples/python/bipartite.py
+++ b/examples/python/bipartite.py
@@ -1,6 +1,6 @@
 from infomap import Infomap
 
-im = Infomap(two_level=True, silent=True)
+im = Infomap(two_level=True)
 
 # Set the start id for bipartite nodes
 im.bipartite_start_id = 5

--- a/examples/python/evaluate-partition.py
+++ b/examples/python/evaluate-partition.py
@@ -1,21 +1,21 @@
-from infomap import Infomap
+from infomap import Network, Options
 
 # Compare codelengths for two different partitions of a network
 # composed of two triangles {0,1,2} and {5,6,7} connected by a
 # chain of two nodes in the middle {3,4}.
 
-im = Infomap(two_level=True, silent=True)
+net = Network()
 
 # Add weight as an optional third argument
-im.add_link(0, 1)
-im.add_link(0, 2)
-im.add_link(1, 2)
-im.add_link(2, 3)
-im.add_link(3, 4)
-im.add_link(4, 5)
-im.add_link(5, 6)
-im.add_link(5, 7)
-im.add_link(6, 7)
+net.add_link(0, 1)
+net.add_link(0, 2)
+net.add_link(1, 2)
+net.add_link(2, 3)
+net.add_link(3, 4)
+net.add_link(4, 5)
+net.add_link(5, 6)
+net.add_link(5, 7)
+net.add_link(6, 7)
 
 # Three modules, with the chain in its own module
 partition1 = {
@@ -41,10 +41,11 @@ partition2 = {
     7: 2,
 }
 
-# Set initial partition on the Infomap instance to keep it during multiple runs
-im.initial_partition = partition1
+# no_infomap skips optimization and just calculates the codelength
+# of the given partition
+opts = Options(two_level=True, no_infomap=True)
 
-result = im.run(no_infomap=True)
+result = net.run(options=opts, initial_partition=partition1)
 
 print(
     f"Partition one with {result.num_top_modules} modules -> "
@@ -52,8 +53,7 @@ print(
 )
 
 
-# Set initial partition as run parameter to only use it for this run (will be restored to partition1 after)
-result = im.run(initial_partition=partition2, no_infomap=True)
+result = net.run(options=opts, initial_partition=partition2)
 
 print(
     f"Partition two with {result.num_top_modules} modules -> "

--- a/examples/python/file-io.py
+++ b/examples/python/file-io.py
@@ -1,8 +1,8 @@
 import pathlib
 
-from infomap import Infomap
+from infomap import Infomap, Network, Options
 
-im = Infomap(silent=True)
+im = Infomap()
 
 name = "ninetriangles"
 filename = f"../networks/{name}.net"
@@ -48,11 +48,12 @@ print(f"Writing tree to output/{name}.tree...")
 im.write(f"output/{name}.tree")
 
 print("Read back .clu file and only calculate codelength...")
-im2 = Infomap(
-    silent=True, two_level=True, no_infomap=True, cluster_data=f"output/{name}.clu"
+net2 = Network.from_file(filename)
+result2 = net2.run(
+    options=Options(
+        two_level=True, no_infomap=True, cluster_data=f"output/{name}.clu"
+    )
 )
-im2.read_file(filename)
-result2 = im2.run()
 print(
     f"Found {result2.max_depth} levels with {result2.num_top_modules} top modules "
     f"and codelength: {result2.codelength:.8f} bits"

--- a/examples/python/infomap-networkx.py
+++ b/examples/python/infomap-networkx.py
@@ -66,7 +66,7 @@ G = nx.karate_club_graph()
 
 print("Building Infomap network from a NetworkX graph...")
 print("Find communities with Infomap...")
-result = run(G, two_level=True, silent=True, num_trials=20)
+result = run(G, two_level=True, num_trials=20)
 
 print(
     f"Found {result.num_top_modules} modules with codelength "
@@ -91,7 +91,7 @@ G.add_edge("b", "c")
 G.add_edge("d", "e")
 G.add_edge("d", "f")
 G.add_edge("e", "f")
-result = run(G, silent=True)
+result = run(G)
 print("#node_id module_id flow state_id")
 for node in result.nodes(states=True):
     print(node.node_id, node.module_id, node.flow, node.state_id)
@@ -112,7 +112,7 @@ G.add_node(32, node_id=3, layer_id=2)
 G.add_edge(11, 21)
 G.add_edge(22, 32)
 # Pass multilayer_inter_intra_format=False for full multilayer format via a Network
-result = run(G, silent=True)
+result = run(G)
 print("#node_id module_id flow state_id layer_id")
 for node in result.nodes(states=True):
     print(

--- a/examples/python/links.py
+++ b/examples/python/links.py
@@ -1,6 +1,6 @@
 from infomap import Infomap
 
-im = Infomap(silent=True)
+im = Infomap()
 im.read_file("../networks/states.net")
 result = im.run()
 

--- a/examples/python/metadata.py
+++ b/examples/python/metadata.py
@@ -1,26 +1,21 @@
-from infomap import Infomap
+from infomap import Network, Options
 
 # Changing eta to 2 results in three modules that maps to metadata categories
 eta = 1
-im = Infomap(two_level=True, silent=True, meta_data_rate=eta)
+net = Network()
 
 # Two triangles connected by {2, 3}
-im.add_link(0, 1)
-im.add_link(0, 2)
-im.add_link(2, 1)
-im.add_link(2, 3)
-im.add_link(3, 4)
-im.add_link(3, 5)
-im.add_link(4, 5)
+net.add_link(0, 1)
+net.add_link(0, 2)
+net.add_link(2, 1)
+net.add_link(2, 3)
+net.add_link(3, 4)
+net.add_link(3, 5)
+net.add_link(4, 5)
 
-im.set_meta_data(0, 2)
-im.set_meta_data(1, 2)
-im.set_meta_data(2, 1)
-im.set_meta_data(3, 1)
-im.set_meta_data(4, 3)
-im.set_meta_data(5, 3)
+net.set_meta_data({0: 2, 1: 2, 2: 1, 3: 1, 4: 3, 5: 3})
 
-result = im.run()
+result = net.run(options=Options(two_level=True, meta_data_rate=eta))
 
 print(
     f"\nFound {result.num_top_modules} modules with codelength "

--- a/examples/python/modify-network.py
+++ b/examples/python/modify-network.py
@@ -1,17 +1,17 @@
-from infomap import Infomap
+from infomap import Network, Options
 
-im = Infomap(two_level=True, silent=True)
+net = Network()
 
 # Add weight as an optional third argument
-im.add_link(1, 2)
-im.add_link(1, 3)
-im.add_link(2, 3)
-im.add_link(3, 4)
-im.add_link(4, 5)
-im.add_link(4, 6)
-im.add_link(5, 6)
+net.add_link(1, 2)
+net.add_link(1, 3)
+net.add_link(2, 3)
+net.add_link(3, 4)
+net.add_link(4, 5)
+net.add_link(4, 6)
+net.add_link(5, 6)
 
-result = im.run()
+result = net.run(options=Options(two_level=True))
 
 print(
     f"Found {result.num_top_modules} modules with codelength "
@@ -23,13 +23,15 @@ modules = result.modules()
 print("Modify the network and test partition...")
 
 # Do some modification to the network
-im.add_link(1, 5)
+net.add_link(1, 5)
 # Note that removing links will not remove nodes if they become unconnected
-im.remove_link(5, 6)
+net.remove_link(5, 6)
 
-# Run again with the optimal partition from the original network as initial solution
-# Set no_infomap to skip optimization and just calculate the codelength
-result = im.run(initial_partition=modules, no_infomap=True)
+# Run again with the optimal partition from the original network as initial
+# solution. no_infomap skips optimization and just calculates the codelength.
+result = net.run(
+    options=Options(two_level=True, no_infomap=True), initial_partition=modules
+)
 
 print(
     f"Found {result.num_top_modules} modules with codelength "

--- a/examples/python/multilayer.py
+++ b/examples/python/multilayer.py
@@ -12,7 +12,7 @@ def print_result(result):
         print(f"{node.layer_id} {node.node_id} {node.module_id}")
 
 
-im = Infomap(silent=True)
+im = Infomap()
 print("\nAdding multilayer network...")
 
 # from (layer1, node1) to (layer2, node2) with optional weight
@@ -27,7 +27,7 @@ print_result(result)
 # Add only intra-layer links and let Infomap provide
 # inter-layer links by relaxing the random walker's
 # constraint to its current layer
-im = Infomap(silent=True)
+im = Infomap()
 print("\nAdding intra-layer network...")
 
 # Add layer_id, source_node_id, target_node_id and optional weight

--- a/examples/python/simple-networkx.py
+++ b/examples/python/simple-networkx.py
@@ -10,7 +10,7 @@ G.add_edge(11, 21, weight=2)
 G.add_edge(22, 32)
 
 # One call from a NetworkX graph to an immutable Result.
-result = run(G, silent=True)
+result = run(G)
 
 for node in sorted(result.nodes(states=True), key=lambda n: n.state_id):
     print(

--- a/examples/python/simple.py
+++ b/examples/python/simple.py
@@ -1,6 +1,6 @@
 from infomap import Infomap
 
-im = Infomap(two_level=True, silent=True)
+im = Infomap(two_level=True)
 
 # Optionally add nodes with names
 im.add_node(0, "Node 0")

--- a/examples/python/state-network.py
+++ b/examples/python/state-network.py
@@ -1,6 +1,6 @@
 from infomap import Infomap
 
-im = Infomap(two_level=True, silent=True)
+im = Infomap(two_level=True)
 
 im.set_name(1, "PRE")
 im.set_name(2, "SCIENCE")

--- a/interfaces/python/source/concepts/choosing-a-method.md
+++ b/interfaces/python/source/concepts/choosing-a-method.md
@@ -108,7 +108,7 @@ for i in range(n_groups * n_per):
             g.add_edge(i, j)
 
 # Infomap: compress the flow
-result = infomap.run(g, two_level=True, seed=123, num_trials=10, silent=True)
+result = infomap.run(g, two_level=True, seed=123, num_trials=10)
 infomap_mods = result.modules()
 
 # Louvain and Leiden: maximise modularity

--- a/interfaces/python/source/concepts/flow-and-random-walks.md
+++ b/interfaces/python/source/concepts/flow-and-random-walks.md
@@ -135,7 +135,7 @@ print("Edges:", list(G.edges()))
 
 ```{code-cell} python
 # Run Infomap on the directed network
-result = infomap.run(G, directed=True, silent=True, seed=123, num_trials=10)
+result = infomap.run(G, directed=True, seed=123, num_trials=10)
 
 # Read per-node flow (stationary visit frequency) and module assignments
 flow    = {node.node_id: node.flow       for node in result.nodes()}

--- a/interfaces/python/source/concepts/hierarchy-and-the-multilevel-map.md
+++ b/interfaces/python/source/concepts/hierarchy-and-the-multilevel-map.md
@@ -187,7 +187,7 @@ from infomap import Network, run
 net = Network()
 for u, v, w in links:
     net.add_link(u, v, w)
-result = run(net, silent=True, num_trials=10, seed=123)
+result = run(net, num_trials=10, seed=123)
 
 print(f"Tree depth (num_levels): {result.num_levels}")
 print(f"Top-level modules:       {result.num_top_modules}")
@@ -198,7 +198,7 @@ assert result.num_top_modules == 3
 
 # The bundled copy is the same network; the two must agree exactly.
 result_pkg = infomap.run(infomap.datasets.nine_triangles(),
-                         silent=True, num_trials=10, seed=123)
+                         num_trials=10, seed=123)
 assert result.codelength == result_pkg.codelength
 ```
 

--- a/interfaces/python/source/concepts/state-nodes-and-higher-order-flow.md
+++ b/interfaces/python/source/concepts/state-nodes-and-higher-order-flow.md
@@ -99,7 +99,7 @@ links = [
 for src, tgt, w in links:
     net.add_link(src, tgt, w)
 
-result = run(net, two_level=True, directed=True, seed=123, num_trials=10, silent=True)
+result = run(net, two_level=True, directed=True, seed=123, num_trials=10)
 
 print(f"Modules: {result.num_top_modules}")
 for node in sorted(result.nodes(states=True), key=lambda n: n.state_id):
@@ -155,7 +155,7 @@ above exactly:
 ```{code-cell} python
 net_pkg = infomap.datasets.states()
 result_pkg = infomap.run(net_pkg, two_level=True, directed=True,
-                         seed=123, num_trials=10, silent=True)
+                         seed=123, num_trials=10)
 
 print(f"Modules: {result_pkg.num_top_modules}, "
       f"codelength {result_pkg.codelength:.4f} bits per step")

--- a/interfaces/python/source/concepts/the-map-equation.md
+++ b/interfaces/python/source/concepts/the-map-equation.md
@@ -145,7 +145,7 @@ g = nx.karate_club_graph()
 print(f"Nodes: {g.number_of_nodes()}, Edges: {g.number_of_edges()}")
 
 # Two-level search, 10 independent trials, fixed seed for reproducibility.
-result = infomap.run(g, two_level=True, seed=123, num_trials=10, silent=True)
+result = infomap.run(g, two_level=True, seed=123, num_trials=10)
 
 modules = result.modules()            # {node_id: module_id}
 n_top   = result.num_top_modules

--- a/interfaces/python/source/flow-models/bipartite.md
+++ b/interfaces/python/source/flow-models/bipartite.md
@@ -105,7 +105,7 @@ print(f"Nodes with id >= {BIPARTITE_START} are treated as type-B (items).")
 ### Run and inspect modules
 
 ```{code-cell} python
-result = run(net, two_level=True, num_trials=10, seed=123, silent=True)
+result = run(net, two_level=True, num_trials=10, seed=123)
 
 modules = result.modules()   # {node_id: module_id}
 
@@ -136,7 +136,7 @@ for u, v, w in [
     (0, 6, 0.2), (2, 4, 0.2),
 ]:
     net_std.add_link(u, v, w)
-result_std = run(net_std, two_level=True, num_trials=10, seed=123, silent=True)
+result_std = run(net_std, two_level=True, num_trials=10, seed=123)
 
 print(f"unipartite run: {result_std.num_top_modules} modules, L={result_std.codelength:.4f}")
 print(f"bipartite run:  {result.num_top_modules} modules, L={result.codelength:.4f}")

--- a/interfaces/python/source/flow-models/memory-and-state.md
+++ b/interfaces/python/source/flow-models/memory-and-state.md
@@ -172,7 +172,7 @@ g.add_weighted_edges_from([
     ("l", "i", 1.0), ("l", "m", 1.0), ("m", "i", 1.0), ("m", "l", 1.0),
 ])
 
-result_first = run(g, two_level=True, directed=True, seed=123, num_trials=20, silent=True)
+result_first = run(g, two_level=True, directed=True, seed=123, num_trials=20)
 print(f"First-order modules: {result_first.num_top_modules}")
 print(f"Codelength         : {result_first.codelength:.4f} bits")
 
@@ -190,7 +190,7 @@ Now the state network. The bundled `states()` loader carries the two contexts of
 for directed flow).
 
 ```{code-cell} python
-result = run(infomap.datasets.states(), num_trials=20, seed=123, silent=True)
+result = run(infomap.datasets.states(), num_trials=20, seed=123)
 
 print(f"State nodes  : {len(list(result.nodes(states=True)))}")
 print(f"Modules found: {result.num_top_modules}")

--- a/interfaces/python/source/flow-models/metadata.md
+++ b/interfaces/python/source/flow-models/metadata.md
@@ -158,7 +158,7 @@ attribute-pure modules.
 ```{code-cell} python
 import infomap
 import networkx as nx
-from infomap import Network, run
+from infomap import Network, Options, run
 
 # Two triangles joined by a bridge edge
 G = nx.Graph()
@@ -183,7 +183,7 @@ for node_id, category in metadata.items():
 ### Topology only (rate = 0)
 
 ```{code-cell} python
-result_topo = run(net, meta_data_rate=0, silent=True, num_trials=10)
+result_topo = run(net, options=Options(meta_data_rate=0), num_trials=10)
 mods_topo = result_topo.modules()
 
 print(f"Topology-only partition: {result_topo.num_top_modules} modules")
@@ -202,7 +202,7 @@ At rate 0, Infomap finds the two topological communities: {1, 2, 3} and
 ### Metadata-aware (rate = 2)
 
 ```{code-cell} python
-result_meta = run(net, meta_data_rate=2.0, silent=True, num_trials=10)
+result_meta = run(net, options=Options(meta_data_rate=2.0), num_trials=10)
 mods_meta = result_meta.modules()
 
 print(f"Metadata-aware partition: {result_meta.num_top_modules} modules")
@@ -249,7 +249,7 @@ for node_id, category in metadata.items():
 print(f"{'meta_data_rate':>14}  {'modules':>8}  {'codelength':>12}")
 print("-" * 38)
 for eta in [0.0, 0.5, 1.0, 2.0, 5.0]:
-    r = run(net_sweep, meta_data_rate=eta, num_trials=10, seed=123, silent=True)
+    r = run(net_sweep, options=Options(meta_data_rate=eta), num_trials=10, seed=123)
     print(f"{eta:>14.1f}  {r.num_top_modules:>8}  {r.codelength:>12.4f}")
 ```
 

--- a/interfaces/python/source/flow-models/multilayer.md
+++ b/interfaces/python/source/flow-models/multilayer.md
@@ -145,7 +145,7 @@ and {*i*, *j*, *k*} from Layer 2. Node *i* is bi-modular: one module per layer.
 
 ```{code-cell} python
 import infomap
-from infomap import Network, run
+from infomap import Network, Options, run
 
 names = {1: "i", 2: "j", 3: "k", 4: "l", 5: "m"}
 
@@ -162,7 +162,7 @@ net = Network()
 for layer, src, tgt, w in intra_links:
     net.add_multilayer_intra_link(layer, src, tgt, w)
 
-result = run(net, multilayer_relax_rate=0.15, seed=123, num_trials=10, silent=True)
+result = run(net, options=Options(multilayer_relax_rate=0.15), seed=123, num_trials=10)
 
 state_nodes = list(result.nodes(states=True))
 print(f"Modules found : {result.num_top_modules}")
@@ -291,7 +291,7 @@ for r in [0.01, 0.15, 0.50, 0.90, 1.00]:
     net_r = Network()
     for layer, src, tgt, w in intra_links:
         net_r.add_multilayer_intra_link(layer, src, tgt, w)
-    result_r = run(net_r, multilayer_relax_rate=r, seed=123, num_trials=10, silent=True)
+    result_r = run(net_r, options=Options(multilayer_relax_rate=r), seed=123, num_trials=10)
     results.append((r, result_r.num_top_modules, result_r.codelength))
 
 print(f"{'relax rate':>12}  {'modules':>8}  {'codelength':>12}")
@@ -331,13 +331,13 @@ for layer, src, tgt, w in intra_links:
 net_aligned.add_multilayer_inter_link(1, 1, 2, 0.4)
 net_aligned.add_multilayer_inter_link(2, 1, 1, 0.4)
 
-result_aligned = run(net_aligned, seed=123, num_trials=10, silent=True)
+result_aligned = run(net_aligned, seed=123, num_trials=10)
 print(f"Modules found : {result_aligned.num_top_modules}")
 print(f"Codelength    : {result_aligned.codelength:.4f} bits")
 
 # The same construction ships with the package; the two must agree exactly.
 result_pkg = infomap.run(infomap.datasets.multilayer_intra_inter(),
-                         seed=123, num_trials=10, silent=True)
+                         seed=123, num_trials=10)
 assert result_aligned.codelength == result_pkg.codelength
 ```
 
@@ -365,12 +365,12 @@ inter_links = [
 for src, tgt, w in inter_links:
     net_full.add_multilayer_link(src, tgt, w)
 
-result_full = run(net_full, seed=123, num_trials=10, silent=True)
+result_full = run(net_full, seed=123, num_trials=10)
 print(f"Modules found : {result_full.num_top_modules}")
 print(f"Codelength    : {result_full.codelength:.4f} bits")
 
 result_pkg = infomap.run(infomap.datasets.multilayer(),
-                         seed=123, num_trials=10, silent=True)
+                         seed=123, num_trials=10)
 assert result_full.codelength == result_pkg.codelength
 ```
 
@@ -396,9 +396,10 @@ net_self = Network()
 for layer, src, tgt, w in intra_links:
     net_self.add_multilayer_intra_link(layer, src, tgt, w)
 
-result_self = run(net_self, multilayer_relax_rate=0.15,
-                  multilayer_relax_to_self=True,
-                  seed=123, num_trials=10, silent=True)
+result_self = run(net_self,
+                  options=Options(multilayer_relax_rate=0.15,
+                                  multilayer_relax_to_self=True),
+                  seed=123, num_trials=10)
 
 n_links_self = len(list(result_self.links()))
 n_links_default = len(list(result.links()))

--- a/interfaces/python/source/flow-models/temporal.md
+++ b/interfaces/python/source/flow-models/temporal.md
@@ -109,7 +109,7 @@ transitions automatically using a relax rate of 0.25.
 import infomap
 import networkx as nx
 import matplotlib.pyplot as plt
-from infomap import Network, run
+from infomap import Network, Options, run
 from docs_viz import draw_partition, module_palette
 
 # Three time windows; (source, target) pairs active in each window.
@@ -129,7 +129,7 @@ for layer_id, edges in edges_by_layer.items():
     for u, v in edges:
         net.add_multilayer_intra_link(layer_id, u, v)
 
-result = run(net, multilayer_relax_rate=0.25, silent=True, seed=123)
+result = run(net, options=Options(multilayer_relax_rate=0.25), seed=123)
 print(f"Top-level modules : {result.num_top_modules}")
 print(f"Codelength        : {result.codelength:.4f} bits/step")
 ```

--- a/interfaces/python/source/index.rst
+++ b/interfaces/python/source/index.rst
@@ -34,7 +34,7 @@ Quick start
     import infomap
 
     graph = nx.karate_club_graph()
-    result = infomap.run(graph, seed=123, num_trials=20, silent=True)
+    result = infomap.run(graph, seed=123, num_trials=20)
 
     print(result.num_top_modules, "modules")
     print(result.modules())

--- a/interfaces/python/source/quickstart.rst
+++ b/interfaces/python/source/quickstart.rst
@@ -17,7 +17,7 @@ Run on a graph
     import infomap
 
     graph = nx.karate_club_graph()
-    result = infomap.run(graph, seed=123, num_trials=20, silent=True)
+    result = infomap.run(graph, seed=123, num_trials=20)
 
     print(result.num_top_modules)   # 3
     print(result.codelength)        # 4.0874 bits per step
@@ -33,7 +33,7 @@ Without any graph library installed, the bundled example networks in
 
 .. code-block:: python
 
-    result = infomap.run(infomap.datasets.two_triangles(), silent=True)
+    result = infomap.run(infomap.datasets.two_triangles())
 
 Build a network step by step
 -----------------------------
@@ -51,7 +51,7 @@ directly:
     net.add_link(0, 1)
     net.add_link(1, 2)
     net.add_link(2, 0)
-    result = run(net, silent=True)
+    result = run(net)
 
     print(result.codelength)
 
@@ -63,7 +63,7 @@ does not, such as a different edge-weight attribute or explicit directedness:
     from infomap import Network, run
 
     net = Network.from_networkx(graph, weight="capacity")
-    result = run(net, num_trials=20, silent=True)
+    result = run(net, num_trials=20)
 
 Reusable configuration
 ----------------------

--- a/interfaces/python/source/robustness/incomplete-data.md
+++ b/interfaces/python/source/robustness/incomplete-data.md
@@ -153,7 +153,7 @@ print(f"({removal_fraction:.0%} of links removed)")
 
 ```{code-cell} python
 # Standard Infomap: no regularization
-result_std = infomap.run(g_sparse, two_level=True, seed=99, num_trials=10, silent=True)
+result_std = infomap.run(g_sparse, two_level=True, seed=99, num_trials=10)
 
 # Regularized Infomap. We use regularization_strength=0.5 (gentler than the
 # default 1.0, which over-regularizes this 70%-sparse graph toward one module).
@@ -162,9 +162,7 @@ result_reg = infomap.run(
     two_level=True,
     seed=99,
     num_trials=10,
-    silent=True,
-    regularized=True,
-    regularization_strength=0.5,
+    options=infomap.Options(regularized=True, regularization_strength=0.5),
 )
 
 modules_std = result_std.modules()

--- a/interfaces/python/source/the-infomap-class.md
+++ b/interfaces/python/source/the-infomap-class.md
@@ -35,7 +35,7 @@ and its results are identical to the functional path.
 ```{code-cell} python
 from infomap import Infomap
 
-im = Infomap(silent=True, seed=123, num_trials=10)
+im = Infomap(seed=123, num_trials=10)
 im.add_link(0, 1)
 im.add_link(1, 2)
 im.add_link(2, 0)

--- a/interfaces/python/source/workflows/hpc.md
+++ b/interfaces/python/source/workflows/hpc.md
@@ -152,8 +152,7 @@ for spec in shard_specs:
         net,
         num_trials=spec["num_trials"],
         seed=spec["seed"],
-        silent=True,
-    )
+        )
 
     print(
         f"shard {spec['shard_id']}: seed={spec['seed']}"

--- a/interfaces/python/source/workflows/scanpy.md
+++ b/interfaces/python/source/workflows/scanpy.md
@@ -171,7 +171,7 @@ matrix is a standard SciPy CSR matrix that you can pass straight to
 ```{code-cell} python
 A = adata.obsp["connectivities"]
 
-result = infomap.run(A, silent=True, seed=123, num_trials=5)
+result = infomap.run(A, seed=123, num_trials=5)
 
 print(f"Modules:    {result.num_top_modules}")
 print(f"Codelength: {result.codelength:.4f} bits/step")

--- a/interfaces/python/source/working-with-infomap/inputs.md
+++ b/interfaces/python/source/working-with-infomap/inputs.md
@@ -74,7 +74,7 @@ g.add_weighted_edges_from([
     (2, 3, 0.5),                               # weak bridge
 ])
 
-result = infomap.run(g, two_level=True, seed=123, num_trials=5, silent=True)
+result = infomap.run(g, two_level=True, seed=123, num_trials=5)
 
 print(f"Modules:    {result.num_top_modules}")
 print(f"Codelength: {result.codelength:.4f} bits/step")
@@ -90,7 +90,7 @@ DataFrame; for other label types (tuples, frozensets), use
 ```{code-cell} python
 g_str = nx.Graph([("alice", "bob"), ("bob", "carol"), ("dave", "eve")])
 
-result = infomap.run(g_str, two_level=True, seed=123, silent=True)
+result = infomap.run(g_str, two_level=True, seed=123)
 print(result.to_dataframe(["name", "module_id"]).to_string(index=False))
 ```
 
@@ -102,7 +102,7 @@ it.
 from infomap import Network, run
 
 net = Network.from_networkx(g_str)
-result = run(net, seed=123, silent=True)
+result = run(net, seed=123)
 
 named = {net.node_id_to_label[nid]: mid for nid, mid in result.modules().items()}
 print("Named assignments:", named)
@@ -129,7 +129,7 @@ import igraph as ig
 edges = [(0, 1), (1, 2), (2, 0), (3, 4), (4, 5), (5, 3), (2, 3)]
 g_ig = ig.Graph(n=6, edges=edges)
 
-result = infomap.run(g_ig, two_level=True, seed=123, num_trials=5, silent=True)
+result = infomap.run(g_ig, two_level=True, seed=123, num_trials=5)
 print(f"igraph route: {result.num_top_modules} modules, {result.codelength:.4f} bits/step")
 ```
 
@@ -140,7 +140,7 @@ g_ig_w = ig.Graph(n=6, edges=edges)
 g_ig_w.es["weight"] = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.5]
 
 net = Network.from_igraph(g_ig_w, edge_weights="weight")
-result = run(net, two_level=True, seed=123, num_trials=5, silent=True)
+result = run(net, two_level=True, seed=123, num_trials=5)
 print(f"igraph (weighted): {result.num_top_modules} modules, {result.codelength:.4f} bits/step")
 ```
 
@@ -171,7 +171,7 @@ cols = [1, 0, 2, 1, 0, 2,  4, 3, 5, 4, 3, 5,  3, 2]
 data = [1.0] * 12 + [0.5, 0.5]
 A = sp.coo_matrix((data, (rows, cols)), shape=(6, 6))
 
-result = infomap.run(A, two_level=True, seed=123, num_trials=5, silent=True)
+result = infomap.run(A, two_level=True, seed=123, num_trials=5)
 print(f"SciPy route: {result.num_top_modules} modules, {result.codelength:.4f} bits/step")
 ```
 
@@ -181,7 +181,7 @@ ignores the stored values. Here with the defaults spelled out:
 
 ```{code-cell} python
 net = Network.from_scipy_sparse_matrix(A, directed=False, weighted=True)
-result = run(net, two_level=True, seed=123, num_trials=5, silent=True)
+result = run(net, two_level=True, seed=123, num_trials=5)
 print(f"via Network: {result.num_top_modules} modules")
 ```
 
@@ -207,8 +207,7 @@ edges_df = pd.DataFrame({
 
 result = infomap.run(
     edges_df[["source", "target", "weight"]].to_numpy(),
-    two_level=True, seed=123, num_trials=5, silent=True,
-)
+    two_level=True, seed=123, num_trials=5, )
 print(f"pandas route: {result.num_top_modules} modules, {result.codelength:.4f} bits/step")
 ```
 
@@ -261,7 +260,7 @@ content = """*Vertices
 path = Path(tempfile.mkdtemp()) / "twotriangles.net"
 path.write_text(content)
 
-result = infomap.run(str(path), two_level=True, seed=123, num_trials=5, silent=True)
+result = infomap.run(str(path), two_level=True, seed=123, num_trials=5)
 print(f"file route: {result.num_top_modules} modules, {result.codelength:.4f} bits/step")
 for node in result.nodes():
     print(f"  {node.name}: module {node.module_id}")
@@ -316,7 +315,7 @@ network = {
 path = Path(tempfile.mkdtemp()) / "twotriangles.json"
 path.write_text(json.dumps(network))
 
-result = infomap.run(str(path), two_level=True, seed=123, num_trials=5, silent=True)
+result = infomap.run(str(path), two_level=True, seed=123, num_trials=5)
 print(f"json route: {result.num_top_modules} modules, {result.codelength:.4f} bits/step")
 ```
 
@@ -366,7 +365,7 @@ net.add_link(0, 1); net.add_link(1, 2); net.add_link(2, 0)   # triangle A
 net.add_link(3, 4); net.add_link(4, 5); net.add_link(5, 3)   # triangle B
 net.add_link(2, 3, 0.5)                                       # weak bridge
 
-result = run(net, two_level=True, seed=123, num_trials=5, silent=True)
+result = run(net, two_level=True, seed=123, num_trials=5)
 print(result.to_dataframe(["node_id", "name", "module_id", "flow"]).to_string(index=False))
 ```
 
@@ -384,12 +383,11 @@ across them:
 
 ```{code-cell} python
 runs = {
-    "NetworkX":     infomap.run(g, two_level=True, seed=123, num_trials=5, silent=True),
-    "SciPy sparse": infomap.run(A, two_level=True, seed=123, num_trials=5, silent=True),
+    "NetworkX":     infomap.run(g, two_level=True, seed=123, num_trials=5),
+    "SciPy sparse": infomap.run(A, two_level=True, seed=123, num_trials=5),
     "edge list":    infomap.run(
         edges_df[["source", "target", "weight"]].to_numpy(),
-        two_level=True, seed=123, num_trials=5, silent=True,
-    ),
+        two_level=True, seed=123, num_trials=5, ),
 }
 for route, res in runs.items():
     print(f"  {res.codelength:.4f}  {route}")

--- a/interfaces/python/source/working-with-infomap/results-and-iteration.md
+++ b/interfaces/python/source/working-with-infomap/results-and-iteration.md
@@ -88,7 +88,7 @@ import pandas as pd
 
 g = nx.karate_club_graph()
 
-result = infomap.run(g, two_level=True, seed=123, num_trials=10, silent=True)
+result = infomap.run(g, two_level=True, seed=123, num_trials=10)
 ```
 
 ### The Result object
@@ -158,7 +158,7 @@ for cluster in range(3):
         g_hier.add_edge(base, cluster * 30 + ((sub + 1) % 3) * 10)
     g_hier.add_edge(cluster * 30, ((cluster + 1) % 3) * 30)
 
-result_hier = infomap.run(g_hier, seed=123, num_trials=10, silent=True)
+result_hier = infomap.run(g_hier, seed=123, num_trials=10)
 
 print(f"Hierarchy levels: {result_hier.num_levels}")
 top_mods = result_hier.modules(depth=1)
@@ -257,7 +257,7 @@ searches from different seeds and comparing their codelengths:
 
 ```{code-cell} python
 codelengths = [
-    infomap.run(g, two_level=True, seed=seed, num_trials=1, silent=True).codelength
+    infomap.run(g, two_level=True, seed=seed, num_trials=1).codelength
     for seed in range(1, 11)
 ]
 

--- a/interfaces/python/source/working-with-infomap/running-and-options.md
+++ b/interfaces/python/source/working-with-infomap/running-and-options.md
@@ -32,7 +32,6 @@ result = infomap.run(
     seed=123,        # reproducible
     num_trials=10,   # keep the best of 10 restarts
     two_level=True,  # flat partition; omit for the multilevel default
-    silent=True,     # skip the engine's console log
 )
 print(result.num_top_modules, result.codelength)
 ```
@@ -101,7 +100,7 @@ each result to the code that produced it.
 ```{code-cell} python
 # Two runs with the same seed produce the same partition.
 for attempt in range(2):
-    result = infomap.run(G_ring, two_level=True, seed=123, num_trials=10, silent=True)
+    result = infomap.run(G_ring, two_level=True, seed=123, num_trials=10)
     print(f"Run {attempt + 1}: modules={result.num_top_modules}, L={result.codelength:.4f}")
 ```
 
@@ -116,7 +115,7 @@ landscape has many near-degenerate minima, and a single trial is unreliable.
 # On the noisy graph, different seeds land in different local minima.
 print("Single trial (num_trials=1), five different seeds:")
 for seed in [1, 7, 42, 99, 123]:
-    result = infomap.run(G_noisy, two_level=True, seed=seed, num_trials=1, silent=True)
+    result = infomap.run(G_noisy, two_level=True, seed=seed, num_trials=1)
     print(f"  seed={seed}: L={result.codelength:.4f}, modules={result.num_top_modules}")
 ```
 
@@ -124,7 +123,7 @@ for seed in [1, 7, 42, 99, 123]:
 # More trials explore more of the landscape and find a lower, stable minimum.
 print("Fixed seed=123, varying num_trials:")
 for num_trials in [1, 5, 20]:
-    result = infomap.run(G_noisy, two_level=True, seed=123, num_trials=num_trials, silent=True)
+    result = infomap.run(G_noisy, two_level=True, seed=123, num_trials=num_trials)
     print(f"  num_trials={num_trials:2d}: L={result.codelength:.4f}, modules={result.num_top_modules}")
 ```
 
@@ -187,7 +186,7 @@ def hierarchical_graph():
 G_hier = hierarchical_graph()
 
 for two_level in [False, True]:
-    result = infomap.run(G_hier, two_level=two_level, seed=123, num_trials=10, silent=True)
+    result = infomap.run(G_hier, two_level=two_level, seed=123, num_trials=10)
 
     m_top = result.modules(depth=1)    # top-level groups
     m_leaf = result.modules(depth=-1)  # finest-level assignments
@@ -239,7 +238,7 @@ print(f"Directed graph: {G_dir.number_of_nodes()} nodes, {G_dir.number_of_edges(
 
 for directed in [False, True]:
     result = infomap.run(G_dir, directed=directed, two_level=True,
-                         seed=123, num_trials=10, silent=True)
+                         seed=123, num_trials=10)
     print(f"directed={directed}: modules={result.num_top_modules}, L={result.codelength:.4f}")
 ```
 
@@ -271,7 +270,7 @@ print()
 
 for mt in [0.5, 1.0, 2.0, 4.0, 8.0]:
     result = infomap.run(G_ring, two_level=True, markov_time=mt,
-                         seed=123, num_trials=10, silent=True)
+                         seed=123, num_trials=10)
     print(f"  markov_time={mt:.1f}: {result.num_top_modules} modules")
 ```
 
@@ -303,7 +302,7 @@ for label, kwargs in [
     ("regularized, strength=0.5", {"regularized": True, "regularization_strength": 0.5}),
     ("regularized (default 1.0)", {"regularized": True}),
 ]:
-    result = infomap.run(G_karate, two_level=True, seed=123, num_trials=10, silent=True, **kwargs)
+    result = infomap.run(G_karate, two_level=True, seed=123, num_trials=10, **kwargs)
     print(f"{label}: modules={result.num_top_modules}, L={result.codelength:.4f}")
 ```
 
@@ -324,14 +323,14 @@ from myst_nb import glue
 single_L = []
 for s in range(1, 13):
     single_L.append(
-        infomap.run(G_noisy, two_level=True, seed=s, num_trials=1, silent=True).codelength
+        infomap.run(G_noisy, two_level=True, seed=s, num_trials=1).codelength
     )
 
 # ... versus the lowest codelength a longer search finds. Several seeds at 50
 # trials each, so the reference is the best partition rather than one lucky (or
 # unlucky) run; take the floor of everything shown so the line is a true minimum.
 best_L = min(
-    infomap.run(G_noisy, two_level=True, seed=s, num_trials=50, silent=True).codelength
+    infomap.run(G_noisy, two_level=True, seed=s, num_trials=50).codelength
     for s in (1, 42, 123)
 )
 best_L = min([best_L, *single_L])

--- a/interfaces/python/source/working-with-infomap/visualizing-and-exporting.md
+++ b/interfaces/python/source/working-with-infomap/visualizing-and-exporting.md
@@ -62,7 +62,7 @@ import infomap
 
 g = nx.karate_club_graph()
 
-result = infomap.run(g, two_level=True, seed=123, num_trials=10, silent=True)
+result = infomap.run(g, two_level=True, seed=123, num_trials=10)
 modules = result.modules()           # {node_id: module_id}
 
 print(f"Nodes: {g.number_of_nodes()}, Edges: {g.number_of_edges()}")
@@ -183,7 +183,7 @@ Navigator, and `.tree`/`.clu` load in the alluvial diagram generator and other
 scripts.
 
 ```{code-cell} python
-im = infomap.Infomap(two_level=True, seed=123, num_trials=10, silent=True)
+im = infomap.Infomap(two_level=True, seed=123, num_trials=10)
 im.add_networkx_graph(g)
 im.run()
 

--- a/test/python/test_docs_examples_surface.py
+++ b/test/python/test_docs_examples_surface.py
@@ -1,0 +1,232 @@
+"""Our own examples and docs must not teach the deprecated API surface.
+
+Enforces the steering decided on the 3.0 roadmap (#742): the runnable
+examples and the documentation pages use the ``Result`` accessors, the
+``Network.from_*`` builders, and carry advanced configuration through
+``Options`` — never the docs-only-deprecated legacy mirror or advanced-tier
+keyword arguments passed directly to ``Infomap(...)``/``run(...)``.
+
+Receiver conventions checked (matching the docs' own naming): a deprecated
+result/build accessor is a violation when read off an ``Infomap`` instance
+named ``im``; the same attribute names on ``result``/``net`` are the blessed
+surface. The API reference under ``source/api/`` is excluded — it documents
+the deprecated members on purpose.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.fast
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLES = REPO_ROOT / "examples" / "python"
+DOCS = REPO_ROOT / "interfaces" / "python" / "source"
+
+# The legacy result/build/config mirror on Infomap (docs-only deprecated
+# since 2.14; see test_deprecations.py). Curated by hand: introspecting
+# docstrings would misclassify blessed members whose docstrings merely
+# *contain* parameter-level deprecation directives (e.g. run()).
+DEPRECATED_INSTANCE_MEMBERS = (
+    "codelength",
+    "codelengths",
+    "effective_num_leaf_modules",
+    "effective_num_top_modules",
+    "elapsed_time",
+    "entropy_rate",
+    "flow_links",
+    "get_dataframe",
+    "get_effective_num_modules",
+    "get_links",
+    "get_modules",
+    "get_multilevel_modules",
+    "get_name",
+    "get_names",
+    "get_nodes",
+    "get_state_names",
+    "get_tree",
+    "have_memory",
+    "index_codelength",
+    "leaf_modules",
+    "links",
+    "max_depth",
+    "meta_codelength",
+    "meta_entropy",
+    "module_codelength",
+    "modules",
+    "multilevel_modules",
+    "names",
+    "nodes",
+    "num_leaf_modules",
+    "num_levels",
+    "num_non_trivial_top_modules",
+    "num_top_modules",
+    "one_level_codelength",
+    "physical_nodes",
+    "physical_tree",
+    "relative_codelength_savings",
+    "state_names",
+    "to_dataframe",
+    "tree",
+)
+
+# Deprecated whichever receiver they are called on (only Infomap has them).
+DEPRECATED_ANY_RECEIVER = (
+    "get_dataframe",
+    "get_effective_num_modules",
+    "get_links",
+    "get_modules",
+    "get_multilevel_modules",
+    "get_name",
+    "get_names",
+    "get_nodes",
+    "get_state_names",
+    "get_tree",
+    "add_networkx_graph",
+    "add_igraph_graph",
+    "add_scipy_sparse_matrix",
+    "add_edge_index",
+    "run_with_options",
+)
+
+_IM_RECEIVER = re.compile(
+    r"\bim\.(" + "|".join(DEPRECATED_INSTANCE_MEMBERS) + r")\b"
+)
+_ANY_RECEIVER = re.compile(
+    r"\.(" + "|".join(DEPRECATED_ANY_RECEIVER) + r")\("
+)
+_DEPRECATED_CLASSMETHODS = re.compile(
+    r"\bInfomap\.(from_options|from_scipy_sparse_matrix|from_edge_index)\("
+)
+# Infomap(...) construction, method run (any receiver), and the functional
+# run(...) (bare name or module-qualified).
+_CALL_HEADS = re.compile(r"(?:\bInfomap|\.run|(?<![\w.])run)\s*\(")
+
+
+def _load_common_tier() -> set[str]:
+    overrides = json.loads(
+        (REPO_ROOT / "interfaces" / "parameters" / "overrides.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    flags = overrides["tiers"]["python"]["common"]
+    return {flag.removeprefix("--").replace("-", "_") for flag in flags}
+
+
+def _advanced_kwargs() -> set[str]:
+    from infomap._options import _OPTION_FIELD_NAMES
+
+    return set(_OPTION_FIELD_NAMES) - _load_common_tier()
+
+
+def _source_files() -> list[Path]:
+    files = sorted(EXAMPLES.glob("*.py"))
+    files += sorted(
+        path
+        for path in DOCS.rglob("*.md")
+        if "api" not in path.relative_to(DOCS).parts
+    )
+    files += sorted(
+        path
+        for path in DOCS.rglob("*.rst")
+        if "api" not in path.relative_to(DOCS).parts
+    )
+    return files
+
+
+def _call_argument_spans(text: str) -> list[str]:
+    """The argument text of every Infomap(...)/…run(...) call in ``text``."""
+    spans = []
+    for match in _CALL_HEADS.finditer(text):
+        depth = 0
+        start = match.end() - 1
+        for position in range(start, len(text)):
+            if text[position] == "(":
+                depth += 1
+            elif text[position] == ")":
+                depth -= 1
+                if depth == 0:
+                    spans.append(text[start + 1 : position])
+                    break
+    return spans
+
+
+_KWARG = re.compile(r"(?<![\w.\"'])(\w+)\s*=(?!=)")
+
+
+def _strip_nested_option_calls(argument_text: str) -> str:
+    # Kwargs inside Options(...) or options={...} are the blessed carrier;
+    # remove those regions before scanning for direct advanced kwargs.
+    argument_text = re.sub(r"Options\s*\([^)]*\)", "Options()", argument_text)
+    argument_text = re.sub(r"options\s*=\s*\{[^}]*\}", "options={}", argument_text)
+    return argument_text
+
+
+# Deliberate exceptions. Keep this list short and justified; every entry
+# should reference why the page must mention the deprecated surface.
+ALLOWLIST: dict[str, set[str]] = {
+    # The migration guide shows the legacy surface next to its replacement
+    # on purpose -- that is the page's whole point.
+    "interfaces/python/source/the-infomap-class.md": {
+        "codelength",
+        "get_modules",
+        "nodes",
+        "num_top_modules",
+        "to_dataframe",
+        "add_networkx_graph",
+    },
+    # Result has no file writers yet (#760), so exporting .tree/.clu from a
+    # NetworkX source still requires the deprecated Infomap adapter. Remove
+    # this entry when #760 lands.
+    "interfaces/python/source/working-with-infomap/visualizing-and-exporting.md": {
+        "add_networkx_graph",
+    },
+}
+
+
+def _allowed(rel: str, name: str) -> bool:
+    return name in ALLOWLIST.get(rel, set())
+
+
+def test_docs_and_examples_avoid_the_deprecated_surface():
+    if not DOCS.is_dir():
+        pytest.skip("docs source not available (wheel/sdist test run)")
+
+    advanced = _advanced_kwargs()
+    violations: list[str] = []
+
+    for path in _source_files():
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        rel = path.relative_to(REPO_ROOT)
+
+        for match in _IM_RECEIVER.finditer(text):
+            if not _allowed(str(rel), match.group(1)):
+                violations.append(f"{rel}: im.{match.group(1)} (use the Result API)")
+        for match in _ANY_RECEIVER.finditer(text):
+            if not _allowed(str(rel), match.group(1)):
+                violations.append(
+                    f"{rel}: .{match.group(1)}() (deprecated; use Result/Network)"
+                )
+        for match in _DEPRECATED_CLASSMETHODS.finditer(text):
+            if not _allowed(str(rel), match.group(1)):
+                violations.append(
+                    f"{rel}: Infomap.{match.group(1)}() (use Network.from_* or run())"
+                )
+        for span in _call_argument_spans(text):
+            span = _strip_nested_option_calls(span)
+            for kwarg in _KWARG.findall(span):
+                if kwarg in advanced:
+                    violations.append(
+                        f"{rel}: advanced kwarg {kwarg}= passed directly "
+                        "(carry it via Options)"
+                    )
+
+    assert not violations, (
+        "our own examples/docs teach the deprecated or advanced-tier "
+        "surface:\n" + "\n".join(sorted(set(violations)))
+    )


### PR DESCRIPTION
# Summary

Steers our own teaching surface to the blessed API, per the tier decision on #738 and the deprecations landed in #741 (#753):

- **Examples** (`examples/python/`): stripped `silent=True` everywhere (quiet is the library default); rewrote `evaluate-partition.py`, `modify-network.py`, `metadata.py`, and the second half of `file-io.py` from the stateful `Infomap` mirror to `Network.from_file`/builders with `run(options=Options(...), initial_partition=...)`. `metadata.py` now showcases the `set_meta_data` mapping overload.
- **Docs pages**: advanced-tier kwargs (`multilayer_relax_rate`, `meta_data_rate`, `regularized`, `regularization_strength`, `no_infomap`, `cluster_data`, ...) are carried via `options=Options(...)`; the common tier (`seed`, `num_trials`, `two_level`, `directed`, `markov_time`) stays as direct kwargs. `silent=True` removed from ~27 pages.
- **Enforcement test** (`test/python/test_docs_examples_surface.py`): receiver-aware scan that fails when our examples or docs teach the deprecated legacy mirror (`im.<result-accessor>`, `add_*_graph`, `Infomap.from_*`) or pass an advanced-tier kwarg directly to `Infomap(...)`/`run(...)`. The advanced set is derived from the generated option fields minus the common tier in `overrides.json`, so the test tracks the catalog automatically. A short, justified allowlist covers the migration guide (shows legacy on purpose) and the `.tree`/`.clu` export page, which needs the deprecated adapter until `Result` grows file writers (#760, filed while working on this).

Closes #742

# Verification

- `pytest test/python`: 552 passed, 2 skipped (includes the new enforcement test)
- `make test-python-doctest`: 38 doctests + ruff, all green
- `make test-python-examples`: all rewritten examples run clean
- `make build-docs`: all code cells execute; the only warnings are the 6 known proxy-blocked intersphinx inventory fetches (environment limitation, unrelated)

# Notes

- The enforcement test excludes `source/api/**` (the API reference documents deprecated members on purpose) and skips when the docs source is absent (wheel/sdist test runs).
- The allowlist entry for `visualizing-and-exporting.md` is annotated to be removed when #760 lands.
- No generated files touched; docs and examples only, plus the new test.

---
_Generated by [Claude Code](https://claude.ai/code/session_017XjuZM32ZUn1AbeWJVXuyi)_