### PR TITLE
Python API, parameter catalog, and documentation modernization

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,16 +84,15 @@ For direct control over Infomap-specific options and result access:
 
 .. code-block:: python
 
-    from infomap import Infomap, Options
+    from infomap import Infomap
 
-    options = Options(two_level=True, silent=True, num_trials=20, seed=123)
-    im = Infomap.from_options(options)
+    im = Infomap(two_level=True, num_trials=20, seed=123)
     im.add_link(0, 1)
     im.add_link(1, 2)
-    im.run()
+    result = im.run()
 
-    print(im.num_top_modules, im.codelength)
-    print(im.to_dataframe(columns=["node_id", "module_id", "flow"], index="node_id"))
+    print(result.num_top_modules, result.codelength)
+    print(result.to_dataframe(columns=["node_id", "module_id", "flow"], index="node_id"))
 
 .. _PyPI: https://pypi.org/project/infomap/
 .. _`Infomap Python API`: https://mapequation.org/infomap-python-docs/

--- a/interfaces/python/source/api/deprecations.rst
+++ b/interfaces/python/source/api/deprecations.rst
@@ -19,19 +19,25 @@ two tiers:
   the :class:`Infomap` signatures.
 - **Advanced tier** — the long tail of tuning and I/O options. From 2.15 these
   are ``.. deprecated::`` on the :class:`Infomap` signatures and leave them in
-  3.0. Pass them through :class:`Options` instead::
+  3.0. Most are *tuning* options that stay available — only their entry point
+  moves — so pass them through :class:`Options` instead::
 
       import infomap
 
       options = infomap.Options(regularized=True, flow_tolerance=1e-12)
       result = infomap.run("network.net", options=options)
 
-  The same :class:`Options` object works with :meth:`Network.run`. Every option
-  remains available — only its *entry point* moves from a per-call keyword to
-  :class:`Options`.
+  The same :class:`Options` object works with :meth:`Network.run`. A few
+  advanced options migrate elsewhere rather than to :class:`Options`, and each
+  keyword's ``.. deprecated::`` note states its own path: the file-output
+  options (``no_file_output``, ``tree``, ``clu``, ``out_name``, …) move to the
+  ``Result.write_*`` / ``Network.write_*`` methods, and ``silent`` / ``verbose``
+  give way to logging (see :doc:`/working-with-infomap/running-and-options`).
 
-The advanced-tier deprecations are documentation-only: no runtime warning fires,
-so existing code keeps running unchanged until 3.0.
+Passing an advanced-tier keyword to :class:`Infomap` or :meth:`Infomap.run`
+emits a :class:`PendingDeprecationWarning` (silent by default; surface it with
+``python -W`` or a logging filter). Routing the option through :class:`Options`
+is the warning-free path, so existing code keeps running unchanged until 3.0.
 
 Redesigned result access
 -------------------------

--- a/interfaces/python/source/working-with-infomap/inputs.md
+++ b/interfaces/python/source/working-with-infomap/inputs.md
@@ -63,11 +63,20 @@ Two one-shot helpers return native types instead of a
 pass ``trials`` or ``num_trials``, not both.
 
 The ``from_*`` constructors deliberately name their input-reading arguments in
-each library's own idiom — NetworkX ``weight`` (an attribute name), igraph
-``edge_weights``/``vertex_weights``, SciPy ``weighted`` (a bool), edge-index
-``edge_weight`` (an array) — rather than forcing one spelling across sources.
-The ``directed`` defaults likewise follow each source's convention (a SciPy
-adjacency matrix is undirected by default, a ``(2, E)`` edge index directed).
+each library's own idiom rather than forcing one spelling across sources, and
+their ``directed`` defaults follow each source's own convention. The weight
+argument and directedness therefore differ by source:
+
+| Source | Weight argument | Directedness |
+| --- | --- | --- |
+| NetworkX | `weight` (attribute name, default `"weight"`) | read from the graph (`Graph` vs `DiGraph`) |
+| igraph | `edge_weights` (attribute name; also `vertex_weights`) | read from the graph (`g.is_directed()`) |
+| SciPy sparse | `weighted` (bool) | `directed=` (default `False`) |
+| `(2, E)` edge index | `edge_weight` (array) | `directed=` (default `True`) |
+
+Because NetworkX and igraph carry directedness on the graph object, they take
+no ``directed`` argument; SciPy and the edge index do, and they default
+differently, so pass ``directed=`` explicitly when it matters.
 
 ## NetworkX
 

--- a/interfaces/python/source/working-with-infomap/running-and-options.md
+++ b/interfaces/python/source/working-with-infomap/running-and-options.md
@@ -472,6 +472,13 @@ How the routing behaves:
   (see {meth}`Network.run <infomap.Network.run>`), so records come from the
   stateful {class}`~infomap.Infomap` and non-`Network` {func}`infomap.run`
   inputs. The `infomap` command-line interface is unaffected.
+- **`silent` is fixed at construction for the stateful engine.** Because the
+  engine bakes silence in when the {class}`~infomap.Infomap` is built, passing
+  `silent=False` to {meth}`Infomap.run <infomap.Infomap.run>` on an instance
+  constructed silent (the default) cannot re-enable the classic stdout log —
+  construct with `silent=False`, or route the log through logging. The one-shot
+  {func}`infomap.run` builds a fresh engine per call, so its `silent=` takes
+  effect there.
 
 ## Going deeper
 

--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -33,6 +33,7 @@ from ._options import (
     Options,
     OutputFormat,
     _construct_args,
+    _warn_advanced_tier_kwargs,
 )
 from ._logging import apply_engine_log_overrides as _apply_engine_log_overrides
 from ._logging import disable_log, enable_log
@@ -171,6 +172,8 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         # Remembered so run() can explain why a routed run of an instance
         # constructed *before* logging was configured produces no records.
         self._engine_constructed_silent = bool(kwargs.get("silent", True))
+        # The stale-silent advisory in _run_from_options fires at most once.
+        self._warned_stale_silent = False
         self._core = Core(_package_construct_args()(args, **kwargs))
         self._network = Network(core=self._core)
         self.node_id_to_label = {}
@@ -363,8 +366,10 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             methods to write results).
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. Use
+                Result.write_tree/write_flow_tree/write_clu (write_clu takes
+                depth_level) or Network.write_pajek/write_state_network. The flag only
+                acts when an output directory is passed via the raw args escape hatch.
         no_file_output : bool, optional
             Do not write output files.
 
@@ -373,8 +378,10 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             methods to write results).
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. Use
+                Result.write_tree/write_flow_tree/write_clu (write_clu takes
+                depth_level) or Network.write_pajek/write_state_network. The flag only
+                acts when an output directory is passed via the raw args escape hatch.
         tree : bool, optional
             Write the modular hierarchy to a tree file. Enabled by default when no other
             output format is selected.
@@ -384,8 +391,10 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             methods to write results).
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. Use
+                Result.write_tree/write_flow_tree/write_clu (write_clu takes
+                depth_level) or Network.write_pajek/write_state_network. The flag only
+                acts when an output directory is passed via the raw args escape hatch.
         ftree : bool, optional
             Write the modular hierarchy and aggregated links between nested modules to
             an ftree file. Used by Network Navigator.
