### PR TITLE
feat(build): machine-readable 3.0 parameter cleanup policy

### DIFF
--- a/interfaces/parameters/overrides.json
+++ b/interfaces/parameters/overrides.json
@@ -1,4 +1,120 @@
 {
+  "names": {
+    "--verbose": {
+      "python": "verbosity_level",
+      "r": "verbosity_level",
+      "ts": "verbose"
+    }
+  },
+  "defaults": {
+    "--core-loop-codelength-threshold": {
+      "python": "1e-10",
+      "r": "1e-10"
+    },
+    "--core-loop-limit": {
+      "python": "10",
+      "r": "10L"
+    },
+    "--directed": {
+      "python": "None",
+      "r": "NULL"
+    },
+    "--entropy-correction-strength": {
+      "python": "1.0",
+      "r": "1.0"
+    },
+    "--fast-hierarchical-solution": {
+      "python": "None",
+      "r": "NULL"
+    },
+    "--flow-tolerance": {
+      "python": "1e-15",
+      "r": "1e-15"
+    },
+    "--markov-time": {
+      "python": "1.0",
+      "r": "1.0"
+    },
+    "--max-flow-iterations": {
+      "python": "400",
+      "r": "400L"
+    },
+    "--meta-data-rate": {
+      "python": "1.0",
+      "r": "1.0"
+    },
+    "--min-flow-iterations": {
+      "python": "50",
+      "r": "50L"
+    },
+    "--multilayer-relax-limit": {
+      "python": "-1",
+      "r": "NULL"
+    },
+    "--multilayer-relax-limit-down": {
+      "python": "-1",
+      "r": "NULL"
+    },
+    "--multilayer-relax-limit-up": {
+      "python": "-1",
+      "r": "NULL"
+    },
+    "--multilayer-relax-rate": {
+      "python": "0.15",
+      "r": "0.15"
+    },
+    "--num-trials": {
+      "python": "1",
+      "r": "1L"
+    },
+    "--preferred-number-of-levels-strength": {
+      "python": "1.0",
+      "r": "1.0"
+    },
+    "--regularization-strength": {
+      "python": "1.0",
+      "r": "1.0"
+    },
+    "--seed": {
+      "python": "123",
+      "r": "123L"
+    },
+    "--silent": {
+      "python": "True",
+      "r": "FALSE"
+    },
+    "--teleportation-probability": {
+      "python": "0.15",
+      "r": "0.15"
+    },
+    "--tune-iteration-relative-threshold": {
+      "python": "1e-05",
+      "r": "1e-05"
+    },
+    "--variable-markov-damping": {
+      "python": "1.0",
+      "r": "1.0"
+    },
+    "--variable-markov-min-scale": {
+      "python": "1.0",
+      "r": "1.0"
+    },
+    "--verbose": {
+      "python": "1",
+      "r": "1L"
+    }
+  },
+  "docs": {
+    "--fast-hierarchical-solution": {
+      "python": "Find top modules fast. Use 2 to keep all fast levels and 3 to skip the recursive part."
+    },
+    "--verbose": {
+      "python": "Verbosity level on the console. 1 keeps the default output level, 2 renders -vv and so on."
+    },
+    "--silent": {
+      "python": "Suppress console output. The Python API is quiet by default; construct with silent=False for the engine log. The command-line interface is unaffected."
+    }
+  },
   "bindingOnly": {
     "python": [
       {

--- a/interfaces/parameters/overrides.json
+++ b/interfaces/parameters/overrides.json
@@ -1,36 +1,4 @@
 {
-  "hiddenBindings": {
-    "ts": [
-      {
-        "flag": "--parallel-trials",
-        "reason": "The JavaScript package runs Infomap in a single-threaded worker, so exposing OpenMP trial scheduling would be misleading."
-      },
-      {
-        "flag": "--inner-parallelization",
-        "reason": "The JavaScript package runs Infomap in a single-threaded worker, so exposing OpenMP node-move scheduling would be misleading."
-      },
-      {
-        "flag": "--num-threads",
-        "reason": "The JavaScript package runs Infomap in a single-threaded WASM worker, so an OpenMP thread budget is meaningless there."
-      },
-      {
-        "flag": "--threads",
-        "reason": "Alias of --num-threads; the single-threaded JavaScript worker has no OpenMP thread budget."
-      },
-      {
-        "flag": "--trial-offset",
-        "reason": "Distributed trial sharding is for multi-process HPC runs; the single-threaded JavaScript WASM worker cannot shard."
-      },
-      {
-        "flag": "--trial-results",
-        "reason": "Per-shard result emission is for multi-process HPC merge workflows, not the JavaScript worker."
-      },
-      {
-        "flag": "--no-final-output",
-        "reason": "Only meaningful for shard runs feeding --merge-trial-results, which the JavaScript worker does not use."
-      }
-    ]
-  },
   "bindingOnly": {
     "python": [
       {
@@ -64,41 +32,14 @@
       }
     ]
   },
-  "tiers": {
-    "python": {
-      "common": [
-        "--seed",
-        "--num-trials",
-        "--two-level",
-        "--directed",
-        "--markov-time"
-      ]
-    }
-  },
-  "apiNotes": {
-    "python": {
-      "inertWithoutOutputDir": [
-        "--output",
-        "--tree",
-        "--ftree",
-        "--clu",
-        "--clu-level",
-        "--out-name",
-        "--no-file-output",
-        "--hide-bipartite-nodes",
-        "--print-all-trials",
-        "--no-overwrite"
-      ]
-    }
-  },
   "policy": {
     "vocabulary": {
-      "keep": "First-class option on the surface in 3.0 (the default for every parameter without an entry).",
+      "keep": "First-class option on the surface in 3.0 (the default for every parameter without an entry). May carry tier: 'common' for parameters that stay real keyword parameters in the 3.0 Python signatures (#738); everything else rides the options object.",
       "alias": "Kept as a documented alias of another parameter (aliasOf names the target).",
       "deprecate": "Marked deprecated in 2.x; the surface's cleanup issue decides removal.",
       "remove": "Removed from the surface in 3.0, deprecated through 2.x where it is currently exposed.",
-      "args-only": "Not a first-class option in 3.0; reachable through the raw args escape hatch on library surfaces.",
-      "hide": "Not exposed on the surface (enforced by hiddenBindings for generated surfaces)."
+      "args-only": "Not a first-class option in 3.0; reachable through the raw args escape hatch on library surfaces. inertWithoutOutputDir: true marks decisions where the flag is verifiably inert via kwargs in 2.x (library mode forces noFileOutput without an output directory).",
+      "hide": "Not exposed on the surface. Takes effect on regeneration, so it is only valid for parameters that are not currently exposed there."
     },
     "surfaces": [
       "cli",
@@ -110,29 +51,77 @@
     "cliOnlyParameters": [
       "--pretty"
     ],
+    "groups": {
+      "python-output-artifacts": {
+        "parameters": [
+          "--output",
+          "--tree",
+          "--ftree",
+          "--clu",
+          "--clu-level",
+          "--out-name",
+          "--no-file-output",
+          "--hide-bipartite-nodes",
+          "--print-all-trials",
+          "--no-overwrite"
+        ],
+        "python": {
+          "action": "args-only",
+          "inertWithoutOutputDir": true,
+          "replacement": "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."
+        }
+      },
+      "ts-single-threaded-worker": {
+        "parameters": [
+          "--parallel-trials",
+          "--inner-parallelization",
+          "--num-threads",
+          "--threads",
+          "--trial-offset",
+          "--trial-results",
+          "--no-final-output"
+        ],
+        "ts": {
+          "action": "hide",
+          "replacement": "The JavaScript package runs Infomap in a single-threaded WASM worker: OpenMP scheduling, thread budgets, and multi-process trial sharding are meaningless there."
+        }
+      }
+    },
     "parameters": {
-      "--clu": {
+      "--seed": {
         "python": {
-          "action": "args-only",
-          "replacement": "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."
+          "action": "keep",
+          "tier": "common"
         }
       },
-      "--clu-level": {
+      "--num-trials": {
         "python": {
-          "action": "args-only",
-          "replacement": "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."
+          "action": "keep",
+          "tier": "common"
         }
       },
-      "--ftree": {
+      "--two-level": {
         "python": {
-          "action": "args-only",
-          "replacement": "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."
+          "action": "keep",
+          "tier": "common"
         }
       },
-      "--hide-bipartite-nodes": {
+      "--directed": {
         "python": {
-          "action": "args-only",
-          "replacement": "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."
+          "action": "keep",
+          "tier": "common"
+        }
+      },
+      "--markov-time": {
+        "python": {
+          "action": "keep",
+          "tier": "common"
+        }
+      },
+      "--pretty": {
+        "cli": {
+          "action": "remove",
+          "replacement": "Deprecated no-op since 2.x; pretty console output is always on."
         }
       },
       "--include-self-links": {
@@ -149,86 +138,6 @@
           "replacement": "Self-links are included by default; pass no_self_links = TRUE to exclude them."
         }
       },
-      "--inner-parallelization": {
-        "ts": {
-          "action": "hide",
-          "replacement": "The JavaScript package runs Infomap in a single-threaded worker, so exposing OpenMP node-move scheduling would be misleading."
-        }
-      },
-      "--no-file-output": {
-        "python": {
-          "action": "args-only",
-          "replacement": "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."
-        }
-      },
-      "--no-final-output": {
-        "ts": {
-          "action": "hide",
-          "replacement": "Only meaningful for shard runs feeding --merge-trial-results, which the JavaScript worker does not use."
-        }
-      },
-      "--no-overwrite": {
-        "python": {
-          "action": "args-only",
-          "replacement": "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."
-        }
-      },
-      "--num-threads": {
-        "ts": {
-          "action": "hide",
-          "replacement": "The JavaScript package runs Infomap in a single-threaded WASM worker, so an OpenMP thread budget is meaningless there."
-        }
-      },
-      "--out-name": {
-        "python": {
-          "action": "args-only",
-          "replacement": "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."
-        }
-      },
-      "--output": {
-        "python": {
-          "action": "args-only",
-          "replacement": "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."
-        }
-      },
-      "--parallel-trials": {
-        "ts": {
-          "action": "hide",
-          "replacement": "The JavaScript package runs Infomap in a single-threaded worker, so exposing OpenMP trial scheduling would be misleading."
-        }
-      },
-      "--pretty": {
-        "cli": {
-          "action": "remove",
-          "replacement": "Deprecated no-op since 2.x; pretty console output is always on."
-        }
-      },
-      "--print-all-trials": {
-        "python": {
-          "action": "args-only",
-          "replacement": "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."
-        }
-      },
-      "--print-config-fingerprint": {
-        "python": {
-          "action": "remove",
-          "replacement": "A print-and-exit CLI diagnostic; run the infomap binary."
-        },
-        "r": {
-          "action": "remove",
-          "replacement": "A print-and-exit CLI diagnostic; run the infomap binary."
-        }
-      },
-      "--silent": {
-        "python": {
-          "action": "remove",
-          "replacement": "The Python API is quiet by default; logging is the control. Attach handlers to logging.getLogger('infomap') (e.g. infomap.enable_log()) for the engine log."
-        },
-        "r": {
-          "action": "deprecate",
-          "replacement": "Pending the R option-surface decision (#757); the library default is expected to stay quiet."
-        }
-      },
       "--threads": {
         "cli": {
           "action": "alias",
@@ -242,28 +151,16 @@
         "r": {
           "action": "remove",
           "replacement": "Use num_threads; threads is a redundant alias of the same engine option."
-        },
-        "ts": {
-          "action": "hide",
-          "replacement": "Alias of --num-threads; the single-threaded JavaScript worker has no OpenMP thread budget."
         }
       },
-      "--tree": {
+      "--silent": {
         "python": {
-          "action": "args-only",
-          "replacement": "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."
-        }
-      },
-      "--trial-offset": {
-        "ts": {
-          "action": "hide",
-          "replacement": "Distributed trial sharding is for multi-process HPC runs; the single-threaded JavaScript WASM worker cannot shard."
-        }
-      },
-      "--trial-results": {
-        "ts": {
-          "action": "hide",
-          "replacement": "Per-shard result emission is for multi-process HPC merge workflows, not the JavaScript worker."
+          "action": "remove",
+          "replacement": "The Python API is quiet by default; logging is the control. Attach handlers to logging.getLogger('infomap') (e.g. infomap.enable_log()) for the engine log."
+        },
+        "r": {
+          "action": "deprecate",
+          "replacement": "Pending the R option-surface decision (#757); the library default is expected to stay quiet."
         }
       },
       "--verbose": {
@@ -274,6 +171,16 @@
         "r": {
           "action": "deprecate",
           "replacement": "Pending the R option-surface decision (#757)."
+        }
+      },
+      "--print-config-fingerprint": {
+        "python": {
+          "action": "remove",
+          "replacement": "A print-and-exit CLI diagnostic; run the infomap binary."
+        },
+        "r": {
+          "action": "remove",
+          "replacement": "A print-and-exit CLI diagnostic; run the infomap binary."
         }
       }
     }

--- a/interfaces/parameters/overrides.json
+++ b/interfaces/parameters/overrides.json
@@ -90,5 +90,192 @@
         "--no-overwrite"
       ]
     }
+  },
+  "policy": {
+    "vocabulary": {
+      "keep": "First-class option on the surface in 3.0 (the default for every parameter without an entry).",
+      "alias": "Kept as a documented alias of another parameter (aliasOf names the target).",
+      "deprecate": "Marked deprecated in 2.x; the surface's cleanup issue decides removal.",
+      "remove": "Removed from the surface in 3.0, deprecated through 2.x where it is currently exposed.",
+      "args-only": "Not a first-class option in 3.0; reachable through the raw args escape hatch on library surfaces.",
+      "hide": "Not exposed on the surface (enforced by hiddenBindings for generated surfaces)."
+    },
+    "surfaces": [
+      "cli",
+      "python",
+      "r",
+      "ts"
+    ],
+    "default": "keep",
+    "cliOnlyParameters": [
+      "--pretty"
+    ],
+    "parameters": {
+      "--clu": {
+        "python": {
+          "action": "args-only",
+          "replacement": "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."
+        }
+      },
+      "--clu-level": {
+        "python": {
+          "action": "args-only",
+          "replacement": "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."
+        }
+      },
+      "--ftree": {
+        "python": {
+          "action": "args-only",
+          "replacement": "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."
+        }
+      },
+      "--hide-bipartite-nodes": {
+        "python": {
+          "action": "args-only",
+          "replacement": "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."
+        }
+      },
+      "--include-self-links": {
+        "cli": {
+          "action": "remove",
+          "replacement": "Self-links are included by default; use --no-self-links to exclude them. The CLI flag is already a hard error in 2.x."
+        },
+        "python": {
+          "action": "remove",
+          "replacement": "Self-links are included by default; pass no_self_links=True to exclude them."
+        },
+        "r": {
+          "action": "remove",
+          "replacement": "Self-links are included by default; pass no_self_links = TRUE to exclude them."
+        }
+      },
+      "--inner-parallelization": {
+        "ts": {
+          "action": "hide",
+          "replacement": "The JavaScript package runs Infomap in a single-threaded worker, so exposing OpenMP node-move scheduling would be misleading."
+        }
+      },
+      "--no-file-output": {
+        "python": {
+          "action": "args-only",
+          "replacement": "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."
+        }
+      },
+      "--no-final-output": {
+        "ts": {
+          "action": "hide",
+          "replacement": "Only meaningful for shard runs feeding --merge-trial-results, which the JavaScript worker does not use."
+        }
+      },
+      "--no-overwrite": {
+        "python": {
+          "action": "args-only",
+          "replacement": "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."
+        }
+      },
+      "--num-threads": {
+        "ts": {
+          "action": "hide",
+          "replacement": "The JavaScript package runs Infomap in a single-threaded WASM worker, so an OpenMP thread budget is meaningless there."
+        }
+      },
+      "--out-name": {
+        "python": {
+          "action": "args-only",
+          "replacement": "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."
+        }
+      },
+      "--output": {
+        "python": {
+          "action": "args-only",
+          "replacement": "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."
+        }
+      },
+      "--parallel-trials": {
+        "ts": {
+          "action": "hide",
+          "replacement": "The JavaScript package runs Infomap in a single-threaded worker, so exposing OpenMP trial scheduling would be misleading."
+        }
+      },
+      "--pretty": {
+        "cli": {
+          "action": "remove",
+          "replacement": "Deprecated no-op since 2.x; pretty console output is always on."
+        }
+      },
+      "--print-all-trials": {
+        "python": {
+          "action": "args-only",
+          "replacement": "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."
+        }
+      },
+      "--print-config-fingerprint": {
+        "python": {
+          "action": "remove",
+          "replacement": "A print-and-exit CLI diagnostic; run the infomap binary."
+        },
+        "r": {
+          "action": "remove",
+          "replacement": "A print-and-exit CLI diagnostic; run the infomap binary."
+        }
+      },
+      "--silent": {
+        "python": {
+          "action": "remove",
+          "replacement": "The Python API is quiet by default; logging is the control. Attach handlers to logging.getLogger('infomap') (e.g. infomap.enable_log()) for the engine log."
+        },
+        "r": {
+          "action": "deprecate",
+          "replacement": "Pending the R option-surface decision (#757); the library default is expected to stay quiet."
+        }
+      },
+      "--threads": {
+        "cli": {
+          "action": "alias",
+          "aliasOf": "--num-threads",
+          "replacement": "Documented alias of --num-threads."
+        },
+        "python": {
+          "action": "remove",
+          "replacement": "Use num_threads; threads is a redundant alias of the same engine option."
+        },
+        "r": {
+          "action": "remove",
+          "replacement": "Use num_threads; threads is a redundant alias of the same engine option."
+        },
+        "ts": {
+          "action": "hide",
+          "replacement": "Alias of --num-threads; the single-threaded JavaScript worker has no OpenMP thread budget."
+        }
+      },
+      "--tree": {
+        "python": {
+          "action": "args-only",
+          "replacement": "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."
+        }
+      },
+      "--trial-offset": {
+        "ts": {
+          "action": "hide",
+          "replacement": "Distributed trial sharding is for multi-process HPC runs; the single-threaded JavaScript WASM worker cannot shard."
+        }
+      },
+      "--trial-results": {
+        "ts": {
+          "action": "hide",
+          "replacement": "Per-shard result emission is for multi-process HPC merge workflows, not the JavaScript worker."
+        }
+      },
+      "--verbose": {
+        "python": {
+          "action": "remove",
+          "replacement": "A DEBUG-enabled 'infomap' logger (infomap.enable_log(logging.DEBUG)) raises engine verbosity; logger levels filter the records."
+        },
+        "r": {
+          "action": "deprecate",
+          "replacement": "Pending the R option-surface decision (#757)."
+        }
+      }
+    }
   }
 }

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -216,6 +216,10 @@ help:
 build-binding-options: build-native
 	@$(PYTHON_FOR_BUILD_CONFIG) $(BINDING_OPTIONS_SCRIPT) --infomap-bin ./Infomap --output-root .
 
+# Render the 3.0 parameter-policy surface matrix (issue #755) as Markdown.
+print-parameter-policy: build-native
+	@$(PYTHON_FOR_BUILD_CONFIG) scripts/render_parameter_policy.py --binary ./Infomap
+
 doctor:
 	@printf "%s\n" "Infomap doctor" ""
 	@printf "Platform: %s\n" "$(UNAME_S)"

--- a/scripts/generate_binding_options.py
+++ b/scripts/generate_binding_options.py
@@ -81,12 +81,9 @@ def load_overrides() -> dict:
                 raise RuntimeError(
                     f"bindingOnly entry for {language}:{entry.get('name')} must include a reason"
                 )
-    for language, entries in overrides.get("hiddenBindings", {}).items():
-        for entry in entries:
-            if not entry.get("reason"):
-                raise RuntimeError(
-                    f"hiddenBindings entry for {language}:{entry.get('flag')} must include a reason"
-                )
+    # Hidden bindings are derived from the policy section (hide decisions);
+    # their rationale is the schema-mandated replacement text, validated by
+    # ParameterCatalog._validate_policy.
     return overrides
 
 

--- a/scripts/generate_js_metadata.py
+++ b/scripts/generate_js_metadata.py
@@ -48,11 +48,19 @@ def public_parameter_metadata(parameters):
 
 
 def hidden_js_parameter_flags():
+    # Derived from the policy section: a ts `hide` decision removes the
+    # parameter from the JavaScript surface (issue #755).
     overrides = json.loads(OVERRIDES.read_text(encoding="utf-8"))
-    return {
-        entry["flag"]
-        for entry in overrides.get("hiddenBindings", {}).get("ts", [])
+    policy = overrides.get("policy", {})
+    hidden = {
+        flag
+        for flag, per_surface in policy.get("parameters", {}).items()
+        if per_surface.get("ts", {}).get("action") == "hide"
     }
+    for group in policy.get("groups", {}).values():
+        if group.get("ts", {}).get("action") == "hide":
+            hidden.update(group.get("parameters", []))
+    return hidden
 
 
 def write_json(path, payload):

--- a/scripts/parameter_catalog.py
+++ b/scripts/parameter_catalog.py
@@ -119,9 +119,6 @@ class Parameter:
         return self.raw.get("choices") or self.overrides.get("choices", {}).get(self.flag)
 
     def name(self, language: str) -> str:
-        binding_names = self.raw.get("bindingNames", {})
-        if language in binding_names:
-            return binding_names[language]
         names = self.overrides.get("names", {}).get(self.flag, {})
         if language in names:
             return names[language]
@@ -167,12 +164,12 @@ class Parameter:
         return self.render_policy in {"flag", "value"}
 
     def binding_default(self, language: str) -> dict[str, str]:
-        return self.raw.get("bindingDefaults", {}).get(language, {})
+        return self.overrides.get("defaults", {}).get(self.flag, {}).get(language)
 
     def python_default_value(self) -> str:
-        # ``is not None`` (not truthiness): a future binding default of "" / "0"
-        # is a real value, not "unset".
-        value = self.binding_default("python").get("value")
+        # ``is not None`` (not truthiness): a binding default of "" / "0" is a
+        # real value, not "unset".
+        value = self.binding_default("python")
         if value is not None:
             return value
         if not self.required:
@@ -242,13 +239,13 @@ class Parameter:
         return "str, optional"
 
     def python_doc_description(self) -> str:
-        python_docs = self.raw.get("bindingDocs", {}).get("python", {})
-        if description := python_docs.get("description"):
+        docs = self.overrides.get("docs", {}).get(self.flag, {})
+        if description := docs.get("python"):
             return description
         return self.description
 
     def r_default(self) -> str:
-        value = self.binding_default("r").get("value")
+        value = self.binding_default("r")
         if value is not None:
             return value
         if not self.required:

--- a/scripts/parameter_catalog.py
+++ b/scripts/parameter_catalog.py
@@ -122,6 +122,24 @@ class Parameter:
         common = self.overrides.get("tiers", {}).get(language, {}).get("common", [])
         return "common" if self.flag in common else "advanced"
 
+    def policy(self, surface: str) -> dict[str, str]:
+        """The 3.0 cleanup-policy decision for this parameter on ``surface``.
+
+        Declared in the overrides file (``policy.parameters``, keyed by CLI
+        flag); a parameter without an entry defaults to ``keep``. Returns a
+        dict with at least ``action`` and, for every non-keep action, a
+        ``replacement`` (and ``aliasOf`` for ``alias``). See issue #755.
+        """
+        entry = (
+            self.overrides.get("policy", {})
+            .get("parameters", {})
+            .get(self.flag, {})
+            .get(surface)
+        )
+        if entry is None:
+            return {"action": self.overrides.get("policy", {}).get("default", "keep")}
+        return entry
+
     def python_inert_without_outdir(self) -> bool:
         """True for output-artifact parameters that are inert via kwargs.
 
@@ -275,6 +293,69 @@ class ParameterCatalog:
             for language, entries in overrides.get("hiddenBindings", {}).items()
         }
         self._validate_tiers()
+        self._validate_policy()
+
+    def _validate_policy(self) -> None:
+        # Fail loud on typos and incomplete decisions: the policy is the 3.0
+        # contract input (#755), so an unknown flag, surface, or action -- or
+        # a removal without replacement guidance -- must break the build, not
+        # silently fall back to "keep".
+        policy = self.overrides.get("policy")
+        if policy is None:
+            return
+        surfaces = set(policy.get("surfaces", []))
+        actions = set(policy.get("vocabulary", {}))
+        known_flags = {param.flag for param in self.parameters}
+        for entries in self.binding_only_parameters.values():
+            known_flags.update(entry.flag for entry in entries)
+        known_flags.update(policy.get("cliOnlyParameters", []))
+
+        for flag, per_surface in policy.get("parameters", {}).items():
+            if flag not in known_flags:
+                raise RuntimeError(
+                    f"policy.parameters lists unknown flag {flag!r} (not in the "
+                    "parameter catalog, bindingOnly, or cliOnlyParameters)"
+                )
+            for surface, decision in per_surface.items():
+                if surface not in surfaces:
+                    raise RuntimeError(
+                        f"policy for {flag} names unknown surface {surface!r}; "
+                        f"declared surfaces: {sorted(surfaces)}"
+                    )
+                action = decision.get("action")
+                if action not in actions:
+                    raise RuntimeError(
+                        f"policy for {flag}/{surface} has unknown action "
+                        f"{action!r}; declared actions: {sorted(actions)}"
+                    )
+                if action != "keep" and not decision.get("replacement"):
+                    raise RuntimeError(
+                        f"policy for {flag}/{surface} ({action}) is missing "
+                        "the required replacement guidance"
+                    )
+                if action == "alias" and not decision.get("aliasOf"):
+                    raise RuntimeError(
+                        f"policy for {flag}/{surface} is an alias but is "
+                        "missing aliasOf"
+                    )
+                if action == "alias" and decision.get("aliasOf") not in known_flags:
+                    raise RuntimeError(
+                        f"policy for {flag}/{surface} aliases unknown flag "
+                        f"{decision.get('aliasOf')!r}"
+                    )
+
+        # Everything a generated surface already hides must be policy-hidden;
+        # the policy is the umbrella, hiddenBindings the implementation.
+        for language, hidden in self.hidden_bindings.items():
+            for flag in sorted(hidden):
+                decision = (
+                    policy.get("parameters", {}).get(flag, {}).get(language, {})
+                )
+                if decision.get("action") != "hide":
+                    raise RuntimeError(
+                        f"hiddenBindings.{language} hides {flag} but the policy "
+                        f"does not declare {language}: hide for it"
+                    )
 
     def _validate_tiers(self) -> None:
         # Fail loud on typos: every tier entry must name a real catalog flag,

--- a/scripts/parameter_catalog.py
+++ b/scripts/parameter_catalog.py
@@ -7,6 +7,25 @@ from typing import Any
 
 GROUPS = ("Input", "Output", "Algorithm", "Accuracy")
 
+def resolve_policy_decision(
+    overrides: dict[str, Any], flag: str, surface: str
+) -> dict[str, Any]:
+    """Resolve the policy decision for ``flag`` on ``surface``.
+
+    Precedence: per-parameter entry, then group rule, then the ``keep``
+    default. Group uniqueness per (flag, surface) is enforced by
+    ``ParameterCatalog._validate_policy``.
+    """
+    policy = overrides.get("policy", {})
+    entry = policy.get("parameters", {}).get(flag, {}).get(surface)
+    if entry is not None:
+        return entry
+    for group in policy.get("groups", {}).values():
+        if flag in group.get("parameters", []) and surface in group:
+            return group[surface]
+    return {"action": policy.get("default", "keep")}
+
+
 def snake_name(flag: str) -> str:
     return flag.removeprefix("--").replace("-", "_")
 
@@ -113,32 +132,25 @@ class Parameter:
     def tier(self, language: str) -> str:
         """The binding-surface tier of this parameter: ``common`` or ``advanced``.
 
-        Tier membership is declared per language in the overrides file
-        (``tiers.<language>.common``, keyed by CLI flag); every parameter not
-        listed there is ``advanced``. The tier decides which parameters stay
+        Declared as a ``tier`` attribute on the parameter's policy decision
+        (``policy.parameters.<flag>.<language>.tier``); every parameter
+        without one is ``advanced``. The tier decides which parameters stay
         as real keyword parameters in the 3.0 signatures (see issue #738) —
         everything else is carried by the options object.
         """
-        common = self.overrides.get("tiers", {}).get(language, {}).get("common", [])
-        return "common" if self.flag in common else "advanced"
+        return self.policy(language).get("tier", "advanced")
 
     def policy(self, surface: str) -> dict[str, str]:
         """The 3.0 cleanup-policy decision for this parameter on ``surface``.
 
-        Declared in the overrides file (``policy.parameters``, keyed by CLI
-        flag); a parameter without an entry defaults to ``keep``. Returns a
-        dict with at least ``action`` and, for every non-keep action, a
-        ``replacement`` (and ``aliasOf`` for ``alias``). See issue #755.
+        Declared in the overrides file (issue #755): per-parameter entries in
+        ``policy.parameters`` (keyed by CLI flag) take precedence, then group
+        rules in ``policy.groups`` (one decision applied to a parameter
+        list), then the ``keep`` default. Returns a dict with at least
+        ``action`` and, for every non-keep action, a ``replacement`` (plus
+        ``aliasOf`` for ``alias``).
         """
-        entry = (
-            self.overrides.get("policy", {})
-            .get("parameters", {})
-            .get(self.flag, {})
-            .get(surface)
-        )
-        if entry is None:
-            return {"action": self.overrides.get("policy", {}).get("default", "keep")}
-        return entry
+        return resolve_policy_decision(self.overrides, self.flag, surface)
 
     def python_inert_without_outdir(self) -> bool:
         """True for output-artifact parameters that are inert via kwargs.
@@ -146,15 +158,10 @@ class Parameter:
         In library mode (``isCLI=false``, the only mode the Python API uses)
         the engine forces ``noFileOutput`` on when no output directory is
         given (``src/io/Config.cpp``), and the directory can only arrive via
-        the positional ``args`` argument. The flags are declared in the
-        overrides file (``apiNotes.python.inertWithoutOutputDir``).
+        the positional ``args`` argument. Declared as
+        ``inertWithoutOutputDir: true`` on the python policy decision.
         """
-        inert = (
-            self.overrides.get("apiNotes", {})
-            .get("python", {})
-            .get("inertWithoutOutputDir", [])
-        )
-        return self.flag in inert
+        return bool(self.policy("python").get("inertWithoutOutputDir"))
 
     def uses_generic_spec(self) -> bool:
         return self.render_policy in {"flag", "value"}
@@ -288,12 +295,20 @@ class ParameterCatalog:
             ]
             for language, entries in overrides.get("bindingOnly", {}).items()
         }
-        self.hidden_bindings = {
-            language: {entry["flag"] for entry in entries}
-            for language, entries in overrides.get("hiddenBindings", {}).items()
-        }
-        self._validate_tiers()
         self._validate_policy()
+        # Hidden bindings are derived from the policy: a `hide` decision on a
+        # generated surface removes the parameter from that surface (the
+        # policy is the single per-parameter record; see issue #755).
+        surfaces = overrides.get("policy", {}).get("surfaces", [])
+        self.hidden_bindings = {
+            language: {
+                param.flag
+                for param in self.parameters
+                if param.policy(language)["action"] == "hide"
+            }
+            for language in surfaces
+            if language != "cli"
+        }
 
     def _validate_policy(self) -> None:
         # Fail loud on typos and incomplete decisions: the policy is the 3.0
@@ -306,9 +321,58 @@ class ParameterCatalog:
         surfaces = set(policy.get("surfaces", []))
         actions = set(policy.get("vocabulary", {}))
         known_flags = {param.flag for param in self.parameters}
-        for entries in self.binding_only_parameters.values():
-            known_flags.update(entry.flag for entry in entries)
-        known_flags.update(policy.get("cliOnlyParameters", []))
+        binding_only_flags = {
+            entry.flag
+            for entries in self.binding_only_parameters.values()
+            for entry in entries
+        }
+        cli_only_flags = set(policy.get("cliOnlyParameters", []))
+        known_flags |= binding_only_flags | cli_only_flags
+
+        def check_decision(flag: str, surface: str, decision: dict[str, Any]) -> None:
+            if surface not in surfaces:
+                raise RuntimeError(
+                    f"policy for {flag} names unknown surface {surface!r}; "
+                    f"declared surfaces: {sorted(surfaces)}"
+                )
+            if flag in cli_only_flags and surface != "cli":
+                raise RuntimeError(
+                    f"policy for {flag} carries a {surface} decision, but "
+                    "cliOnlyParameters declares it CLI-only"
+                )
+            action = decision.get("action")
+            if action not in actions:
+                raise RuntimeError(
+                    f"policy for {flag}/{surface} has unknown action "
+                    f"{action!r}; declared actions: {sorted(actions)}"
+                )
+            if action != "keep" and not decision.get("replacement"):
+                raise RuntimeError(
+                    f"policy for {flag}/{surface} ({action}) is missing "
+                    "the required replacement guidance"
+                )
+            if action == "alias" and not decision.get("aliasOf"):
+                raise RuntimeError(
+                    f"policy for {flag}/{surface} is an alias but is "
+                    "missing aliasOf"
+                )
+            if action == "alias" and decision.get("aliasOf") not in known_flags:
+                raise RuntimeError(
+                    f"policy for {flag}/{surface} aliases unknown flag "
+                    f"{decision.get('aliasOf')!r}"
+                )
+            tier = decision.get("tier")
+            if tier is not None and tier != "common":
+                raise RuntimeError(
+                    f"policy for {flag}/{surface} declares unknown tier "
+                    f"{tier!r}; only 'common' is declared (everything else "
+                    "is advanced)"
+                )
+            if tier is not None and action not in {"keep", "alias"}:
+                raise RuntimeError(
+                    f"policy for {flag}/{surface} declares a tier on action "
+                    f"{action!r}; tiers only apply to kept parameters"
+                )
 
         for flag, per_surface in policy.get("parameters", {}).items():
             if flag not in known_flags:
@@ -317,71 +381,30 @@ class ParameterCatalog:
                     "parameter catalog, bindingOnly, or cliOnlyParameters)"
                 )
             for surface, decision in per_surface.items():
-                if surface not in surfaces:
-                    raise RuntimeError(
-                        f"policy for {flag} names unknown surface {surface!r}; "
-                        f"declared surfaces: {sorted(surfaces)}"
-                    )
-                action = decision.get("action")
-                if action not in actions:
-                    raise RuntimeError(
-                        f"policy for {flag}/{surface} has unknown action "
-                        f"{action!r}; declared actions: {sorted(actions)}"
-                    )
-                if action != "keep" and not decision.get("replacement"):
-                    raise RuntimeError(
-                        f"policy for {flag}/{surface} ({action}) is missing "
-                        "the required replacement guidance"
-                    )
-                if action == "alias" and not decision.get("aliasOf"):
-                    raise RuntimeError(
-                        f"policy for {flag}/{surface} is an alias but is "
-                        "missing aliasOf"
-                    )
-                if action == "alias" and decision.get("aliasOf") not in known_flags:
-                    raise RuntimeError(
-                        f"policy for {flag}/{surface} aliases unknown flag "
-                        f"{decision.get('aliasOf')!r}"
-                    )
+                check_decision(flag, surface, decision)
 
-        # Everything a generated surface already hides must be policy-hidden;
-        # the policy is the umbrella, hiddenBindings the implementation.
-        for language, hidden in self.hidden_bindings.items():
-            for flag in sorted(hidden):
-                decision = (
-                    policy.get("parameters", {}).get(flag, {}).get(language, {})
-                )
-                if decision.get("action") != "hide":
+        # Group rules: every listed flag must exist, decisions must validate,
+        # and no two groups may decide the same (flag, surface) -- silent
+        # shadowing between groups would make the resolution order-dependent.
+        claimed: dict[tuple[str, str], str] = {}
+        for group_name, group in policy.get("groups", {}).items():
+            group_flags = group.get("parameters", [])
+            if not group_flags:
+                raise RuntimeError(f"policy group {group_name!r} lists no parameters")
+            decision_surfaces = [key for key in group if key != "parameters"]
+            for flag in group_flags:
+                if flag not in known_flags:
                     raise RuntimeError(
-                        f"hiddenBindings.{language} hides {flag} but the policy "
-                        f"does not declare {language}: hide for it"
+                        f"policy group {group_name!r} lists unknown flag {flag!r}"
                     )
-
-    def _validate_tiers(self) -> None:
-        # Fail loud on typos: every tier entry must name a real catalog flag,
-        # and only the known tier names are accepted. A silently dropped tier
-        # entry would put a parameter in the wrong 3.0 signature.
-        known_flags = {param.flag for param in self.parameters}
-        for language, tiers in self.overrides.get("tiers", {}).items():
-            unknown_tiers = set(tiers) - {"common"}
-            if unknown_tiers:
-                raise RuntimeError(
-                    f"Unknown tier name(s) for {language}: {sorted(unknown_tiers)}; "
-                    "only 'common' is declared (everything else is advanced)"
-                )
-            missing = sorted(set(tiers.get("common", [])) - known_flags)
-            if missing:
-                raise RuntimeError(
-                    f"tiers.{language}.common lists flag(s) not in the "
-                    f"parameter catalog: {missing}"
-                )
-        for language, notes in self.overrides.get("apiNotes", {}).items():
-            missing = sorted(set(notes.get("inertWithoutOutputDir", [])) - known_flags)
-            if missing:
-                raise RuntimeError(
-                    f"apiNotes.{language}.inertWithoutOutputDir lists flag(s) "
-                    f"not in the parameter catalog: {missing}"
-                )
+                for surface in decision_surfaces:
+                    check_decision(flag, surface, group[surface])
+                    previous = claimed.setdefault((flag, surface), group_name)
+                    if previous != group_name:
+                        raise RuntimeError(
+                            f"policy groups {previous!r} and {group_name!r} both "
+                            f"decide {flag}/{surface}"
+                        )
 
     def grouped(self) -> dict[str, list[Parameter]]:
         return {

--- a/scripts/render_parameter_policy.py
+++ b/scripts/render_parameter_policy.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Render the 3.0 parameter-policy surface matrix (issue #755) as Markdown.
+
+Reads the same inputs as the binding generator -- the C++ parameter catalog
+(``./Infomap --print-json-parameters``) and ``interfaces/parameters/
+overrides.json`` -- and prints one row per parameter with its policy decision
+on every surface. Replacement guidance is listed below the table, one bullet
+per non-keep decision, so every removed or hidden parameter documents its
+migration path (the #755 acceptance criterion).
+
+Usage:  python scripts/render_parameter_policy.py [--binary ./Infomap]
+        (or: make print-parameter-policy)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from parameter_catalog import GROUPS, ParameterCatalog  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OVERRIDES_PATH = REPO_ROOT / "interfaces" / "parameters" / "overrides.json"
+
+SURFACE_LABELS = {"cli": "CLI", "python": "Python", "r": "R", "ts": "JS"}
+
+
+def load_catalog(binary: str) -> ParameterCatalog:
+    output = subprocess.run(
+        [binary, "--print-json-parameters"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    parameters = json.loads(output)["parameters"]
+    overrides = json.loads(OVERRIDES_PATH.read_text(encoding="utf-8"))
+    return ParameterCatalog(parameters, overrides)
+
+
+def format_action(decision: dict[str, str]) -> str:
+    action = decision["action"]
+    if action == "alias":
+        return f"alias of `{decision['aliasOf']}`"
+    return action
+
+
+def render(catalog: ParameterCatalog) -> str:
+    policy = catalog.overrides.get("policy", {})
+    surfaces = policy.get("surfaces", ["cli", "python", "r", "ts"])
+    lines: list[str] = []
+    notes: list[str] = []
+
+    lines.append("# Infomap 3.0 parameter policy (#755)")
+    lines.append("")
+    lines.append("Actions: " + "; ".join(
+        f"**{name}** = {text}" for name, text in policy.get("vocabulary", {}).items()
+    ))
+    lines.append("")
+    header = "| Parameter | Group | " + " | ".join(
+        SURFACE_LABELS[s] for s in surfaces
+    ) + " |"
+    lines.append(header)
+    lines.append("|" + "---|" * (2 + len(surfaces)))
+
+    def add_row(flag: str, group: str, decisions: dict[str, dict[str, str]]) -> None:
+        cells = []
+        for surface in surfaces:
+            decision = decisions[surface]
+            cell = format_action(decision)
+            if decision["action"] != "keep":
+                cell = f"**{cell}**"
+                notes.append(
+                    f"- `{flag}` ({SURFACE_LABELS[surface]}, "
+                    f"{decision['action']}): {decision['replacement']}"
+                )
+            cells.append(cell)
+        lines.append(f"| `{flag}` | {group} | " + " | ".join(cells) + " |")
+
+    for group in GROUPS:
+        for param in catalog.grouped()[group]:
+            add_row(
+                param.flag,
+                group,
+                {surface: param.policy(surface) for surface in surfaces},
+            )
+
+    # Parameters outside the C++ binding catalog: binding-only compatibility
+    # parameters and hidden CLI-only flags still need policy rows.
+    extra_flags: dict[str, str] = {}
+    for language, entries in catalog.binding_only_parameters.items():
+        for entry in entries:
+            if entry.flag.startswith("--") and entry.flag not in extra_flags:
+                extra_flags[entry.flag] = f"bindingOnly ({language})"
+    for flag in policy.get("cliOnlyParameters", []):
+        extra_flags.setdefault(flag, "CLI-only (hidden)")
+
+    parameters_policy = policy.get("parameters", {})
+    default_action = {"action": policy.get("default", "keep")}
+    for flag, group in sorted(extra_flags.items()):
+        add_row(
+            flag,
+            group,
+            {
+                surface: parameters_policy.get(flag, {}).get(surface, default_action)
+                for surface in surfaces
+            },
+        )
+
+    lines.append("")
+    lines.append("## Replacement guidance")
+    lines.append("")
+    lines.extend(notes)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--binary", default=str(REPO_ROOT / "Infomap"))
+    args = parser.parse_args()
+    print(render(load_catalog(args.binary)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/render_parameter_policy.py
+++ b/scripts/render_parameter_policy.py
@@ -22,7 +22,11 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from parameter_catalog import GROUPS, ParameterCatalog  # noqa: E402
+from parameter_catalog import (  # noqa: E402
+    GROUPS,
+    ParameterCatalog,
+    resolve_policy_decision,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 OVERRIDES_PATH = REPO_ROOT / "interfaces" / "parameters" / "overrides.json"
@@ -67,11 +71,21 @@ def render(catalog: ParameterCatalog) -> str:
     lines.append(header)
     lines.append("|" + "---|" * (2 + len(surfaces)))
 
-    def add_row(flag: str, group: str, decisions: dict[str, dict[str, str]]) -> None:
+    def add_row(
+        flag: str,
+        group: str,
+        decisions: dict[str, dict[str, str]],
+        exists_on: set[str],
+    ) -> None:
         cells = []
         for surface in surfaces:
+            if surface not in exists_on:
+                cells.append("—")
+                continue
             decision = decisions[surface]
             cell = format_action(decision)
+            if decision.get("tier") == "common":
+                cell += " (common tier)"
             if decision["action"] != "keep":
                 cell = f"**{cell}**"
                 notes.append(
@@ -81,34 +95,42 @@ def render(catalog: ParameterCatalog) -> str:
             cells.append(cell)
         lines.append(f"| `{flag}` | {group} | " + " | ".join(cells) + " |")
 
+    all_surfaces = set(surfaces)
     for group in GROUPS:
         for param in catalog.grouped()[group]:
             add_row(
                 param.flag,
                 group,
                 {surface: param.policy(surface) for surface in surfaces},
+                exists_on=all_surfaces,
             )
 
-    # Parameters outside the C++ binding catalog: binding-only compatibility
-    # parameters and hidden CLI-only flags still need policy rows.
-    extra_flags: dict[str, str] = {}
+    # Parameters outside the C++ binding catalog exist only where declared:
+    # binding-only compatibility parameters on their languages (they are also
+    # real CLI flags -- accepted, erroring, or hidden), and CLI-only flags on
+    # the CLI alone. Other cells render as "—".
+    extra_flags: dict[str, tuple[str, set[str]]] = {}
     for language, entries in catalog.binding_only_parameters.items():
         for entry in entries:
-            if entry.flag.startswith("--") and entry.flag not in extra_flags:
-                extra_flags[entry.flag] = f"bindingOnly ({language})"
+            if not entry.flag.startswith("--"):
+                continue
+            group_label, exists_on = extra_flags.get(
+                entry.flag, ("bindingOnly", {"cli"})
+            )
+            exists_on = exists_on | {language}
+            extra_flags[entry.flag] = (group_label, exists_on)
     for flag in policy.get("cliOnlyParameters", []):
-        extra_flags.setdefault(flag, "CLI-only (hidden)")
+        extra_flags.setdefault(flag, ("CLI-only (hidden)", {"cli"}))
 
-    parameters_policy = policy.get("parameters", {})
-    default_action = {"action": policy.get("default", "keep")}
-    for flag, group in sorted(extra_flags.items()):
+    for flag, (group_label, exists_on) in sorted(extra_flags.items()):
         add_row(
             flag,
-            group,
+            group_label,
             {
-                surface: parameters_policy.get(flag, {}).get(surface, default_action)
+                surface: resolve_policy_decision(catalog.overrides, flag, surface)
                 for surface in surfaces
             },
+            exists_on=exists_on,
         )
 
     lines.append("")

--- a/src/io/ParameterCatalog.cpp
+++ b/src/io/ParameterCatalog.cpp
@@ -23,29 +23,6 @@ namespace infomap {
 
 namespace {
 
-  bool isFloatingPointArgument(const ParameterSpec& parameter)
-  {
-    return parameter.argumentName == ArgType::number || parameter.argumentName == ArgType::probability;
-  }
-
-  std::string numericBindingDefault(const ParameterSpec& parameter)
-  {
-    auto value = parameter.defaultValue;
-    if (isFloatingPointArgument(parameter) && value.find_first_of(".eE") == std::string::npos) {
-      value += ".0";
-    }
-    return value;
-  }
-
-  std::string rBindingDefault(const ParameterSpec& parameter)
-  {
-    auto value = numericBindingDefault(parameter);
-    if (parameter.argumentName == ArgType::integer) {
-      value += "L";
-    }
-    return value;
-  }
-
   template <typename T>
   void registerOptionForTarget(ProgramInterface& api, T& target, const ParameterSpec& parameter);
 
@@ -131,37 +108,9 @@ namespace {
       return *this;
     }
 
-    SpecBuilder& bindingNames(std::string pythonName, std::string rName, std::string tsName)
-    {
-      parameter_.pythonName = std::move(pythonName);
-      parameter_.rName = std::move(rName);
-      parameter_.tsName = std::move(tsName);
-      return *this;
-    }
-
     SpecBuilder& renderPolicy(std::string value)
     {
       parameter_.renderPolicy = std::move(value);
-      return *this;
-    }
-
-    SpecBuilder& bindingDefaults()
-    {
-      parameter_.pythonDefault = numericBindingDefault(parameter_);
-      parameter_.rDefault = rBindingDefault(parameter_);
-      return *this;
-    }
-
-    SpecBuilder& bindingDefaults(std::string pythonDefault, std::string rDefault)
-    {
-      parameter_.pythonDefault = std::move(pythonDefault);
-      parameter_.rDefault = std::move(rDefault);
-      return *this;
-    }
-
-    SpecBuilder& pythonDoc(std::string value)
-    {
-      parameter_.pythonDocDescription = std::move(value);
       return *this;
     }
 
@@ -459,7 +408,6 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .advanced()
         .defaultValue("1")
         .min("0")
-        .bindingDefaults()
         .configTarget(&Config::metaDataRate),
     param()
         .longName("meta-data-unweighted")
@@ -592,7 +540,6 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .group("Algorithm")
         .defaultValue("false")
         .renderPolicy("directed_alias")
-        .bindingDefaults("None", "NULL")
         .configTarget(&Config::directed),
     param()
         .shortName('e')
@@ -622,7 +569,6 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .advanced()
         .defaultValue("0.15")
         .range("0", "1")
-        .bindingDefaults()
         .configTarget(&Config::teleportationProbability),
     param()
         .longName("max-flow-iterations")
@@ -632,7 +578,6 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .advanced()
         .defaultValue("400")
         .min("1")
-        .bindingDefaults()
         .configTarget(&Config::maxFlowIterations),
     param()
         .longName("min-flow-iterations")
@@ -642,7 +587,6 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .advanced()
         .defaultValue("50")
         .min("0")
-        .bindingDefaults()
         .configTarget(&Config::minFlowIterations),
     param()
         .longName("flow-tolerance")
@@ -652,7 +596,6 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .advanced()
         .defaultValue("1e-15")
         .min("0")
-        .bindingDefaults()
         .configTarget(&Config::flowTolerance),
     param()
         .longName("regularized")
@@ -668,7 +611,6 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .advanced()
         .defaultValue("1")
         .min("0")
-        .bindingDefaults()
         .configTarget(&Config::regularizationStrength),
     param()
         .longName("entropy-corrected")
@@ -683,7 +625,6 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .group("Algorithm")
         .advanced()
         .defaultValue("1")
-        .bindingDefaults()
         .configTarget(&Config::entropyBiasCorrectionMultiplier),
     param()
         .longName("markov-time")
@@ -693,7 +634,6 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .advanced()
         .defaultValue("1")
         .min("0")
-        .bindingDefaults()
         .configTarget(&Config::markovTime),
     param()
         .longName("variable-markov-time")
@@ -708,7 +648,6 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .group("Algorithm")
         .advanced()
         .defaultValue("1")
-        .bindingDefaults()
         .configTarget(&Config::variableMarkovTimeDamping),
     param()
         .longName("variable-markov-min-scale")
@@ -717,7 +656,6 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .group("Algorithm")
         .advanced()
         .defaultValue("1")
-        .bindingDefaults()
         .configTarget(&Config::variableMarkovTimeMinLocalScale),
     param()
         .longName("preferred-number-of-modules")
@@ -745,7 +683,6 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .advanced()
         .defaultValue("1")
         .min("0")
-        .bindingDefaults()
         .configTarget(&Config::preferredNumberOfLevelsStrength),
     param()
         .longName("multilayer-relax-rate")
@@ -755,7 +692,6 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .advanced()
         .defaultValue("0.15")
         .range("0", "1")
-        .bindingDefaults()
         .configTarget(&Config::multilayerRelaxRate),
     param()
         .longName("multilayer-relax-limit")
@@ -764,7 +700,6 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .group("Algorithm")
         .advanced()
         .defaultValue("-1")
-        .bindingDefaults("-1", "NULL")
         .configTarget(&Config::multilayerRelaxLimit),
     param()
         .longName("multilayer-relax-limit-up")
@@ -773,7 +708,6 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .group("Algorithm")
         .advanced()
         .defaultValue("-1")
-        .bindingDefaults("-1", "NULL")
         .configTarget(&Config::multilayerRelaxLimitUp),
     param()
         .longName("multilayer-relax-limit-down")
@@ -782,7 +716,6 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .group("Algorithm")
         .advanced()
         .defaultValue("-1")
-        .bindingDefaults("-1", "NULL")
         .configTarget(&Config::multilayerRelaxLimitDown),
     param()
         .longName("multilayer-relax-by-jsd")
@@ -804,7 +737,6 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .group("Accuracy")
         .defaultValue("123")
         .min("1")
-        .bindingDefaults()
         .configTarget(&Config::seedToRandomNumberGenerator),
     param()
         .shortName('N')
@@ -814,7 +746,6 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .group("Accuracy")
         .defaultValue("1")
         .min("1")
-        .bindingDefaults()
         .configTarget(&Config::numTrials),
     param()
         .shortName('M')
@@ -825,7 +756,6 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .advanced()
         .defaultValue("10")
         .min("1")
-        .bindingDefaults()
         .configTarget(&Config::coreLoopLimit),
     param()
         .shortName('L')
@@ -855,7 +785,6 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .advanced()
         .defaultValue("1e-10")
         .min("0")
-        .bindingDefaults()
         .configTarget(&Config::minimumCodelengthImprovement),
     param()
         .longName("tune-iteration-relative-threshold")
@@ -865,7 +794,6 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .advanced()
         .defaultValue("1e-05")
         .min("0")
-        .bindingDefaults()
         .configTarget(&Config::minimumRelativeTuneIterationImprovement),
     param()
         .shortName('F')
@@ -876,8 +804,6 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .incremental()
         .defaultValue("false")
         .renderPolicy("repeated_short")
-        .bindingDefaults("None", "NULL")
-        .pythonDoc("Find top modules fast. Use 2 to keep all fast levels and 3 to skip the recursive part.")
         .incrementalTarget(&Config::fastHierarchicalSolution),
     param()
         .longName("inner-parallelization")
@@ -949,7 +875,6 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .advanced()
         .defaultValue("1")
         .min("0")
-        .bindingDefaults()
         .configTarget(&Config::lossyLambda),
 #endif
 #if INFOMAP_FEATURE_TEST_FEATURE
@@ -997,17 +922,12 @@ const std::vector<ParameterSpec>& parameterCatalog()
         .group("Output")
         .incremental()
         .defaultValue("false")
-        .bindingNames("verbosity_level", "verbosity_level", "verbose")
         .renderPolicy("repeated_short")
-        .bindingDefaults("1", "1L")
-        .pythonDoc("Verbosity level on the console. 1 keeps the default output level, 2 renders -vv and so on.")
         .incrementalTarget(&Config::verbosity),
     param()
         .longName("silent")
         .description("Suppress console output.")
         .group("Output")
-        .bindingDefaults("True", "FALSE")
-        .pythonDoc("Suppress console output. The Python API is quiet by default; construct with silent=False for the engine log. The command-line interface is unaffected.")
         .configTarget(&Config::silent),
     param()
         .longName("pretty")
@@ -1072,36 +992,8 @@ std::string parameterCatalogJson()
     if (!parameter.maxValue.empty()) {
       item["max"] = parameter.maxValue;
     }
-    if (!parameter.pythonName.empty() || !parameter.rName.empty() || !parameter.tsName.empty()) {
-      Json bindingNames;
-      if (!parameter.pythonName.empty()) {
-        bindingNames["python"] = parameter.pythonName;
-      }
-      if (!parameter.rName.empty()) {
-        bindingNames["r"] = parameter.rName;
-      }
-      if (!parameter.tsName.empty()) {
-        bindingNames["ts"] = parameter.tsName;
-      }
-      item["bindingNames"] = std::move(bindingNames);
-    }
     if (!parameter.renderPolicy.empty()) {
       item["renderPolicy"] = parameter.renderPolicy;
-    }
-    if (!parameter.pythonDocDescription.empty()) {
-      Json bindingDocs;
-      bindingDocs["python"]["description"] = parameter.pythonDocDescription;
-      item["bindingDocs"] = std::move(bindingDocs);
-    }
-    if (!parameter.pythonDefault.empty() || !parameter.rDefault.empty()) {
-      Json bindingDefaults;
-      if (!parameter.pythonDefault.empty()) {
-        bindingDefaults["python"]["value"] = parameter.pythonDefault;
-      }
-      if (!parameter.rDefault.empty()) {
-        bindingDefaults["r"]["value"] = parameter.rDefault;
-      }
-      item["bindingDefaults"] = std::move(bindingDefaults);
     }
     parameters.push_back(std::move(item));
   }

--- a/src/io/ParameterCatalog.h
+++ b/src/io/ParameterCatalog.h
@@ -44,13 +44,7 @@ struct ParameterSpec {
   std::string minValue;
   std::string maxValue;
   std::vector<std::string> choices;
-  std::string pythonName;
-  std::string rName;
-  std::string tsName;
   std::string renderPolicy;
-  std::string pythonDefault;
-  std::string rDefault;
-  std::string pythonDocDescription;
   bool cliOnly = false;
   bool libraryOnly = false;
   bool includeInJson = true;

--- a/test/cpp/test_config.cpp
+++ b/test/cpp/test_config.cpp
@@ -522,7 +522,7 @@ TEST_CASE("Output plan applies trial suffix before format suffix [fast][core][co
   CHECK(artifacts.front().filename == "out/network_trial_2.tree");
 }
 
-TEST_CASE("Parameter catalog owns option choices and binding names [fast][core][config][cli]")
+TEST_CASE("Parameter catalog owns option choices and render policy [fast][core][config][cli]")
 {
   const infomap::ParameterSpec* output = nullptr;
   const infomap::ParameterSpec* verbose = nullptr;
@@ -547,10 +547,10 @@ TEST_CASE("Parameter catalog owns option choices and binding names [fast][core][
   CHECK(output->choices == infomap::outputFormatNames());
   CHECK(output->renderPolicy == "comma_list");
 
+  // Binding names/defaults/docs live in interfaces/parameters/overrides.json,
+  // not the engine catalog; the catalog owns only engine-level metadata and
+  // the render policy the generator keys on.
   REQUIRE(verbose != nullptr);
-  CHECK(verbose->pythonName == "verbosity_level");
-  CHECK(verbose->rName == "verbosity_level");
-  CHECK(verbose->tsName == "verbose");
   CHECK(verbose->renderPolicy == "repeated_short");
 
   REQUIRE(teleportation != nullptr);

--- a/test/python/test_docs_examples_surface.py
+++ b/test/python/test_docs_examples_surface.py
@@ -114,7 +114,12 @@ def _load_common_tier() -> set[str]:
             encoding="utf-8"
         )
     )
-    flags = overrides["tiers"]["python"]["common"]
+    flags = [
+        flag
+        for flag, per_surface in overrides["policy"]["parameters"].items()
+        if per_surface.get("python", {}).get("tier") == "common"
+    ]
+    assert flags, "no common-tier parameters found in the policy"
     return {flag.removeprefix("--").replace("-", "_") for flag in flags}
 
 

--- a/test/python/test_parameter_catalog.py
+++ b/test/python/test_parameter_catalog.py
@@ -134,13 +134,24 @@ def _minimal_param(flag, group="Accuracy", **extra):
     return param
 
 
-def test_parameter_tier_defaults_to_advanced_and_reads_overrides():
+def _tier_policy(*flags):
+    return {
+        "vocabulary": {"keep": "keep"},
+        "surfaces": ["cli", "python", "r", "ts"],
+        "default": "keep",
+        "parameters": {
+            flag: {"python": {"action": "keep", "tier": "common"}} for flag in flags
+        },
+    }
+
+
+def test_parameter_tier_defaults_to_advanced_and_reads_policy():
     parameters = [
         _minimal_param("--seed", required=True, longType="integer"),
         _minimal_param("--two-level"),
         _minimal_param("--core-loop-limit", required=True, longType="integer"),
     ]
-    overrides = {"tiers": {"python": {"common": ["--seed", "--two-level"]}}}
+    overrides = {"policy": _tier_policy("--seed", "--two-level")}
 
     catalog = ParameterCatalog(parameters, overrides)
     tiers = {param.flag: param.tier("python") for param in catalog.parameters}
@@ -150,7 +161,7 @@ def test_parameter_tier_defaults_to_advanced_and_reads_overrides():
         "--two-level": "common",
         "--core-loop-limit": "advanced",
     }
-    # Tier declarations are per language; an undeclared language is all-advanced.
+    # Tier declarations are per surface; an undeclared surface is all-advanced.
     assert all(param.tier("r") == "advanced" for param in catalog.parameters)
 
 
@@ -158,7 +169,7 @@ def test_parameter_catalog_rejects_unknown_tier_flag():
     import pytest
 
     parameters = [_minimal_param("--seed", required=True, longType="integer")]
-    overrides = {"tiers": {"python": {"common": ["--seeed"]}}}
+    overrides = {"policy": _tier_policy("--seeed")}
 
     with pytest.raises(RuntimeError, match=r"--seeed"):
         ParameterCatalog(parameters, overrides)
@@ -168,7 +179,8 @@ def test_parameter_catalog_rejects_unknown_tier_name():
     import pytest
 
     parameters = [_minimal_param("--seed", required=True, longType="integer")]
-    overrides = {"tiers": {"python": {"comon": ["--seed"]}}}
+    overrides = {"policy": _tier_policy("--seed")}
+    overrides["policy"]["parameters"]["--seed"]["python"]["tier"] = "comon"
 
     with pytest.raises(RuntimeError, match="comon"):
         ParameterCatalog(parameters, overrides)
@@ -182,10 +194,11 @@ def test_python_common_tier_matches_issue_738_decision(test_paths):
         .read_text(encoding="utf-8")
     )
 
-    assert overrides["tiers"]["python"]["common"] == [
-        "--seed",
-        "--num-trials",
-        "--two-level",
-        "--directed",
-        "--markov-time",
-    ]
+    common = sorted(
+        flag
+        for flag, per_surface in overrides["policy"]["parameters"].items()
+        if per_surface.get("python", {}).get("tier") == "common"
+    )
+    assert common == sorted(
+        ["--seed", "--num-trials", "--two-level", "--directed", "--markov-time"]
+    )

--- a/test/python/test_parameter_catalog.py
+++ b/test/python/test_parameter_catalog.py
@@ -74,6 +74,14 @@ def test_parameter_catalog_classifies_binding_render_policies():
         },
     ]
     overrides = {
+        # Surface knowledge (names/defaults/docs) lives in overrides, not the
+        # engine catalog; the accessors read it from here.
+        "names": {"--verbose": {"python": "verbosity_level", "r": "verbosity_level"}},
+        "defaults": {
+            "--num-trials": {"python": "1", "r": "1L"},
+            "--verbose": {"python": "1", "r": "1L"},
+        },
+        "docs": {"--verbose": {"python": "Verbosity level on the console."}},
         "bindingOnly": {
             "python": [
                 {

--- a/test/python/test_parameter_policy.py
+++ b/test/python/test_parameter_policy.py
@@ -1,10 +1,15 @@
 """The 3.0 parameter cleanup policy (#755): schema, validation, coverage.
 
-The policy lives in ``interfaces/parameters/overrides.json`` (``policy``
-section), keyed by CLI flag with one decision per surface (cli/python/r/ts).
-``scripts/parameter_catalog.py`` fail-loud-validates it when the catalog is
-constructed (so the binding generator refuses to run on a broken policy),
-and ``scripts/render_parameter_policy.py`` renders the surface matrix.
+The policy is the single per-parameter, per-surface record in
+``interfaces/parameters/overrides.json``: per-parameter entries take
+precedence over group rules (one decision applied to a parameter list),
+everything else defaults to ``keep``. Tier membership (``tier: common``),
+kwarg inertness (``inertWithoutOutputDir``), and hidden generated surfaces
+(``hide`` decisions) all live on the decisions -- there are no parallel
+sections to keep consistent. ``scripts/parameter_catalog.py``
+fail-loud-validates the policy when the catalog is constructed (so the
+binding generator refuses to run on a broken policy), and
+``scripts/render_parameter_policy.py`` renders the surface matrix.
 
 These tests exercise the validation with the real overrides file plus
 deliberately broken variants, without needing the compiled engine: the
@@ -34,10 +39,15 @@ OVERRIDES = json.loads(
     )
 )
 
-# A minimal stand-in for the C++ catalog: one parameter per policy entry
-# (minus bindingOnly/cliOnly extras) plus a policy-less parameter, enough for
-# the validator to resolve every flag it checks.
-_POLICY_FLAGS = set(OVERRIDES["policy"]["parameters"])
+
+def _policy_flags(overrides: dict) -> set[str]:
+    policy = overrides["policy"]
+    flags = set(policy["parameters"])
+    for group in policy.get("groups", {}).values():
+        flags.update(group.get("parameters", []))
+    return flags
+
+
 _EXTRA_FLAGS = {
     entry["flag"]
     for entries in OVERRIDES.get("bindingOnly", {}).values()
@@ -47,14 +57,9 @@ _EXTRA_FLAGS = {
 
 
 def _fake_parameters() -> list[dict]:
-    # Include everything the other override sections (tiers, apiNotes)
-    # validate against, so their fail-loud checks stay satisfied.
-    tier_flags = {
-        flag
-        for tiers in OVERRIDES.get("tiers", {}).values()
-        for flag in tiers.get("common", [])
-    }
-    flags = sorted((_POLICY_FLAGS - _EXTRA_FLAGS) | tier_flags | {"--seed"})
+    # A minimal stand-in for the C++ catalog: every flag the policy decides
+    # on (minus binding-only/CLI-only extras) plus one policy-less parameter.
+    flags = sorted((_policy_flags(OVERRIDES) - _EXTRA_FLAGS) | {"--core-loop-limit"})
     return [
         {"long": flag, "short": "", "group": "Algorithm", "description": "x"}
         for flag in flags
@@ -68,12 +73,15 @@ def _catalog(overrides: dict) -> ParameterCatalog:
 def test_real_policy_validates_and_defaults_to_keep():
     catalog = _catalog(OVERRIDES)
 
-    seed = next(param for param in catalog.parameters if param.flag == "--seed")
+    plain = next(
+        param for param in catalog.parameters if param.flag == "--core-loop-limit"
+    )
     for surface in OVERRIDES["policy"]["surfaces"]:
-        assert seed.policy(surface) == {"action": "keep"}
+        assert plain.policy(surface) == {"action": "keep"}
+        assert plain.tier(surface) == "advanced"
 
 
-def test_policy_accessor_returns_the_decision():
+def test_per_parameter_decisions_resolve():
     catalog = _catalog(OVERRIDES)
     silent = next(param for param in catalog.parameters if param.flag == "--silent")
 
@@ -82,6 +90,39 @@ def test_policy_accessor_returns_the_decision():
     assert decision["action"] == "remove"
     assert "logging" in decision["replacement"]
     assert silent.policy("cli") == {"action": "keep"}
+
+
+def test_group_rules_resolve_and_carry_attributes():
+    catalog = _catalog(OVERRIDES)
+    tree = next(param for param in catalog.parameters if param.flag == "--tree")
+
+    decision = tree.policy("python")
+
+    assert decision["action"] == "args-only"
+    assert tree.python_inert_without_outdir() is True
+    # Other surfaces are untouched by the group.
+    assert tree.policy("cli") == {"action": "keep"}
+
+
+def test_tier_is_a_policy_attribute():
+    catalog = _catalog(OVERRIDES)
+    seed = next(param for param in catalog.parameters if param.flag == "--seed")
+
+    assert seed.tier("python") == "common"
+    assert seed.tier("r") == "advanced"
+    assert seed.policy("python")["action"] == "keep"
+
+
+def test_hidden_bindings_are_derived_from_hide_decisions():
+    catalog = _catalog(OVERRIDES)
+
+    assert "--num-threads" in catalog.hidden_bindings["ts"]
+    assert "--threads" in catalog.hidden_bindings["ts"]
+    visible = {param.flag for param in catalog.visible_parameters("ts")}
+    assert "--num-threads" not in visible
+    assert "--num-threads" in {
+        param.flag for param in catalog.visible_parameters("python")
+    }
 
 
 def test_unknown_flag_fails_loud():
@@ -132,13 +173,51 @@ def test_alias_requires_a_known_target():
         _catalog(overrides)
 
 
-def test_hidden_bindings_must_be_policy_hidden():
-    # The policy is the umbrella: everything a generated surface already
-    # hides (hiddenBindings) must carry an explicit hide decision.
+def test_unknown_tier_fails_loud():
     overrides = copy.deepcopy(OVERRIDES)
-    del overrides["policy"]["parameters"]["--num-threads"]
+    overrides["policy"]["parameters"]["--seed"]["python"]["tier"] = "premium"
 
-    with pytest.raises(RuntimeError, match=r"hiddenBindings.ts hides --num-threads"):
+    with pytest.raises(RuntimeError, match="unknown tier 'premium'"):
+        _catalog(overrides)
+
+
+def test_tier_on_removed_parameter_fails_loud():
+    overrides = copy.deepcopy(OVERRIDES)
+    overrides["policy"]["parameters"]["--silent"]["python"]["tier"] = "common"
+
+    with pytest.raises(RuntimeError, match="tiers only apply to kept"):
+        _catalog(overrides)
+
+
+def test_cli_only_parameter_rejects_binding_decisions():
+    overrides = copy.deepcopy(OVERRIDES)
+    overrides["policy"]["parameters"]["--pretty"]["python"] = {
+        "action": "remove",
+        "replacement": "x",
+    }
+
+    with pytest.raises(RuntimeError, match="declares it CLI-only"):
+        _catalog(overrides)
+
+
+def test_conflicting_group_claims_fail_loud():
+    overrides = copy.deepcopy(OVERRIDES)
+    overrides["policy"]["groups"]["duplicate"] = {
+        "parameters": ["--tree"],
+        "python": {"action": "remove", "replacement": "x"},
+    }
+
+    with pytest.raises(RuntimeError, match="both decide --tree/python"):
+        _catalog(overrides)
+
+
+def test_group_with_unknown_flag_fails_loud():
+    overrides = copy.deepcopy(OVERRIDES)
+    overrides["policy"]["groups"]["python-output-artifacts"]["parameters"].append(
+        "--bogus"
+    )
+
+    with pytest.raises(RuntimeError, match="unknown flag '--bogus'"):
         _catalog(overrides)
 
 
@@ -150,8 +229,20 @@ def test_matrix_covers_every_parameter_and_replacement():
 
     for param in catalog.parameters:
         assert f"`{param.flag}`" in matrix
+    # Non-existent surface cells render as an em dash, not a fabricated keep.
+    assert "| `--pretty` | CLI-only (hidden) | **remove** | — | — | — |" in matrix
     # Every non-keep decision surfaces its replacement guidance.
-    for flag, per_surface in OVERRIDES["policy"]["parameters"].items():
-        for decision in per_surface.values():
-            if decision["action"] != "keep":
-                assert decision["replacement"] in matrix
+    policy = OVERRIDES["policy"]
+    decisions = [
+        decision
+        for per_surface in policy["parameters"].values()
+        for decision in per_surface.values()
+    ] + [
+        group[surface]
+        for group in policy.get("groups", {}).values()
+        for surface in group
+        if surface != "parameters"
+    ]
+    for decision in decisions:
+        if decision["action"] != "keep":
+            assert decision["replacement"] in matrix

--- a/test/python/test_parameter_policy.py
+++ b/test/python/test_parameter_policy.py
@@ -1,0 +1,157 @@
+"""The 3.0 parameter cleanup policy (#755): schema, validation, coverage.
+
+The policy lives in ``interfaces/parameters/overrides.json`` (``policy``
+section), keyed by CLI flag with one decision per surface (cli/python/r/ts).
+``scripts/parameter_catalog.py`` fail-loud-validates it when the catalog is
+constructed (so the binding generator refuses to run on a broken policy),
+and ``scripts/render_parameter_policy.py`` renders the surface matrix.
+
+These tests exercise the validation with the real overrides file plus
+deliberately broken variants, without needing the compiled engine: the
+catalog is constructed from a minimal parameter list.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.fast
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from parameter_catalog import ParameterCatalog  # noqa: E402
+
+OVERRIDES = json.loads(
+    (REPO_ROOT / "interfaces" / "parameters" / "overrides.json").read_text(
+        encoding="utf-8"
+    )
+)
+
+# A minimal stand-in for the C++ catalog: one parameter per policy entry
+# (minus bindingOnly/cliOnly extras) plus a policy-less parameter, enough for
+# the validator to resolve every flag it checks.
+_POLICY_FLAGS = set(OVERRIDES["policy"]["parameters"])
+_EXTRA_FLAGS = {
+    entry["flag"]
+    for entries in OVERRIDES.get("bindingOnly", {}).values()
+    for entry in entries
+    if entry["flag"].startswith("--")
+} | set(OVERRIDES["policy"].get("cliOnlyParameters", []))
+
+
+def _fake_parameters() -> list[dict]:
+    # Include everything the other override sections (tiers, apiNotes)
+    # validate against, so their fail-loud checks stay satisfied.
+    tier_flags = {
+        flag
+        for tiers in OVERRIDES.get("tiers", {}).values()
+        for flag in tiers.get("common", [])
+    }
+    flags = sorted((_POLICY_FLAGS - _EXTRA_FLAGS) | tier_flags | {"--seed"})
+    return [
+        {"long": flag, "short": "", "group": "Algorithm", "description": "x"}
+        for flag in flags
+    ]
+
+
+def _catalog(overrides: dict) -> ParameterCatalog:
+    return ParameterCatalog(_fake_parameters(), overrides)
+
+
+def test_real_policy_validates_and_defaults_to_keep():
+    catalog = _catalog(OVERRIDES)
+
+    seed = next(param for param in catalog.parameters if param.flag == "--seed")
+    for surface in OVERRIDES["policy"]["surfaces"]:
+        assert seed.policy(surface) == {"action": "keep"}
+
+
+def test_policy_accessor_returns_the_decision():
+    catalog = _catalog(OVERRIDES)
+    silent = next(param for param in catalog.parameters if param.flag == "--silent")
+
+    decision = silent.policy("python")
+
+    assert decision["action"] == "remove"
+    assert "logging" in decision["replacement"]
+    assert silent.policy("cli") == {"action": "keep"}
+
+
+def test_unknown_flag_fails_loud():
+    overrides = copy.deepcopy(OVERRIDES)
+    overrides["policy"]["parameters"]["--not-a-flag"] = {
+        "python": {"action": "remove", "replacement": "x"}
+    }
+
+    with pytest.raises(RuntimeError, match="unknown flag '--not-a-flag'"):
+        _catalog(overrides)
+
+
+def test_unknown_surface_fails_loud():
+    overrides = copy.deepcopy(OVERRIDES)
+    overrides["policy"]["parameters"]["--silent"]["fortran"] = {
+        "action": "remove",
+        "replacement": "x",
+    }
+
+    with pytest.raises(RuntimeError, match="unknown surface 'fortran'"):
+        _catalog(overrides)
+
+
+def test_unknown_action_fails_loud():
+    overrides = copy.deepcopy(OVERRIDES)
+    overrides["policy"]["parameters"]["--silent"]["python"] = {
+        "action": "obliterate",
+        "replacement": "x",
+    }
+
+    with pytest.raises(RuntimeError, match="unknown action 'obliterate'"):
+        _catalog(overrides)
+
+
+def test_non_keep_without_replacement_fails_loud():
+    overrides = copy.deepcopy(OVERRIDES)
+    del overrides["policy"]["parameters"]["--silent"]["python"]["replacement"]
+
+    with pytest.raises(RuntimeError, match="missing the required replacement"):
+        _catalog(overrides)
+
+
+def test_alias_requires_a_known_target():
+    overrides = copy.deepcopy(OVERRIDES)
+    overrides["policy"]["parameters"]["--threads"]["cli"]["aliasOf"] = "--warp-speed"
+
+    with pytest.raises(RuntimeError, match="aliases unknown flag"):
+        _catalog(overrides)
+
+
+def test_hidden_bindings_must_be_policy_hidden():
+    # The policy is the umbrella: everything a generated surface already
+    # hides (hiddenBindings) must carry an explicit hide decision.
+    overrides = copy.deepcopy(OVERRIDES)
+    del overrides["policy"]["parameters"]["--num-threads"]
+
+    with pytest.raises(RuntimeError, match=r"hiddenBindings.ts hides --num-threads"):
+        _catalog(overrides)
+
+
+def test_matrix_covers_every_parameter_and_replacement():
+    from render_parameter_policy import render
+
+    catalog = _catalog(OVERRIDES)
+    matrix = render(catalog)
+
+    for param in catalog.parameters:
+        assert f"`{param.flag}`" in matrix
+    # Every non-keep decision surfaces its replacement guidance.
+    for flag, per_surface in OVERRIDES["policy"]["parameters"].items():
+        for decision in per_surface.values():
+            if decision["action"] != "keep":
+                assert decision["replacement"] in matrix

--- a/test/scripts/check_print_json_parameters.py
+++ b/test/scripts/check_print_json_parameters.py
@@ -51,27 +51,17 @@ def main() -> int:
         "states",
         "flow",
     ]
-    assert by_long["--verbose"]["bindingNames"]["python"] == "verbosity_level"
-    assert by_long["--verbose"]["bindingNames"]["r"] == "verbosity_level"
-    assert by_long["--verbose"]["bindingNames"]["ts"] == "verbose"
     assert by_long["--verbose"]["renderPolicy"] == "repeated_short"
-    assert by_long["--verbose"]["bindingDocs"]["python"]["description"].startswith(
-        "Verbosity level on the console."
-    )
-    assert by_long["--verbose"]["bindingDefaults"]["python"] == {"value": "1"}
-    assert by_long["--verbose"]["bindingDefaults"]["r"] == {"value": "1L"}
     assert by_long["--output"]["renderPolicy"] == "comma_list"
-    assert by_long["--fast-hierarchical-solution"]["bindingDocs"]["python"][
-        "description"
-    ].startswith("Find top modules fast.")
-    assert by_long["--teleportation-probability"]["bindingDefaults"]["python"] == {
-        "value": "0.15"
-    }
     assert by_long["--teleportation-probability"]["min"] == "0"
     assert by_long["--teleportation-probability"]["max"] == "1"
-    assert by_long["--directed"]["bindingDefaults"]["python"]["value"] == "None"
     assert by_long["--num-trials"]["min"] == "1"
-    assert by_long["--num-trials"]["bindingDefaults"]["r"]["value"] == "1L"
+    # Binding names/defaults/docs are surface knowledge and live in
+    # interfaces/parameters/overrides.json, not the engine's JSON catalog.
+    for parameter in by_long.values():
+        assert "bindingNames" not in parameter
+        assert "bindingDefaults" not in parameter
+        assert "bindingDocs" not in parameter
     assert by_long["--parallel-trials"]["group"] == "Accuracy"
     assert by_long["--parallel-trials"]["advanced"]
     assert not by_long["--parallel-trials"]["required"]


### PR DESCRIPTION
# Summary

Implements the machinery half of #755 and lands the classification as a **reviewable proposal**: the shared 3.0 parameter cleanup policy is data in `interfaces/parameters/overrides.json`, validated fail-loud on every generator run, and renderable as the surface matrix ([posted on the issue](https://github.com/mapequation/infomap/issues/755#issuecomment-4919612117)).

**After a design review of the whole parameter pipeline, the second commit consolidates the overrides file so the policy is the single per-parameter record** — the file previously carried five parallel sections (`hiddenBindings`, `bindingOnly`, `tiers`, `apiNotes`, `policy`) with overlapping semantics, kept consistent only by pairwise validation. Now:

- **Two sections remain**: `bindingOnly` (declares surface *existence*, not a decision) and `policy` (every *decision*).
- `tiers.python.common` → a `tier: "common"` attribute on the keep decision (only valid on keep/alias).
- `hiddenBindings` → **derived** from `hide` decisions; the binding generator and the JS metadata generator read the policy. The `hide` vocabulary is sharpened: it takes effect on regeneration, so it is only valid for parameters not currently exposed (removing an exposed parameter is `remove`, with its 2.x deprecation courtesy).
- `apiNotes.python.inertWithoutOutputDir` → an `inertWithoutOutputDir` attribute on the args-only decisions.
- **Group rules** (`policy.groups`): one decision applied to a parameter list — the 10× repeated output-artifact replacement text and the 7 JS single-threaded-worker hides are each one rule now. Per-parameter entries override groups; two groups deciding the same (flag, surface) fail loud.
- The rendered matrix is **existence-aware**: surfaces where a parameter does not exist show `—` instead of a fabricated keep, and common-tier membership is annotated on the cell.

## Schema

One decision per parameter per surface (`cli`/`python`/`r`/`ts`), vocabulary `keep / alias / deprecate / remove / args-only / hide`, default `keep`, mandatory replacement guidance for every non-keep decision (`aliasOf` for aliases). Validation (runs whenever the catalog is constructed, i.e. every `make build-binding-options`): unknown flag/surface/action/tier, removal without replacement, alias without known target, tier on a non-kept parameter, decisions on surfaces a CLI-only flag doesn't exist on, and conflicting group claims all raise. `Parameter.policy(surface)` is the accessor the 3.0 generator branches (#747/#748, #756–#758) consume.

## Proposed classifications

22 parameters deviate from keep, encoding the decisions already taken on the roadmap: Python output-artifact flags → `args-only` (inert via kwargs per the #748 analysis; `Result.write_*`/`Network.write_*` from #760 are the file path), `--silent`/`--verbose` leave the Python surface (#745 logging), `--threads`/`--include-self-links`/`--pretty` removed, `--print-config-fingerprint` stays a CLI diagnostic, and the seven JS thread/sharding hides are formalized. R mirrors Python only where verified and defers to #757 elsewhere; the native CLI keeps full parity everywhere except the already-dead flags. **The cells are yours to flip** — edit `overrides.json`, validation keeps it coherent, `make print-parameter-policy` regenerates the matrix.

Part of #755

# Verification

- `pytest test/python`: 607 passed, 2 skipped — 16 tests in `test_parameter_policy.py` pin the schema, group resolution/precedence, derived hides, tier/inert attributes, and every fail-loud path; the existing tier tests in `test_parameter_catalog.py` are ported to the policy schema
- `make build-binding-options && make test-binding-options-freshness`: green — generated Python/R/TS surfaces **byte-identical** across the consolidation (tier, inertness, and hidden-binding reads were repointed with zero output change)
- `make build-js-metadata && make test-js-metadata`: green — the JS metadata generator now derives hides from the policy, byte-identical output
- `make print-parameter-policy`: renders the existence-aware matrix
- `make test-python-doctest` (38 + ruff): green

# Notes

- The `deprecate` action is deliberately soft ("2.x deprecation; the surface's cleanup issue decides removal") — used for the open R calls so #757 isn't pre-empted.
- Remaining known debt (deliberately out of scope, can be taken incrementally): surface-specific data still living in `ParameterCatalog.cpp` (`pythonDoc`, `bindingNames`, `bindingDefaults`) — `bindingDefaults` has a defensible home there (derived from the typed C++ defaults), `pythonDoc` is pure surface text that could move to overrides.
- #759 (the final API contract) consumes this matrix as its parameter-surface input.