### PR TITLE
feat(python): public error taxonomy with InfomapError base

### DIFF
--- a/interfaces/python/source/api/errors.rst
+++ b/interfaces/python/source/api/errors.rst
@@ -1,0 +1,44 @@
+Errors
+======
+
+.. currentmodule:: infomap
+
+Everything the engine reports as a failure — an unreadable input file, an
+invalid ``args`` string, an option conflict, an unwritable output path — is
+raised as :class:`InfomapError` or one of its subclasses, with the engine's
+message preserved. Catch the base class to handle any Infomap failure, or a
+subclass for targeted handling::
+
+    import infomap
+
+    try:
+        result = infomap.run("network.net")
+    except infomap.NetworkParseError as error:
+        print(f"Bad input file: {error}")
+    except infomap.InfomapError as error:
+        print(f"Infomap failed: {error}")
+
+Compatibility
+-------------
+
+Through 2.x, :class:`InfomapError` inherits :class:`RuntimeError` — the type
+engine errors were raised as before the taxonomy existed — so existing
+``except RuntimeError`` code keeps working. :class:`NotRunError` additionally
+keeps :class:`ValueError` in its MRO, the type the results-before-run guard
+raised previously. Plan for these legacy bases to detach in 3.0: catch
+:class:`InfomapError` (or a subclass), not the legacy bases.
+
+Errors that are not Infomap failures keep their standard Python types:
+invalid argument *values* passed to the Python API raise :class:`ValueError`
+or :class:`TypeError` as usual.
+
+The taxonomy
+------------
+
+.. autoexception:: InfomapError
+
+.. autoexception:: NetworkParseError
+
+.. autoexception:: NotRunError
+
+.. autoexception:: StaleResultError

--- a/interfaces/python/source/api/index.rst
+++ b/interfaces/python/source/api/index.rst
@@ -31,6 +31,9 @@ incremental, repeated-run workflows.
    * - :doc:`iterators`
      - :class:`InfoNode` and the tree-walking iterators returned by
        :meth:`Result.tree`, :meth:`Result.leaf_modules`, and friends.
+   * - :doc:`errors`
+     - :class:`InfomapError` and its subclasses -- the exception types every
+       engine failure is raised as.
    * - :doc:`integrations`
      - Scanpy (:func:`infomap.tl.infomap`), GraphRAG, and the distributed-trial
        merge tool.
@@ -49,5 +52,6 @@ incremental, repeated-run workflows.
    export
    infomap
    iterators
+   errors
    integrations
    datasets

--- a/interfaces/python/source/flow-models/multilayer.md
+++ b/interfaces/python/source/flow-models/multilayer.md
@@ -432,8 +432,8 @@ assert n_links_self < n_links_default
   {func}`infomap.run`: the relax rate used when no explicit inter-layer links are
   provided.
 - {meth}`infomap.Result.modules` needs `states=True` on multilayer networks to
-  return state-node assignments; `states=False` raises a `RuntimeError` on
-  higher-order networks.
+  return state-node assignments; `states=False` raises an
+  {class}`~infomap.InfomapError` on higher-order networks.
 - {meth}`infomap.Result.nodes` with `states=True` iterates state nodes; each
   exposes `.node_id` (physical), `.state_id`, `.layer_id`, `.module_id`, and
   `.flow`.