@@ -395,8 +404,10 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             methods to write results).
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. Use
+                Result.write_tree/write_flow_tree/write_clu (write_clu takes
+                depth_level) or Network.write_pajek/write_state_network. The flag only
+                acts when an output directory is passed via the raw args escape hatch.
         clu : bool, optional
             Write top-level module ids for each node to a clu file.
 
@@ -405,8 +416,10 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             methods to write results).
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. Use
+                Result.write_tree/write_flow_tree/write_clu (write_clu takes
+                depth_level) or Network.write_pajek/write_state_network. The flag only
+                acts when an output directory is passed via the raw args escape hatch.
         clu_level : int, optional
             With --clu or --output clu, write module ids at this depth from the root.
             Use -1 for bottom-level modules.
@@ -416,8 +429,10 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             methods to write results).
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. Use
+                Result.write_tree/write_flow_tree/write_clu (write_clu takes
+                depth_level) or Network.write_pajek/write_state_network. The flag only
+                acts when an output directory is passed via the raw args escape hatch.
         output : sequence of str, optional
             Write selected output formats as a comma-separated list without spaces, e.g.
             -o clu,tree,ftree. Options: clu, tree, ftree, newick, json, csv, network,
@@ -428,8 +443,10 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             methods to write results).
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. Use
+                Result.write_tree/write_flow_tree/write_clu (write_clu takes
+                depth_level) or Network.write_pajek/write_state_network. The flag only
+                acts when an output directory is passed via the raw args escape hatch.
         hide_bipartite_nodes : bool, optional
             Hide bipartite nodes in output by projecting the solution to primary nodes.
 
@@ -438,8 +455,10 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             methods to write results).
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. Use
+                Result.write_tree/write_flow_tree/write_clu (write_clu takes
+                depth_level) or Network.write_pajek/write_state_network. The flag only
+                acts when an output directory is passed via the raw args escape hatch.
         print_all_trials : bool, optional
             Write each trial to separate output files. Has effect only when --num-trials
             is greater than 1.
@@ -449,8 +468,10 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             methods to write results).
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. Use
+                Result.write_tree/write_flow_tree/write_clu (write_clu takes
+                depth_level) or Network.write_pajek/write_state_network. The flag only
+                acts when an output directory is passed via the raw args escape hatch.
         no_overwrite : bool, optional
             Fail with an output error if any target output file already exists. By
             default existing files are replaced.
@@ -460,14 +481,16 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             methods to write results).
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. Use
+                Result.write_tree/write_flow_tree/write_clu (write_clu takes
+                depth_level) or Network.write_pajek/write_state_network. The flag only
+                acts when an output directory is passed via the raw args escape hatch.
         print_config_fingerprint : bool, optional
             Print the canonical configuration fingerprint and exit.
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. A print-and-exit
+                CLI diagnostic; run the infomap binary.
         timing_json : str, optional
             Write machine-readable run timing JSON to this path. Use - for stdout.
 
@@ -521,15 +544,18 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             -vv and so on.
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. A DEBUG-enabled
+                'infomap' logger (infomap.enable_log(logging.DEBUG)) raises engine
+                verbosity; logger levels filter the records.
         silent : bool, optional
             Suppress console output. The Python API is quiet by default; construct with
             silent=False for the engine log. The command-line interface is unaffected.
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. The Python API is
+                quiet by default; logging is the control. Attach handlers to
+                logging.getLogger('infomap') (e.g. infomap.enable_log()) for the engine
+                log.
         pretty : bool | None, optional
             Deprecated. Accepted for backward compatibility; has no effect. Passing it
             explicitly emits a DeprecationWarning.
@@ -796,8 +822,8 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             Alias for --num-threads.
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. Use num_threads;
+                threads is a redundant alias of the same engine option.
         prefer_modular_solution : bool, optional
             Prefer a modular solution even when one module gives a lower codelength.
 
@@ -824,6 +850,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
                 DeprecationWarning,
                 stacklevel=2,
             )
+        _warn_advanced_tier_kwargs(locals(), "init")
         options = Options._from_locals(locals())
         self._init_from_options(args, options)
 
@@ -1014,8 +1041,10 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             methods to write results).
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. Use
+                Result.write_tree/write_flow_tree/write_clu (write_clu takes
+                depth_level) or Network.write_pajek/write_state_network. The flag only
+                acts when an output directory is passed via the raw args escape hatch.
         no_file_output : bool, optional
             Do not write output files.
 
@@ -1024,8 +1053,10 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             methods to write results).
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. Use
+                Result.write_tree/write_flow_tree/write_clu (write_clu takes
+                depth_level) or Network.write_pajek/write_state_network. The flag only
+                acts when an output directory is passed via the raw args escape hatch.
         tree : bool, optional
             Write the modular hierarchy to a tree file. Enabled by default when no other
             output format is selected.
@@ -1035,8 +1066,10 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             methods to write results).
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. Use
+                Result.write_tree/write_flow_tree/write_clu (write_clu takes
+                depth_level) or Network.write_pajek/write_state_network. The flag only
+                acts when an output directory is passed via the raw args escape hatch.
         ftree : bool, optional
             Write the modular hierarchy and aggregated links between nested modules to
             an ftree file. Used by Network Navigator.
@@ -1046,8 +1079,10 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             methods to write results).
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. Use
+                Result.write_tree/write_flow_tree/write_clu (write_clu takes
+                depth_level) or Network.write_pajek/write_state_network. The flag only
+                acts when an output directory is passed via the raw args escape hatch.
         clu : bool, optional
             Write top-level module ids for each node to a clu file.
 
@@ -1056,8 +1091,10 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             methods to write results).
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. Use
+                Result.write_tree/write_flow_tree/write_clu (write_clu takes
+                depth_level) or Network.write_pajek/write_state_network. The flag only
+                acts when an output directory is passed via the raw args escape hatch.
         clu_level : int, optional
             With --clu or --output clu, write module ids at this depth from the root.
             Use -1 for bottom-level modules.
@@ -1067,8 +1104,10 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             methods to write results).
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. Use
+                Result.write_tree/write_flow_tree/write_clu (write_clu takes
+                depth_level) or Network.write_pajek/write_state_network. The flag only
+                acts when an output directory is passed via the raw args escape hatch.
         output : sequence of str, optional
             Write selected output formats as a comma-separated list without spaces, e.g.
             -o clu,tree,ftree. Options: clu, tree, ftree, newick, json, csv, network,
@@ -1079,8 +1118,10 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             methods to write results).
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. Use
+                Result.write_tree/write_flow_tree/write_clu (write_clu takes
+                depth_level) or Network.write_pajek/write_state_network. The flag only
+                acts when an output directory is passed via the raw args escape hatch.
         hide_bipartite_nodes : bool, optional
             Hide bipartite nodes in output by projecting the solution to primary nodes.
 
