### PR TITLE
spike(python): nanobind backend behind the Core boundary (#743)

### DIFF
--- a/spikes/nanobind/CMakeLists.txt
+++ b/spikes/nanobind/CMakeLists.txt
@@ -1,0 +1,39 @@
+# Nanobind spike build (#743). Not wired into packaging; build manually:
+#
+#   cmake -S spikes/nanobind -B build/nanobind-spike \
+#     -DCMAKE_BUILD_TYPE=Release \
+#     -Dnanobind_DIR=$(.venv/bin/python -m nanobind --cmake_dir)
+#   cmake --build build/nanobind-spike -j
+#
+# Mirrors the SWIG extension's build inputs: every src/*.cpp, -DAS_LIB,
+# C++17, OpenMP, -O3.
+
+cmake_minimum_required(VERSION 3.18)
+project(infomap_nanobind_spike LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
+find_package(Python 3.11 COMPONENTS Interpreter Development.Module REQUIRED)
+find_package(nanobind CONFIG REQUIRED)
+find_package(OpenMP REQUIRED)
+
+get_filename_component(REPO_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../.." ABSOLUTE)
+file(GLOB_RECURSE INFOMAP_SOURCES "${REPO_ROOT}/src/*.cpp")
+
+nanobind_add_module(_infomap_nb STABLE_ABI infomap_nb.cpp ${INFOMAP_SOURCES})
+target_include_directories(_infomap_nb PRIVATE
+  "${REPO_ROOT}"
+  "${REPO_ROOT}/vendor/fmt/include"
+  "${REPO_ROOT}/vendor/nlohmann_json/include")
+target_compile_definitions(_infomap_nb PRIVATE AS_LIB)
+target_link_libraries(_infomap_nb PRIVATE OpenMP::OpenMP_CXX)
+# The SWIG extension exports the engine's symbols with default visibility;
+# loading both extensions in one process interposes them across modules and
+# breaks whichever loads second. Hide everything but the module init so the
+# spike coexists with the SWIG backend (needed for parity comparisons).
+target_compile_options(_infomap_nb PRIVATE -fvisibility=hidden -fvisibility-inlines-hidden)
+target_link_options(_infomap_nb PRIVATE -Wl,--exclude-libs,ALL)

--- a/spikes/nanobind/README.md
+++ b/spikes/nanobind/README.md
@@ -1,0 +1,48 @@
+# Nanobind spike (#743)
+
+A minimal nanobind backend behind the `Core` boundary, built to answer the
+go/no-go question in issue #743. **Not wired into packaging** — the shipped
+extension is still SWIG.
+
+## What it covers
+
+- `Core`-subset binding of `InfomapWrapper` (construct-from-flags, build
+  verbs, `run`, `getModules`, scalars, one writer)
+- Zero-copy NumPy views over `NodeData` (`get_node_data` returns a dict of
+  ndarrays whose owner capsule shares one `shared_ptr<NodeData>`; today's
+  SWIG path copies every column into a Python list)
+- C++ exceptions raised directly as the public taxonomy
+  (`infomap.errors.InfomapError` / `NetworkParseError`) at the binding layer
+- Coexistence with the SWIG extension in one process (requires the symbol
+  hygiene in `CMakeLists.txt`: `-fvisibility=hidden` +
+  `--exclude-libs ALL` — both extensions embed the engine)
+
+## What it deliberately skips (the bulk of a real port)
+
+The live tree-walking iterator surface (`InfoNode`, the five iterator types
+— public, documented API), the `network()` sub-object, most writers, meta
+data, the multilayer bulk paths, and the build-backend migration
+(setuptools + pregenerated SWIG C++ → CMake/scikit-build-core).
+
+## Build and run
+
+```sh
+.venv/bin/pip install nanobind
+cmake -S spikes/nanobind -B build/nanobind-spike \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DPython_EXECUTABLE=$PWD/.venv/bin/python \
+  -Dnanobind_DIR=$(.venv/bin/python -m nanobind --cmake_dir)
+cmake --build build/nanobind-spike -j
+.venv/bin/python spikes/nanobind/bench.py
+```
+
+## Results (Linux x86-64, Python 3.11, GCC, -O3, OpenMP)
+
+|  | SWIG (shipped) | nanobind spike |
+|---|---|---|
+| Extension size | 3.9 MB (3.4 MB stripped) + 111 kB shadow module | 0.9 MB |
+| Import time (best of 5, fresh process) | 40.6 ms | 1.7 ms |
+| `get_node_data`, 100k nodes / 500k links | 325 ms (today's list path); 383 ms via `np.asarray` | **17 ms, zero-copy** |
+| Result parity (modules, codelength, all NodeData columns) | — | identical, given the same `addLink` sequence |
+
+See the full go/no-go report on issue #743.

--- a/spikes/nanobind/bench.py
+++ b/spikes/nanobind/bench.py
@@ -1,0 +1,152 @@
+"""Measurements for the nanobind spike (#743).
+
+Compares the SWIG backend (the shipped extension) against the nanobind spike
+module on the four axes the issue asks for: artifact size, import time,
+get_node_data throughput, and result parity. Run from the repo root after
+building the spike (see CMakeLists.txt):
+
+    .venv/bin/python spikes/nanobind/bench.py
+"""
+
+from __future__ import annotations
+
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SPIKE_BUILD = REPO_ROOT / "build" / "nanobind-spike"
+sys.path.insert(0, str(SPIKE_BUILD))
+
+RUN_FLAGS = "--two-level --silent --seed 123 --num-trials 1"
+
+
+def _sizes() -> None:
+    import infomap._swig as _  # ensure the package resolves
+
+    swig_so = next(
+        (REPO_ROOT / "interfaces" / "python" / "src" / "infomap").glob("_infomap*.so")
+    )
+    nb_so = next(SPIKE_BUILD.glob("_infomap_nb*.so"))
+    print("== artifact size ==")
+    for label, path in (("SWIG", swig_so), ("nanobind", nb_so)):
+        raw = path.stat().st_size
+        stripped = subprocess.run(
+            ["sh", "-c", f"cp {path} /tmp/bench_strip.so && strip /tmp/bench_strip.so && stat -c %s /tmp/bench_strip.so"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        print(f"  {label:9s} {raw/1e6:6.1f} MB   (stripped {int(stripped)/1e6:.1f} MB)")
+    shadow = (REPO_ROOT / "interfaces" / "python" / "src" / "infomap" / "_swig.py").stat().st_size
+    print(f"  SWIG shadow module (_swig.py): {shadow/1e3:.0f} kB")
+
+
+def _import_time() -> None:
+    print("== import time (best of 5, fresh process) ==")
+    cases = {
+        "SWIG (_infomap + _swig shadow)": "import infomap._swig",
+        "nanobind (_infomap_nb)": f"import sys; sys.path.insert(0, {str(SPIKE_BUILD)!r}); import _infomap_nb",
+    }
+    for label, stmt in cases.items():
+        timings = []
+        for _ in range(5):
+            code = f"import time; t0 = time.perf_counter(); {stmt}; print(time.perf_counter() - t0)"
+            out = subprocess.run(
+                [sys.executable, "-c", code], capture_output=True, text=True, check=True,
+                cwd=REPO_ROOT,
+            ).stdout.strip()
+            timings.append(float(out) * 1000)
+        print(f"  {label:34s} {min(timings):6.1f} ms")
+
+
+def _links(num_nodes: int, num_links: int, seed: int = 42) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    links = rng.integers(0, num_nodes, size=(num_links, 2), dtype=np.uint64)
+    return links[links[:, 0] != links[:, 1]]
+
+
+def _throughput_and_parity(num_nodes: int = 100_000, num_links: int = 500_000) -> None:
+    import _infomap_nb
+    from infomap import Infomap
+
+    links = _links(num_nodes, num_links)
+    print(f"== get_node_data throughput ({num_nodes:,} nodes, {len(links):,} links) ==")
+
+    nb_core = _infomap_nb.Core(RUN_FLAGS)
+    nb_core.addLinksFromArray(links)
+    t0 = time.perf_counter()
+    nb_core.run("")
+    run_seconds = time.perf_counter() - t0
+
+    # Identical input path: both backends see the same addLink sequence in
+    # the same order (the adapters aggregate duplicates differently, which
+    # would break result parity for reasons unrelated to the binding layer).
+    im = Infomap(args=RUN_FLAGS)
+    im._core.addLinks(
+        [int(s) for s in links[:, 0]],
+        [int(t) for t in links[:, 1]],
+        [1.0] * len(links),
+    )
+    im.run()
+    swig_core = im._core
+
+    def bench(fn, repeat=7):
+        timings = []
+        for _ in range(repeat):
+            t0 = time.perf_counter()
+            fn()
+            timings.append(time.perf_counter() - t0)
+        return min(timings) * 1000, statistics.median(timings) * 1000
+
+    # SWIG as the package consumes it today (result.py _Snapshot):
+    # one traversal, then list() per column.
+    def swig_lists():
+        data = swig_core.get_node_data(1, False)
+        return [list(data.node_id), list(data.state_id), list(data.module_id),
+                list(data.flow), list(data.depth), list(data.layer_id),
+                list(data.child_index), list(data.modular_centrality),
+                list(data.path_flat), list(data.path_len)]
+
+    # SWIG best case: numpy conversion of the SWIG vectors instead of lists.
+    def swig_numpy():
+        data = swig_core.get_node_data(1, False)
+        return [np.asarray(col) for col in (
+            data.node_id, data.state_id, data.module_id, data.flow, data.depth,
+            data.layer_id, data.child_index, data.modular_centrality,
+            data.path_flat, data.path_len)]
+
+    # nanobind: one traversal, zero-copy views.
+    def nb_views():
+        return nb_core.get_node_data(1, False)
+
+    for label, fn in (("SWIG -> lists (today's path)", swig_lists),
+                      ("SWIG -> np.asarray", swig_numpy),
+                      ("nanobind -> zero-copy views", nb_views)):
+        best, median = bench(fn)
+        print(f"  {label:31s} best {best:8.1f} ms   median {median:8.1f} ms")
+    print(f"  (engine run itself: {run_seconds:.1f} s)")
+
+    print("== parity ==")
+    nb_modules = dict(nb_core.getModules(1, False))
+    swig_modules = dict(swig_core.getModules(1, False))
+    print(f"  getModules identical: {nb_modules == swig_modules} "
+          f"({len(nb_modules):,} nodes)")
+    print(f"  codelength identical: {nb_core.codelength() == swig_core.codelength()}")
+    nb_data = nb_core.get_node_data(1, False)
+    swig_data = swig_core.get_node_data(1, False)
+    same = all(
+        np.array_equal(np.asarray(nb_data[col]), np.asarray(getattr(swig_data, col)))
+        for col in ("node_id", "state_id", "module_id", "flow", "depth",
+                    "layer_id", "child_index", "modular_centrality",
+                    "path_flat", "path_len")
+    )
+    print(f"  NodeData columns identical: {same}")
+
+
+if __name__ == "__main__":
+    _sizes()
+    _import_time()
+    _throughput_and_parity()

--- a/spikes/nanobind/infomap_nb.cpp
+++ b/spikes/nanobind/infomap_nb.cpp
@@ -1,0 +1,149 @@
+// Nanobind spike for issue #743: a minimal engine binding behind the Core
+// boundary, covering the measured paths (construct, build, run, getModules,
+// getNodeData) plus the two capabilities the spike must demonstrate:
+//
+//   1. Zero-copy NumPy views over NodeData (the SWIG path copies every column
+//      into a Python list).
+//   2. C++ exceptions mapped to the typed Python taxonomy (infomap.errors)
+//      at the binding layer instead of in Python wrappers.
+//
+// NOT covered (documented in the go/no-go report): the live tree-walking
+// iterator surface (InfoNode, InfomapIterator, ...) which is public API, the
+// network() sub-object, writers, and the ~40 remaining Core methods. Those
+// are mechanical but constitute the bulk of a real port.
+
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/map.h>
+#include <nanobind/stl/vector.h>
+
+#include "src/Infomap.h"
+
+#include <cstring>
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace nb = nanobind;
+
+namespace {
+
+// Classify engine messages the same way infomap.errors does, so the binding
+// raises the public taxonomy directly with no Python-side translation layer.
+bool isParseMessage(const std::string& message)
+{
+  static const char* prefixes[] = {
+    "Can't parse", "Cannot parse", "Cannot open input file",
+    "Can't open file", "Unrecognized heading", "JSON parse error"
+  };
+  for (const char* prefix : prefixes) {
+    if (message.rfind(prefix, 0) == 0)
+      return true;
+  }
+  return message.find("read permissions") != std::string::npos;
+}
+
+// Cached handles to the public taxonomy (infomap.errors). Resolved lazily on
+// first throw so importing the spike module alone does not import infomap.
+nb::object taxonomyClass(const char* name)
+{
+  nb::object errors = nb::module_::import_("infomap.errors");
+  return errors.attr(name);
+}
+
+// One zero-copy NumPy view over a NodeData column. The ndarray owner is a
+// capsule holding a shared_ptr to the whole NodeData, so every column keeps
+// the snapshot alive independently and Python never copies the buffer.
+template <typename T>
+nb::object columnView(const std::shared_ptr<infomap::NodeData>& data, const std::vector<T>& column)
+{
+  auto* holder = new std::shared_ptr<infomap::NodeData>(data);
+  nb::capsule owner(holder, [](void* p) noexcept {
+    delete static_cast<std::shared_ptr<infomap::NodeData>*>(p);
+  });
+  const size_t shape[1] = { column.size() };
+  return nb::cast(nb::ndarray<nb::numpy, const T, nb::ndim<1>>(
+      column.data(), 1, shape, owner));
+}
+
+} // namespace
+
+using infomap::InfomapWrapper;
+
+NB_MODULE(_infomap_nb, m)
+{
+  m.doc() = "Nanobind spike backend for the infomap Core boundary (#743)";
+
+  // std::exception -> the public taxonomy, message preserved. This replaces
+  // both SWIG's blanket RuntimeError mapping AND the Python-side
+  // _translate_engine_errors re-raise for the bound surface.
+  nb::register_exception_translator([](const std::exception_ptr& p, void*) {
+    try {
+      std::rethrow_exception(p);
+    } catch (const std::exception& e) {
+      const std::string message = e.what();
+      nb::object cls = taxonomyClass(isParseMessage(message) ? "NetworkParseError" : "InfomapError");
+      PyErr_SetString(reinterpret_cast<PyObject*>(cls.ptr()), message.c_str());
+    }
+  });
+
+  nb::class_<InfomapWrapper>(m, "Core")
+      .def(nb::init<const std::string&>())
+      .def("run", [](InfomapWrapper& im, const std::string& args) { im.run(args); },
+           nb::arg("args") = "")
+      .def("readInputData", &InfomapWrapper::readInputData,
+           nb::arg("filename") = "", nb::arg("accumulate") = true)
+      .def("addNode", nb::overload_cast<unsigned int>(&InfomapWrapper::addNode))
+      .def("addName", &InfomapWrapper::addName)
+      .def("addStateNode", &InfomapWrapper::addStateNode)
+      .def("addLink",
+           [](InfomapWrapper& im, unsigned int sourceId, unsigned int targetId, double weight) {
+             im.addLink(sourceId, targetId, weight);
+           },
+           nb::arg("sourceId"), nb::arg("targetId"), nb::arg("weight") = 1.0)
+      // Bulk link input from a contiguous (n, 2) uint64 array, mirroring the
+      // SWIG addLinksFromNumpy fast path.
+      .def("addLinksFromArray",
+           [](InfomapWrapper& im, nb::ndarray<const uint64_t, nb::ndim<2>, nb::c_contig> links) {
+             if (links.shape(1) != 2)
+               throw std::runtime_error("links array must have shape (n, 2)");
+             const uint64_t* p = links.data();
+             for (size_t i = 0; i < links.shape(0); ++i)
+               im.addLink(static_cast<unsigned int>(p[2 * i]),
+                          static_cast<unsigned int>(p[2 * i + 1]), 1.0);
+           })
+      .def("getModules", &InfomapWrapper::getModules,
+           nb::arg("level") = 1, nb::arg("states") = false)
+      .def("getNames", nb::overload_cast<>(&InfomapWrapper::getNames, nb::const_))
+      .def("haveModules", [](const InfomapWrapper& im) { return im.haveModules(); })
+      .def("haveMemory", [](const InfomapWrapper& im) { return im.haveMemory(); })
+      .def("codelength", [](const InfomapWrapper& im) { return im.codelength(); })
+      .def("numTopModules", [](const InfomapWrapper& im) { return im.numTopModules(); })
+      .def("maxTreeDepth", &InfomapWrapper::maxTreeDepth)
+      .def("writeTree",
+           [](InfomapWrapper& im, const std::string& filename, bool states) {
+             im.writeTree(filename, states);
+           },
+           nb::arg("filename"), nb::arg("states") = false)
+      // The spike's centerpiece: one C++ traversal, then zero-copy NumPy
+      // views. The dict holds one ndarray per column; each view shares the
+      // same shared_ptr<NodeData> owner.
+      .def("get_node_data",
+           [](InfomapWrapper& im, int level, bool states) {
+             auto data = std::make_shared<infomap::NodeData>(im.getNodeData(level, states));
+             nb::dict out;
+             out["node_id"] = columnView(data, data->node_id);
+             out["state_id"] = columnView(data, data->state_id);
+             out["module_id"] = columnView(data, data->module_id);
+             out["flow"] = columnView(data, data->flow);
+             out["depth"] = columnView(data, data->depth);
+             out["layer_id"] = columnView(data, data->layer_id);
+             out["child_index"] = columnView(data, data->child_index);
+             out["modular_centrality"] = columnView(data, data->modular_centrality);
+             out["path_flat"] = columnView(data, data->path_flat);
+             out["path_len"] = columnView(data, data->path_len);
+             return out;
+           },
+           nb::arg("level") = 1, nb::arg("states") = false);
+}


### PR DESCRIPTION
# Summary

**A working proof that we can swap SWIG for [nanobind](https://github.com/wjakob/nanobind) without touching anything above `_bindings.py` — and what we'd gain.** This is the #743 spike as reviewable code: ~150 lines of binding code in `spikes/nanobind/`, deliberately **not wired into packaging**. The shipped extension is still SWIG; this exists to be read, built, and measured. Full go/no-go report on #743.

## What this is

`_core.py` was designed as the single boundary to the engine precisely so the binding technology could be swapped "by rewriting only this file". This spike cashes that in: a nanobind module binding `InfomapWrapper` directly (the same C++ class SWIG wraps), covering the measured paths — construct-from-flags, build verbs, `run`, `getModules`, scalars — plus the two capabilities that motivate the whole exercise:

1. **Zero-copy NumPy views over `NodeData`.** `get_node_data` returns a dict of ndarrays that alias the C++ vectors; the owner capsule holds a `shared_ptr<NodeData>`, so the views stay valid even after the `Core` object is gone, and Python never copies a buffer. Today's SWIG path converts every column to a Python list.
2. **C++ exceptions raised directly as our public taxonomy** (#744). The binding-layer translator classifies engine messages and raises `infomap.errors.NetworkParseError`/`InfomapError` itself — the Python-side re-raise layer (`_translate_engine_errors`) becomes redundant for the bound surface.

## How nanobind differs from SWIG, concretely for us

| | SWIG (today) | nanobind |
|---|---|---|
| Binding definition | `.i` interface files + a generated 25k-line C++ wrapper + a 3 200-line Python shadow module, regenerated with a version-pinned SWIG binary | ~150 lines of ordinary C++ you read and debug directly; no generation step, no shadow module |
| Dispatch | String-based dynamic dispatch through the shadow module's Python classes | Direct C++ calls; signatures, defaults, and keyword args declared at the binding site |
| NumPy | `std::vector` ↔ Python through the sequence protocol (copies, slow) | First-class `ndarray` API with zero-copy views and ownership capsules |
| Exceptions | Blanket `std::exception → RuntimeError`; typing bolted on in Python wrappers | Custom translators — the taxonomy raised at the source |
| Wheels | One wheel per Python version per platform | Supports the stable ABI (Python ≥ 3.12): **one wheel per platform** |
| Multi-language | Also generates our R binding from the same `.i` — SWIG stays in the repo regardless (JS is emscripten, unaffected either way) | Python-only |

## What this means for the R binding

The R wrapper is generated from the **same `Infomap.i`** with the same pinned SWIG, so a Python move to nanobind is *"add nanobind for Python"*, never *"remove SWIG"*:

- **SWIG toolchain stays**: the version pin, the R freshness gate, and the `.i` files remain for R. A Python port adds a second binding technology; the repo-side simplification (no generated churn, no shadow module) applies to the Python outputs only.
- **But the shared `.i` gets *lighter* for R.** Today `Infomap.i` is full of `SWIGPYTHON` blocks (buffer adapters, the log sink, interrupt polling, exception handling), and Python-motivated edits keep touching the R wrapper — #763 is a concrete example, where a Python-only feature forced an R wrapper regeneration because the shared header block is copied verbatim. With Python on nanobind, all of that migrates out and `Infomap.i` shrinks to the R-relevant subset: fewer spurious R regenerations, less risk of Python changes breaking R.
- **Cross-language parity lives in `InfomapWrapper`, not in the `.i`.** R already exposes its own gated subset (`SWIGR` guards, R-specific helpers like `getStateName`), so the shared `.i` never guaranteed parity by itself. The real shared contract is the `InfomapWrapper` C++ class, which both bindings target — unchanged by this. The parameter surface is generated per language from the catalog and is unaffected.
- **The long-term question is separate**: fully retiring SWIG would require moving R to cpp11/Rcpp (nanobind is Python-only). R's SWIG usage is stable and R CMD check-tuned; nothing in this spike creates pressure to touch it.

## How it performs

Measured on this branch (`bench.py`, Linux x86-64, Python 3.11, GCC -O3, OpenMP; same engine, same flags):

| Axis | SWIG (shipped) | nanobind spike | Factor |
|---|---|---|---|
| Extension size | 3.9 MB (3.4 MB stripped) + 111 kB `_swig.py` | **0.9 MB** | ~4× |
| Import time (fresh process, best of 5) | 40.6 ms | **1.7 ms** | ~24× |
| `get_node_data`, 100k nodes / 500k links | 325 ms (today's list path) | **17 ms, zero-copy** | ~19× |
| Result parity | — | `getModules`, `codelength`, all 10 `NodeData` columns byte-identical | gate passes |

Notes on honesty: the spike binds ~20 of the ~50 methods `Core` uses, so a full port's `.so` lands above 0.9 MB — but SWIG's size is dominated by generated dispatch that scales with its whole surface, so the gap stays large. The 41 ms import is mostly the shadow module executing 3 200 lines of class definitions at import time; that cost disappears structurally. The 17 ms extraction is essentially the C++ traversal itself — the binding adds nothing measurable. `Result`'s snapshot materialization, `to_dataframe`, and `to_networkx` would inherit the ~19× directly.

## What it means for us

- **The Core boundary works as designed.** The swap experiment needed zero changes above `_bindings.py`. That was the architectural bet of the API refactor, now validated.
- **Not a 3.0 gate** (per the issue text). The 3.0 identity is API/parameter cleanup; nothing depends on the backend.
- **The 3.0 surface cut shrinks the port.** The big unbound piece is the live tree-walking iterator surface (`InfoNode` + five iterator types, public API). If 3.0's `Result` keeps moving toward snapshot-based access — `get_node_data` already carries everything, including CSR-encoded paths — the iterators can be reimplemented in Python over the snapshot instead of bound, and the port shrinks to roughly what this spike already implements, plus packaging.
- **Suggested path if we want it**: opt-in variant first (backend selected at `_bindings.py`, e.g. by env var), gated on the full parity suite + `test_no_swig_leak.py`; the default switch is a separate decision. Sequenced after #747/#748.

## Other things a maintainer will want to know

- **The real cost is packaging, not binding code.** Today's wheels compile a pregenerated `infomap_wrap.cpp` with setuptools — no SWIG at build time. Nanobind wants CMake (scikit-build-core) and compiles binding code at build time; migrating the Windows/macOS/manylinux wheel matrix is its own project, independent of the binding code.
- **Symbol-hygiene footgun found during the spike**: both extensions embed the engine, so loading them side by side in one process breaks whichever loads second — unless the module is built with `-fvisibility=hidden` + `--exclude-libs ALL` (the spike's CMakeLists does). Any opt-in-variant plan must keep this.
- **Stable ABI** (`abi3`, Python ≥ 3.12) would collapse the per-Python-version wheel matrix to one wheel per platform. Not exercised in the spike (built for 3.11), but it's nanobind's headline packaging win and SWIG cannot do it.
- **Maintenance surface**: nanobind is header-mostly, actively maintained (same author as pybind11), used by SciPy, JAX and PyTorch tooling; the version-pinned-SWIG-binary freshness gate and the generated-file churn in diffs both go away for Python.
- The engine run itself is unaffected — same C++, same OpenMP, identical results.

## Try it

```sh
.venv/bin/pip install nanobind
cmake -S spikes/nanobind -B build/nanobind-spike -DCMAKE_BUILD_TYPE=Release \
  -DPython_EXECUTABLE=$PWD/.venv/bin/python \
  -Dnanobind_DIR=$(.venv/bin/python -m nanobind --cmake_dir)
cmake --build build/nanobind-spike -j
.venv/bin/python spikes/nanobind/bench.py
```

Part of #743 (left open as the tracker for the opt-in variant).

# Verification

- `bench.py` on this branch reproduces the table above; parity section verifies `getModules`, `codelength`, and all `NodeData` columns byte-identical against the SWIG backend on a 100k-node network fed the same `addLink` sequence
- Typed-exception behavior exercised: unparsable/missing input → `infomap.errors.NetworkParseError`; bad flags → `infomap.errors.InfomapError` (both still `RuntimeError` per the 2.x contract)
- SWIG + nanobind coexistence in one process verified (required for the parity run itself)
- The shipped package is untouched: full fast suite green; no packaging, CI, or import-path changes

# Notes

- Draft on purpose: this is discussion material for the #743 go/no-go, not a merge candidate as-is. Merging it only adds an inert `spikes/` directory — also fine.
- The spike pins nothing: `nanobind` is installed ad hoc, not added to any extras.