### PR TITLE
feat(python): file writers on Result and Network

### DIFF
--- a/interfaces/python/source/api/network.rst
+++ b/interfaces/python/source/api/network.rst
@@ -10,4 +10,5 @@ library with a ``from_*`` constructor, or build it incrementally with the
 
 .. autoclass:: Network
    :members:
+   :inherited-members:
    :show-inheritance:

--- a/interfaces/python/source/api/result.rst
+++ b/interfaces/python/source/api/result.rst
@@ -9,6 +9,7 @@ are methods with defaults (``modules(depth=1)``, ``nodes()``, ``to_dataframe()``
 
 .. autoclass:: Result
    :members:
+   :inherited-members:
 
 :class:`TreeNode` is the lightweight, immutable per-node view yielded by
 :meth:`Result.nodes`.

--- a/interfaces/python/source/working-with-infomap/visualizing-and-exporting.md
+++ b/interfaces/python/source/working-with-infomap/visualizing-and-exporting.md
@@ -16,7 +16,8 @@ kernelspec:
 :class: tip
 This chapter covers the docs visualisation helper, the in-memory
 graph export (`to_networkx` / `to_igraph` for GraphML and, via NetworkX, GEXF),
-and the native `.tree` / `.clu` formats written by the stateful Infomap.
+and the native `.tree` / `.clu` formats written straight off the
+{class}`~infomap.Result`.
 ```
 
 ## A picture and a file
@@ -30,9 +31,9 @@ covers two ways to get it out:
 
 The in-memory export turns the result into an annotated graph with
 {func}`infomap.to_networkx` or {func}`infomap.to_igraph`, which you then write
-with the graph library's own writer (GraphML for both; GEXF is NetworkX-only). The stateful
-{class}`~infomap.Infomap` writes the engine's native text formats, `.tree` and
-`.clu`.
+with the graph library's own writer (GraphML for both; GEXF is NetworkX-only).
+The {class}`~infomap.Result` writes the engine's native text formats, `.tree`
+and `.clu`, directly.
 
 ## Export formats
 
@@ -176,21 +177,17 @@ For igraph users, {func}`infomap.to_igraph` returns the same annotation on an
 
 ### Export to .tree and .clu
 
-The stateful {class}`~infomap.Infomap` writes the engine's native text formats:
-build one, run it, and call its `write_*` methods.
-These formats feed the mapequation.org tools: `.ftree` opens in the Network
+The {class}`~infomap.Result` carries the engine's native text writers, so the
+`result` from the run above writes the files directly — whatever built the
+network. These formats feed the mapequation.org tools: `.ftree` opens in the Network
 Navigator, and `.tree`/`.clu` load in the alluvial diagram generator and other
 scripts.
 
 ```{code-cell} python
-im = infomap.Infomap(two_level=True, seed=123, num_trials=10)
-im.add_networkx_graph(g)
-im.run()
-
 tree_path = os.path.join(tmp, "karate.tree")   # full hierarchy with flow
 clu_path = os.path.join(tmp, "karate.clu")      # flat node_id, module, flow
-im.write_tree(tree_path)
-im.write_clu(clu_path)
+result.write_tree(tree_path)
+result.write_clu(clu_path)
 
 print(f"Wrote {os.path.getsize(tree_path):,} byte tree file")
 print(f"Wrote {os.path.getsize(clu_path):,} byte clu file")
@@ -224,7 +221,8 @@ The `.tree` path column uses colon-separated integers: `1:3` means the third
 node listed inside top module 1. For hierarchical runs with more than two levels
 you will see paths like `2:1:4`. The `.clu` format uses the top-level module
 number only; pass `depth_level` to `write_clu` to report a different level.
-`im.write_flow_tree` writes a `.ftree` file that adds intra-module link flows.
+`result.write_flow_tree` writes a `.ftree` file that adds intra-module link
+flows.
 
 ### The find_communities shortcut
 
@@ -288,14 +286,16 @@ print("Temp directory removed.")
   {class}`~infomap.Infomap`, not a {class}`~infomap.Result`. (`write_gexf`
   supports NetworkX only.)
 
-**Native engine formats** (written by the stateful {class}`~infomap.Infomap`)
+**Native engine formats** (written by the {class}`~infomap.Result`)
 
-- {meth}`infomap.Infomap.write_tree` writes a `.tree` file with the hierarchical
+- {meth}`infomap.Result.write_tree` writes a `.tree` file with the hierarchical
   path, flow, name, and node id for every node.
-- {meth}`infomap.Infomap.write_clu` writes a `.clu` flat table; pass
+- {meth}`infomap.Result.write_clu` writes a `.clu` flat table; pass
   `depth_level` to choose the level.
-- {meth}`infomap.Infomap.write_flow_tree` writes a `.ftree` file that adds
+- {meth}`infomap.Result.write_flow_tree` writes a `.ftree` file that adds
   intra-module link flows.
+- {meth}`infomap.Result.write` dispatches on the file extension. The stateful
+  {class}`~infomap.Infomap` keeps the same writers through 2.x.
 
 ## Going deeper
 

--- a/interfaces/python/src/infomap/io/writers.py
+++ b/interfaces/python/src/infomap/io/writers.py
@@ -1,3 +1,21 @@
+"""File writers for the engine's native text formats.
+
+Three hosts share these mixins (#760):
+
+- :class:`~infomap.Result` carries the *result-artifact* writers
+  (``.tree``/``.ftree``/``.clu``/Newick/JSON/CSV): the artifacts are derived
+  from the partition, so the immutable result is their natural home. Access
+  is generation-guarded like all node-level ``Result`` access.
+- :class:`~infomap.Network` carries the *network-describing* writers
+  (``write_pajek``, ``write_state_network``): they serialize the input, not
+  the partition.
+- :class:`~infomap.Infomap` keeps the full historical set through 2.x.
+
+Each host provides ``_writer_core()`` returning the engine core to write
+from; the default resolves ``self._core`` (Infomap, Network), and ``Result``
+overrides it with its stale-guard.
+"""
+
 from __future__ import annotations
 
 import os
@@ -10,12 +28,24 @@ if TYPE_CHECKING:
     from .._core import Core
 
 
-class _InfomapWritersMixin:
-    # Attribute provided by the composing ``Infomap`` host. Declared under
-    # TYPE_CHECKING so pyright resolves these mixin accesses without affecting
-    # runtime (annotations only; the host supplies the real value).
+class _WritersBase:
+    # Empty slots: Result composes these mixins and is slots-based; a mixin
+    # without __slots__ would silently add a __dict__ to every Result.
+    __slots__ = ()
+
+    # Attribute provided by the composing host. Declared under TYPE_CHECKING
+    # so pyright resolves the mixin accesses without affecting runtime.
     if TYPE_CHECKING:
         _core: Core
+
+    def _writer_core(self) -> "Core":
+        return self._core
+
+
+class _ResultWritersMixin(_WritersBase):
+    """Writers for the result-derived artifacts (tree/ftree/clu/...)."""
+
+    __slots__ = ()
 
     def write(self, filename: str | os.PathLike[str], *args, **kwargs) -> None:
         """Write results to file, inferring the format from the extension.
@@ -84,8 +114,9 @@ class _InfomapWritersMixin:
         depth_level : int, optional
             The depth in the hierarchical tree to write.
         """
+        core = self._writer_core()
         with _translate_engine_errors():
-            self._core.writeClu(os.fspath(filename), states, depth_level)
+            core.writeClu(os.fspath(filename), states, depth_level)
 
     def write_tree(
         self, filename: str | os.PathLike[str], states: bool = False
@@ -105,8 +136,9 @@ class _InfomapWritersMixin:
         states : bool, optional
             If the state nodes should be included. Default ``False``.
         """
+        core = self._writer_core()
         with _translate_engine_errors():
-            self._core.writeTree(os.fspath(filename), states)
+            core.writeTree(os.fspath(filename), states)
 
     def write_flow_tree(
         self, filename: str | os.PathLike[str], states: bool = False
@@ -126,8 +158,9 @@ class _InfomapWritersMixin:
         states : bool, optional
             If the state nodes should be included. Default ``False``.
         """
+        core = self._writer_core()
         with _translate_engine_errors():
-            self._core.writeFlowTree(os.fspath(filename), states)
+            core.writeFlowTree(os.fspath(filename), states)
 
     def write_newick(
         self, filename: str | os.PathLike[str], states: bool = False
@@ -147,8 +180,9 @@ class _InfomapWritersMixin:
         states : bool, optional
             If the state nodes should be included. Default ``False``.
         """
+        core = self._writer_core()
         with _translate_engine_errors():
-            self._core.writeNewickTree(os.fspath(filename), states)
+            core.writeNewickTree(os.fspath(filename), states)
 
     def write_json(
         self, filename: str | os.PathLike[str], states: bool = False
@@ -168,8 +202,9 @@ class _InfomapWritersMixin:
         states : bool, optional
             If the state nodes should be included. Default ``False``.
         """
+        core = self._writer_core()
         with _translate_engine_errors():
-            self._core.writeJsonTree(os.fspath(filename), states)
+            core.writeJsonTree(os.fspath(filename), states)
 
     def write_csv(
         self, filename: str | os.PathLike[str], states: bool = False
@@ -189,8 +224,15 @@ class _InfomapWritersMixin:
         states : bool, optional
             If the state nodes should be included. Default ``False``.
         """
+        core = self._writer_core()
         with _translate_engine_errors():
-            self._core.writeCsvTree(os.fspath(filename), states)
+            core.writeCsvTree(os.fspath(filename), states)
+
+
+class _NetworkWritersMixin(_WritersBase):
+    """Writers that serialize the network input, not the partition."""
+
+    __slots__ = ()
 
     def write_state_network(self, filename: str | os.PathLike[str]) -> None:
         """Write internal state network to file.
@@ -205,8 +247,9 @@ class _InfomapWritersMixin:
         ----------
         filename : str or os.PathLike
         """
+        core = self._writer_core()
         with _translate_engine_errors():
-            self._core.network().writeStateNetwork(os.fspath(filename))
+            core.network().writeStateNetwork(os.fspath(filename))
 
     def write_pajek(
         self, filename: str | os.PathLike[str], flow: bool = False
@@ -225,5 +268,12 @@ class _InfomapWritersMixin:
         flow : bool, optional
             If the flow should be included. Default ``False``.
         """
+        core = self._writer_core()
         with _translate_engine_errors():
-            self._core.network().writePajekNetwork(os.fspath(filename), flow)
+            core.network().writePajekNetwork(os.fspath(filename), flow)
+
+
+class _InfomapWritersMixin(_ResultWritersMixin, _NetworkWritersMixin):
+    """The stateful ``Infomap``'s full historical writer set (kept through 2.x)."""
+
+    __slots__ = ()

--- a/interfaces/python/src/infomap/network.py
+++ b/interfaces/python/src/infomap/network.py
@@ -31,13 +31,14 @@ from typing import Any
 from ._core import Core, apply_initial_partition
 from ._logging import engine_log_routing as _engine_log_routing
 from .errors import NetworkParseError, _translate_engine_errors
+from .io.writers import _NetworkWritersMixin
 from ._network_input import add_bulk_links as _add_bulk_links
 from ._network_input import first_order_unpacker as _first_order_unpacker
 from ._network_input import flat_multilayer_unpacker as _flat_multilayer_unpacker
 from ._network_input import paired_multilayer_unpacker as _paired_multilayer_unpacker
 
 
-class Network:
+class Network(_NetworkWritersMixin):
     """A first-class Infomap network input builder.
 
     Build a network with the fluent ``add_*``/``set_*`` verbs (each returns

--- a/interfaces/python/src/infomap/result.py
+++ b/interfaces/python/src/infomap/result.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any
 
 from ._optional import require_pandas
 from .errors import InfomapError, StaleResultError, _translate_engine_errors
+from .io.writers import _ResultWritersMixin
 from ._results import (
     _DATAFRAME_COLUMN_ALIASES,
     _DEFAULT_TO_DATAFRAME_COLUMNS,
@@ -210,7 +211,7 @@ class _Snapshot:
         return len(self.node_id)
 
 
-class Result:
+class Result(_ResultWritersMixin):
     """Immutable snapshot of an Infomap run.
 
     Returned by :meth:`Infomap.run` (and the functional :func:`infomap.run`) and
@@ -218,6 +219,12 @@ class Result:
     tree-derived metrics (the ``effective_num_*`` modules) and
     node/tree/dataframe data are materialized lazily and guarded against the
     engine being re-run.
+
+    Carries the result-artifact file writers (``write_tree``, ``write_clu``,
+    ``write_flow_tree``, ...): write the mapequation.org tool files straight
+    off the result, whatever built it. Like all node-level access, writing is
+    generation-guarded — a stale ``Result`` raises instead of writing the
+    rebuilt tree.
 
     Read scalars as **properties** and collections as **methods** (with
     defaults):
@@ -392,6 +399,12 @@ class Result:
         )
 
     # -- lazy node-data extraction ------------------------------------------
+
+    def _writer_core(self):
+        # The writer mixin's core hook: file writers read the live C++ result
+        # tree, so they are generation-guarded like every node-level access.
+        self._check_generation()
+        return self._engine._core
 
     def _check_generation(self) -> None:
         """Guard live C++ tree access against a re-run of the bound engine."""

--- a/test/python/test_docs_examples_surface.py
+++ b/test/python/test_docs_examples_surface.py
@@ -180,12 +180,6 @@ ALLOWLIST: dict[str, set[str]] = {
         "to_dataframe",
         "add_networkx_graph",
     },
-    # Result has no file writers yet (#760), so exporting .tree/.clu from a
-    # NetworkX source still requires the deprecated Infomap adapter. Remove
-    # this entry when #760 lands.
-    "interfaces/python/source/working-with-infomap/visualizing-and-exporting.md": {
-        "add_networkx_graph",
-    },
 }
 
 

--- a/test/python/test_result_writers.py
+++ b/test/python/test_result_writers.py
@@ -1,0 +1,140 @@
+"""File writers on Result and Network (#760).
+
+The blessed path can write the mapequation.org tool files: the
+result-artifact writers (tree/ftree/clu/Newick/JSON/CSV) live on
+:class:`Result`, the network-describing writers (pajek/state network) on
+:class:`Network`, and :class:`Infomap` keeps its full historical set through
+2.x. Result writers are generation-guarded like all node-level access.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import infomap
+from infomap import Infomap, Network, Options, StaleResultError
+
+
+pytestmark = pytest.mark.fast
+
+_LINKS = [(1, 2), (2, 3), (1, 3), (3, 4), (4, 5), (5, 6), (4, 6)]
+
+
+@pytest.fixture
+def run_result(make_infomap):
+    im = make_infomap(two_level=True)
+    im.add_links(_LINKS)
+    return im, im.run()
+
+
+@pytest.mark.parametrize(
+    ("result_writer", "legacy_writer"),
+    [
+        ("write_tree", "write_tree"),
+        ("write_flow_tree", "write_flow_tree"),
+        ("write_clu", "write_clu"),
+        ("write_newick", "write_newick"),
+        ("write_json", "write_json"),
+        ("write_csv", "write_csv"),
+    ],
+)
+def test_result_writer_matches_legacy_infomap_writer(
+    run_result, tmp_path, result_writer, legacy_writer
+):
+    im, result = run_result
+    from_result = tmp_path / "from_result.out"
+    from_legacy = tmp_path / "from_legacy.out"
+
+    getattr(result, result_writer)(from_result)
+    getattr(im, legacy_writer)(from_legacy)
+
+    assert from_result.read_bytes() == from_legacy.read_bytes()
+
+
+def test_result_write_dispatches_on_extension(run_result, tmp_path):
+    _, result = run_result
+
+    result.write(tmp_path / "partition.clu")
+    result.write(tmp_path / "partition.ftree")
+
+    assert (tmp_path / "partition.clu").stat().st_size > 0
+    assert (tmp_path / "partition.ftree").stat().st_size > 0
+
+
+def test_result_write_rejects_network_formats(run_result, tmp_path):
+    # .net maps to the pajek writer, which describes the input network and
+    # lives on Network/Infomap, not on the result.
+    _, result = run_result
+
+    with pytest.raises(NotImplementedError, match="pajek"):
+        result.write(tmp_path / "network.net")
+
+
+def test_stale_result_writers_raise(run_result, tmp_path):
+    im, result = run_result
+    im.run()  # rebuilds the C++ result tree; `result` is now stale
+
+    with pytest.raises(StaleResultError, match="stale Result"):
+        result.write_tree(tmp_path / "stale.tree")
+
+
+def test_functional_run_result_writes_without_the_stateful_class(tmp_path):
+    result = infomap.run(_LINKS, two_level=True, seed=123)
+
+    result.write_tree(tmp_path / "functional.tree")
+
+    content = (tmp_path / "functional.tree").read_text()
+    assert content.startswith("#")
+    assert " 1 " in content or ":" in content
+
+
+def test_network_run_result_writes(tmp_path):
+    net = Network().add_links(_LINKS)
+    result = net.run(options=Options(two_level=True, seed=123))
+
+    result.write_clu(tmp_path / "network.clu")
+
+    assert (tmp_path / "network.clu").stat().st_size > 0
+
+
+def _data_lines(path: Path) -> list[str]:
+    # The header comments embed the engine's construction flags, which differ
+    # between a Network engine and an Infomap engine; the payload must not.
+    return [
+        line for line in path.read_text().splitlines() if not line.startswith("#")
+    ]
+
+
+def test_network_writers_match_legacy_infomap_writers(make_infomap, tmp_path):
+    net = Network().add_links(_LINKS)
+    im = make_infomap()
+    im.add_links(_LINKS)
+
+    net.write_pajek(tmp_path / "net.net")
+    im.write_pajek(tmp_path / "im.net")
+    net.write_state_network(tmp_path / "net.states")
+    im.write_state_network(tmp_path / "im.states")
+
+    assert _data_lines(tmp_path / "net.net") == _data_lines(tmp_path / "im.net")
+    assert _data_lines(tmp_path / "net.states") == _data_lines(tmp_path / "im.states")
+
+
+def test_result_writers_accept_path_objects(run_result, tmp_path):
+    _, result = run_result
+    target: Path = tmp_path / "pathlib.tree"
+
+    result.write_tree(target)
+
+    assert target.stat().st_size > 0
+
+
+def test_result_stays_slots_based():
+    # The writer mixin must not reintroduce a __dict__ on the slots-based,
+    # immutable Result.
+    result = infomap.run(_LINKS, two_level=True, seed=123)
+
+    assert not hasattr(result, "__dict__")
+    with pytest.raises(AttributeError, match="immutable"):
+        result.write_tree = None

--- a/test/python/test_result_writers.py
+++ b/test/python/test_result_writers.py
@@ -13,8 +13,7 @@ from pathlib import Path
 
 import pytest
 
-import infomap
-from infomap import Infomap, Network, Options, StaleResultError
+from infomap import Network, Options, StaleResultError, run
 
 
 pytestmark = pytest.mark.fast
@@ -81,7 +80,7 @@ def test_stale_result_writers_raise(run_result, tmp_path):
 
 
 def test_functional_run_result_writes_without_the_stateful_class(tmp_path):
-    result = infomap.run(_LINKS, two_level=True, seed=123)
+    result = run(_LINKS, two_level=True, seed=123)
 
     result.write_tree(tmp_path / "functional.tree")
 
@@ -133,7 +132,7 @@ def test_result_writers_accept_path_objects(run_result, tmp_path):
 def test_result_stays_slots_based():
     # The writer mixin must not reintroduce a __dict__ on the slots-based,
     # immutable Result.
-    result = infomap.run(_LINKS, two_level=True, seed=123)
+    result = run(_LINKS, two_level=True, seed=123)
 
     assert not hasattr(result, "__dict__")
     with pytest.raises(AttributeError, match="immutable"):


### PR DESCRIPTION
# Summary

Closes the last gap in the blessed path (#760): a `Result` from `infomap.run(g)` or `Network...run()` had no way to produce the mapequation.org tool files — the `write_*` methods lived only on the stateful `Infomap`, which pinned the docs' export page to the deprecated `add_networkx_graph` adapter (allowlisted in the #742 enforcement test with a pointer to this issue).

The writers mixin is split by what the artifact describes:

- **`Result`** carries the result-artifact writers: `write` (extension dispatch), `write_tree`, `write_flow_tree`, `write_clu`, `write_newick`, `write_json`, `write_csv`. Writing reads the live C++ result tree, so it is **generation-guarded** like all node-level `Result` access — a stale `Result` raises `StaleResultError` instead of writing the rebuilt tree. The mixins declare empty `__slots__` so the slots-based, immutable `Result` stays free of a `__dict__`.
- **`Network`** carries the network-describing writers (`write_pajek`, `write_state_network`) — they serialize the input, not the partition. Consistently, `result.write("x.net")` raises `NotImplementedError`.
- **`Infomap`** keeps its full historical writer set through 2.x, now composed from the two mixins — no behavior change.

The export docs page now writes `.tree`/`.clu` straight off the `result` with no deprecated member, and the corresponding allowlist entry in `test_docs_examples_surface.py` is removed — the issue's acceptance criterion. The blessed one-liner works end to end:

```python
result = infomap.run(g, two_level=True, seed=123, num_trials=10)
result.write_flow_tree("karate.ftree")   # open in the Network Navigator
```

Closes #760

# Verification

- `pytest test/python`: 591 passed, 2 skipped — 14 new tests in `test_result_writers.py`: byte parity against the legacy `Infomap.write_*` for all six result formats (same engine → identical files), extension dispatch, `.net`-on-Result rejection, the stale-guard, the functional-`run` and `Network.run` paths, `Network` writer parity (payload lines; headers embed construction flags), `os.PathLike` acceptance, and the slots/immutability invariant
- `test_docs_examples_surface.py` passes with the allowlist entry removed — the export page teaches only the blessed surface now
- `make test-python-doctest` (38 + ruff), `make test-python-typecheck-core` (0 errors): green
- `make build-docs`: the rewritten export page executes; `Result`/`Network` API pages render the inherited writers via `:inherited-members:`; only the known proxy-blocked intersphinx warnings

# Notes

- Unblocks part of #747 (the legacy-mirror removal): the export story no longer needs the deprecated build adapter. Issue #760 is on the 3.0 milestone.
- `Infomap.write_*` is intentionally *not* deprecated here — the stateful class keeps its writers through 2.x; whether they leave in 3.0 is #747/#759 territory.
- Built on a side branch (`claude/result-writers-760`) to keep it independent of the nanobind-spike branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_017XjuZM32ZUn1AbeWJVXuyi)_