@@ -1089,8 +1130,10 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             methods to write results).
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. Use
+                Result.write_tree/write_flow_tree/write_clu (write_clu takes
+                depth_level) or Network.write_pajek/write_state_network. The flag only
+                acts when an output directory is passed via the raw args escape hatch.
         print_all_trials : bool, optional
             Write each trial to separate output files. Has effect only when --num-trials
             is greater than 1.
@@ -1100,8 +1143,10 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             methods to write results).
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. Use
+                Result.write_tree/write_flow_tree/write_clu (write_clu takes
+                depth_level) or Network.write_pajek/write_state_network. The flag only
+                acts when an output directory is passed via the raw args escape hatch.
         no_overwrite : bool, optional
             Fail with an output error if any target output file already exists. By
             default existing files are replaced.
@@ -1111,14 +1156,16 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             methods to write results).
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. Use
+                Result.write_tree/write_flow_tree/write_clu (write_clu takes
+                depth_level) or Network.write_pajek/write_state_network. The flag only
+                acts when an output directory is passed via the raw args escape hatch.
         print_config_fingerprint : bool, optional
             Print the canonical configuration fingerprint and exit.
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. A print-and-exit
+                CLI diagnostic; run the infomap binary.
         timing_json : str, optional
             Write machine-readable run timing JSON to this path. Use - for stdout.
 
@@ -1172,15 +1219,18 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             -vv and so on.
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. A DEBUG-enabled
+                'infomap' logger (infomap.enable_log(logging.DEBUG)) raises engine
+                verbosity; logger levels filter the records.
         silent : bool, optional
             Suppress console output. The Python API is quiet by default; construct with
             silent=False for the engine log. The command-line interface is unaffected.
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. The Python API is
+                quiet by default; logging is the control. Attach handlers to
+                logging.getLogger('infomap') (e.g. infomap.enable_log()) for the engine
+                log.
         pretty : bool | None, optional
             Deprecated. Accepted for backward compatibility; has no effect. Passing it
             explicitly emits a DeprecationWarning.
@@ -1447,8 +1497,8 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             Alias for --num-threads.
 
             .. deprecated:: 2.15
-                Pass it via ``Options`` to ``infomap.run()`` or ``Network.run()``
-                instead; this keyword leaves the ``Infomap`` signature in 3.0.
+                This keyword leaves the ``Infomap`` signature in 3.0. Use num_threads;
+                threads is a redundant alias of the same engine option.
         prefer_modular_solution : bool, optional
             Prefer a modular solution even when one module gives a lower codelength.
 
@@ -1484,6 +1534,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
                 DeprecationWarning,
                 stacklevel=2,
             )
+        _warn_advanced_tier_kwargs(locals(), "run")
         options = Options._from_locals(locals())
         return self._run_from_options(args, initial_partition, options)
     # === END generated ===
@@ -2768,7 +2819,10 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
     def _run_from_options(self, args, initial_partition, options):
         kwargs = options.to_kwargs()
         if _is_log_routed():
