### PR TITLE
feat(python): route the engine log through Python logging

### DIFF
--- a/interfaces/R/generated/infomap_wrap.cpp
+++ b/interfaces/R/generated/infomap_wrap.cpp
@@ -1631,6 +1631,7 @@ template <typename T> T SwigValueInit() {
 /* Includes the header in the wrapper code */
 #include "src/Infomap.h"
 #include "src/io/Features.h"
+#include "src/utils/Log.h"
 #ifdef SWIGPYTHON
 namespace infomap {
 int run(const std::string& flags);
@@ -1640,7 +1641,11 @@ int run(const std::string& flags);
 #include <cstdint>
 #include <cstring>
 #include <limits>
+#include <mutex>
 #include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 #endif
 // SWIG strips namespaces, so include infomap in global namespace in wrapper code
 using namespace infomap;

--- a/interfaces/python/generated/infomap_wrap.cpp
+++ b/interfaces/python/generated/infomap_wrap.cpp
@@ -3717,6 +3717,7 @@ namespace swig {
 /* Includes the header in the wrapper code */
 #include "src/Infomap.h"
 #include "src/io/Features.h"
+#include "src/utils/Log.h"
 #ifdef SWIGPYTHON
 namespace infomap {
 int run(const std::string& flags);
@@ -3726,7 +3727,11 @@ int run(const std::string& flags);
 #include <cstdint>
 #include <cstring>
 #include <limits>
+#include <mutex>
 #include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 #endif
 // SWIG strips namespaces, so include infomap in global namespace in wrapper code
 using namespace infomap;
@@ -7094,6 +7099,106 @@ SWIGINTERN PyObject *std_map_Sl_std_pair_Sl_unsigned_SS_int_Sc_unsigned_SS_int_S
     }
 SWIGINTERN void std_map_Sl_std_pair_Sl_unsigned_SS_int_Sc_unsigned_SS_int_Sg__Sc_double_Sg__erase__SWIG_1(std::map< std::pair< unsigned int,unsigned int >,double > *self,std::map< std::pair< unsigned int,unsigned int >,double >::iterator position){ self->erase(position); }
 SWIGINTERN void std_map_Sl_std_pair_Sl_unsigned_SS_int_Sc_unsigned_SS_int_Sg__Sc_double_Sg__erase__SWIG_2(std::map< std::pair< unsigned int,unsigned int >,double > *self,std::map< std::pair< unsigned int,unsigned int >,double >::iterator first,std::map< std::pair< unsigned int,unsigned int >,double >::iterator last){ self->erase(first, last); }
+
+namespace {
+
+// Bridges infomap::Log lines to a Python callable `callback(level, line)`.
+//
+// Threading contract (see issue #745): the SWIG module never releases the
+// GIL, so during run() the *calling* thread holds it for the whole call and
+// may enter Python directly. Lines written by other threads (OpenMP task
+// threads emit -vv detail lines) must NEVER acquire the GIL — the calling
+// thread waits for them at OpenMP barriers while holding it, so a worker
+// blocking in PyGILState_Ensure() would deadlock. Such lines are queued
+// under a mutex and drained by the next GIL-holding write, or by
+// _drain_log_queue() after run() returns.
+class PythonLogSink : public infomap::LogSink {
+public:
+  explicit PythonLogSink(PyObject* callable) : m_callable(callable)
+  {
+    Py_INCREF(m_callable);
+  }
+
+  // Only constructed/destroyed from Python calls (GIL held).
+  ~PythonLogSink() override { Py_DECREF(m_callable); }
+
+  PythonLogSink(const PythonLogSink&) = delete;
+  PythonLogSink& operator=(const PythonLogSink&) = delete;
+
+  void writeLine(unsigned int level, const std::string& line) override
+  {
+    if (!PyGILState_Check()) {
+      std::lock_guard<std::mutex> lock(m_mutex);
+      m_queued.emplace_back(level, line);
+      return;
+    }
+    drainQueued();
+    deliver(level, line);
+  }
+
+  void drainQueued()
+  {
+    // Caller must hold the GIL.
+    std::vector<std::pair<unsigned int, std::string>> pending;
+    {
+      std::lock_guard<std::mutex> lock(m_mutex);
+      pending.swap(m_queued);
+    }
+    for (const auto& entry : pending)
+      deliver(entry.first, entry.second);
+  }
+
+private:
+  void deliver(unsigned int level, const std::string& line)
+  {
+    PyObject* result = PyObject_CallFunction(m_callable, "(Is)", level, line.c_str());
+    if (result == nullptr) {
+      // A raising log callback must not kill the engine run — same policy
+      // as the logging module's own handler-error swallowing.
+      PyErr_WriteUnraisable(m_callable);
+      return;
+    }
+    Py_DECREF(result);
+  }
+
+  PyObject* m_callable;
+  std::mutex m_mutex;
+  std::vector<std::pair<unsigned int, std::string>> m_queued;
+};
+
+PythonLogSink* g_pythonLogSink = nullptr;
+
+} // namespace
+
+
+namespace infomap {
+// Install `callback(level, line)` as the process-global engine log sink,
+// replacing stream output; pass None to uninstall and restore stream output.
+// Called with the GIL held (any Python call). Must not race with a running
+// engine — Log state is process-global.
+void _set_log_callback(PyObject* callback)
+{
+  if (g_pythonLogSink != nullptr) {
+    Log::setSink(nullptr);
+    delete g_pythonLogSink;
+    g_pythonLogSink = nullptr;
+  }
+  if (callback != Py_None) {
+    g_pythonLogSink = new PythonLogSink(callback);
+    Log::setSink(g_pythonLogSink);
+  }
+}
+
+// Deliver lines queued by non-GIL-holding threads and flush the calling
+// thread's trailing partial line. Call after an engine run returns.
+void _drain_log_queue()
+{
+  Log::flushSinkLines();
+  if (g_pythonLogSink != nullptr)
+    g_pythonLogSink->drainQueued();
+}
+}
+
 
 namespace infomap {
 std::string pythonEnabledFeaturesString()
@@ -55457,6 +55562,48 @@ SWIGINTERN PyObject *map_pair_uint_uint_double_swiginit(PyObject *SWIGUNUSEDPARM
   return SWIG_Python_InitShadowInstance(args);
 }
 
+SWIGINTERN PyObject *_wrap__set_log_callback(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  PyObject *arg1 = 0 ;
+  PyObject *swig_obj[1] ;
+  
+  (void)self;
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  arg1 = swig_obj[0];
+  {
+    try {
+      infomap::_set_log_callback(arg1);
+    } catch (const std::exception& e) {
+      SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap__drain_log_queue(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  
+  (void)self;
+  if (!SWIG_Python_UnpackTuple(args, "_drain_log_queue", 0, 0, 0)) SWIG_fail;
+  {
+    try {
+      infomap::_drain_log_queue();
+    } catch (const std::exception& e) {
+      SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap__enabled_features_string(PyObject *self, PyObject *args) {
   PyObject *resultobj = 0;
   std::string result;
@@ -60414,6 +60561,8 @@ static PyMethodDef SwigMethods[] = {
 	 { "delete_map_pair_uint_uint_double", _wrap_delete_map_pair_uint_uint_double, METH_O, NULL},
 	 { "map_pair_uint_uint_double_swigregister", map_pair_uint_uint_double_swigregister, METH_O, NULL},
 	 { "map_pair_uint_uint_double_swiginit", map_pair_uint_uint_double_swiginit, METH_VARARGS, NULL},
+	 { "_set_log_callback", _wrap__set_log_callback, METH_O, NULL},
+	 { "_drain_log_queue", _wrap__drain_log_queue, METH_NOARGS, NULL},
 	 { "_enabled_features_string", _wrap__enabled_features_string, METH_NOARGS, NULL},
 	 { "run", _wrap_run, METH_O, NULL},
 	 { "NodeData_node_id_set", _wrap_NodeData_node_id_set, METH_VARARGS, NULL},

--- a/interfaces/python/generated/infomap_wrap.cpp
+++ b/interfaces/python/generated/infomap_wrap.cpp
@@ -7178,6 +7178,11 @@ namespace infomap {
 // engine — Log state is process-global.
 void _set_log_callback(PyObject* callback)
 {
+  // Fail fast on a non-callable: installing it would turn every log write
+  // into a swallowed PyErr_WriteUnraisable, silently disabling the log.
+  if (callback != Py_None && PyCallable_Check(callback) == 0) {
+    throw std::runtime_error("log callback must be callable (or None to uninstall)");
+  }
   if (g_pythonLogSink != nullptr) {
     Log::setSink(nullptr);
     delete g_pythonLogSink;

--- a/interfaces/python/source/api/functions.rst
+++ b/interfaces/python/source/api/functions.rst
@@ -17,6 +17,16 @@ Graph-package entry points
 .. autofunction:: find_communities
 .. autofunction:: find_igraph_communities
 
+Engine log
+----------
+
+The engine log becomes Python log records on the ``"infomap"`` logger when
+that logger has handlers; see the routing rules in
+:doc:`/working-with-infomap/running-and-options`.
+
+.. autofunction:: enable_log
+.. autofunction:: disable_log
+
 Information-theoretic primitives
 --------------------------------
 

--- a/interfaces/python/source/working-with-infomap/running-and-options.md
+++ b/interfaces/python/source/working-with-infomap/running-and-options.md
@@ -419,6 +419,49 @@ These are the keyword arguments to {func}`infomap.run`:
 For the full set of options as a searchable table, see the
 {class}`~infomap.Options` reference in the {doc}`/api/index`.
 
+## Routing the engine log through Python logging
+
+The Python API is quiet by default. When you do want the engine's progress
+log — in application logs, a notebook, or a file — attach a handler to the
+standard `"infomap"` logger and run with `silent=False`. Every visible engine
+log line then becomes a log record instead of stdout output: default lines at
+`INFO`, `-v`/`-vv` detail lines (`verbosity_level=2` and up) at `DEBUG`.
+
+```{code-cell} python
+import logging
+import infomap
+
+logger = logging.getLogger("infomap")
+handler = logging.StreamHandler()
+handler.setFormatter(logging.Formatter("%(levelname)s infomap: %(message)s"))
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
+result = infomap.run(
+    [(1, 2), (1, 3), (2, 3), (3, 4), (4, 5), (4, 6), (5, 6)],
+    options=infomap.Options(silent=False),
+)
+
+logger.removeHandler(handler)
+print(f"Found {result.num_top_modules} modules")
+```
+
+How the routing engages:
+
+- **Only handlers attached directly to `logging.getLogger("infomap")` count.**
+  `logging.basicConfig(...)` alone does not reroute the engine log — without
+  an `"infomap"` handler, `silent=False` prints to stdout exactly as before.
+- **`silent` still gates emission.** With the quiet default, no records are
+  produced even when a handler is attached; pass
+  `options=Options(silent=False)` (or `silent=False` on
+  {class}`~infomap.Infomap`) to emit.
+- **Routed output is plain lines.** The colors and the live progress line are
+  terminal features; log records get one clean line each.
+- **{class}`~infomap.Network` engines are silent for their whole lifetime**
+  (see {meth}`Network.run <infomap.Network.run>`), so records come from the
+  stateful {class}`~infomap.Infomap` and non-`Network` {func}`infomap.run`
+  inputs. The `infomap` command-line interface is unaffected.
+
 ## Going deeper
 
 - The {doc}`options guide notebook </examples/options-guide>` lists every

--- a/interfaces/python/source/working-with-infomap/running-and-options.md
+++ b/interfaces/python/source/working-with-infomap/running-and-options.md
@@ -422,39 +422,50 @@ For the full set of options as a searchable table, see the
 ## Routing the engine log through Python logging
 
 The Python API is quiet by default. When you do want the engine's progress
-log — in application logs, a notebook, or a file — attach a handler to the
-standard `"infomap"` logger and run with `silent=False`. Every visible engine
-log line then becomes a log record instead of stdout output: default lines at
-`INFO`, `-v`/`-vv` detail lines (`verbosity_level=2` and up) at `DEBUG`.
+log — in a notebook, application logs, or a file — one line opts in:
 
 ```{code-cell} python
-import logging
 import infomap
 
-logger = logging.getLogger("infomap")
-handler = logging.StreamHandler()
-handler.setFormatter(logging.Formatter("%(levelname)s infomap: %(message)s"))
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
+infomap.enable_log()
 
-result = infomap.run(
-    [(1, 2), (1, 3), (2, 3), (3, 4), (4, 5), (4, 6), (5, 6)],
-    options=infomap.Options(silent=False),
-)
+result = infomap.run([(1, 2), (1, 3), (2, 3), (3, 4), (4, 5), (4, 6), (5, 6)])
 
-logger.removeHandler(handler)
+infomap.disable_log()
 print(f"Found {result.num_top_modules} modules")
 ```
 
-How the routing engages:
+{func}`~infomap.enable_log` attaches a plain handler to the standard
+`"infomap"` logger; that is all the opt-in is. For full control — formats,
+files, your logging pipeline — skip the helper and configure the logger with
+standard {mod}`logging`; any handler attached directly to it engages the same
+routing:
 
+```python
+import logging
+
+logging.getLogger("infomap").addHandler(my_handler)
+logging.getLogger("infomap").setLevel(logging.INFO)
+```
+
+How the routing behaves:
+
+- **Logging is the control.** With handlers attached, every engine run emits
+  records — no `silent=False` needed, and `silent=` is ignored for emission.
+  Tune volume with logger/handler levels (`logging.WARNING` silences the
+  engine's INFO lines); remove the handlers to go back to classic stdout
+  output gated by `silent=`.
+- **Levels map naturally.** Default lines arrive at `INFO`. A logger enabled
+  for `DEBUG` (`infomap.enable_log(logging.DEBUG)`) automatically raises the
+  engine verbosity to `-vv`, so its detail lines arrive at `DEBUG`.
 - **Only handlers attached directly to `logging.getLogger("infomap")` count.**
   `logging.basicConfig(...)` alone does not reroute the engine log — without
   an `"infomap"` handler, `silent=False` prints to stdout exactly as before.
-- **`silent` still gates emission.** With the quiet default, no records are
-  produced even when a handler is attached; pass
-  `options=Options(silent=False)` (or `silent=False` on
-  {class}`~infomap.Infomap`) to emit.
+- **Configure logging before creating a stateful engine.** The engine bakes
+  its silence in at construction, so an {class}`~infomap.Infomap` created
+  *before* logging was configured cannot emit records (its runs warn to
+  explain why). The one-shot {func}`infomap.run` always respects the current
+  logging configuration.
 - **Routed output is plain lines.** The colors and the live progress line are
   terminal features; log records get one clean line each.
 - **{class}`~infomap.Network` engines are silent for their whole lifetime**

--- a/interfaces/python/src/infomap/_bindings.py
+++ b/interfaces/python/src/infomap/_bindings.py
@@ -1,4 +1,9 @@
 from ._swig import *  # noqa: F401,F403
 
+# Star-import skips underscore-prefixed names; the private engine hooks the
+# package layers need are re-exported explicitly.
+from ._swig import _drain_log_queue as _drain_log_queue
+from ._swig import _set_log_callback as _set_log_callback
+
 
 __all__ = [name for name in globals() if not name.startswith("_")]

--- a/interfaces/python/src/infomap/_core.py
+++ b/interfaces/python/src/infomap/_core.py
@@ -22,6 +22,12 @@ from ._bindings import InfomapWrapper  # noqa: F401  (the only engine import)
 from ._bindings import build_info as build_info  # module-level engine function
 from ._bindings import run as run  # module-level engine function (CLI driver)
 
+# Engine log-sink hooks (issue #745), re-exported through this single boundary
+# for infomap._logging: install/remove the process-global line sink, and drain
+# lines queued by non-GIL-holding threads after an engine call returns.
+from ._bindings import _drain_log_queue as drain_log_queue  # noqa: F401
+from ._bindings import _set_log_callback as set_log_callback  # noqa: F401
+
 # Documented tree-walking iterator/node types returned by ``Infomap.tree`` /
 # ``leaf_modules`` and the physical variants (source/api/iterators.rst). They are
 # public API, so they're re-exported through this single boundary -- like

--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -34,7 +34,10 @@ from ._options import (
     OutputFormat,
     _construct_args,
 )
+from ._logging import apply_engine_log_overrides as _apply_engine_log_overrides
+from ._logging import disable_log, enable_log
 from ._logging import engine_log_routing as _engine_log_routing
+from ._logging import is_routed as _is_log_routed
 from ._results import _InfomapResultsMixin
 from ._results import entropy, perplexity, plogp
 from .errors import NetworkParseError, _translate_engine_errors
@@ -83,6 +86,8 @@ __all__ = [
     "Result",
     "TreeNode",
     "build_info",
+    "disable_log",
+    "enable_log",
     "entropy",
     "find_communities",
     "find_igraph_communities",
@@ -157,7 +162,16 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
     """
 
     def _init_from_options(self, args, options):
-        self._core = Core(_package_construct_args()(args, **options.to_kwargs()))
+        # In routed log mode (handlers on the "infomap" logger), logging is
+        # the emission control: strip --silent from the constructor args (the
+        # C++ engine composes constructor + run args additively, so a --silent
+        # baked in here could never be undone at run time) and let a
+        # DEBUG-enabled logger raise the engine verbosity.
+        kwargs = _apply_engine_log_overrides(options.to_kwargs())
+        # Remembered so run() can explain why a routed run of an instance
+        # constructed *before* logging was configured produces no records.
+        self._engine_constructed_silent = bool(kwargs.get("silent", True))
+        self._core = Core(_package_construct_args()(args, **kwargs))
         self._network = Network(core=self._core)
         self.node_id_to_label = {}
         # Run-generation token: incremented on every run(). A Result stamps the
@@ -2702,7 +2716,20 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             self.initial_partition = old_partition
 
     def _run_from_options(self, args, initial_partition, options):
-        args = _package_construct_args()(args, **options.to_kwargs())
+        kwargs = options.to_kwargs()
+        if _is_log_routed():
+            if self._engine_constructed_silent:
+                warnings.warn(
+                    "the 'infomap' logger has handlers, but this Infomap "
+                    "instance was created silent before logging was "
+                    "configured, so the run emits no log records. Configure "
+                    "logging (e.g. infomap.enable_log()) before creating the "
+                    "instance, or create it with silent=False.",
+                    UserWarning,
+                    stacklevel=3,
+                )
+            kwargs = _apply_engine_log_overrides(kwargs)
+        args = _package_construct_args()(args, **kwargs)
 
         # classify=True: the engine reads auxiliary input (cluster_data,
         # meta_data) at run time, so input failures surfacing here become

--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -34,6 +34,7 @@ from ._options import (
     OutputFormat,
     _construct_args,
 )
+from ._logging import engine_log_routing as _engine_log_routing
 from ._results import _InfomapResultsMixin
 from ._results import entropy, perplexity, plogp
 from .errors import NetworkParseError, _translate_engine_errors
@@ -1523,7 +1524,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         NetworkParseError
             If the file cannot be opened or its content cannot be parsed.
         """
-        with _translate_engine_errors(NetworkParseError):
+        with _engine_log_routing(), _translate_engine_errors(NetworkParseError):
             self._core.readInputData(filename, accumulate)
 
     def add_node(self, node_id, name=None, teleportation_weight=None):
@@ -2708,10 +2709,10 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         # NetworkParseError; everything else is InfomapError.
         if initial_partition is not None:
             with self._initial_partition(initial_partition):
-                with _translate_engine_errors(classify=True):
+                with _engine_log_routing(), _translate_engine_errors(classify=True):
                     self._core.run(args)
         else:
-            with _translate_engine_errors(classify=True):
+            with _engine_log_routing(), _translate_engine_errors(classify=True):
                 self._core.run(args)
 
         # Stamp a fresh Result with the new generation (shared helper). The C++

--- a/interfaces/python/src/infomap/_logging.py
+++ b/interfaces/python/src/infomap/_logging.py
@@ -1,18 +1,24 @@
 """Routing of the engine console log into Python :mod:`logging` (#745).
 
 The engine writes its console output through the C++ ``Log`` class. When the
-user has attached handlers to ``logging.getLogger("infomap")``, the package
-installs a process-global line sink at the SWIG boundary and every visible
-engine log line becomes a log record instead of stdout output: default lines
-at ``INFO``, ``-v``/``-vv`` detail lines at ``DEBUG``. Without handlers the
-engine writes to stdout exactly as before.
+user has attached handlers to ``logging.getLogger("infomap")`` (one line:
+:func:`infomap.enable_log`), the package installs a process-global line sink
+at the SWIG boundary and every visible engine log line becomes a log record
+instead of stdout output: default lines at ``INFO``, ``-v``/``-vv`` detail
+lines at ``DEBUG``. Without handlers the engine writes to stdout exactly as
+before.
+
+In routed mode, logging is the control: the engine is un-silenced regardless
+of the ``silent`` option (silence with logger levels or by removing the
+handlers), and a DEBUG-enabled logger raises the engine verbosity so detail
+records exist to filter. In classic (stdout) mode ``silent=`` keeps gating
+emission as always.
 
 Routing deliberately keys on handlers attached *directly* to the
 ``"infomap"`` logger, not on propagated root handlers: pytest and
 ``logging.basicConfig`` both attach root handlers, and rerouting on those
 would silently change the stdout behavior of every ``silent=False`` script.
 
-``silent=`` gates emission engine-side, upstream of the sink, in both modes.
 The sink is process-global (C++ ``Log`` state already is), matching the
 existing one-run-at-a-time constraint.
 """
@@ -20,6 +26,7 @@ existing one-run-at-a-time constraint.
 from __future__ import annotations
 
 import logging
+import sys
 from contextlib import contextmanager
 
 logger = logging.getLogger("infomap")
@@ -76,3 +83,88 @@ def engine_log_routing():
         yield
     finally:
         _drain()
+
+
+def is_routed() -> bool:
+    """Whether engine log routing is engaged for the next engine call."""
+    return bool(logger.handlers)
+
+
+def apply_engine_log_overrides(kwargs: dict) -> dict:
+    """Make logging the emission control when routing is engaged.
+
+    Applied to the option kwargs right before they are rendered to engine
+    args (both at ``Infomap`` construction and per run): strip ``silent`` so
+    the engine emits — the user asked for the log by configuring the logger;
+    silence with logger levels instead — and, when the logger is enabled for
+    DEBUG, raise the engine verbosity to ``-vv`` (unless the user already
+    chose a higher ``verbosity_level``) so detail records exist to filter.
+    Returns ``kwargs`` untouched when routing is not engaged.
+    """
+    if not is_routed():
+        return kwargs
+    kwargs = dict(kwargs)
+    kwargs["silent"] = False
+    if logger.isEnabledFor(logging.DEBUG):
+        current = kwargs.get("verbosity_level") or 1
+        if current <= 1:
+            kwargs["verbosity_level"] = 2
+    return kwargs
+
+
+_helper_handler: logging.Handler | None = None
+
+
+def enable_log(level: int = logging.INFO) -> logging.Handler:
+    """Show the engine log as Python log records, in one line.
+
+    Attaches a plain ``%(message)s`` stream handler (stdout) to the
+    ``"infomap"`` logger and sets the logger level, which engages the log
+    routing: every engine run emits records — no ``silent=False`` needed —
+    and stdout output is replaced by the records. Pass
+    ``level=logging.DEBUG`` for the engine's ``-vv`` detail lines.
+
+    Idempotent: repeated calls reuse the same handler and only adjust the
+    level. Undo with :func:`disable_log`. For full control (formatting,
+    files, propagation), skip this helper and configure
+    ``logging.getLogger("infomap")`` with standard :mod:`logging` instead.
+
+    Parameters
+    ----------
+    level : int, optional
+        The logger level, by default ``logging.INFO``. Use
+        ``logging.DEBUG`` to include the engine's detail lines.
+
+    Returns
+    -------
+    logging.Handler
+        The installed handler (useful for reformatting or removal).
+
+    Examples
+    --------
+    >>> import infomap
+    >>> handler = infomap.enable_log()
+    >>> infomap.disable_log()
+    """
+    global _helper_handler
+    if _helper_handler is None:
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        _helper_handler = handler
+    if _helper_handler not in logger.handlers:
+        logger.addHandler(_helper_handler)
+    logger.setLevel(level)
+    return _helper_handler
+
+
+def disable_log() -> None:
+    """Remove the handler installed by :func:`enable_log`.
+
+    Handlers the user attached themselves are left untouched; with no
+    handlers remaining, the engine goes back to classic stdout output
+    (gated by ``silent=``).
+    """
+    global _helper_handler
+    if _helper_handler is not None:
+        logger.removeHandler(_helper_handler)
+        _helper_handler = None

--- a/interfaces/python/src/infomap/_logging.py
+++ b/interfaces/python/src/infomap/_logging.py
@@ -1,0 +1,78 @@
+"""Routing of the engine console log into Python :mod:`logging` (#745).
+
+The engine writes its console output through the C++ ``Log`` class. When the
+user has attached handlers to ``logging.getLogger("infomap")``, the package
+installs a process-global line sink at the SWIG boundary and every visible
+engine log line becomes a log record instead of stdout output: default lines
+at ``INFO``, ``-v``/``-vv`` detail lines at ``DEBUG``. Without handlers the
+engine writes to stdout exactly as before.
+
+Routing deliberately keys on handlers attached *directly* to the
+``"infomap"`` logger, not on propagated root handlers: pytest and
+``logging.basicConfig`` both attach root handlers, and rerouting on those
+would silently change the stdout behavior of every ``silent=False`` script.
+
+``silent=`` gates emission engine-side, upstream of the sink, in both modes.
+The sink is process-global (C++ ``Log`` state already is), matching the
+existing one-run-at-a-time constraint.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+
+logger = logging.getLogger("infomap")
+
+# Engine message levels at or above this become DEBUG records; below, INFO.
+_ENGINE_DEBUG_FROM_LEVEL = 1
+
+_installed = False
+
+
+def _emit(level: int, line: str) -> None:
+    logger.log(
+        logging.DEBUG if level >= _ENGINE_DEBUG_FROM_LEVEL else logging.INFO,
+        "%s",
+        line,
+    )
+
+
+def _sync_engine_routing() -> None:
+    """Install or remove the engine-to-logging bridge for the next engine call."""
+    # Imported lazily: _core imports _bindings at module load, and this module
+    # is imported by the facade/network layers that _core must not depend on.
+    from ._core import drain_log_queue, set_log_callback
+
+    global _installed
+    should_route = bool(logger.handlers)
+    if should_route and not _installed:
+        set_log_callback(_emit)
+        _installed = True
+    elif not should_route and _installed:
+        # Deliver anything still queued before the sink goes away.
+        drain_log_queue()
+        set_log_callback(None)
+        _installed = False
+
+
+def _drain() -> None:
+    if _installed:
+        from ._core import drain_log_queue
+
+        drain_log_queue()
+
+
+@contextmanager
+def engine_log_routing():
+    """Engage/disengage log routing around one engine call.
+
+    Syncs the sink against the current handler configuration on entry and, on
+    exit, drains lines queued by non-GIL-holding threads (OpenMP task threads
+    emit ``-vv`` detail lines) plus any trailing partial line.
+    """
+    _sync_engine_routing()
+    try:
+        yield
+    finally:
+        _drain()

--- a/interfaces/python/src/infomap/_swig.py
+++ b/interfaces/python/src/infomap/_swig.py
@@ -3064,6 +3064,12 @@ class map_pair_uint_uint_double(object):
 # Register map_pair_uint_uint_double in _infomap:
 _infomap.map_pair_uint_uint_double_swigregister(map_pair_uint_uint_double)
 
+def _set_log_callback(callback):
+    return _infomap._set_log_callback(callback)
+
+def _drain_log_queue():
+    return _infomap._drain_log_queue()
+
 def _enabled_features_string():
     return _infomap._enabled_features_string()
 

--- a/interfaces/python/src/infomap/network.py
+++ b/interfaces/python/src/infomap/network.py
@@ -29,6 +29,7 @@ import warnings
 from typing import Any
 
 from ._core import Core, apply_initial_partition
+from ._logging import engine_log_routing as _engine_log_routing
 from .errors import NetworkParseError, _translate_engine_errors
 from ._network_input import add_bulk_links as _add_bulk_links
 from ._network_input import first_order_unpacker as _first_order_unpacker
@@ -307,12 +308,12 @@ class Network:
         # classify=True mirrors Infomap.run(): input failures surfacing at
         # run time (cluster_data, meta_data) become NetworkParseError.
         if initial_partition is None:
-            with _translate_engine_errors(classify=True):
+            with _engine_log_routing(), _translate_engine_errors(classify=True):
                 self._core.run(rendered_args)
         else:
             apply_initial_partition(self._core, initial_partition)
             try:
-                with _translate_engine_errors(classify=True):
+                with _engine_log_routing(), _translate_engine_errors(classify=True):
                     self._core.run(rendered_args)
             finally:
                 # Applies to this run only, mirroring Infomap.run().
@@ -338,7 +339,7 @@ class Network:
         NetworkParseError
             If the file cannot be opened or its content cannot be parsed.
         """
-        with _translate_engine_errors(NetworkParseError):
+        with _engine_log_routing(), _translate_engine_errors(NetworkParseError):
             self._core.readInputData(filename, accumulate)
         return self
 

--- a/interfaces/swig/Infomap.i
+++ b/interfaces/swig/Infomap.i
@@ -478,6 +478,11 @@ namespace infomap {
 // engine — Log state is process-global.
 void _set_log_callback(PyObject* callback)
 {
+  // Fail fast on a non-callable: installing it would turn every log write
+  // into a swallowed PyErr_WriteUnraisable, silently disabling the log.
+  if (callback != Py_None && PyCallable_Check(callback) == 0) {
+    throw std::runtime_error("log callback must be callable (or None to uninstall)");
+  }
   if (g_pythonLogSink != nullptr) {
     Log::setSink(nullptr);
     delete g_pythonLogSink;

--- a/interfaces/swig/Infomap.i
+++ b/interfaces/swig/Infomap.i
@@ -7,6 +7,7 @@
 /* Includes the header in the wrapper code */
 #include "src/Infomap.h"
 #include "src/io/Features.h"
+#include "src/utils/Log.h"
 #ifdef SWIGPYTHON
 namespace infomap {
 int run(const std::string& flags);
@@ -16,7 +17,11 @@ int run(const std::string& flags);
 #include <cstdint>
 #include <cstring>
 #include <limits>
+#include <mutex>
 #include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 #endif
 // SWIG strips namespaces, so include infomap in global namespace in wrapper code
 using namespace infomap;
@@ -393,6 +398,108 @@ namespace std {
 }
 
 #ifdef SWIGPYTHON
+%{
+namespace {
+
+// Bridges infomap::Log lines to a Python callable `callback(level, line)`.
+//
+// Threading contract (see issue #745): the SWIG module never releases the
+// GIL, so during run() the *calling* thread holds it for the whole call and
+// may enter Python directly. Lines written by other threads (OpenMP task
+// threads emit -vv detail lines) must NEVER acquire the GIL — the calling
+// thread waits for them at OpenMP barriers while holding it, so a worker
+// blocking in PyGILState_Ensure() would deadlock. Such lines are queued
+// under a mutex and drained by the next GIL-holding write, or by
+// _drain_log_queue() after run() returns.
+class PythonLogSink : public infomap::LogSink {
+public:
+  explicit PythonLogSink(PyObject* callable) : m_callable(callable)
+  {
+    Py_INCREF(m_callable);
+  }
+
+  // Only constructed/destroyed from Python calls (GIL held).
+  ~PythonLogSink() override { Py_DECREF(m_callable); }
+
+  PythonLogSink(const PythonLogSink&) = delete;
+  PythonLogSink& operator=(const PythonLogSink&) = delete;
+
+  void writeLine(unsigned int level, const std::string& line) override
+  {
+    if (!PyGILState_Check()) {
+      std::lock_guard<std::mutex> lock(m_mutex);
+      m_queued.emplace_back(level, line);
+      return;
+    }
+    drainQueued();
+    deliver(level, line);
+  }
+
+  void drainQueued()
+  {
+    // Caller must hold the GIL.
+    std::vector<std::pair<unsigned int, std::string>> pending;
+    {
+      std::lock_guard<std::mutex> lock(m_mutex);
+      pending.swap(m_queued);
+    }
+    for (const auto& entry : pending)
+      deliver(entry.first, entry.second);
+  }
+
+private:
+  void deliver(unsigned int level, const std::string& line)
+  {
+    PyObject* result = PyObject_CallFunction(m_callable, "(Is)", level, line.c_str());
+    if (result == nullptr) {
+      // A raising log callback must not kill the engine run — same policy
+      // as the logging module's own handler-error swallowing.
+      PyErr_WriteUnraisable(m_callable);
+      return;
+    }
+    Py_DECREF(result);
+  }
+
+  PyObject* m_callable;
+  std::mutex m_mutex;
+  std::vector<std::pair<unsigned int, std::string>> m_queued;
+};
+
+PythonLogSink* g_pythonLogSink = nullptr;
+
+} // namespace
+%}
+
+%inline %{
+namespace infomap {
+// Install `callback(level, line)` as the process-global engine log sink,
+// replacing stream output; pass None to uninstall and restore stream output.
+// Called with the GIL held (any Python call). Must not race with a running
+// engine — Log state is process-global.
+void _set_log_callback(PyObject* callback)
+{
+  if (g_pythonLogSink != nullptr) {
+    Log::setSink(nullptr);
+    delete g_pythonLogSink;
+    g_pythonLogSink = nullptr;
+  }
+  if (callback != Py_None) {
+    g_pythonLogSink = new PythonLogSink(callback);
+    Log::setSink(g_pythonLogSink);
+  }
+}
+
+// Deliver lines queued by non-GIL-holding threads and flush the calling
+// thread's trailing partial line. Call after an engine run returns.
+void _drain_log_queue()
+{
+  Log::flushSinkLines();
+  if (g_pythonLogSink != nullptr)
+    g_pythonLogSink->drainQueued();
+}
+}
+%}
+
 %rename(_enabled_features_string) infomap::pythonEnabledFeaturesString;
 %inline %{
 namespace infomap {

--- a/src/utils/Log.cpp
+++ b/src/utils/Log.cpp
@@ -12,6 +12,8 @@
 #ifndef INFOMAP_R
 #include <iostream>
 #endif
+#include <array>
+#include <memory>
 #include <streambuf>
 
 namespace infomap {
@@ -22,6 +24,91 @@ namespace {
   protected:
     int_type overflow(int_type c) override { return traits_type::not_eof(c); }
   };
+
+  // Buffers characters until '\n' and delivers each complete line to the
+  // installed sink, tagged with this buffer's level. One instance per
+  // (thread, level) — see sinkStreamsForThisThread() — so concurrent
+  // threads assemble their lines independently and never tear each other's
+  // output. The sink pointer is re-read at delivery time, so an uninstall
+  // between writes simply drops the remainder instead of dereferencing a
+  // dead sink.
+  class SinkLineBuf : public std::streambuf {
+  public:
+    explicit SinkLineBuf(unsigned int level) : m_level(level) {}
+
+    void flushPending()
+    {
+      if (!m_line.empty())
+        deliver();
+    }
+
+  protected:
+    int_type overflow(int_type c) override
+    {
+      if (traits_type::eq_int_type(c, traits_type::eof()))
+        return traits_type::not_eof(c);
+      const char ch = traits_type::to_char_type(c);
+      if (ch == '\n')
+        deliver();
+      else
+        m_line.push_back(ch);
+      return c;
+    }
+
+    std::streamsize xsputn(const char* s, std::streamsize n) override
+    {
+      for (std::streamsize i = 0; i < n; ++i)
+        overflow(traits_type::to_int_type(s[i]));
+      return n;
+    }
+
+  private:
+    void deliver()
+    {
+      if (LogSink* sink = Log::sink())
+        sink->writeLine(m_level, m_line);
+      m_line.clear();
+    }
+
+    unsigned int m_level;
+    std::string m_line;
+  };
+
+  struct SinkStream {
+    explicit SinkStream(unsigned int level, std::streamsize precision)
+        : buf(level), stream(&buf)
+    {
+      stream.precision(precision);
+    }
+
+    SinkLineBuf buf;
+    std::ostream stream;
+  };
+
+  // Detail lines above -vvv share the deepest assembler; in practice levels
+  // are 0..3.
+  constexpr unsigned int kNumSinkLevels = 4;
+
+  // The default precision applied to assemblers created after Log::init set
+  // it (worker threads create theirs lazily on first write).
+  std::streamsize g_sinkDefaultPrecision = 6;
+
+  using SinkStreams = std::array<std::unique_ptr<SinkStream>, kNumSinkLevels>;
+
+  SinkStreams& sinkStreamsForThisThread()
+  {
+    thread_local SinkStreams streams;
+    return streams;
+  }
+
+  SinkStream& sinkStreamAt(unsigned int level)
+  {
+    const auto index = level < kNumSinkLevels ? level : kNumSinkLevels - 1;
+    auto& slot = sinkStreamsForThisThread()[index];
+    if (!slot)
+      slot = std::make_unique<SinkStream>(index, g_sinkDefaultPrecision);
+    return *slot;
+  }
 
 } // namespace
 
@@ -34,9 +121,45 @@ std::ostream& Log::defaultStream()
 #endif
 
 std::ostream* Log::s_ostream = nullptr;
+LogSink* Log::s_sink = nullptr;
 unsigned int Log::s_verboseLevel = 0;
 bool Log::s_silent = false;
 thread_local unsigned int Log::s_threadMuteDepth = 0;
+
+void Log::setSink(LogSink* sink)
+{
+  s_sink = sink;
+}
+
+void Log::flushSinkLines()
+{
+  for (auto& slot : sinkStreamsForThisThread()) {
+    if (slot)
+      slot->buf.flushPending();
+  }
+}
+
+std::ostream& Log::sinkStream(unsigned int level)
+{
+  return sinkStreamAt(level).stream;
+}
+
+std::streamsize Log::sinkPrecision()
+{
+  return sinkStreamAt(0).stream.precision();
+}
+
+std::streamsize Log::sinkPrecision(std::streamsize precision)
+{
+  // Apply to every assembler of the calling thread (save/restore pairs like
+  // `auto old = Log::precision(9)` must round-trip regardless of the level
+  // written next), and remember it for assemblers other threads create later.
+  g_sinkDefaultPrecision = precision;
+  const auto previous = sinkStreamAt(0).stream.precision();
+  for (unsigned int level = 0; level < kNumSinkLevels; ++level)
+    sinkStreamAt(level).stream.precision(precision);
+  return previous;
+}
 
 void Log::setNoOutput()
 {
@@ -48,6 +171,11 @@ void Log::setNoOutput()
 
 bool Log::isWritingToStdout()
 {
+  // With a sink installed, lines go to the sink, never the process stdout —
+  // this keeps the Console layer from emitting ANSI or live-progress
+  // redraws into structured log records.
+  if (s_sink != nullptr)
+    return false;
 #ifdef INFOMAP_R
   // The R build always routes Log through the Rprintf bridge (s_ostream), never
   // the process stdout, and does not even include <iostream>.

--- a/src/utils/Log.cpp
+++ b/src/utils/Log.cpp
@@ -13,6 +13,7 @@
 #include <iostream>
 #endif
 #include <array>
+#include <atomic>
 #include <memory>
 #include <streambuf>
 
@@ -90,8 +91,10 @@ namespace {
   constexpr unsigned int kNumSinkLevels = 4;
 
   // The default precision applied to assemblers created after Log::init set
-  // it (worker threads create theirs lazily on first write).
-  std::streamsize g_sinkDefaultPrecision = 6;
+  // it. Atomic: worker threads read it when lazily creating their
+  // thread-local assemblers (first -vv detail write) while the calling
+  // thread may be inside a Log::precision save/restore pair.
+  std::atomic<std::streamsize> g_sinkDefaultPrecision { 6 };
 
   using SinkStreams = std::array<std::unique_ptr<SinkStream>, kNumSinkLevels>;
 

--- a/src/utils/Log.h
+++ b/src/utils/Log.h
@@ -15,11 +15,25 @@
 #include <ostream>
 #include <limits>
 #include <iomanip>
+#include <string>
 #include <type_traits>
 
 namespace infomap {
 
 struct hideIf;
+
+/// Receiver for complete log lines, installed with Log::setSink. Each line is
+/// delivered newline-stripped, tagged with the verbosity level of the Log
+/// object that wrote it (0 = default output, >= 1 = -v/-vv detail).
+/// writeLine may be called from any thread that logs (at elevated verbosity,
+/// OpenMP task threads emit detail lines); implementations synchronize
+/// themselves. Visibility filtering (silent, verbosity, thread-mute) happens
+/// upstream, so the sink only ever sees lines that would have been printed.
+class LogSink {
+public:
+  virtual ~LogSink() = default;
+  virtual void writeLine(unsigned int level, const std::string& line) = 0;
+};
 
 class Log {
   using ostreamFuncPtr = std::add_pointer_t<std::ostream&(std::ostream&)>;
@@ -121,6 +135,21 @@ public:
   /// Guarantee zero output: redirect to a null sink and set silent.
   static void setNoOutput();
 
+  /// Install a line sink that replaces stream output entirely: every visible
+  /// log line is delivered to @p sink (tagged with its message level) instead
+  /// of the configured output stream. Pass nullptr to uninstall and restore
+  /// stream output. The caller owns the sink and must keep it alive until it
+  /// is uninstalled; install/uninstall must not race with a running engine
+  /// (Log state is process-global, like init()/setOutputStream()).
+  static void setSink(LogSink* sink);
+
+  static LogSink* sink() { return s_sink; }
+
+  /// Flush the calling thread's partially assembled sink lines (text written
+  /// without a trailing newline) through to the sink. Call after an engine
+  /// run returns so a trailing partial line is not silently dropped.
+  static void flushSinkLines();
+
   static std::ostream& getOutputStream() { return ostream(); }
 
   /// Whether the active Log sink is the process stdout, i.e. not redirected via
@@ -129,7 +158,10 @@ public:
   /// avoid emitting ANSI into a redirected sink.
   static bool isWritingToStdout();
 
-  static std::streamsize precision() { return ostream().precision(); }
+  static std::streamsize precision()
+  {
+    return s_sink ? sinkPrecision() : ostream().precision();
+  }
 
   static std::streamsize precision(std::streamsize precision)
   {
@@ -140,6 +172,8 @@ public:
     // the stream; do not "fix" this by querying ostream() here (that reintroduces the race).
     if (s_threadMuteDepth > 0)
       return precision;
+    if (s_sink)
+      return sinkPrecision(precision);
     return ostream().precision(precision);
   }
 
@@ -151,7 +185,11 @@ private:
   unsigned int m_level;
   unsigned int m_maxLevel;
   bool m_visible;
-  std::ostream& m_ostream = ostream();
+  // With a sink installed, bind to the calling thread's per-level line
+  // assembler so every line is tagged with the level it was written at and
+  // concurrent threads cannot tear each other's lines. m_level is declared
+  // before m_ostream, so it is initialized first.
+  std::ostream& m_ostream = streamFor(m_level);
 
   static std::ostream& ostream()
   {
@@ -161,10 +199,21 @@ private:
     return s_ostream ? *s_ostream : defaultStream();
 #endif
   }
+  static std::ostream& streamFor(unsigned int level)
+  {
+    return s_sink ? sinkStream(level) : ostream();
+  }
+  // Thread-local per-level line assembler; defined in Log.cpp.
+  static std::ostream& sinkStream(unsigned int level);
+  // Set/get the line-assembler precision for the calling thread (and the
+  // default applied to assemblers created later); defined in Log.cpp.
+  static std::streamsize sinkPrecision(std::streamsize precision);
+  static std::streamsize sinkPrecision();
 #ifndef INFOMAP_R
   static std::ostream& defaultStream();
 #endif
   static std::ostream* s_ostream;
+  static LogSink* s_sink;
   static unsigned int s_verboseLevel;
   static bool s_silent;
   static thread_local unsigned int s_threadMuteDepth;

--- a/test/python/test_logging.py
+++ b/test/python/test_logging.py
@@ -13,7 +13,9 @@ attaches one, so these tests double as the guard for that rule.
 
 from __future__ import annotations
 
+import ctypes
 import logging
+import sys
 
 import pytest
 
@@ -21,6 +23,22 @@ from infomap import Infomap
 
 
 pytestmark = pytest.mark.fast
+
+
+def _engine_stdout(capfd) -> str:
+    """Read the engine's stdout from the fd-level capture.
+
+    The engine writes via ``std::cout``; under pytest's fd-level capture
+    stdout is a pipe, so the C runtime fully buffers the log and it must be
+    flushed before reading (mirrors test_run_functional._engine_log —
+    silence/emptiness assertions would otherwise pass or fail on stale
+    buffer contents).
+    """
+    if sys.platform == "win32":
+        ctypes.cdll.msvcrt.fflush(None)
+    else:
+        ctypes.CDLL(None).fflush(None)
+    return capfd.readouterr().out
 
 
 class ListHandler(logging.Handler):
@@ -53,7 +71,7 @@ def _run_triangle(**kwargs):
 
 
 def test_engine_log_routes_to_logging_and_not_stdout(infomap_log_handler, capfd):
-    capfd.readouterr()
+    _engine_stdout(capfd)  # drain log buffered by earlier (unflushed) tests
 
     _run_triangle(silent=False)
 
@@ -63,7 +81,7 @@ def test_engine_log_routes_to_logging_and_not_stdout(infomap_log_handler, capfd)
     messages = [record.getMessage() for record in records]
     assert any("Infomap" in message for message in messages)
     # Routed mode replaces stdout output entirely.
-    assert capfd.readouterr().out == ""
+    assert _engine_stdout(capfd) == ""
 
 
 def test_default_lines_are_info_and_detail_lines_are_debug(infomap_log_handler):
@@ -105,13 +123,13 @@ def test_routing_disengages_when_handlers_are_removed(infomap_log_handler, capfd
     logger.removeHandler(infomap_log_handler)
     try:
         infomap_log_handler.records.clear()
-        capfd.readouterr()
+        _engine_stdout(capfd)
 
         _run_triangle(silent=False)
 
         # Back to the classic stdout path, no records.
         assert infomap_log_handler.records == []
-        assert capfd.readouterr().out != ""
+        assert _engine_stdout(capfd) != ""
     finally:
         logger.addHandler(infomap_log_handler)  # fixture teardown removes it
 
@@ -120,20 +138,20 @@ def test_propagated_root_handlers_do_not_engage_routing(capfd):
     # pytest attaches a capture handler to the root logger; the "infomap"
     # logger itself has none here. The engine must keep writing to stdout.
     assert not logging.getLogger("infomap").handlers
-    capfd.readouterr()
+    _engine_stdout(capfd)
 
     _run_triangle(silent=False)
 
-    assert capfd.readouterr().out != ""
+    assert _engine_stdout(capfd) != ""
 
 
 def test_read_file_routes_through_logging(infomap_log_handler, capfd, test_paths):
-    capfd.readouterr()
+    _engine_stdout(capfd)
     im = Infomap(silent=False)
 
     im.read_file(str(test_paths.example_networks / "ninetriangles.net"))
 
-    assert capfd.readouterr().out == ""
+    assert _engine_stdout(capfd) == ""
 
 
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")

--- a/test/python/test_logging.py
+++ b/test/python/test_logging.py
@@ -19,7 +19,7 @@ import sys
 
 import pytest
 
-from infomap import Infomap
+from infomap import Infomap, disable_log, enable_log
 
 
 pytestmark = pytest.mark.fast
@@ -201,13 +201,11 @@ def test_instance_constructed_before_logging_config_warns(infomap_log_handler):
 
 
 def test_enable_log_is_a_one_line_opt_in(capfd):
-    import infomap as infomap_package
-
-    handler = infomap_package.enable_log()
+    handler = enable_log()
     try:
         assert handler in logging.getLogger("infomap").handlers
         # Idempotent: a second call reuses the handler.
-        assert infomap_package.enable_log() is handler
+        assert enable_log() is handler
         assert logging.getLogger("infomap").handlers.count(handler) == 1
         _engine_stdout(capfd)
 
@@ -219,7 +217,7 @@ def test_enable_log_is_a_one_line_opt_in(capfd):
         assert "Infomap v" in out
         assert "\x1b[" not in out
     finally:
-        infomap_package.disable_log()
+        disable_log()
 
     assert handler not in logging.getLogger("infomap").handlers
     _engine_stdout(capfd)

--- a/test/python/test_logging.py
+++ b/test/python/test_logging.py
@@ -1,0 +1,156 @@
+"""Engine-log routing into Python logging (#745).
+
+Routing engages per engine call, only when handlers are attached directly to
+``logging.getLogger("infomap")``: then every visible engine log line becomes
+a record (default lines at INFO, ``-v``/``-vv`` detail at DEBUG) and stdout
+stays clean. Without handlers the engine writes to stdout exactly as before
+(pinned by test_run_functional.py). ``silent=`` gates emission upstream in
+both modes.
+
+Propagated root handlers deliberately do NOT engage routing — pytest itself
+attaches one, so these tests double as the guard for that rule.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from infomap import Infomap
+
+
+pytestmark = pytest.mark.fast
+
+
+class ListHandler(logging.Handler):
+    def __init__(self):
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+@pytest.fixture
+def infomap_log_handler():
+    logger = logging.getLogger("infomap")
+    handler = ListHandler()
+    logger.addHandler(handler)
+    old_level = logger.level
+    logger.setLevel(logging.DEBUG)
+    yield handler
+    logger.removeHandler(handler)
+    logger.setLevel(old_level)
+
+
+def _run_triangle(**kwargs):
+    im = Infomap(**kwargs)
+    im.add_link(1, 2)
+    im.add_link(2, 3)
+    im.add_link(1, 3)
+    return im.run()
+
+
+def test_engine_log_routes_to_logging_and_not_stdout(infomap_log_handler, capfd):
+    capfd.readouterr()
+
+    _run_triangle(silent=False)
+
+    records = infomap_log_handler.records
+    assert records, "expected engine log records on the 'infomap' logger"
+    assert all(record.name == "infomap" for record in records)
+    messages = [record.getMessage() for record in records]
+    assert any("Infomap" in message for message in messages)
+    # Routed mode replaces stdout output entirely.
+    assert capfd.readouterr().out == ""
+
+
+def test_default_lines_are_info_and_detail_lines_are_debug(infomap_log_handler):
+    _run_triangle(silent=False, verbosity_level=2)
+
+    levels = {record.levelno for record in infomap_log_handler.records}
+    assert logging.INFO in levels
+    assert logging.DEBUG in levels
+    # The banner is a default (INFO) line; indented detail lines are DEBUG.
+    debug_messages = [
+        record.getMessage()
+        for record in infomap_log_handler.records
+        if record.levelno == logging.DEBUG
+    ]
+    assert any("run Infomap" in message for message in debug_messages)
+
+
+def test_silent_default_emits_no_records(infomap_log_handler):
+    _run_triangle()
+
+    assert infomap_log_handler.records == []
+
+
+def test_records_are_plain_lines_without_ansi(infomap_log_handler):
+    _run_triangle(silent=False)
+
+    for record in infomap_log_handler.records:
+        message = record.getMessage()
+        assert "\x1b[" not in message
+        assert "\r" not in message
+        assert "\n" not in message
+
+
+def test_routing_disengages_when_handlers_are_removed(infomap_log_handler, capfd):
+    _run_triangle(silent=False)
+    assert infomap_log_handler.records
+
+    logger = logging.getLogger("infomap")
+    logger.removeHandler(infomap_log_handler)
+    try:
+        infomap_log_handler.records.clear()
+        capfd.readouterr()
+
+        _run_triangle(silent=False)
+
+        # Back to the classic stdout path, no records.
+        assert infomap_log_handler.records == []
+        assert capfd.readouterr().out != ""
+    finally:
+        logger.addHandler(infomap_log_handler)  # fixture teardown removes it
+
+
+def test_propagated_root_handlers_do_not_engage_routing(capfd):
+    # pytest attaches a capture handler to the root logger; the "infomap"
+    # logger itself has none here. The engine must keep writing to stdout.
+    assert not logging.getLogger("infomap").handlers
+    capfd.readouterr()
+
+    _run_triangle(silent=False)
+
+    assert capfd.readouterr().out != ""
+
+
+def test_read_file_routes_through_logging(infomap_log_handler, capfd, test_paths):
+    capfd.readouterr()
+    im = Infomap(silent=False)
+
+    im.read_file(str(test_paths.example_networks / "ninetriangles.net"))
+
+    assert capfd.readouterr().out == ""
+
+
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+def test_raising_log_handler_does_not_kill_the_run(infomap_log_handler):
+    class RaisingHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            raise RuntimeError("handler boom")
+
+    logger = logging.getLogger("infomap")
+    raising = RaisingHandler()
+    logger.addHandler(raising)
+    try:
+        # A handler that raises straight out of emit() propagates through
+        # logger.log into the C++ sink's callback, which swallows it with
+        # PyErr_WriteUnraisable (hence the ignored unraisable warning): a
+        # broken log handler must not kill the engine run.
+        result = _run_triangle(silent=False)
+        assert result.num_top_modules >= 1
+    finally:
+        logger.removeHandler(raising)

--- a/test/python/test_logging.py
+++ b/test/python/test_logging.py
@@ -84,8 +84,37 @@ def test_engine_log_routes_to_logging_and_not_stdout(infomap_log_handler, capfd)
     assert _engine_stdout(capfd) == ""
 
 
-def test_default_lines_are_info_and_detail_lines_are_debug(infomap_log_handler):
-    _run_triangle(silent=False, verbosity_level=2)
+def test_routed_mode_emits_without_silent_false(infomap_log_handler, capfd):
+    # Logging is the control in routed mode: configuring the logger is the
+    # whole opt-in, no silent=False needed (and silent=True is ignored).
+    _engine_stdout(capfd)
+
+    _run_triangle()
+
+    assert infomap_log_handler.records
+    assert _engine_stdout(capfd) == ""
+
+    infomap_log_handler.records.clear()
+    _run_triangle(silent=True)
+
+    assert infomap_log_handler.records
+
+
+def test_routed_mode_is_silenced_with_logger_levels(infomap_log_handler):
+    logger = logging.getLogger("infomap")
+    logger.setLevel(logging.WARNING)
+
+    _run_triangle()
+
+    # The engine emits, but logging drops the INFO records: the pythonic
+    # silence in routed mode.
+    assert infomap_log_handler.records == []
+
+
+def test_debug_logger_raises_engine_verbosity_automatically(infomap_log_handler):
+    # The fixture leaves the logger enabled for DEBUG, so the run gets -vv
+    # detail without any verbosity_level kwarg.
+    _run_triangle()
 
     levels = {record.levelno for record in infomap_log_handler.records}
     assert logging.INFO in levels
@@ -99,10 +128,13 @@ def test_default_lines_are_info_and_detail_lines_are_debug(infomap_log_handler):
     assert any("run Infomap" in message for message in debug_messages)
 
 
-def test_silent_default_emits_no_records(infomap_log_handler):
+def test_info_logger_keeps_default_engine_verbosity(infomap_log_handler):
+    logging.getLogger("infomap").setLevel(logging.INFO)
+
     _run_triangle()
 
-    assert infomap_log_handler.records == []
+    levels = {record.levelno for record in infomap_log_handler.records}
+    assert levels == {logging.INFO}
 
 
 def test_records_are_plain_lines_without_ansi(infomap_log_handler):
@@ -151,6 +183,50 @@ def test_read_file_routes_through_logging(infomap_log_handler, capfd, test_paths
 
     im.read_file(str(test_paths.example_networks / "ninetriangles.net"))
 
+    assert _engine_stdout(capfd) == ""
+
+
+def test_instance_constructed_before_logging_config_warns(infomap_log_handler):
+    logger = logging.getLogger("infomap")
+    logger.removeHandler(infomap_log_handler)
+    im = Infomap()  # constructed silent: no handlers at this point
+    im.add_link(1, 2)
+    logger.addHandler(infomap_log_handler)
+
+    with pytest.warns(UserWarning, match="before logging was configured"):
+        im.run()
+
+    # The engine baked --silent in at construction, so no records exist.
+    assert infomap_log_handler.records == []
+
+
+def test_enable_log_is_a_one_line_opt_in(capfd):
+    import infomap as infomap_package
+
+    handler = infomap_package.enable_log()
+    try:
+        assert handler in logging.getLogger("infomap").handlers
+        # Idempotent: a second call reuses the handler.
+        assert infomap_package.enable_log() is handler
+        assert logging.getLogger("infomap").handlers.count(handler) == 1
+        _engine_stdout(capfd)
+
+        _run_triangle()
+
+        # The helper's stdout handler prints the records: one opt-in line,
+        # engine progress visible, no silent=False anywhere.
+        out = _engine_stdout(capfd)
+        assert "Infomap v" in out
+        assert "\x1b[" not in out
+    finally:
+        infomap_package.disable_log()
+
+    assert handler not in logging.getLogger("infomap").handlers
+    _engine_stdout(capfd)
+
+    _run_triangle()
+
+    # Classic quiet default is back.
     assert _engine_stdout(capfd) == ""
 
 


### PR DESCRIPTION
# Summary

Implements #745 per the [threading design note](https://github.com/mapequation/infomap/issues/745#issuecomment-4914285587): the engine console log becomes Python `logging` records when the user has configured the `"infomap"` logger; everything else behaves exactly as today.

**The opt-in is one line:**

```python
infomap.enable_log()          # or: logging.getLogger("infomap").addHandler(...)
result = infomap.run(g)       # progress arrives as log records; no silent=False needed
```

- **C++ (`Log`)**: `Log::setSink(LogSink*)` installs a process-global line sink that replaces stream output. With a sink installed, each `Log` binds to a `thread_local` per-level line assembler, so every line is delivered newline-stripped and tagged with the level it was written at (0 = default, ≥ 1 = `-v`/`-vv` detail), and concurrent threads cannot tear each other's lines. Visibility filtering stays upstream. `isWritingToStdout()` returns false with a sink, so the `Console` layer emits no ANSI or `\r` live-progress redraws into records. `Log::precision` round-trips against the assemblers (the assembler default precision is atomic — worker threads read it during lazy creation).
- **SWIG boundary (Python only)**: `PythonLogSink` bridges lines to a Python callable (validated callable up front). The module never releases the GIL, so the calling thread enters Python directly; lines from other threads (OpenMP task threads emit `-vv` detail) are queued under a mutex and drained by the next GIL-holding write or after the call returns — a worker must never acquire the GIL (barrier deadlock). A raising callback is swallowed with `PyErr_WriteUnraisable`. R and JS builds untouched.
- **Python semantics — logging is the control in routed mode**: with handlers attached directly to the `"infomap"` logger, every run emits records (`silent=` is ignored for emission; silence with logger levels or by removing handlers), and a DEBUG-enabled logger automatically raises the engine verbosity to `-vv` so detail records exist to filter. Default lines → `INFO`, detail → `DEBUG`, stdout stays clean. Without handlers, classic stdout behavior gated by `silent=` is unchanged. An `Infomap` constructed *before* logging was configured cannot emit (the engine composes constructor + run args additively, so its baked-in `--silent` cannot be undone at run time) — its runs warn with the fix; the one-shot `infomap.run` constructs per call and always respects the current configuration.
- **`enable_log(level=logging.INFO)` / `disable_log()`**: the blessed notebook one-liner — attaches an idempotent plain stdout handler and sets the logger level. Raw `logging` configuration remains first-class and engages the same routing.
- **Docs**: the how-to section leads with the one-liner (executed example renders live records); `enable_log`/`disable_log` documented in the API reference (docs-surface enforced).

**One deviation from the design note, in the direction it flagged as an open question** (follow-up posted on #745): routing keys on handlers attached *directly* to `logging.getLogger("infomap")`, not `hasHandlers()` — the propagation-following gate would reroute behind the user's back in every pytest session (root capture handler) and every `basicConfig()` script.

Closes #745

# Verification

- `pytest test/python`: 577 passed, 2 skipped — `test_logging.py` covers routing on/off by handler presence, emission-without-`silent=False`, logging-level silencing, automatic `-vv` at DEBUG, INFO-only mapping, no-ANSI/no-`\r` record content, disengage on handler removal, propagated-root-handlers-don't-engage, the constructed-before-config warning, `enable_log`/`disable_log` (idempotency + classic-path restoration), `read_file` routing, and raising-handler survival via `PyErr_WriteUnraisable`
- Existing stdout contract tests (`test_run_functional.py` capfd) pass unchanged
- `make test-native` and `make test-cpp-stream-policy`: green
- `make test-python-swig-freshness` + `make test-r-swig-freshness` (SWIG 4.4.1 pinned) and `make test-binding-options-freshness`: fresh
- `make test-python-doctest` (38 + ruff), `make test-python-typecheck-core` (0 errors), `make test-python-examples`: green
- `make build-docs`: executed examples render the records; only the known proxy-blocked intersphinx warnings

# Notes

- `Network` engines remain silent for their whole lifetime (existing behavior), so 2.x records come from the stateful `Infomap` and non-`Network` `infomap.run` inputs; the 3.0 logging flip revisits this together with #748's signature cut.
- The sink is process-global, matching the existing process-global `Log` state; concurrent engine runs in threads remain unsupported, unchanged.
- 3.0 endpoint per the design note: routing always on, `NullHandler` per library convention, `silent`/`-vv` semantics leave the Python surface.