### PR TITLE
Python API: review fixes, adapter-surface cleanup, and parameter-catalog guards

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,15 @@ if(BUILD_TESTING)
     set_tests_properties(print_json_parameters PROPERTIES LABELS "fast;core;parser;cli")
 
     add_test(
+        NAME binding_defaults
+        COMMAND
+            "${Python3_EXECUTABLE}"
+            "${CMAKE_CURRENT_SOURCE_DIR}/test/scripts/check_binding_defaults.py"
+            "$<TARGET_FILE:infomap_cli>"
+    )
+    set_tests_properties(binding_defaults PROPERTIES LABELS "fast;core;parser;cli")
+
+    add_test(
         NAME shell_completion
         COMMAND
             "${Python3_EXECUTABLE}"

--- a/examples/notebooks/_support.py
+++ b/examples/notebooks/_support.py
@@ -3,7 +3,7 @@ from matplotlib import cm
 from matplotlib import colors as mpl_colors
 from pathlib import Path
 
-from infomap.io.networkx import run_networkx
+from infomap.io.networkx import _run_networkx
 import matplotlib.pyplot as plt
 import networkx as nx
 import numpy as np
@@ -142,7 +142,7 @@ def _module_series(infomap_result, node_mapping):
 
 
 def partition(G, initial_partition=None, **infomap_args):
-    im, node_mapping = run_networkx(
+    im, node_mapping = _run_networkx(
         G,
         initial_partition=initial_partition,
         **infomap_args,

--- a/interfaces/python/source/api/deprecations.rst
+++ b/interfaces/python/source/api/deprecations.rst
@@ -1,0 +1,63 @@
+Deprecation policy
+==================
+
+.. currentmodule:: infomap
+
+Infomap's Python API follows a predictable deprecation contract so you can rely
+on it across releases. Nothing listed here is removed before 3.0; until then
+the old spelling keeps working, and the reference docs mark each deprecated name
+with the release it was deprecated in.
+
+Signature tiers
+---------------
+
+The keyword arguments on :class:`Infomap` and :meth:`Infomap.run` are split into
+two tiers:
+
+- **Common tier** — the handful of options most runs touch (``seed``,
+  ``num_trials``, ``two_level``, ``directed``, ``markov_time``). These stay on
+  the :class:`Infomap` signatures.
+- **Advanced tier** — the long tail of tuning and I/O options. From 2.15 these
+  are ``.. deprecated::`` on the :class:`Infomap` signatures and leave them in
+  3.0. Pass them through :class:`Options` instead::
+
+      import infomap
+
+      options = infomap.Options(regularized=True, flow_tolerance=1e-12)
+      result = infomap.run("network.net", options=options)
+
+  The same :class:`Options` object works with :meth:`Network.run`. Every option
+  remains available — only its *entry point* moves from a per-call keyword to
+  :class:`Options`.
+
+The advanced-tier deprecations are documentation-only: no runtime warning fires,
+so existing code keeps running unchanged until 3.0.
+
+Redesigned result access
+-------------------------
+
+The stateful accessors on :class:`Infomap` (``get_modules``, ``codelength``,
+``num_top_modules``, and friends) are ``.. deprecated:: 2.14`` in favour of the
+immutable :class:`Result` that :func:`run` and :meth:`Infomap.run` return. Read
+scalars as properties (``result.codelength``) and collections as methods
+(``result.modules()``, ``result.nodes()``, ``result.tree()``). See
+:doc:`/working-with-infomap/results-and-iteration`.
+
+Compatibility aliases
+---------------------
+
+- ``include_self_links`` is a deprecated alias kept for backward compatibility.
+  Self-links are included by default; pass ``no_self_links=True`` to exclude
+  them. Passing ``include_self_links`` explicitly emits a
+  :class:`DeprecationWarning`.
+- ``pretty`` is a deprecated no-op — pretty console output is always on. Passing
+  it explicitly emits a :class:`DeprecationWarning`.
+
+Error base classes
+------------------
+
+Through 2.x, :class:`InfomapError` inherits :class:`RuntimeError` and
+:class:`NotRunError` also keeps :class:`ValueError` in its MRO, so pre-taxonomy
+``except RuntimeError`` / ``except ValueError`` code keeps working. These legacy
+bases detach in 3.0 — catch :class:`InfomapError` (or a subclass) instead. See
+:doc:`errors`.

--- a/interfaces/python/source/api/index.rst
+++ b/interfaces/python/source/api/index.rst
@@ -40,6 +40,9 @@ incremental, repeated-run workflows.
    * - :doc:`datasets`
      - The bundled example networks, one loader per network
        (:func:`infomap.datasets.two_triangles` and friends).
+   * - :doc:`deprecations`
+     - The deprecation contract: signature tiers, the 2.15 → 3.0 timeline, and
+       the compatibility aliases.
 
 .. toctree::
    :hidden:
@@ -55,3 +58,4 @@ incremental, repeated-run workflows.
    errors
    integrations
    datasets
+   deprecations

--- a/interfaces/python/source/flow-models/bipartite.md
+++ b/interfaces/python/source/flow-models/bipartite.md
@@ -52,9 +52,10 @@ other type from those files (it does not filter the in-memory
 {class}`~infomap.Result`).
 ```
 
-Two options change this treatment: `skip_adjust_bipartite_flow=True` keeps
-flow on the type-B nodes so both types are coded, and
-`bipartite_teleportation=True` makes a directed run teleport with
+Two engine options change this treatment, passed via
+{class}`~infomap.Options` (e.g. `run(net, options=Options(skip_adjust_bipartite_flow=True))`):
+`skip_adjust_bipartite_flow=True` keeps flow on the type-B nodes so both types
+are coded, and `bipartite_teleportation=True` makes a directed run teleport with
 bipartite-aware jumps instead of the default two-step unipartite scheme.
 
 ## Users and items in shared clusters
@@ -216,8 +217,8 @@ weak cross-cluster links.
 |---|---|---|
 | `bipartite_start_id` | {class}`~infomap.Network` attribute | First node id of the type-B block (the second type); declares the network bipartite |
 | `hide_bipartite_nodes` | {class}`~infomap.Infomap` (file-writing runs) | Omit the type-B nodes from written output files (the in-memory result keeps both types) |
-| `skip_adjust_bipartite_flow` | {func}`infomap.run` | Keep flow on the type-B nodes instead of folding it onto type-A |
-| `bipartite_teleportation` | {func}`infomap.run` | On directed runs, teleport with bipartite-aware jumps instead of the two-step unipartite scheme |
+| `skip_adjust_bipartite_flow` | {class}`~infomap.Options` → {func}`infomap.run` | Keep flow on the type-B nodes instead of folding it onto type-A |
+| `bipartite_teleportation` | {class}`~infomap.Options` → {func}`infomap.run` | On directed runs, teleport with bipartite-aware jumps instead of the two-step unipartite scheme |
 
 ## Going deeper
 

--- a/interfaces/python/source/workflows/graphrag.md
+++ b/interfaces/python/source/workflows/graphrag.md
@@ -133,8 +133,9 @@ result = run_graphrag_communities(
     num_trials=5,
 )
 
-print(f"Map equation codelength: {result.infomap.codelength:.4f} bits/step")
-print(f"Top-level communities:   {result.infomap.num_top_modules}")
+partition = result.result  # the immutable Result from the run
+print(f"Map equation codelength: {partition.codelength:.4f} bits/step")
+print(f"Top-level communities:   {partition.num_top_modules}")
 ```
 
 ### Per-entity community assignments

--- a/interfaces/python/source/working-with-infomap/inputs.md
+++ b/interfaces/python/source/working-with-infomap/inputs.md
@@ -58,7 +58,16 @@ spelling out (see Pitfalls).
 Two one-shot helpers return native types instead of a
 {class}`~infomap.Result`: {func}`infomap.find_communities` (a NetworkX-style
 ``list[set]``) and {func}`infomap.find_igraph_communities` (an
-``igraph.VertexClustering``).
+``igraph.VertexClustering``). Both accept ``trials`` (a convenience alias for
+``num_trials``) and default to ``10`` — a robust default for a single call;
+pass ``trials`` or ``num_trials``, not both.
+
+The ``from_*`` constructors deliberately name their input-reading arguments in
+each library's own idiom — NetworkX ``weight`` (an attribute name), igraph
+``edge_weights``/``vertex_weights``, SciPy ``weighted`` (a bool), edge-index
+``edge_weight`` (an array) — rather than forcing one spelling across sources.
+The ``directed`` defaults likewise follow each source's convention (a SciPy
+adjacency matrix is undirected by default, a ``(2, E)`` edge index directed).
 
 ## NetworkX
 

--- a/interfaces/python/source/working-with-infomap/running-and-options.md
+++ b/interfaces/python/source/working-with-infomap/running-and-options.md
@@ -414,7 +414,7 @@ These are the keyword arguments to {func}`infomap.run`:
 | `markov_time` | float | 1.0 | Resolution scale |
 | `regularized` | bool | False | Bayesian regularization for sparse data |
 | `regularization_strength` | float | 1.0 | How strongly to regularize |
-| `silent` | bool | False | Suppress console output |
+| `silent` | bool | True | Suppress console output (the Python API is quiet by default) |
 
 For the full set of options as a searchable table, see the
 {class}`~infomap.Options` reference in the {doc}`/api/index`.

--- a/interfaces/python/source/working-with-infomap/visualizing-and-exporting.md
+++ b/interfaces/python/source/working-with-infomap/visualizing-and-exporting.md
@@ -278,13 +278,15 @@ print("Temp directory removed.")
 
 - {func}`infomap.to_networkx` builds a NetworkX graph from the result's (state)
   nodes, annotated with `infomap_module`, `infomap_path`, per-level ids, and
-  `flow` (all strings); write it with `nx.write_graphml` / `nx.write_gexf`.
+  `flow` as native Python types (module ids and level ids as `int`, `flow` as
+  `float`, `infomap_path` as `str`); write it with `nx.write_graphml` /
+  `nx.write_gexf`.
 - {func}`infomap.to_igraph` builds the same graph as an `igraph.Graph`.
 - {func}`infomap.io.export.write_graphml`, {func}`infomap.io.export.write_gexf`,
   and {func}`infomap.io.export.annotate_networkx_graph` instead annotate *your
-  own* graph with the partition. They take a post-run stateful
-  {class}`~infomap.Infomap`, not a {class}`~infomap.Result`. (`write_gexf`
-  supports NetworkX only.)
+  own* graph with the partition. They accept either a post-run stateful
+  {class}`~infomap.Infomap` or the {class}`~infomap.Result` it returned.
+  (`write_gexf` supports NetworkX only.)
 
 **Native engine formats** (written by the {class}`~infomap.Result`)
 

--- a/interfaces/python/src/infomap/_logging.py
+++ b/interfaces/python/src/infomap/_logging.py
@@ -129,6 +129,10 @@ def enable_log(level: int = logging.INFO) -> logging.Handler:
     files, propagation), skip this helper and configure
     ``logging.getLogger("infomap")`` with standard :mod:`logging` instead.
 
