### PR TITLE
Python API surface, parameter catalog, and documentation overhaul

### DIFF
--- a/interfaces/python/source/api/deprecations.rst
+++ b/interfaces/python/source/api/deprecations.rst
@@ -50,8 +50,8 @@ Compatibility aliases
   Self-links are included by default; pass ``no_self_links=True`` to exclude
   them. Passing ``include_self_links`` explicitly emits a
   :class:`DeprecationWarning`.
-- ``pretty`` is a deprecated no-op — pretty console output is always on. Passing
-  it explicitly emits a :class:`DeprecationWarning`.
+- ``pretty`` is a deprecated no-op — it is accepted for backward compatibility
+  but has no effect. Passing it explicitly emits a :class:`DeprecationWarning`.
 
 Error base classes
 ------------------

--- a/interfaces/python/source/workflows/hpc.md
+++ b/interfaces/python/source/workflows/hpc.md
@@ -152,7 +152,7 @@ for spec in shard_specs:
         net,
         num_trials=spec["num_trials"],
         seed=spec["seed"],
-        )
+    )
 
     print(
         f"shard {spec['shard_id']}: seed={spec['seed']}"

--- a/interfaces/python/source/working-with-infomap/inputs.md
+++ b/interfaces/python/source/working-with-infomap/inputs.md
@@ -216,7 +216,7 @@ edges_df = pd.DataFrame({
 
 result = infomap.run(
     edges_df[["source", "target", "weight"]].to_numpy(),
-    two_level=True, seed=123, num_trials=5, )
+    two_level=True, seed=123, num_trials=5)
 print(f"pandas route: {result.num_top_modules} modules, {result.codelength:.4f} bits/step")
 ```
 
@@ -396,7 +396,7 @@ runs = {
     "SciPy sparse": infomap.run(A, two_level=True, seed=123, num_trials=5),
     "edge list":    infomap.run(
         edges_df[["source", "target", "weight"]].to_numpy(),
-        two_level=True, seed=123, num_trials=5, ),
+        two_level=True, seed=123, num_trials=5),
 }
 for route, res in runs.items():
     print(f"  {res.codelength:.4f}  {route}")

--- a/interfaces/python/source/working-with-infomap/running-and-options.md
+++ b/interfaces/python/source/working-with-infomap/running-and-options.md
@@ -297,12 +297,12 @@ karate club the prior quickly overwhelms the data:
 # the prior already outweighs the data and collapses them into one.
 G_karate = nx.karate_club_graph()
 
-for label, kwargs in [
-    ("baseline",                  {}),
-    ("regularized, strength=0.5", {"regularized": True, "regularization_strength": 0.5}),
-    ("regularized (default 1.0)", {"regularized": True}),
+for label, options in [
+    ("baseline",                  infomap.Options()),
+    ("regularized, strength=0.5", infomap.Options(regularized=True, regularization_strength=0.5)),
+    ("regularized (default 1.0)", infomap.Options(regularized=True)),
 ]:
-    result = infomap.run(G_karate, two_level=True, seed=123, num_trials=10, **kwargs)
+    result = infomap.run(G_karate, options=options, two_level=True, seed=123, num_trials=10)
     print(f"{label}: modules={result.num_top_modules}, L={result.codelength:.4f}")
 ```
 

--- a/src/utils/FlowCalculator.cpp
+++ b/src/utils/FlowCalculator.cpp
@@ -716,12 +716,7 @@ void FlowCalculator::calcDirectedRegularizedFlow(const StateNetwork& network, co
   double err = 0.0;
 
   do {
-    double oldErr = err;
     err = iteration(iterations);
-
-    // Perturb the system if equilibrium
-    if (std::abs(err - oldErr) < 1e-15) {
-    }
 
     ++iterations;
   } while (iterations < config.maxFlowIterations && (err > config.flowTolerance || iterations < config.minFlowIterations));
@@ -978,23 +973,16 @@ void FlowCalculator::calcDirectedRegularizedMultilayerFlow(const StateNetwork& n
   };
 
   unsigned int iterations = 0;
-  unsigned int maxIterations = 200;
   double err = 0.0;
 
   do {
-    double oldErr = err;
     err = iteration(iterations);
 
-    // Perturb the system if equilibrium
-    if (std::abs(err - oldErr) < 1e-15) {
-    }
-
     ++iterations;
-  } while (iterations < maxIterations && (err > config.flowTolerance || iterations < config.minFlowIterations));
+  } while (iterations < config.maxFlowIterations && (err > config.flowTolerance || iterations < config.minFlowIterations));
 
-  if (iterations == maxIterations && err > config.flowTolerance) {
+  if (iterations == config.maxFlowIterations && err > config.flowTolerance) {
     Console::warn(0, "PageRank calculation stopped after the maximum of {} iterations with diff {:g}.", iterations, err);
-  } else {
   }
 
   for (unsigned int i = 0; i < layerTeleFlow.size(); ++i) {


### PR DESCRIPTION
## Summary

This branch reworks the Python-facing surface around a single source of truth (the C++ parameter catalog plus `interfaces/parameters/overrides.json`), which drives the Python, R, and JS bindings.

**Python API**
- Functional `infomap.run(input, options=..., **overrides)` front door with type-based dispatch; adapter-only kwargs are rejected with a pointer to the matching `Network.from_*` constructor.
- Reusable `Options` (with `InfomapOptions` back-compat alias); immutable `Result` with a run-generation token that raises `StaleResultError` on node-level access after a re-run.
- Public error taxonomy (`InfomapError` base + `NetworkParseError`, `NotRunError`, `StaleResultError`), keeping `RuntimeError`/`ValueError` in the MRO through 2.x.
- Engine log routed through Python `logging`; public `io` namespace, file writers on `Result`/`Network`, and `tl` re-exports.
- New engine options exposed: `max_flow_iterations`, `min_flow_iterations`, `flow_tolerance`.

**Parameter catalog**
- Machine-readable 3.0 cleanup policy (per-parameter/group decisions, validated hard at generation time — unknown flag/surface/action or a removal without replacement guidance breaks the build).
- Signature tiers: the common tier (`seed`, `num_trials`, `two_level`, `directed`, `markov_time`) stays as keyword arguments; the advanced tier is documentation-deprecated and moves to `Options` in 3.0.
- C++ catalog stopped emitting binding names/defaults/docs; these now live in `overrides.json`. Generated Python/R/JS outputs stay consistent with the policy.

**Documentation**
- New deprecation-policy and error pages; examples and docs steered toward `Options` and the common tier.

## Verification

- `make build-native` and `make build-native FEATURES=regularized-multilayer` — both clean under `-Wall -Wextra`.
- `make test-native` — all 24 C++ doctest suites pass.
- Python unit suite (`pytest -m "not slow and not perf"`) — 598 passed, 3 skipped.
- Functional CLI check of the flow fix: a regularized multilayer run now stops at the requested `--max-flow-iterations` (verified 3 and 7) instead of a fixed 200.

## Notes

Review follow-ups included on this branch:
- **Bug fix:** `calcDirectedRegularizedMultilayerFlow` honored the new `flow-tolerance`/`min-flow-iterations` knobs but kept a hardcoded `maxIterations = 200`, so `--max-flow-iterations` was silently ignored on that path (the catalog advertises the flag for regularized flow models). Now uses `config.maxFlowIterations`; leftover empty perturbation `if`/`else` blocks removed in both regularized flow functions.
- **Docs:** routed the advanced regularization options through `Options` on the page that introduces the tier split; corrected the `pretty` deprecation wording; tidied a few code-cell formatting artifacts.

Known low-priority gaps deferred (need maintainer decisions): the binding generator doesn't emit the `Literal`-alias imports the facade references (fails loud in CI if a new `choices` parameter is added); `check_binding_defaults.py` only checks the Python default direction; `disable_log()` unconditionally restores `propagate=True`; and the NetworkX `find_communities` default `trials` changed 1 → 10 (documented, for igraph parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFAwazh53Qj27FxeKxMQen)_