-            if self._engine_constructed_silent:
+            # Warn once per instance: a run loop would otherwise repeat the
+            # same advisory on every call and train the user to ignore it.
+            if self._engine_constructed_silent and not self._warned_stale_silent:
+                self._warned_stale_silent = True
                 warnings.warn(
                     "the 'infomap' logger has handlers, but this Infomap "
                     "instance was created silent before logging was "

--- a/interfaces/python/src/infomap/_logging.py
+++ b/interfaces/python/src/infomap/_logging.py
@@ -113,6 +113,11 @@ def apply_engine_log_overrides(kwargs: dict) -> dict:
 
 
 _helper_handler: logging.Handler | None = None
+# The logger's ``propagate`` value captured when enable_log() first turned it
+# off, so disable_log() can restore exactly that -- rather than forcing the
+# library default back on and clobbering a user who set propagate=False on
+# purpose. ``None`` means "nothing captured / helper inactive".
+_saved_propagate: bool | None = None
 
 
 def enable_log(level: int = logging.INFO) -> logging.Handler:
@@ -150,7 +155,7 @@ def enable_log(level: int = logging.INFO) -> logging.Handler:
     >>> handler = infomap.enable_log()
     >>> infomap.disable_log()
     """
-    global _helper_handler
+    global _helper_handler, _saved_propagate
     if _helper_handler is None:
         handler = logging.StreamHandler(sys.stdout)
         handler.setFormatter(logging.Formatter("%(message)s"))
@@ -158,7 +163,10 @@ def enable_log(level: int = logging.INFO) -> logging.Handler:
     if _helper_handler not in logger.handlers:
         logger.addHandler(_helper_handler)
     # Don't double-print through a root handler (e.g. logging.basicConfig());
-    # disable_log() puts propagation back.
+    # disable_log() puts propagation back to whatever it was. Capture only on
+    # the first activation so repeated calls don't record the already-off value.
+    if _saved_propagate is None:
+        _saved_propagate = logger.propagate
     logger.propagate = False
     logger.setLevel(level)
     return _helper_handler
@@ -171,9 +179,12 @@ def disable_log() -> None:
     handlers remaining, the engine goes back to classic stdout output
     (gated by ``silent=``).
     """
-    global _helper_handler
+    global _helper_handler, _saved_propagate
     if _helper_handler is not None:
         logger.removeHandler(_helper_handler)
         _helper_handler = None
-        # Restore the default so records reach ancestor handlers again.
-        logger.propagate = True
+        # Restore propagation to whatever enable_log() found, so a user who set
+        # propagate=False on purpose keeps it (default library state is True).
+        if _saved_propagate is not None:
+            logger.propagate = _saved_propagate
+            _saved_propagate = None

--- a/interfaces/python/src/infomap/_options.py
+++ b/interfaces/python/src/infomap/_options.py
@@ -37,6 +37,115 @@ FlowModel = Literal[
     "undirected", "directed", "undirdir", "outdirdir", "rawdir", "precomputed"
 ]
 
+_ADVANCED_TIER_KWARGS = {
+    "skip_adjust_bipartite_flow": (False, False, "keep", None),
+    "bipartite_teleportation": (False, False, "keep", None),
+    "weight_threshold": (None, None, "keep", None),
+    "no_self_links": (False, False, "keep", None),
+    "node_limit": (None, None, "keep", None),
+    "matchable_multilayer_ids": (None, None, "keep", None),
+    "cluster_data": (None, None, "keep", None),
+    "assign_to_neighbouring_module": (False, False, "keep", None),
+    "meta_data": (None, None, "keep", None),
+    "meta_data_rate": (1.0, 1.0, "keep", None),
+    "meta_data_unweighted": (False, False, "keep", None),
+    "no_infomap": (False, False, "keep", None),
+    "out_name": (None, None, "args-only", "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."),
+    "no_file_output": (False, False, "args-only", "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."),
+    "tree": (False, False, "args-only", "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."),
+    "ftree": (False, False, "args-only", "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."),
+    "clu": (False, False, "args-only", "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."),
+    "clu_level": (None, None, "args-only", "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."),
+    "output": (None, None, "args-only", "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."),
+    "hide_bipartite_nodes": (False, False, "args-only", "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."),
+    "print_all_trials": (False, False, "args-only", "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."),
+    "no_overwrite": (False, False, "args-only", "Use Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or Network.write_pajek/write_state_network. The flag only acts when an output directory is passed via the raw args escape hatch."),
+    "print_config_fingerprint": (False, False, "remove", "A print-and-exit CLI diagnostic; run the infomap binary."),
+    "timing_json": (None, None, "keep", None),
+    "summary_json": (None, None, "keep", None),
+    "manifest_json": (None, None, "keep", None),
+    "memory_report": (False, False, "keep", None),
+    "trial_offset": (None, None, "keep", None),
+    "trial_results": (None, None, "keep", None),
+    "no_final_output": (False, False, "keep", None),
+    "verbosity_level": (1, 1, "remove", "A DEBUG-enabled 'infomap' logger (infomap.enable_log(logging.DEBUG)) raises engine verbosity; logger levels filter the records."),
+    "silent": (True, False, "remove", "The Python API is quiet by default; logging is the control. Attach handlers to logging.getLogger('infomap') (e.g. infomap.enable_log()) for the engine log."),
+    "flow_model": (None, None, "keep", None),
+    "recorded_teleportation": (False, False, "keep", None),
+    "use_node_weights_as_flow": (False, False, "keep", None),
+    "to_nodes": (False, False, "keep", None),
+    "teleportation_probability": (0.15, 0.15, "keep", None),
+    "max_flow_iterations": (400, 400, "keep", None),
+    "min_flow_iterations": (50, 50, "keep", None),
+    "flow_tolerance": (1e-15, 1e-15, "keep", None),
+    "regularized": (False, False, "keep", None),
+    "regularization_strength": (1.0, 1.0, "keep", None),
+    "entropy_corrected": (False, False, "keep", None),
+    "entropy_correction_strength": (1.0, 1.0, "keep", None),
+    "variable_markov_time": (False, False, "keep", None),
+    "variable_markov_damping": (1.0, 1.0, "keep", None),
+    "variable_markov_min_scale": (1.0, 1.0, "keep", None),
+    "preferred_number_of_modules": (None, None, "keep", None),
+    "preferred_number_of_levels": (None, None, "keep", None),
+    "preferred_number_of_levels_strength": (1.0, 1.0, "keep", None),
+    "multilayer_relax_rate": (0.15, 0.15, "keep", None),
+    "multilayer_relax_limit": (-1, -1, "keep", None),
+    "multilayer_relax_limit_up": (-1, -1, "keep", None),
+    "multilayer_relax_limit_down": (-1, -1, "keep", None),
+    "multilayer_relax_by_jsd": (False, False, "keep", None),
+    "multilayer_relax_to_self": (False, False, "keep", None),
+    "core_loop_limit": (10, 10, "keep", None),
+    "core_level_limit": (None, None, "keep", None),
+    "tune_iteration_limit": (None, None, "keep", None),
+    "core_loop_codelength_threshold": (1e-10, 1e-10, "keep", None),
+    "tune_iteration_relative_threshold": (1e-05, 1e-05, "keep", None),
+    "fast_hierarchical_solution": (None, None, "keep", None),
+    "inner_parallelization": (False, False, "keep", None),
+    "parallel_trials": (False, False, "keep", None),
+    "converge": (False, False, "keep", None),
+    "num_threads": (None, None, "keep", None),
+    "threads": (None, None, "remove", "Use num_threads; threads is a redundant alias of the same engine option."),
+    "prefer_modular_solution": (False, False, "keep", None),
+    "num_random_moves": (None, None, "keep", None),
+    "max_degree_for_random_moves": (None, None, "keep", None),
+}
+
+
+def _warn_advanced_tier_kwargs(passed, context):
+    # Advanced-tier keywords are docs-only deprecated on the Infomap()/run()
+    # signatures (issue #741) and move off them in 3.0. Emit a
+    # PendingDeprecationWarning -- silent by default, so it nags no one until
+    # 3.0 nears -- when one is set to a non-default value on a direct call.
+    # Internal funnels (the Options path builds Infomap(**resolved), the graph
+    # adapters, the from_* class methods) reach the same methods from inside
+    # the package; the caller-frame check skips them so only user-typed
+    # keywords are flagged.
+    caller = sys._getframe(2)
+    if caller.f_code.co_filename.startswith(_PACKAGE_PREFIX):
+        return
+    baseline = 1 if context == "run" else 0
+    for name, spec in _ADVANCED_TIER_KWARGS.items():
+        default = spec[baseline]
+        if passed.get(name, default) != default:
+            action, replacement = spec[2], spec[3]
+            lead = (
+                f"'{name}' is deprecated on the Infomap() and run() "
+                "signatures and leaves them in 3.0. "
+            )
+            if action in ("keep", "alias"):
+                guidance = (
+                    "Pass it via Options to infomap.run() or "
+                    "Network.run() instead."
+                )
+            elif replacement is not None:
+                guidance = replacement
+            else:
+                guidance = ""
+            warnings.warn(
+                lead + guidance, PendingDeprecationWarning, stacklevel=3
+            )
+
+
 _INPUT_OPTION_SPECS = (
     ("flag", "skip_adjust_bipartite_flow", "--skip-adjust-bipartite-flow", None),
     ("flag", "bipartite_teleportation", "--bipartite-teleportation", None),

--- a/interfaces/python/src/infomap/_run.py
+++ b/interfaces/python/src/infomap/_run.py
@@ -148,7 +148,7 @@ def _reject_adapter_kwargs(kind: str, user_keys: set) -> None:
     if not misdirected:
         return
     names = ", ".join(repr(name) for name in misdirected)
-    raise TypeError(
+    message = (
         f"infomap.run() forwards keyword arguments to the engine, but {names} "
         f"configure how the {kind} input is read, not the engine. Build the "
         f"network explicitly and run it, e.g. "
@@ -156,6 +156,15 @@ def _reject_adapter_kwargs(kind: str, user_keys: set) -> None:
         f"run() builds input with default settings; Network.from_* is the path "
         f"for non-default input."
     )
+    if "directed" in misdirected:
+        # `directed` names the adapter's edge orientation, not the engine's
+        # flow model -- steer users away from that collision explicitly.
+        message += (
+            " (Here 'directed' sets the adapter's edge orientation; for the "
+            "engine's directed flow model pass flow_model='directed' via "
+            "Options.)"
+        )
+    raise TypeError(message)
 
 
 def run(

--- a/interfaces/python/src/infomap/result.py
+++ b/interfaces/python/src/infomap/result.py
@@ -875,7 +875,12 @@ class Result(_ResultWritersMixin):
             sort_columns = _to_dataframe_sort_columns(sort, dataframe.columns)
             dataframe = dataframe.sort_values(sort_columns).reset_index(drop=True)
 
-        if index not in (None, False):
+        if index is not None and index is not False:
+            if index is True:
+                raise TypeError(
+                    "index=True is not a column. Pass a column name (str), or "
+                    "False/None (the default) to keep the RangeIndex."
+                )
             dataframe = dataframe.set_index(index)
 
         return dataframe

--- a/scripts/generate_binding_options.py
+++ b/scripts/generate_binding_options.py
@@ -164,6 +164,11 @@ def _facade_params(catalog: ParameterCatalog):
                 ),
                 "doc_type": param.python_doc_type(),
                 "doc": param.python_doc_description(),
+                # The 3.0 cleanup-policy decision (issue #755) drives both the
+                # docstring migration note and the runtime PendingDeprecationWarning
+                # so the two never diverge from render_parameter_policy.py.
+                "policy": param.policy("python"),
+                "init_default": param.python_default_expr(),
             }
             names.append(name)
             for facade_name in after.get(name, ()):
@@ -205,6 +210,84 @@ def _python_literal_alias_lines(catalog: ParameterCatalog) -> list[str]:
     return lines
 
 
+# Static runtime helper (issue #741): warn when an advanced-tier keyword is set
+# on a *direct* Infomap()/run() call. The message shape mirrors
+# _advanced_tier_note() -- keep/alias parameters point at Options, every other
+# action carries its policy replacement -- so the docstring and the warning
+# never diverge.
+_ADVANCED_TIER_WARNING_HELPER = [
+    "def _warn_advanced_tier_kwargs(passed, context):",
+    "    # Advanced-tier keywords are docs-only deprecated on the Infomap()/run()",
+    "    # signatures (issue #741) and move off them in 3.0. Emit a",
+    "    # PendingDeprecationWarning -- silent by default, so it nags no one until",
+    "    # 3.0 nears -- when one is set to a non-default value on a direct call.",
+    "    # Internal funnels (the Options path builds Infomap(**resolved), the graph",
+    "    # adapters, the from_* class methods) reach the same methods from inside",
+    "    # the package; the caller-frame check skips them so only user-typed",
+    "    # keywords are flagged.",
+    "    caller = sys._getframe(2)",
+    "    if caller.f_code.co_filename.startswith(_PACKAGE_PREFIX):",
+    "        return",
+    '    baseline = 1 if context == "run" else 0',
+    "    for name, spec in _ADVANCED_TIER_KWARGS.items():",
+    "        default = spec[baseline]",
+    "        if passed.get(name, default) != default:",
+    "            action, replacement = spec[2], spec[3]",
+    "            lead = (",
+    "                f\"'{name}' is deprecated on the Infomap() and run() \"",
+    '                "signatures and leaves them in 3.0. "',
+    "            )",
+    '            if action in ("keep", "alias"):',
+    "                guidance = (",
+    '                    "Pass it via Options to infomap.run() or "',
+    '                    "Network.run() instead."',
+    "                )",
+    "            elif replacement is not None:",
+    "                guidance = replacement",
+    "            else:",
+    '                guidance = ""',
+    "            warnings.warn(",
+    "                lead + guidance, PendingDeprecationWarning, stacklevel=3",
+    "            )",
+]
+
+
+def _advanced_tier_kwarg_lines(catalog: ParameterCatalog) -> list[str]:
+    """The runtime advanced-tier warning table plus its helper.
+
+    One entry per advanced-tier catalog parameter (self-deprecated aliases such
+    as ``pretty``/``include_self_links`` warn on their own): the ``init`` and
+    ``run`` "unset" defaults and the policy ``action``/``replacement`` that
+    shape the message. Built from the same policy the docstring note reads.
+    """
+    names, index = _facade_params(catalog)
+    lines: list[str] = ["_ADVANCED_TIER_KWARGS = {"]
+    for name in names:
+        info = index[name]
+        if info.get("tier") != "advanced" or "policy" not in info:
+            continue
+        if name in _SELF_DEPRECATED_PARAMS:
+            continue
+        policy = info["policy"]
+        action = policy.get("action", "keep")
+        replacement = (
+            "None"
+            if action in {"keep", "alias"}
+            else json.dumps(policy["replacement"])
+        )
+        lines.append(
+            f'    "{name}": ({info["init_default"]}, {info["run_default"]}, '
+            f'"{action}", {replacement}),'
+        )
+    lines.append("}")
+    lines.append("")
+    lines.append("")
+    lines.extend(_ADVANCED_TIER_WARNING_HELPER)
+    lines.append("")
+    lines.append("")
+    return lines
+
+
 def generate_python(catalog: ParameterCatalog) -> str:
     grouped = catalog.grouped()
     include_self_links = catalog.binding_only_entry("python", "include_self_links")
@@ -242,6 +325,7 @@ def generate_python(catalog: ParameterCatalog) -> str:
         "",
     ]
     lines.extend(_python_literal_alias_lines(catalog))
+    lines.extend(_advanced_tier_kwarg_lines(catalog))
     for group in GROUPS:
         spec_name = f"_{group.upper()}_OPTION_SPECS"
         lines.append(f"{spec_name} = (")
@@ -768,6 +852,25 @@ _ADVANCED_TIER_NOTE = (
 )
 
 
+def _advanced_tier_note(policy):
+    """The advanced-tier ``.. deprecated::`` note text for a parameter.
+
+    A ``keep``/``alias`` parameter stays available and only its entry point
+    moves, so it points at ``Options``. Every other action (``remove``,
+    ``args-only``, ...) carries its own migration path in the policy's
+    ``replacement`` (the #755 acceptance criterion), which is the correct
+    guidance -- telling the user to "pass it via Options" would contradict
+    both the policy and render_parameter_policy.py.
+    """
+    action = (policy or {}).get("action", "keep")
+    if action in {"keep", "alias"}:
+        return _ADVANCED_TIER_NOTE
+    return (
+        "This keyword leaves the `Infomap` signature in 3.0. "
+        + policy["replacement"]
+    )
+
+
 def _render_facade_docstring_params(names, index):
     lines = []
     for name in names:
@@ -784,7 +887,8 @@ def _render_facade_docstring_params(names, index):
             lines.append(
                 f"            .. deprecated:: {_ADVANCED_TIER_DEPRECATED_IN}"
             )
-            lines.extend(wrap_doc(_ADVANCED_TIER_NOTE, "                "))
+            note = _advanced_tier_note(info.get("policy"))
+            lines.extend(wrap_doc(note, "                "))
     return lines
 
 
@@ -816,6 +920,7 @@ def generate_facade(catalog: ParameterCatalog) -> str:
     lines.extend(_render_facade_docstring_params(names, index))
     lines.append('        """')
     lines.extend(_PRETTY_WARNING_LINES)
+    lines.append('        _warn_advanced_tier_kwargs(locals(), "init")')
     lines.append("        options = Options._from_locals(locals())")
     lines.append("        self._init_from_options(args, options)")
     lines.append("")
@@ -869,6 +974,7 @@ def generate_facade(catalog: ParameterCatalog) -> str:
     lines.append("        initial_partition")
     lines.append('        """')
     lines.extend(_PRETTY_WARNING_LINES)
+    lines.append('        _warn_advanced_tier_kwargs(locals(), "run")')
     lines.append("        options = Options._from_locals(locals())")
     lines.append(
         "        return self._run_from_options(args, initial_partition, options)"

--- a/scripts/parameter_catalog.py
+++ b/scripts/parameter_catalog.py
@@ -293,6 +293,7 @@ class ParameterCatalog:
             for language, entries in overrides.get("bindingOnly", {}).items()
         }
         self._validate_policy()
+        self._validate_override_sections()
         # Hidden bindings are derived from the policy: a `hide` decision on a
         # generated surface removes the parameter from that surface (the
         # policy is the single per-parameter record; see issue #755).
@@ -306,6 +307,44 @@ class ParameterCatalog:
             for language in surfaces
             if language != "cli"
         }