--- a/interfaces/python/src/infomap/__init__.py
+++ b/interfaces/python/src/infomap/__init__.py
@@ -1,3 +1,12 @@
+# The error taxonomy is pure Python and importable without the compiled
+# bindings, so it lives outside the guarded block below.
+from .errors import (
+    __all__ as _ERRORS_ALL,
+    InfomapError as InfomapError,
+    NetworkParseError as NetworkParseError,
+    NotRunError as NotRunError,
+    StaleResultError as StaleResultError,
+)
 from ._version import (
     __author__ as __author__,
     __classifiers__ as __classifiers__,
@@ -27,6 +36,7 @@ _VERSION_ALL = [
 ]
 
 __all__ = list(_VERSION_ALL)
+__all__.extend(_ERRORS_ALL)
 
 # The distributed-trial merge tool lives in the pure-Python ``infomap.merge``
 # module (use ``from infomap.merge import merge_trial_results`` or the CLI

--- a/interfaces/python/src/infomap/_core.py
+++ b/interfaces/python/src/infomap/_core.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from .errors import _translate_engine_errors
+
 from ._bindings import InfomapWrapper  # noqa: F401  (the only engine import)
 from ._bindings import build_info as build_info  # module-level engine function
 from ._bindings import run as run  # module-level engine function (CLI driver)
@@ -37,7 +39,10 @@ from ._bindings import InfomapLeafModuleIterator as InfomapLeafModuleIterator
 
 class Core:
     def __init__(self, args):
-        self._im = InfomapWrapper(args)
+        # Argument/config errors ("Unrecognized option: ...", option
+        # conflicts) are thrown while the wrapper parses ``args``.
+        with _translate_engine_errors():
+            self._im = InfomapWrapper(args)
 
     def get_node_data(self, level=1, states=False):
         """Single-traversal bulk node data over the result tree.

--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -36,6 +36,7 @@ from ._options import (
 )
 from ._results import _InfomapResultsMixin
 from ._results import entropy, perplexity, plogp
+from .errors import NetworkParseError, _translate_engine_errors
 from .result import Result, TreeNode, build_result
 from ._summary import (
     repr_html as _repr_html,
@@ -1516,8 +1517,14 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         accumulate : bool, optional
             If the network data should be accumulated to already added
             nodes and links. Default ``True``.
+
+        Raises
+        ------
+        NetworkParseError
+            If the file cannot be opened or its content cannot be parsed.
         """
-        self._core.readInputData(filename, accumulate)
+        with _translate_engine_errors(NetworkParseError):
+            self._core.readInputData(filename, accumulate)
 
     def add_node(self, node_id, name=None, teleportation_weight=None):
         """Add a node.
@@ -2696,11 +2703,16 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
     def _run_from_options(self, args, initial_partition, options):
         args = _package_construct_args()(args, **options.to_kwargs())
 
+        # classify=True: the engine reads auxiliary input (cluster_data,
+        # meta_data) at run time, so input failures surfacing here become
+        # NetworkParseError; everything else is InfomapError.
         if initial_partition is not None:
             with self._initial_partition(initial_partition):
-                self._core.run(args)
+                with _translate_engine_errors(classify=True):
+                    self._core.run(args)
         else:
-            self._core.run(args)
+            with _translate_engine_errors(classify=True):
+                self._core.run(args)
 
         # Stamp a fresh Result with the new generation (shared helper). The C++
         # result tree is rebuilt on every run(), so any previously returned

--- a/interfaces/python/src/infomap/_results.py
+++ b/interfaces/python/src/infomap/_results.py
@@ -5,6 +5,7 @@ from math import log2
 from typing import TYPE_CHECKING, Any
 
 from ._optional import require_pandas
+from .errors import _translate_engine_errors
 
 
 if TYPE_CHECKING:
@@ -163,10 +164,15 @@ class _InfomapResultsMixin:
     # deprecated public accessor.
 
     def _get_modules_impl(self, depth_level=1, states=False):
-        return self._core.getModules(depth_level, states)
+        # The C++ higher-order guard ("Cannot get modules on higher-order
+        # network without states.") surfaces here; translate it so the legacy
+        # path raises the same taxonomy type as Result.modules().
+        with _translate_engine_errors():
+            return self._core.getModules(depth_level, states)
 
     def _get_multilevel_modules_impl(self, states=False):
-        return self._core.getMultilevelModules(states)
+        with _translate_engine_errors():
+            return self._core.getMultilevelModules(states)
 
     def _get_tree_impl(self, depth_level=1, states=False):
         if self._core.haveMemory() and not states:

--- a/interfaces/python/src/infomap/errors.py
+++ b/interfaces/python/src/infomap/errors.py
@@ -1,0 +1,115 @@
+"""The public error taxonomy for the :mod:`infomap` package.
+
+Engine errors cross the SWIG boundary as bare ``RuntimeError`` with the C++
+message string. The package re-raises them as :class:`InfomapError` (or a
+subclass) at the ``Core`` boundary, so callers can catch Infomap failures
+without also catching unrelated ``RuntimeError``.
+
+Compatibility: :class:`InfomapError` inherits ``RuntimeError`` through 2.x,
+so existing ``except RuntimeError`` code keeps working; the base may detach
+in 3.0. :class:`NotRunError` additionally keeps ``ValueError`` in its MRO
+through 2.x because the results-before-run guard used to raise ``ValueError``.
+
+This module is pure Python and importable without the compiled bindings.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+__all__ = [
+    "InfomapError",
+    "NetworkParseError",
+    "NotRunError",
+    "StaleResultError",
+]
+
+
+class InfomapError(RuntimeError):
+    """Base class for errors raised by the Infomap engine or package.
+
+    Every error the engine reports -- invalid arguments, option conflicts,
+    flow-calculation failures, unwritable output files -- is raised as this
+    class or one of its subclasses. Inherits :class:`RuntimeError` through
+    2.x for backwards compatibility.
+    """
+
+
+class NetworkParseError(InfomapError):
+    """The network input could not be read.
+
+    Raised by :meth:`Infomap.read_file <infomap.Infomap.read_file>`,
+    :meth:`Network.from_file <infomap.Network.from_file>`, and
+    :func:`infomap.run` with a file path, when the input file cannot be
+    opened or its content cannot be parsed. Also raised from ``run()`` when
+    an auxiliary input file (e.g. ``cluster_data``) fails to open or parse.
+    """
+
+
+class NotRunError(InfomapError, ValueError):
+    """Results were requested before the algorithm has run.
+
+    Raised by the exporters and integration helpers when they are handed an
+    :class:`~infomap.Infomap` instance with no module assignments yet.
+    Keeps :class:`ValueError` in its MRO through 2.x because this guard
+    previously raised ``ValueError``.
+    """
+
+
+class StaleResultError(InfomapError):
+    """Node-level data was read from a :class:`~infomap.Result` after a re-run.
+
+    The C++ result tree is rebuilt on every ``run()``, so node-level access
+    on a ``Result`` created by an earlier run raises instead of reading the
+    rebuilt tree. The eager scalars captured at ``run()`` time (codelength,
+    module counts, ...) stay valid on the stale ``Result``.
+    """
+
+
+# Known C++ message patterns that identify an *input* failure surfacing from
+# a run() call (the engine reads cluster/network files at run time). Matched
+# with str.startswith / substring; first hit wins. Everything read_file-side
+# maps to NetworkParseError wholesale, so this table only needs the run-time
+# stragglers.
+_PARSE_MESSAGE_PREFIXES = (
+    "Can't parse",
+    "Cannot parse",
+    "Cannot open input file",
+    "Can't open file",
+    "Unrecognized heading",
+    "JSON parse error",
+)
+_PARSE_MESSAGE_SUBSTRINGS = (
+    # SafeFile's read-side open error ("... read permissions."); the
+    # write-side variant says "write permissions" and stays InfomapError.
+    "read permissions",
+)
+
+
+def _classify_run_message(message: str) -> type[InfomapError] | None:
+    if message.startswith(_PARSE_MESSAGE_PREFIXES):
+        return NetworkParseError
+    if any(fragment in message for fragment in _PARSE_MESSAGE_SUBSTRINGS):
+        return NetworkParseError
+    return None
+
+
+@contextmanager
+def _translate_engine_errors(
+    default: type[InfomapError] = InfomapError, *, classify: bool = False
+):
+    """Re-raise SWIG ``RuntimeError`` as the taxonomy type, message preserved.
+
+    ``default`` is the class used for unrecognized messages; ``classify=True``
+    additionally consults the run-time message table above so input failures
+    surfacing from ``run()`` become :class:`NetworkParseError`. Errors already
+    in the taxonomy pass through untouched.
+    """
+    try:
+        yield
+    except InfomapError:
+        raise
+    except RuntimeError as error:
+        message = str(error)
+        error_class = (_classify_run_message(message) if classify else None) or default
+        raise error_class(message) from None

--- a/interfaces/python/src/infomap/io/_arrays.py
+++ b/interfaces/python/src/infomap/io/_arrays.py
@@ -17,11 +17,13 @@ import math
 from collections.abc import Iterator
 from typing import Any, NamedTuple
 
+from ..errors import NotRunError
+
 
 def require_modules(infomap: Any) -> None:
     """Raise if ``infomap`` has no module assignments yet (i.e. has not run)."""
     if not infomap._core.haveModules():
-        raise ValueError(
+        raise NotRunError(
             "Infomap results are not available. Run Infomap before exporting."
         )
 

--- a/interfaces/python/src/infomap/io/writers.py
+++ b/interfaces/python/src/infomap/io/writers.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING
 
+from ..errors import _translate_engine_errors
+
 
 if TYPE_CHECKING:
     from .._core import Core
@@ -82,7 +84,8 @@ class _InfomapWritersMixin:
         depth_level : int, optional
             The depth in the hierarchical tree to write.
         """
-        self._core.writeClu(os.fspath(filename), states, depth_level)
+        with _translate_engine_errors():
+            self._core.writeClu(os.fspath(filename), states, depth_level)
 
     def write_tree(
         self, filename: str | os.PathLike[str], states: bool = False
@@ -102,7 +105,8 @@ class _InfomapWritersMixin:
         states : bool, optional
             If the state nodes should be included. Default ``False``.
         """
-        self._core.writeTree(os.fspath(filename), states)
+        with _translate_engine_errors():
+            self._core.writeTree(os.fspath(filename), states)
 
     def write_flow_tree(
         self, filename: str | os.PathLike[str], states: bool = False
@@ -122,7 +126,8 @@ class _InfomapWritersMixin:
         states : bool, optional
             If the state nodes should be included. Default ``False``.
         """
-        self._core.writeFlowTree(os.fspath(filename), states)
+        with _translate_engine_errors():
+            self._core.writeFlowTree(os.fspath(filename), states)
 
     def write_newick(
         self, filename: str | os.PathLike[str], states: bool = False
@@ -142,7 +147,8 @@ class _InfomapWritersMixin:
         states : bool, optional
             If the state nodes should be included. Default ``False``.
         """
-        self._core.writeNewickTree(os.fspath(filename), states)
+        with _translate_engine_errors():
+            self._core.writeNewickTree(os.fspath(filename), states)
 
     def write_json(
         self, filename: str | os.PathLike[str], states: bool = False
@@ -162,7 +168,8 @@ class _InfomapWritersMixin:
         states : bool, optional
             If the state nodes should be included. Default ``False``.
         """
-        self._core.writeJsonTree(os.fspath(filename), states)
+        with _translate_engine_errors():
+            self._core.writeJsonTree(os.fspath(filename), states)
 
     def write_csv(
         self, filename: str | os.PathLike[str], states: bool = False
@@ -182,7 +189,8 @@ class _InfomapWritersMixin:
         states : bool, optional
             If the state nodes should be included. Default ``False``.
         """
-        self._core.writeCsvTree(os.fspath(filename), states)
+        with _translate_engine_errors():
+            self._core.writeCsvTree(os.fspath(filename), states)
 
     def write_state_network(self, filename: str | os.PathLike[str]) -> None:
         """Write internal state network to file.
@@ -197,7 +205,8 @@ class _InfomapWritersMixin:
         ----------
         filename : str or os.PathLike
         """
-        self._core.network().writeStateNetwork(os.fspath(filename))
+        with _translate_engine_errors():
+            self._core.network().writeStateNetwork(os.fspath(filename))
 
     def write_pajek(
         self, filename: str | os.PathLike[str], flow: bool = False
@@ -216,4 +225,5 @@ class _InfomapWritersMixin:
         flow : bool, optional
             If the flow should be included. Default ``False``.
         """
-        self._core.network().writePajekNetwork(os.fspath(filename), flow)
+        with _translate_engine_errors():
+            self._core.network().writePajekNetwork(os.fspath(filename), flow)

--- a/interfaces/python/src/infomap/network.py
+++ b/interfaces/python/src/infomap/network.py
@@ -29,6 +29,7 @@ import warnings
 from typing import Any
 
 from ._core import Core, apply_initial_partition
+from .errors import NetworkParseError, _translate_engine_errors
 from ._network_input import add_bulk_links as _add_bulk_links
 from ._network_input import first_order_unpacker as _first_order_unpacker
 from ._network_input import flat_multilayer_unpacker as _flat_multilayer_unpacker
@@ -303,12 +304,16 @@ class Network:
             )
 
         rendered_args = _construct_args(args, **resolved.to_kwargs())
+        # classify=True mirrors Infomap.run(): input failures surfacing at
+        # run time (cluster_data, meta_data) become NetworkParseError.
         if initial_partition is None:
-            self._core.run(rendered_args)
+            with _translate_engine_errors(classify=True):
+                self._core.run(rendered_args)
         else:
             apply_initial_partition(self._core, initial_partition)
             try:
-                self._core.run(rendered_args)
+                with _translate_engine_errors(classify=True):
+                    self._core.run(rendered_args)
             finally:
                 # Applies to this run only, mirroring Infomap.run().
                 apply_initial_partition(self._core, {})
@@ -327,8 +332,14 @@ class Network:
         accumulate : bool, optional
             If the network data should be accumulated to already added
             nodes and links. Default ``True``.
+
+        Raises
+        ------
+        NetworkParseError
+            If the file cannot be opened or its content cannot be parsed.
         """
-        self._core.readInputData(filename, accumulate)
+        with _translate_engine_errors(NetworkParseError):
+            self._core.readInputData(filename, accumulate)
         return self
 
     # ----------------------------------------

--- a/interfaces/python/src/infomap/result.py
+++ b/interfaces/python/src/infomap/result.py
@@ -27,6 +27,7 @@ from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, Any
 
 from ._optional import require_pandas
+from .errors import InfomapError, StaleResultError, _translate_engine_errors
 from ._results import (
     _DATAFRAME_COLUMN_ALIASES,
     _DEFAULT_TO_DATAFRAME_COLUMNS,
@@ -61,8 +62,9 @@ _SNAPSHOT_COLUMNS = (
 )
 
 
-class _StaleResultError(RuntimeError):
-    """Raised when node-level data is read from a Result after a re-run."""
+# Backwards-compatible alias: the stale-result error predates the public
+# taxonomy (infomap.errors) under this private name.
+_StaleResultError = StaleResultError
 
 
 def build_result(engine: Any) -> "Result":
@@ -394,7 +396,7 @@ class Result:
     def _check_generation(self) -> None:
         """Guard live C++ tree access against a re-run of the bound engine."""
         if self._engine._generation != self._generation:
-            raise _StaleResultError(
+            raise StaleResultError(
                 "stale Result: the Infomap instance was re-run since this "
                 "Result was created; node-level data is no longer available "
                 "(the C++ result tree is rebuilt on every run())."
@@ -407,7 +409,7 @@ class Result:
         ``tree()`` / ``leaf_modules()`` hand back live engine iterators rather
         than materialized snapshots. Without this guard, acquiring one and then
         re-running the engine before consuming it would walk a rebuilt C++ tree;
-        instead the first step raises :class:`_StaleResultError`.
+        instead the first step raises :class:`~infomap.StaleResultError`.
         """
         iterator = iter(iterator)
         while True:
@@ -585,7 +587,7 @@ class Result:
 
         Raises
         ------
-        RuntimeError
+        InfomapError
             For a higher-order network when ``states`` is ``False``.
 
         See Also
@@ -594,11 +596,11 @@ class Result:
         tree : Walk the full hierarchical tree.
         """
         if self._have_memory and not states:
-            # RuntimeError (not ValueError) on purpose: the legacy
-            # Infomap.get_modules path surfaces the C++ std::runtime_error
-            # thrown by getModules (src/Infomap.h), and parity tests pin the
-            # error type across both surfaces.
-            raise RuntimeError(
+            # InfomapError (not ValueError) on purpose: the legacy
+            # Infomap.get_modules path translates the C++ std::runtime_error
+            # thrown by getModules (src/Infomap.h) to the same taxonomy type,
+            # and parity tests pin the error type across both surfaces.
+            raise InfomapError(
                 "Cannot get modules on higher-order network without states."
             )
         snapshot = self._snapshot(depth, states)
@@ -698,7 +700,8 @@ class Result:
         modules : Module ids for a single level.
         """
         self._check_generation()
-        return self._engine._core.getMultilevelModules(states)
+        with _translate_engine_errors():
+            return self._engine._core.getMultilevelModules(states)
 
     def leaf_modules(self):
         """Iterate the leaf modules (bottom modules containing leaf nodes),

--- a/test/python/test_errors.py
+++ b/test/python/test_errors.py
@@ -25,12 +25,20 @@ from infomap import (
     NetworkParseError,
     NotRunError,
     StaleResultError,
+    errors as errors_module,
 )
-from infomap.errors import __all__ as _ERRORS_ALL
 from infomap.result import _StaleResultError
 
 
 pytestmark = pytest.mark.fast
+
+# The taxonomy classes as exported at the package top level, keyed by name.
+_TOP_LEVEL_EXPORTS = {
+    "InfomapError": InfomapError,
+    "NetworkParseError": NetworkParseError,
+    "NotRunError": NotRunError,
+    "StaleResultError": StaleResultError,
+}
 
 
 @pytest.fixture
@@ -62,10 +70,9 @@ def test_taxonomy_mro_keeps_runtime_error_through_2x():
 
 
 def test_module_all_matches_package_exports():
-    for name in _ERRORS_ALL:
-        import infomap
-
-        assert getattr(infomap, name) is getattr(infomap.errors, name)
+    assert sorted(errors_module.__all__) == sorted(_TOP_LEVEL_EXPORTS)
+    for name, exported in _TOP_LEVEL_EXPORTS.items():
+        assert getattr(errors_module, name) is exported
 
 
 def test_stale_result_private_alias_is_the_public_class():

--- a/test/python/test_errors.py
+++ b/test/python/test_errors.py
@@ -1,0 +1,161 @@
+"""The public error taxonomy (infomap.errors, #744).
+
+Engine errors cross the SWIG boundary as bare ``RuntimeError``; the package
+re-raises them as :class:`InfomapError` subclasses at the ``Core`` boundary.
+Pins three contracts:
+
+1. The MRO compatibility promises: every taxonomy class is a ``RuntimeError``
+   through 2.x, and ``NotRunError`` additionally keeps ``ValueError`` (the
+   type the results-before-run guard used to raise).
+2. The boundary mapping: construction, ``read_file``, ``run``-time input
+   files, writers, and the higher-order guard each raise the right class
+   with the C++ message preserved.
+3. Parity: the legacy ``Infomap`` accessors and the ``Result`` path raise
+   the same taxonomy type with the same message.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from infomap import (
+    Infomap,
+    InfomapError,
+    Network,
+    NetworkParseError,
+    NotRunError,
+    StaleResultError,
+)
+from infomap.errors import __all__ as _ERRORS_ALL
+from infomap.result import _StaleResultError
+
+
+pytestmark = pytest.mark.fast
+
+
+@pytest.fixture
+def unparsable_network_file(tmp_path):
+    path = tmp_path / "broken.net"
+    path.write_text("*Links\n1 two\n")
+    return str(path)
+
+
+@pytest.fixture
+def higher_order_run(make_infomap):
+    im = make_infomap()
+    im.add_state_node(1, 1)
+    im.add_state_node(2, 1)
+    im.add_state_node(3, 2)
+    im.add_link(1, 2)
+    im.add_link(2, 3)
+    im.add_link(1, 3)
+    return im, im.run()
+
+
+def test_taxonomy_mro_keeps_runtime_error_through_2x():
+    for error_class in (NetworkParseError, NotRunError, StaleResultError):
+        assert issubclass(error_class, InfomapError)
+    assert issubclass(InfomapError, RuntimeError)
+    # The results-before-run guard raised ValueError before the taxonomy;
+    # NotRunError keeps it in the MRO so `except ValueError` code survives 2.x.
+    assert issubclass(NotRunError, ValueError)
+
+
+def test_module_all_matches_package_exports():
+    for name in _ERRORS_ALL:
+        import infomap
+
+        assert getattr(infomap, name) is getattr(infomap.errors, name)
+
+
+def test_stale_result_private_alias_is_the_public_class():
+    assert _StaleResultError is StaleResultError
+
+
+def test_unrecognized_option_raises_infomap_error():
+    with pytest.raises(InfomapError, match="Unrecognized option"):
+        Infomap(args="--bogus-flag", silent=True)
+
+
+def test_read_file_missing_file_raises_network_parse_error(make_infomap):
+    with pytest.raises(NetworkParseError, match="Cannot open file"):
+        make_infomap().read_file("/nonexistent/network.net")
+
+
+def test_read_file_parse_error_raises_network_parse_error(
+    make_infomap, unparsable_network_file
+):
+    with pytest.raises(NetworkParseError, match="Can't parse link data"):
+        make_infomap().read_file(unparsable_network_file)
+
+
+def test_network_from_file_raises_the_same_type_as_infomap_read_file(
+    unparsable_network_file,
+):
+    with pytest.raises(NetworkParseError, match="Can't parse link data"):
+        Network.from_file(unparsable_network_file)
+
+
+def test_run_time_input_failure_raises_network_parse_error(make_infomap):
+    im = make_infomap(cluster_data="/nonexistent/partition.clu")
+    im.add_link(1, 2)
+
+    with pytest.raises(NetworkParseError, match="Cannot open file"):
+        im.run()
+
+
+def test_writer_failure_raises_infomap_error_not_parse_error(make_infomap):
+    im = make_infomap()
+    im.add_link(1, 2)
+    im.run()
+
+    with pytest.raises(InfomapError, match="write permissions") as excinfo:
+        im.write_tree("/nonexistent-dir/result.tree")
+    # An unwritable *output* is an engine error, not an input parse error.
+    assert not isinstance(excinfo.value, NetworkParseError)
+
+
+def test_higher_order_modules_parity_between_legacy_and_result(higher_order_run):
+    im, result = higher_order_run
+
+    with pytest.raises(InfomapError) as legacy:
+        im.get_modules()
+    with pytest.raises(InfomapError) as blessed:
+        result.modules()
+
+    assert str(legacy.value) == str(blessed.value)
+    assert type(legacy.value) is type(blessed.value)
+
+
+def test_higher_order_multilevel_modules_parity(higher_order_run):
+    im, result = higher_order_run
+
+    with pytest.raises(InfomapError) as legacy:
+        im.get_multilevel_modules()
+    with pytest.raises(InfomapError) as blessed:
+        result.multilevel_modules()
+
+    assert str(legacy.value) == str(blessed.value)
+    assert type(legacy.value) is type(blessed.value)
+
+
+def test_stale_result_raises_stale_result_error(make_infomap):
+    im = make_infomap()
+    im.add_link(1, 2)
+    stale = im.run()
+    im.run()
+
+    with pytest.raises(StaleResultError, match="stale Result"):
+        stale.modules()
+
+
+def test_export_before_run_raises_not_run_error(make_infomap):
+    networkx = pytest.importorskip("networkx")
+    from infomap.io.export import annotate_networkx_graph
+
+    graph = networkx.Graph([(0, 1)])
+    im = make_infomap()
+    im.add_networkx_graph(graph)
+
+    with pytest.raises(NotRunError, match="Run Infomap"):
+        annotate_networkx_graph(graph, im)


### PR DESCRIPTION
# Summary

Engine errors crossed the SWIG boundary as bare `RuntimeError` with the C++ message string, so callers could not catch Infomap failures without also catching unrelated `RuntimeError`s. This introduces the public taxonomy from #744 in a new pure-Python `infomap.errors` module (importable without the compiled bindings), exported at the package top level:

- **`InfomapError(RuntimeError)`** — base for every engine/package failure. Keeps `RuntimeError` in the MRO through 2.x so existing `except RuntimeError` code keeps working; the base may detach in 3.0.
- **`NetworkParseError`** — the network input could not be opened or parsed. Raised by `Infomap.read_file` and `Network.from_file`/`read_file` (wholesale), and from `run()` when auxiliary input (`cluster_data`, `meta_data`) fails, via a small known-C++-message table (SafeFile read-side open errors, `Can't parse …`, `Unrecognized heading …`, `JSON parse error …`). Write-side file errors stay base `InfomapError` — the SafeFile messages differ ("read permissions" vs "write permissions").
- **`NotRunError`** — results requested before `run()`. Replaces the `ValueError` from the shared `require_modules` guard but keeps `ValueError` in its MRO through 2.x, so existing handlers survive unchanged.
- **`StaleResultError`** — public name for the former private `_StaleResultError` (kept as an alias); now an `InfomapError`.

Translation happens at the `Core` boundary with the message preserved: engine construction (args parsing), `read_file` on both surfaces, both `run()` paths, the legacy `get_modules`/`get_multilevel_modules` accessors, and the file writers. `Result.modules()`'s Python-side higher-order guard now raises `InfomapError`, so the legacy and `Result` paths raise identical types and messages.

Documented on a new API reference page (`api/errors.rst`) with the compatibility contract and catch examples.

Closes #744

# Verification

- `pytest test/python`: 565 passed, 2 skipped — includes 13 new tests in `test_errors.py` pinning the MRO promises, each boundary mapping (construction, read, run-time input, writers), legacy/Result parity for `modules` and `multilevel_modules`, and the `_StaleResultError` alias
- Existing tests that pinned `RuntimeError` (higher-order, stale) and `ValueError` (export-before-run) pass unchanged — the compatibility MROs are doing their job
- `make test-python-doctest` (38 doctests + ruff), `make test-python-typecheck-core` (0 errors), `make test-binding-options-freshness` (generated block untouched), `make test-python-examples`: all green
- `make build-docs`: the new errors page renders; only the 6 known proxy-blocked intersphinx warnings

# Notes

- The docs-surface contract test enforces the new exports automatically: all four classes are in `infomap.__all__` and documented via `autoexception` on the new page.
- Adapter-side validation errors (e.g. the multilayer "diagonal links" guard in the networkx/igraph adapters) intentionally keep their current types — this PR scopes to the engine boundary per the issue; Python-side argument validation stays `ValueError`/`TypeError`.

---
_Generated by [Claude Code](https://claude.ai/code/session_017XjuZM32ZUn1AbeWJVXuyi)_