+    Turns off propagation while active so records are not *also* emitted by a
+    root handler installed via ``logging.basicConfig`` (which would print each
+    line twice); :func:`disable_log` restores propagation.
+
     Parameters
     ----------
     level : int, optional
@@ -153,6 +157,9 @@ def enable_log(level: int = logging.INFO) -> logging.Handler:
         _helper_handler = handler
     if _helper_handler not in logger.handlers:
         logger.addHandler(_helper_handler)
+    # Don't double-print through a root handler (e.g. logging.basicConfig());
+    # disable_log() puts propagation back.
+    logger.propagate = False
     logger.setLevel(level)
     return _helper_handler
 
@@ -168,3 +175,5 @@ def disable_log() -> None:
     if _helper_handler is not None:
         logger.removeHandler(_helper_handler)
         _helper_handler = None
+        # Restore the default so records reach ancestor handlers again.
+        logger.propagate = True

--- a/interfaces/python/src/infomap/io/__init__.py
+++ b/interfaces/python/src/infomap/io/__init__.py
@@ -5,4 +5,31 @@ Network writers (``writers``), graph-library adapters (``networkx``,
 live here; reach them as ``infomap.io.export`` and so on. The graph adapters
 keep their optional third-party imports inside functions, so importing
 ``infomap`` never requires networkx / igraph / scipy / pandas to be installed.
+
+The result-export helpers are also re-exported at this namespace level (e.g.
+``infomap.io.to_networkx``, ``infomap.io.write_graphml``), mirroring the
+``infomap.tl`` convenience namespace. ``io.export`` has no module-scope
+third-party imports, so this keeps ``import infomap`` dependency-free.
 """
+
+from __future__ import annotations
+
+from .export import (
+    annotate_igraph_graph as annotate_igraph_graph,
+    annotate_networkx_graph as annotate_networkx_graph,
+    to_igraph as to_igraph,
+    to_networkx as to_networkx,
+    write_gexf as write_gexf,
+    write_graphml as write_graphml,
+)
+
+# A curated __all__ so ``from infomap.io import *`` and tooling see only the
+# public export helpers, not the submodules or their imported names.
+__all__ = [
+    "annotate_igraph_graph",
+    "annotate_networkx_graph",
+    "to_igraph",
+    "to_networkx",
+    "write_gexf",
+    "write_graphml",
+]

--- a/interfaces/python/src/infomap/io/edge_index.py
+++ b/interfaces/python/src/infomap/io/edge_index.py
@@ -7,6 +7,11 @@ from typing import Any
 from .._optional import require_numpy
 from ._arrays import undirected_edge_items
 
+# No user-facing API: the adapter (add_edge_index) is reached through
+# Network.from_edge_index / infomap.run(edge_index). Empty __all__ so the
+# submodule stops surfacing its plumbing.
+__all__: list[str] = []
+
 
 def _as_numpy_array(value: Any, *, name: str):
     np = require_numpy("edge_index support")

--- a/interfaces/python/src/infomap/io/export.py
+++ b/interfaces/python/src/infomap/io/export.py
@@ -470,10 +470,11 @@ def to_igraph(
 ) -> "igraph.Graph":
     """Build a python-igraph graph from a :class:`~infomap.Result`.
 
-    Vertices are the result's (state) nodes in ``state_id`` order, carrying the
-    Infomap node ``name`` plus the module/path/flow attributes. Edges come
-    from the partitioned network, with their weights as ``weight``. The
-    attribute values keep their native types, as in :func:`to_networkx`.
+    Vertices are the result's (state) nodes in the order the result yields
+    them, carrying the Infomap node ``name`` plus the module/path/flow
+    attributes. Edges come from the partitioned network, with their weights as
+    ``weight``. The attribute values keep their native types, as in
+    :func:`to_networkx`.
 
     Parameters
     ----------

--- a/interfaces/python/src/infomap/io/igraph.py
+++ b/interfaces/python/src/infomap/io/igraph.py
@@ -221,7 +221,7 @@ def add_igraph_graph(
                     )
                 else:
                     if source_node_id != target_node_id:
-                        raise RuntimeError(
+                        raise ValueError(
                             "Multilayer intra/inter format does not support 'diagonal' links. "
                             "Use `multilayer_inter_intra_format=False`"
                         )

--- a/interfaces/python/src/infomap/io/igraph.py
+++ b/interfaces/python/src/infomap/io/igraph.py
@@ -8,6 +8,11 @@ from typing import Any
 from .._optional import require_igraph
 from ._arrays import apply_node_meta_data, community_node_data
 
+# The only user-facing name here; the adapter (add_igraph_graph) and helpers are
+# reached through Network.from_igraph / infomap.run(). Curated so the submodule
+# stops surfacing its plumbing (require_igraph, community_node_data, ...).
+__all__ = ["find_igraph_communities"]
+
 
 def _import_igraph() -> Any:
     # Thin delegate kept for backwards compatibility (tests import it); the
@@ -297,7 +302,7 @@ def find_igraph_communities(
     *,
     edge_weights: str | Iterable[Any] | None = None,
     vertex_weights: Any = None,
-    trials: int = 10,
+    trials: int | None = None,
     node_id: str = "node_id",
     layer_id: str = "layer_id",
     multilayer_inter_intra_format: bool = True,
@@ -322,8 +327,9 @@ def find_igraph_communities(
     vertex_weights : None, optional
         Accepted for igraph API familiarity but not supported yet.
     trials : int, optional
-        Number of independent trials; the best solution is kept. Default
-        ``10``. Alias for the ``num_trials`` Infomap option.
+        Number of independent trials; the best solution is kept. Convenience
+        alias for the ``num_trials`` Infomap option. Pass ``trials`` or
+        ``num_trials``, not both; if neither is given the default is ``10``.
     node_id : str, optional
         Vertex attribute for physical node ids, implying a state network.
     layer_id : str, optional
@@ -362,7 +368,7 @@ def find_igraph_communities(
         If both ``trials`` and ``num_trials`` are passed.
     """
     ig = _validate_igraph_graph(g)
-    if "num_trials" in infomap_options:
+    if trials is not None and "num_trials" in infomap_options:
         raise ValueError("Pass only one of `trials` and `num_trials`.")
     if g.vcount() == 0:
         if module_attribute is not None:
@@ -375,7 +381,14 @@ def find_igraph_communities(
 
     from .._facade import Infomap
 
-    options = {"silent": True, "no_file_output": True, "num_trials": trials}
+    # `num_trials` is the engine option; `trials` is the convenience alias.
+    # Default to 10 when the caller specified neither; a caller-passed
+    # `num_trials` (only reachable when `trials` is None) wins via update().
+    options = {
+        "silent": True,
+        "no_file_output": True,
+        "num_trials": trials if trials is not None else 10,
+    }
     options.update(infomap_options)
 
     infomap = Infomap(**options)

--- a/interfaces/python/src/infomap/io/networkx.py
+++ b/interfaces/python/src/infomap/io/networkx.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from ._arrays import apply_node_meta_data, community_node_data
 
-# run_networkx and add_networkx_graph are internal plumbing shared with the
+# _run_networkx and add_networkx_graph are internal plumbing shared with the
 # facade and the docs notebooks; only find_communities is public API.
 __all__ = ["find_communities"]
 
@@ -72,7 +72,7 @@ def _to_internal_partition(initial_partition, node_mapping):
     }
 
 
-def run_networkx(
+def _run_networkx(
     g: Any,
     *,
     weight: str | None = "weight",
@@ -190,7 +190,7 @@ def find_communities(
     if "num_trials" not in infomap_options:
         infomap_options["num_trials"] = trials if trials is not None else 10
 
-    infomap, node_mapping = run_networkx(
+    infomap, node_mapping = _run_networkx(
         g,
         weight=weight,
         node_id=node_id,

--- a/interfaces/python/src/infomap/io/networkx.py
+++ b/interfaces/python/src/infomap/io/networkx.py
@@ -298,7 +298,7 @@ def add_networkx_graph(
                     )
                 else:
                     if source_node_id != target_node_id:
-                        raise RuntimeError(
+                        raise ValueError(
                             "Multilayer intra/inter format does not support 'diagonal' links. Use `multilayer_inter_intra_format=False`"
                         )
                     infomap.add_multilayer_inter_link(

--- a/interfaces/python/src/infomap/io/networkx.py
+++ b/interfaces/python/src/infomap/io/networkx.py
@@ -113,6 +113,7 @@ def find_communities(
     node_id: str = "node_id",
     layer_id: str = "layer_id",
     multilayer_inter_intra_format: bool = True,
+    trials: int | None = None,
     initial_partition: Any = None,
     module_attribute: str | None = None,
     flow_attribute: str | None = None,
@@ -143,6 +144,11 @@ def find_communities(
     multilayer_inter_intra_format : bool, optional
         Use intra/inter format to simulate inter-layer links. Default
         ``True``.
+    trials : int, optional
+        Number of independent trials; the best solution is kept. Convenience
+        alias for the ``num_trials`` Infomap option (matching
+        :func:`~infomap.find_igraph_communities`). Pass ``trials`` or
+        ``num_trials``, not both; if neither is given the default is ``10``.
     module_attribute : str, optional
         If set, write each node's module id back to this node attribute on
         ``g``.
@@ -166,9 +172,23 @@ def find_communities(
     -------
     list of set
         A partition of ``g.nodes`` grouped by top-level Infomap module.
+
+    Raises
+    ------
+    ValueError
+        If both ``trials`` and ``num_trials`` are passed.
     """
+    if trials is not None and "num_trials" in infomap_options:
+        raise ValueError("Pass only one of `trials` and `num_trials`.")
+
     if len(g.nodes) == 0:
         return []
+
+    # `num_trials` is the engine option; `trials` is the convenience alias.
+    # Default to 10 (a robust default for a one-call helper, matching the
+    # igraph variant) when the caller specified neither.
+    if "num_trials" not in infomap_options:
+        infomap_options["num_trials"] = trials if trials is not None else 10
 
     infomap, node_mapping = run_networkx(
         g,

--- a/interfaces/python/src/infomap/io/scipy.py
+++ b/interfaces/python/src/infomap/io/scipy.py
@@ -6,6 +6,11 @@ from typing import Any
 from .._optional import require_scipy_sparse
 from ._arrays import undirected_edge_items
 
+# No user-facing API: the adapter (add_scipy_sparse_matrix) is reached through
+# Network.from_scipy_sparse_matrix / infomap.run(A). Empty __all__ so the
+# submodule stops surfacing its plumbing.
+__all__: list[str] = []
+
 
 def _import_sparse() -> Any:
     # Thin delegate kept for backwards compatibility (tests import it); the

--- a/interfaces/python/src/infomap/network.py
+++ b/interfaces/python/src/infomap/network.py
@@ -94,16 +94,19 @@ class Network(_NetworkWritersMixin):
         ``Core`` is passed in.
     """
 
-    #: ``{internal_id: label}`` mapping set by the library constructors
-    #: (``from_networkx``/``from_igraph``/``from_scipy_sparse_matrix``/``from_edge_index``).
-    #: Bare annotation: declares the instance attribute for type-checkers without
-    #: creating it at runtime (no behaviour change).
+    #: ``{internal_id: label}`` mapping populated by the graph-library
+    #: constructors (``from_networkx``/``from_igraph``/``from_scipy_sparse_matrix``/
+    #: ``from_edge_index``). Empty on a manually built or file-loaded ``Network``,
+    #: mirroring :class:`~infomap.Infomap`, so the attribute is always present.
     node_id_to_label: dict[int, Any]
 
     def __init__(self, core=None):
         if core is None:
             core = Core("--silent --no-file-output")
         self._core = core
+        # Always present so attribute access never raises; the graph-library
+        # constructors replace it with the id->label mapping they build.
+        self.node_id_to_label = {}
         # Run-generation token: incremented on every run(). A Result stamps the
         # generation it was created in; node-level access on a stale Result
         # (engine re-ran since) raises instead of reading freed memory. This is

--- a/interfaces/python/src/infomap/tl/__init__.py
+++ b/interfaces/python/src/infomap/tl/__init__.py
@@ -214,7 +214,9 @@ def infomap(
     options.update(infomap_options)
     im = Infomap(args=args, **options)
     obs_names = list(adata.obs_names)
-    mapping = im.add_scipy_sparse_matrix(
+    # Use the internal impl rather than the deprecated public
+    # add_scipy_sparse_matrix accessor the rest of the API steers away from.
+    mapping = im._add_scipy_sparse_matrix_impl(
         matrix,
         directed=directed,
         weighted=use_weights,

--- a/interfaces/python/src/infomap/tl/graphrag.py
+++ b/interfaces/python/src/infomap/tl/graphrag.py
@@ -46,6 +46,10 @@ class GraphRAGRunResult:
     """Result object returned by :func:`run_graphrag_communities`."""
 
     infomap: Any
+    #: The immutable :class:`~infomap.Result` from the run. Read run metrics
+    #: from here (``result.result.codelength``, ``.num_top_modules``) rather
+    #: than the deprecated accessors on the stateful ``infomap`` instance.
+    result: Any
     graph: GraphRAGGraph
     output_dir: Path | None
     nodes: Any
@@ -730,13 +734,14 @@ def run_graphrag_communities(
         **infomap_options,
     )
     im.add_links(_links_array(graph))
-    im.run()
+    result = im.run()
     nodes, communities = _build_tables(im, graph)
     if paths["dir"] is not None:
         nodes.to_parquet(paths["nodes"], index=False)
         communities.to_parquet(paths["communities"], index=False)
     return GraphRAGRunResult(
         infomap=im,
+        result=result,
         graph=graph,
         output_dir=paths["dir"],
         nodes=nodes,

--- a/scripts/generate_js_metadata.py
+++ b/scripts/generate_js_metadata.py
@@ -5,6 +5,8 @@ import json
 import subprocess
 from pathlib import Path
 
+from parameter_catalog import ParameterCatalog
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 OVERRIDES = REPO_ROOT / "interfaces" / "parameters" / "overrides.json"
@@ -39,7 +41,7 @@ def load_parameters(infomap_bin):
 
 
 def public_parameter_metadata(parameters):
-    hidden = hidden_js_parameter_flags()
+    hidden = hidden_js_parameter_flags(parameters)
     return [
         {key: value for key, value in parameter.items() if key in PUBLIC_PARAMETER_KEYS}
         for parameter in parameters
@@ -47,20 +49,15 @@ def public_parameter_metadata(parameters):
     ]
 
 
-def hidden_js_parameter_flags():
-    # Derived from the policy section: a ts `hide` decision removes the
-    # parameter from the JavaScript surface (issue #755).
+def hidden_js_parameter_flags(parameters):
+    # Resolve `ts` `hide` decisions through the shared ParameterCatalog so the
+    # JS surface matches the TypeScript binding generator and the policy matrix
+    # exactly. This honours per-parameter precedence over group rules (a
+    # per-parameter `keep` un-hides a flag its group hides), which an
+    # independent reimplementation here would miss (issue #755).
     overrides = json.loads(OVERRIDES.read_text(encoding="utf-8"))
-    policy = overrides.get("policy", {})
-    hidden = {
-        flag
-        for flag, per_surface in policy.get("parameters", {}).items()
-        if per_surface.get("ts", {}).get("action") == "hide"
-    }
-    for group in policy.get("groups", {}).values():
-        if group.get("ts", {}).get("action") == "hide":
-            hidden.update(group.get("parameters", []))
-    return hidden
+    catalog = ParameterCatalog(parameters, overrides)
+    return catalog.hidden_bindings.get("ts", set())
 
 
 def write_json(path, payload):

--- a/test/python/test_anndata.py
+++ b/test/python/test_anndata.py
@@ -210,7 +210,9 @@ def test_tl_infomap_preserves_obs_name_order_for_string_node_ids(monkeypatch):
     data = _adata()
     seen_node_ids = []
 
-    original_add_scipy_sparse_matrix = infomap.Infomap.add_scipy_sparse_matrix
+    # tl.infomap loads the matrix via the internal impl (not the deprecated
+    # public add_scipy_sparse_matrix accessor), so patch what it actually calls.
+    original_add_scipy_sparse_matrix = infomap.Infomap._add_scipy_sparse_matrix_impl
 
     def recording_add_scipy_sparse_matrix(self, matrix, **kwargs):
         seen_node_ids.extend(kwargs["node_ids"])
@@ -218,7 +220,7 @@ def test_tl_infomap_preserves_obs_name_order_for_string_node_ids(monkeypatch):
 
     monkeypatch.setattr(
         infomap.Infomap,
-        "add_scipy_sparse_matrix",
+        "_add_scipy_sparse_matrix_impl",
         recording_add_scipy_sparse_matrix,
     )
 

--- a/test/python/test_from_graph_constructors.py
+++ b/test/python/test_from_graph_constructors.py
@@ -3,13 +3,24 @@
 import networkx as nx
 import pytest
 
-from infomap import Infomap
+from infomap import Infomap, Network
 
 
 @pytest.mark.fast
 def test_node_id_to_label_initialized_empty():
     im = Infomap(silent=True, no_file_output=True)
     assert im.node_id_to_label == {}
+
+
+@pytest.mark.fast
+def test_network_node_id_to_label_initialized_empty():
+    # A manually built Network exposes an empty mapping instead of raising
+    # AttributeError, mirroring Infomap; the graph-library constructors
+    # replace it with the id->label mapping they build.
+    net = Network()
+    assert net.node_id_to_label == {}
+    net.add_link(1, 2)
+    assert net.node_id_to_label == {}
 
 
 @pytest.mark.fast

--- a/test/python/test_graphrag.py
+++ b/test/python/test_graphrag.py
@@ -511,7 +511,8 @@ def test_run_graphrag_communities_reads_runs_and_writes_outputs(tmp_path):
 
     run = json.loads((output_dir / "infomap_run.json").read_text())
     assert run["trials"] == 1
-    assert run["codelength"] == pytest.approx(result.infomap.codelength)
+    # Read metrics off the immutable Result, not the deprecated Infomap accessor.
+    assert run["codelength"] == pytest.approx(result.result.codelength)
     assert "options" not in run
     assert "seed" not in run
 
@@ -528,7 +529,7 @@ def test_run_graphrag_communities_defaults_to_reproducible_trials(tmp_path):
 
     run = json.loads((tmp_path / "result" / "infomap_run.json").read_text())
     assert run["trials"] == 5
-    assert result.infomap.codelength == pytest.approx(run["codelength"])
+    assert result.result.codelength == pytest.approx(run["codelength"])
 
 
 def test_run_graphrag_communities_accepts_args_passthrough(tmp_path):

--- a/test/python/test_igraph.py
+++ b/test/python/test_igraph.py
@@ -394,6 +394,25 @@ def test_find_igraph_communities_rejects_trial_and_vertex_weight_conflicts():
         infomap.find_igraph_communities(graph, vertex_weights=[1, 1])
 
 
+def test_find_igraph_communities_accepts_num_trials_alone(monkeypatch):
+    # `num_trials` (the engine option name) is accepted on its own, matching
+    # the networkx helper; only passing it *together* with `trials` conflicts.
+    import infomap._facade as facade
+
+    ig = pytest.importorskip("igraph")
+    captured = {}
+    real_infomap = facade.Infomap
+
+    class RecordingInfomap(real_infomap):
+        def __init__(self, *args, **options):
+            captured.update(options)
+            super().__init__(*args, **options)
+
+    monkeypatch.setattr(facade, "Infomap", RecordingInfomap)
+    infomap.find_igraph_communities(ig.Graph(edges=[(0, 1)]), num_trials=4, seed=1)
+    assert captured["num_trials"] == 4
+
+
 class _Recorder:
     flowModelIsSet = True
 

--- a/test/python/test_igraph.py
+++ b/test/python/test_igraph.py
@@ -397,8 +397,6 @@ def test_find_igraph_communities_rejects_trial_and_vertex_weight_conflicts():
 def test_find_igraph_communities_accepts_num_trials_alone(monkeypatch):
     # `num_trials` (the engine option name) is accepted on its own, matching
     # the networkx helper; only passing it *together* with `trials` conflicts.
-    import infomap._facade as facade
-
     ig = pytest.importorskip("igraph")
     captured = {}
     real_infomap = facade.Infomap

--- a/test/python/test_networkx.py
+++ b/test/python/test_networkx.py
@@ -355,3 +355,44 @@ def test_find_communities_skips_unregistered_state_ids(monkeypatch):
     monkeypatch.setattr(facade, "Infomap", FakeInfomap)
     communities = infomap.find_communities(nx.Graph([("x", "y")]))
     assert _flatten(communities) == {"x", "y"}
+
+
+# -- trials parity with the igraph helper -------------------------------------
+
+
+def test_find_communities_trials_default_matches_igraph():
+    import inspect
+
+    nx_default = inspect.signature(infomap.find_communities).parameters["trials"].default
+    ig_default = (
+        inspect.signature(infomap.find_igraph_communities).parameters["trials"].default
+    )
+    # Both use the same sentinel; the effective default (10) is asserted below.
+    assert nx_default is None and ig_default is None
+
+
+def test_find_communities_rejects_trials_and_num_trials_conflict():
+    with pytest.raises(ValueError, match="trials.*num_trials"):
+        infomap.find_communities(nx.Graph([("a", "b")]), trials=1, num_trials=2)
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected",
+    [
+        ({}, 10),                    # neither -> aligned default
+        ({"trials": 7}, 7),          # the convenience alias
+        ({"num_trials": 3}, 3),      # the engine option (back-compat)
+    ],
+)
+def test_find_communities_resolves_num_trials(monkeypatch, kwargs, expected):
+    captured = {}
+    real_infomap = facade.Infomap
+
+    class RecordingInfomap(real_infomap):
+        def __init__(self, *args, **options):
+            captured.update(options)
+            super().__init__(*args, **options)
+
+    monkeypatch.setattr(facade, "Infomap", RecordingInfomap)
+    infomap.find_communities(nx.Graph([("a", "b")]), seed=1, **kwargs)
+    assert captured["num_trials"] == expected

--- a/test/python/test_networkx.py
+++ b/test/python/test_networkx.py
@@ -217,7 +217,7 @@ def test_add_networkx_multilayer_diagonal_link_raises():
     graph.add_edge("a-layer-1", "b-layer-2")
 
     im = infomap.Infomap(silent=True, no_file_output=True)
-    with pytest.raises(RuntimeError, match="diagonal"):
+    with pytest.raises(ValueError, match="diagonal"):
         im.add_networkx_graph(graph)
 
     # The documented workaround (full multilayer format) accepts the same graph.

--- a/test/python/test_public_types.py
+++ b/test/python/test_public_types.py
@@ -79,3 +79,15 @@ def test_io_namespace_is_public():
     assert "io" in infomap.__all__
     assert infomap.io.export.__all__ == sorted(infomap.io.export.__all__)
     from infomap.io.export import to_networkx  # noqa: F401
+
+
+@pytest.mark.fast
+def test_io_namespace_reexports_export_helpers():
+    # The result-export helpers are re-exported at the io namespace level
+    # (e.g. infomap.io.to_networkx), mirroring infomap.tl, so io has a curated
+    # public surface rather than only submodules.
+    import infomap.io as io
+
+    assert io.__all__ == list(infomap.io.export.__all__)
+    for name in io.__all__:
+        assert getattr(io, name) is getattr(infomap.io.export, name)

--- a/test/schemas/json/parameter-catalog.schema.json
+++ b/test/schemas/json/parameter-catalog.schema.json
@@ -11,22 +11,6 @@
     }
   },
   "$defs": {
-    "bindingDefault": {
-      "type": "object",
-      "required": ["value"],
-      "additionalProperties": false,
-      "properties": {
-        "value": { "type": "string" }
-      }
-    },
-    "bindingDoc": {
-      "type": "object",
-      "required": ["description"],
-      "additionalProperties": false,
-      "properties": {
-        "description": { "type": "string" }
-      }
-    },
     "parameter": {
       "type": "object",
       "required": [
@@ -63,37 +47,7 @@
         },
         "min": { "type": "string" },
         "max": { "type": "string" },
-        "bindingNames": {
-          "type": "object",
-          "minProperties": 1,
-          "additionalProperties": false,
-          "properties": {
-            "python": { "type": "string" },
-            "r": { "type": "string" },
-            "ts": { "type": "string" }
-          }
-        },
-        "renderPolicy": { "type": "string" },
-        "bindingDocs": {
-          "type": "object",
-          "minProperties": 1,
-          "additionalProperties": false,
-          "properties": {
-            "python": { "$ref": "#/$defs/bindingDoc" },
-            "r": { "$ref": "#/$defs/bindingDoc" },
-            "ts": { "$ref": "#/$defs/bindingDoc" }
-          }
-        },
-        "bindingDefaults": {
-          "type": "object",
-          "minProperties": 1,
-          "additionalProperties": false,
-          "properties": {
-            "python": { "$ref": "#/$defs/bindingDefault" },
-            "r": { "$ref": "#/$defs/bindingDefault" },
-            "ts": { "$ref": "#/$defs/bindingDefault" }
-          }
-        }
+        "renderPolicy": { "type": "string" }
       },
       "allOf": [
         {

--- a/test/scripts/check_binding_defaults.py
+++ b/test/scripts/check_binding_defaults.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Guard: ``interfaces/parameters/overrides.json`` binding defaults must track
+the C++ engine defaults.
+
+The Python/R signature generator renders the per-language default from
+``overrides.json`` and omits a flag when the caller's value equals that
+default. If a binding default silently drifts from the engine default, the
+generated signature documents (and passes through) the wrong value: the flag
+is not rendered, so the engine quietly uses a different default. The byte-level
+freshness check cannot catch this because it regenerates identical output from
+the unchanged override.
+
+This check compares each declared binding default against the engine default
+from ``--print-json-parameters``. Value-typed parameters must match
+numerically; the handful of boolean *flags* whose binding default intentionally
+diverges (tri-state ``None``, integer verbosity, quiet-by-default) are listed
+below with the reason, so an accidental drift on any other parameter still
+fails loud.
+
+Usage:  check_binding_defaults.py <path-to-Infomap-binary>
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OVERRIDES = REPO_ROOT / "interfaces" / "parameters" / "overrides.json"
+
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from parameter_catalog import ParameterCatalog  # noqa: E402
+
+# Boolean C++ flags whose Python binding default intentionally diverges from
+# the engine's ``false``. Each entry documents why; everything else must match.
+INTENTIONAL_FLAG_DIVERGENCES = {
+    "--silent": "Python API is quiet by default (True); the C++/CLI default is False.",
+    "--directed": "Tri-state None (unset) in the API vs the CLI boolean flag.",
+    "--fast-hierarchical-solution": "Optional int (None = unset) vs the CLI repeated -F flag.",
+    "--verbose": "Integer verbosity_level (default level 1) vs the CLI repeated -v flag.",
+}
+
+
+def _as_bool(value: str) -> bool:
+    return value.strip().lower() in {"true", "1"}
+
+
+def main() -> int:
+    cli = sys.argv[1]
+    result = subprocess.run(
+        [cli, "--print-json-parameters"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    parameters = json.loads(result.stdout)["parameters"]
+    catalog = {param["long"]: param for param in parameters}
+    overrides = json.loads(OVERRIDES.read_text(encoding="utf-8"))
+
+    # Constructing the catalog runs _validate_policy against the *real* engine
+    # flags, so a policy entry (per-parameter, group, or cliOnlyParameters)
+    # naming a stale or misspelled flag fails here in the fast tier -- the unit
+    # tests can only synthesize the catalog from the policy's own flag set.
+    ParameterCatalog(parameters, overrides)
+
+    drift: list[str] = []
+    for flag, per_language in overrides["defaults"].items():
+        param = catalog.get(flag)
+        if param is None:
+            drift.append(
+                f"{flag}: declared in overrides 'defaults' but not in the engine catalog"
+            )
+            continue
+        engine_default = str(param.get("default"))
+        python_default = per_language["python"]
+        # Value-typed parameters carry a longType (integer/number/probability);
+        # boolean flags have none.
+        if param.get("longType") is None:
+            if flag in INTENTIONAL_FLAG_DIVERGENCES:
+                continue
+            if _as_bool(python_default) != _as_bool(engine_default):
+                drift.append(
+                    f"{flag}: engine default {engine_default!r} != binding default "
+                    f"{python_default!r}"
+                )
+            continue
+        if float(engine_default) != float(python_default):
+            drift.append(
+                f"{flag}: engine default {engine_default!r} != binding default "
+                f"{python_default!r}"
+            )
+
+    if drift:
+        print("Binding defaults drifted from engine defaults:", file=sys.stderr)
+        for line in drift:
+            print(f"  - {line}", file=sys.stderr)
+        print(
+            "\nUpdate interfaces/parameters/overrides.json 'defaults' to match the "
+            "engine, or add an intentional divergence to INTENTIONAL_FLAG_DIVERGENCES "
+            "in this script with a reason.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Addresses a review of the recent Python API / parameter-catalog / docs work.

**Python API**
- `Network.node_id_to_label` is initialized to `{}` in `__init__`, so a manually built or file-loaded `Network` exposes the mapping instead of raising `AttributeError` (mirrors `Infomap`).
- `infomap.io` re-exports the result-export helpers (`infomap.io.to_networkx`, `infomap.io.write_graphml`, …) with a curated `__all__`, mirroring `infomap.tl`.
- networkx/igraph adapters raise `ValueError` (not `RuntimeError`) for the user-input "diagonal link" error.
- `enable_log()` disables propagation while active (restored by `disable_log()`), so records aren't double-printed through a `basicConfig` root handler.
- `tl.infomap` calls the internal `_add_scipy_sparse_matrix_impl` instead of the deprecated public accessor; `to_igraph` docstring vertex-order claim corrected.
- `GraphRAGRunResult` now exposes the immutable `Result` so callers read run metrics without the deprecated `Infomap` accessors.

**Documentation**
- Corrected the export chapter: `to_networkx` keeps native attribute types (not "all strings"); the GraphML/GEXF writers accept an `Infomap` *or* a `Result`.
- Fixed the `infomap.run` options table (`silent` is `True` by default — quiet by default).
- Added `api/deprecations.rst` consolidating the signature tiers, the 2.15 → 3.0 timeline, the compatibility aliases, and the error-base detach; linked into the API reference.
- Steered the bipartite chapter's advanced options through `Options`; graphrag examples read via `Result`.

**Parameter catalog / build**
- New `test/scripts/check_binding_defaults.py` (registered as the `binding_defaults` ctest): fails loud when an `overrides.json` binding default drifts from the C++ engine default, and validates the full policy against the real engine catalog so a stale/misspelled flag is caught in the fast tier. Intentional flag divergences (`silent`, `directed`, `fast-hierarchical-solution`, `verbose`) are documented in an allowlist.
- `generate_js_metadata` resolves `ts` `hide` decisions through the shared `ParameterCatalog` (per-parameter precedence over group rules), matching the TS binding generator and the policy matrix — output is byte-identical.
- Dropped `bindingNames`/`bindingDocs`/`bindingDefaults` from the parameter-catalog schema, which the engine JSON is contractually forbidden to emit.

## Verification

- `pytest test/python/` → 592 passed, 3 skipped
- `pyright -p interfaces/python/pyrightconfig-core.json` and full-scope `pyright` → 0 errors
- `ruff check` → clean
- `check_print_json_parameters.py` (schema) and `check_binding_defaults.py` (drift + policy) → pass against a freshly built binary
- `generate_js_metadata.py` output diffed byte-for-byte against the committed `parameters.json` → identical

## Notes

Deliberately left unchanged, with reasons:
- **No runtime warning on `Infomap.run(silent=False)`** — the generated `run` signature defaults `silent=False`, indistinguishable from unset, so a warning would fire on the common `Infomap().run()` call; a correct warning needs a signature-level sentinel. The documentation half is fixed.
- **`--pretty` stays CLI-only in the policy matrix** — this is intentional and test-enforced (`test_cli_only_parameter_rejects_binding_decisions` forbids a Python decision on CLI-only flags; the matrix row is asserted exactly). The policy tracks canonical parameters; `pretty` on Python is a no-op kept for a soft landing.
- The `2.15` deprecation markers are forward-dated to the next release (standard practice), not a bug.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X2hDDAWy24hJEiLHXsypUy)_