+
+    def _known_flags(self) -> set[str]:
+        known = {param.flag for param in self.parameters}
+        known |= {
+            entry.flag
+            for entries in self.binding_only_parameters.values()
+            for entry in entries
+        }
+        known |= set(self.overrides.get("policy", {}).get("cliOnlyParameters", []))
+        return known
+
+    def _validate_override_sections(self) -> None:
+        # The names/defaults/docs sections are keyed by CLI flag and then by
+        # binding language. They are inputs to the generator, not policy, so
+        # _validate_policy does not reach them -- but a typo'd flag or language
+        # key would silently fall back to a generated default (the same silent
+        # drift the policy check guards against, issue #755), so validate them
+        # here too.
+        surfaces = set(self.overrides.get("policy", {}).get("surfaces", []))
+        languages = surfaces - {"cli"} if surfaces else {"python", "r", "ts"}
+        known_flags = self._known_flags()
+        for section in ("names", "defaults", "docs"):
+            for flag, per_language in self.overrides.get(section, {}).items():
+                if flag not in known_flags:
+                    raise RuntimeError(
+                        f"overrides.{section} lists unknown flag {flag!r} (not in "
+                        "the parameter catalog, bindingOnly, or cliOnlyParameters)"
+                    )
+                if not isinstance(per_language, dict):
+                    raise RuntimeError(
+                        f"overrides.{section}[{flag!r}] must map language to value"
+                    )
+                for language in per_language:
+                    if language not in languages:
+                        raise RuntimeError(
+                            f"overrides.{section}[{flag!r}] names unknown language "
+                            f"{language!r}; known languages: {sorted(languages)}"
+                        )
 
     def _validate_policy(self) -> None:
         # Fail loud on typos and incomplete decisions: the policy is the 3.0

--- a/test/python/test_deprecations.py
+++ b/test/python/test_deprecations.py
@@ -147,15 +147,81 @@ def test_deprecated_member_still_documents_deprecation():
     assert ".. deprecated::" in Infomap.codelength.__doc__
 
 
-# -- advanced-tier keyword parameters (docs-only deprecated, #741) -----------
+# -- advanced-tier keyword parameters (#741) --------------------------------
+
+
+def _pending(records):
+    return [
+        str(r.message)
+        for r in records
+        if issubclass(r.category, PendingDeprecationWarning)
+    ]
 
 
 @pytest.mark.fast
-def test_advanced_tier_kwargs_stay_silent_and_functional():
-    """Advanced-tier kwargs are deprecated by documentation only: passing
-    them explicitly emits no DeprecationWarning and keeps working."""
+def test_advanced_tier_kwargs_emit_no_deprecation_warning_and_work():
+    """Advanced-tier kwargs never raise the louder DeprecationWarning (which
+    tools escalate by default) and keep working."""
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
         im = _two_triangles(core_loop_limit=5, flow_model="undirected")
         result = im.run(markov_time=1.0, core_loop_limit=5)
     assert result.num_top_modules >= 1
+
+
+@pytest.mark.fast
+def test_advanced_tier_kwarg_emits_pending_on_direct_call():
+    """A non-default advanced-tier kwarg on a direct Infomap()/run() call
+    emits a PendingDeprecationWarning naming the keyword (issue #741)."""
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        Infomap(silent=True, no_file_output=True, regularized=True)
+    assert any("regularized" in message for message in _pending(records))
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        im = _two_triangles()
+        im.run(core_loop_limit=5)
+    assert any("core_loop_limit" in message for message in _pending(records))
+
+
+@pytest.mark.fast
+def test_advanced_tier_message_follows_policy_action():
+    """The message routes keep-tier kwargs to Options and args-only kwargs to
+    the write_* methods -- never the contradictory 'via Options' for the
+    latter (issue #755)."""
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        Infomap(silent=True, regularized=True, no_file_output=True)
+    messages = _pending(records)
+    regularized = next(m for m in messages if "regularized" in m)
+    no_file_output = next(m for m in messages if "no_file_output" in m)
+    assert "Options" in regularized
+    assert "write_" in no_file_output and "Options" not in no_file_output
+
+
+@pytest.mark.fast
+def test_common_tier_kwargs_emit_no_pending_warning():
+    """Common-tier kwargs stay on the signature and emit nothing."""
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        im = Infomap(silent=True, num_trials=3, markov_time=2.0, two_level=True)
+        im.add_link(0, 1)
+        im.run(num_trials=2)
+    assert _pending(records) == []
+
+
+@pytest.mark.fast
+def test_advanced_tier_kwarg_silent_through_options_and_adapters():
+    """The Options path and the internal adapters funnel through the same
+    Infomap()/run() but from inside the package, so they never warn -- using
+    Options is the sanctioned, nag-free migration."""
+    import infomap
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        infomap.run(
+            [(0, 1), (1, 2), (2, 0)],
+            options=infomap.Options(regularized=True, core_loop_limit=5),
+        )
+    assert _pending(records) == []

--- a/test/python/test_deprecations.py
+++ b/test/python/test_deprecations.py
@@ -16,7 +16,7 @@ import warnings
 
 import pytest
 
-from infomap import Infomap
+from infomap import Infomap, Options, run
 
 
 def _two_triangles(**kwargs) -> Infomap:
@@ -216,12 +216,10 @@ def test_advanced_tier_kwarg_silent_through_options_and_adapters():
     """The Options path and the internal adapters funnel through the same
     Infomap()/run() but from inside the package, so they never warn -- using
     Options is the sanctioned, nag-free migration."""
-    import infomap
-
     with warnings.catch_warnings(record=True) as records:
         warnings.simplefilter("always")
-        infomap.run(
+        run(
             [(0, 1), (1, 2), (2, 0)],
-            options=infomap.Options(regularized=True, core_loop_limit=5),
+            options=Options(regularized=True, core_loop_limit=5),
         )
     assert _pending(records) == []

--- a/test/python/test_docs_examples_surface.py
+++ b/test/python/test_docs_examples_surface.py
@@ -129,8 +129,50 @@ def _advanced_kwargs() -> set[str]:
     return set(_OPTION_FIELD_NAMES) - _load_common_tier()
 
 
+def _rst_python_blocks(text: str) -> str:
+    """The bodies of ``.. code-block:: python`` directives in an RST file.
+
+    The repo-root README mixes Python, R, and shell snippets in one file, so a
+    whole-file scan would flag the R example's ``silent = TRUE``. Restrict it to
+    the Python directives. (Docs under ``source/`` are Python-only, so they are
+    still scanned whole.)
+    """
+    lines = text.splitlines()
+    blocks: list[str] = []
+    index = 0
+    directive = re.compile(r"^\s*\.\.\s+code(?:-block)?::\s*python\s*$")
+    while index < len(lines):
+        if not directive.match(lines[index]):
+            index += 1
+            continue
+        index += 1
+        body: list[str] = []
+        # Skip blank lines between the directive and its indented body.
+        while index < len(lines) and not lines[index].strip():
+            index += 1
+        for line in lines[index:]:
+            if line.strip() and not line.startswith((" ", "\t")):
+                break
+            body.append(line)
+            index += 1
+        blocks.append("\n".join(body))
+    return "\n".join(blocks)
+
+
+def _scannable_text(path: Path) -> str:
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    if path.name == "README.rst":
+        return _rst_python_blocks(text)
+    return text
+
+
 def _source_files() -> list[Path]:
     files = sorted(EXAMPLES.glob("*.py"))
+    # The repo-root README is the front door; keep its Python snippet on the
+    # supported surface too (it lives outside source/, so it needs listing).
+    readme = REPO_ROOT / "README.rst"
+    if readme.is_file():
+        files.append(readme)
     files += sorted(
         path
         for path in DOCS.rglob("*.md")
@@ -200,7 +242,7 @@ def test_docs_and_examples_avoid_the_deprecated_surface():
     violations: list[str] = []
 
     for path in _source_files():
-        text = path.read_text(encoding="utf-8", errors="ignore")
+        text = _scannable_text(path)
         rel = path.relative_to(REPO_ROOT)
 
         for match in _IM_RECEIVER.finditer(text):

--- a/test/python/test_logging.py
+++ b/test/python/test_logging.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import ctypes
 import logging
 import sys
+import warnings
 
 import pytest
 
@@ -198,6 +199,45 @@ def test_instance_constructed_before_logging_config_warns(infomap_log_handler):
 
     # The engine baked --silent in at construction, so no records exist.
     assert infomap_log_handler.records == []
+
+
+def test_disable_log_restores_user_propagate_choice():
+    logger = logging.getLogger("infomap")
+    original = logger.propagate
+    try:
+        logger.propagate = False  # a deliberate user choice
+        enable_log()
+        assert logger.propagate is False  # off while active
+        disable_log()
+        # Restored to the user's choice, not forced back to the True default.
+        assert logger.propagate is False
+
+        logger.propagate = True
+        enable_log()
+        disable_log()
+        assert logger.propagate is True
+    finally:
+        disable_log()
+        logger.propagate = original
+
+
+def test_stale_silent_advisory_warns_at_most_once(infomap_log_handler):
+    logger = logging.getLogger("infomap")
+    logger.removeHandler(infomap_log_handler)
+    im = Infomap()  # constructed silent before logging was configured
+    im.add_link(1, 2)
+    logger.addHandler(infomap_log_handler)
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        im.run()
+        im.run()
+        im.run()
+
+    stale = [
+        r for r in records if "before logging was configured" in str(r.message)
+    ]
+    assert len(stale) == 1
 
 
 def test_enable_log_is_a_one_line_opt_in(capfd):

--- a/test/python/test_parameter_catalog.py
+++ b/test/python/test_parameter_catalog.py
@@ -29,10 +29,6 @@ def test_parameter_catalog_classifies_binding_render_policies():
             "incremental": False,
             "longType": "integer",
             "default": "1",
-            "bindingDefaults": {
-                "python": {"value": "1"},
-                "r": {"value": "1L"},
-            },
         },
         {
             "long": "--verbose",
@@ -43,21 +39,7 @@ def test_parameter_catalog_classifies_binding_render_policies():
             "advanced": False,
             "incremental": True,
             "default": False,
-            "bindingNames": {
-                "python": "verbosity_level",
-                "r": "verbosity_level",
-                "ts": "verbose",
-            },
             "renderPolicy": "repeated_short",
-            "bindingDocs": {
-                "python": {
-                    "description": "Verbosity level on the console.",
-                },
-            },
-            "bindingDefaults": {
-                "python": {"value": "1"},
-                "r": {"value": "1L"},
-            },
         },
         {
             "long": "--output",

--- a/test/python/test_parameter_policy.py
+++ b/test/python/test_parameter_policy.py
@@ -56,10 +56,27 @@ _EXTRA_FLAGS = {
 } | set(OVERRIDES["policy"].get("cliOnlyParameters", []))
 
 
+def _overrides_section_flags(overrides: dict) -> set[str]:
+    # Flags referenced by the names/defaults/docs sections. Many are keep-tier
+    # (so absent from the policy decisions) but must still exist in the catalog
+    # -- the catalog validates these sections too (issue #755).
+    flags: set[str] = set()
+    for section in ("names", "defaults", "docs"):
+        flags.update(overrides.get(section, {}))
+    return flags
+
+
 def _fake_parameters() -> list[dict]:
-    # A minimal stand-in for the C++ catalog: every flag the policy decides
-    # on (minus binding-only/CLI-only extras) plus one policy-less parameter.
-    flags = sorted((_policy_flags(OVERRIDES) - _EXTRA_FLAGS) | {"--core-loop-limit"})
+    # A minimal stand-in for the C++ catalog: every flag the policy decides on
+    # or the override sections reference (minus binding-only/CLI-only extras)
+    # plus one policy-less parameter.
+    flags = sorted(
+        (
+            (_policy_flags(OVERRIDES) | _overrides_section_flags(OVERRIDES))
+            - _EXTRA_FLAGS
+        )
+        | {"--core-loop-limit"}
+    )
     return [
         {"long": flag, "short": "", "group": "Algorithm", "description": "x"}
         for flag in flags

--- a/test/python/test_result.py
+++ b/test/python/test_result.py
@@ -363,6 +363,23 @@ def test_to_dataframe_conflicting_depth_aliases_raise(
         result.to_dataframe(depth=1, level=2)
 
 
+def test_to_dataframe_index_true_is_rejected(make_infomap, example_network_path):
+    pytest.importorskip("pandas")
+
+    im = make_infomap(num_trials=10)
+    im.read_file(str(example_network_path("ninetriangles.net")))
+    result = im.run()
+
+    # index=True has no column to key on; it must raise clearly instead of a
+    # bare pandas KeyError(True).
+    with pytest.raises(TypeError, match="index=True is not a column"):
+        result.to_dataframe(index=True)
+
+    # A real column key still works, and False/None keep the RangeIndex.
+    assert result.to_dataframe(index="node_id").index.name == "node_id"
+    assert result.to_dataframe(index=False).index.name is None
+
+
 def test_to_dataframe_deprecated_aliases_stay_silent(
     make_infomap, example_network_path
 ):

--- a/test/scripts/check_binding_defaults.py
+++ b/test/scripts/check_binding_defaults.py
@@ -10,12 +10,15 @@ is not rendered, so the engine quietly uses a different default. The byte-level
 freshness check cannot catch this because it regenerates identical output from
 the unchanged override.
 
-This check compares each declared binding default against the engine default
-from ``--print-json-parameters``. Value-typed parameters must match
+This check compares each declared binding default -- for *every* binding
+language present in the entry (Python and R today) -- against the engine
+default from ``--print-json-parameters``. Value-typed parameters must match
 numerically; the handful of boolean *flags* whose binding default intentionally
 diverges (tri-state ``None``, integer verbosity, quiet-by-default) are listed
 below with the reason, so an accidental drift on any other parameter still
-fails loud.
+fails loud. A tri-state "unset" literal (Python ``None``, R ``NULL``) carries
+no scalar to compare and is skipped -- that is how a parameter opts a language
+out of the engine default (e.g. R ``NULL`` for the multilayer relax limits).
 
 Usage:  check_binding_defaults.py <path-to-Infomap-binary>
 """
@@ -46,6 +49,20 @@ def _as_bool(value: str) -> bool:
     return value.strip().lower() in {"true", "1"}
 
 
+# Per-language "unset" literals: a tri-state default that carries no scalar to
+# compare against the engine, so the parameter opts that language out of the
+# engine default.
+_UNSET_LITERALS = {"python": {"None"}, "r": {"NULL"}}
+
+
+def _numeric(language: str, value: str) -> float:
+    """Parse a language default literal as a float (R integer suffix aside)."""
+    literal = value.strip()
+    if language == "r" and literal.endswith("L"):
+        literal = literal[:-1]
+    return float(literal)
+
+
 def main() -> int:
     cli = sys.argv[1]
     result = subprocess.run(
@@ -73,23 +90,31 @@ def main() -> int:
             )
             continue
         engine_default = str(param.get("default"))
-        python_default = per_language["python"]
         # Value-typed parameters carry a longType (integer/number/probability);
         # boolean flags have none.
-        if param.get("longType") is None:
-            if flag in INTENTIONAL_FLAG_DIVERGENCES:
+        is_flag = param.get("longType") is None
+        for language, binding_default in per_language.items():
+            if binding_default.strip() in _UNSET_LITERALS.get(language, set()):
+                # Tri-state "unset": no scalar to compare (e.g. R NULL).
                 continue
-            if _as_bool(python_default) != _as_bool(engine_default):
+            if is_flag:
+                if flag in INTENTIONAL_FLAG_DIVERGENCES:
+                    continue
+                if _as_bool(binding_default) != _as_bool(engine_default):
+                    drift.append(
+                        f"{flag} [{language}]: engine default {engine_default!r} != "
+                        f"binding default {binding_default!r}"
+                    )
+                continue
+            try:
+                matches = _numeric(language, binding_default) == float(engine_default)
+            except ValueError:
+                matches = False
+            if not matches:
                 drift.append(
-                    f"{flag}: engine default {engine_default!r} != binding default "
-                    f"{python_default!r}"
+                    f"{flag} [{language}]: engine default {engine_default!r} != "
+                    f"binding default {binding_default!r}"
                 )
-            continue
-        if float(engine_default) != float(python_default):
-            drift.append(
-                f"{flag}: engine default {engine_default!r} != binding default "
-                f"{python_default!r}"
-            )
 
     if drift:
         print("Binding defaults drifted from engine defaults:", file=sys.stderr)


### PR DESCRIPTION
## Summary

This branch modernizes the Python package around three pillars: a coherent, Pythonic **API surface** (single `Core` boundary, immutable generation-guarded `Result`, first-class `Network` builder, public error taxonomy, `io`/`tl` namespaces, Python-logging routing), a **parameter catalog** that is the single source of truth driving the generated Python/R/JS bindings (with a fail-loud-validated 3.0 cleanup policy and signature tiers), and **documentation** steered onto the supported `Options`/common-tier surface with contract tests pinning docs and examples to the real API.

The most recent commits act on a review of that work and address concrete gaps found in it:

- **Advanced-tier deprecation is now policy-consistent and observable.** Each generated `.. deprecated::` note is derived from the cleanup policy instead of a single hard-coded string, so `remove`/`args-only` parameters (`silent`, `verbose`, `threads`, the output-artifact group, …) point at their real migration (logging / `write_*`) rather than the contradictory "pass it via Options". A non-default advanced-tier keyword on a *direct* `Infomap()`/`run()` call now emits a `PendingDeprecationWarning` (silent by default); the `Options` path and internal adapters funnel through the same methods from inside the package and stay warning-free, so routing through `Options` is the nag-free migration.
- **Parameter-catalog guards close silent-drift holes.** The `names`/`defaults`/`docs` override sections are now validated (unknown flag or language fails the build), and `check_binding_defaults.py` compares *every* language's default against the engine (R as well as Python), so a self-consistent but wrong R default no longer passes the byte-level freshness check.
- **Two error surfaces sharpened.** `infomap.run(..., directed=…)` on scipy/edge-index input explains the adapter-vs-flow-model collision; `Result.to_dataframe(index=True)` raises a clear `TypeError` instead of a bare pandas `KeyError`.
- **Logging/advisory UX.** The stale-silent routed-log advisory warns at most once per instance; `disable_log()` restores the logger's prior `propagate` value instead of forcing `True`.
- **Docs.** The repo-root README quick-start moved off the deprecated surface (and is now covered by the examples-surface contract test), an adapter comparison table makes the intentional weight/directedness differences scannable, and the `silent`-fixed-at-construction behavior is documented.

## Verification

- `pytest -m fast` (full fast suite): **426 passed, 1 skipped** (the 3 pre-existing skips/errors elsewhere are missing optional/schema deps in the sandbox, unrelated to these changes).
- `ruff check` and `pyright` (core config): clean on all changed Python files.
- `python scripts/generate_binding_options.py` reproduces the committed generated `_facade.py`/`_options.py` byte-for-byte (freshness guard passes); R/JS generated artifacts are unchanged.
- `check_binding_defaults.py ./Infomap`: all Python and R binding defaults match the engine; verified it now fails on an injected R-default typo.

## Notes

- `_facade.py` and `_options.py` are generated (`make build-binding-options`); the edits are in `scripts/generate_binding_options.py`, `scripts/parameter_catalog.py`, and `interfaces/parameters/overrides.json`.
- Behavioral change worth flagging: `find_communities` (networkx) now defaults to `num_trials=10`, matching `find_igraph_communities` — a stochastic algorithm keeps the best of 10 trials, so this is a better default at ~linear extra runtime.
- `no_file_output=True` (a common defensive idiom) is `args-only` and now emits the silent-by-default `PendingDeprecationWarning`; this is faithful to the 3.0 policy and invisible without `-W`.
- Changelog entries intentionally omitted (generated separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175j4abTt1dnrSLQACDSmDF

---
_Generated by [Claude Code](https://claude.ai/code/session_0175j4abTt1dnrSLQACDSmDF)_