### PR TITLE
test(python): close two silent-drift gaps in the catalog/error guards

### DIFF
--- a/interfaces/python/source/workflows/graphrag.md
+++ b/interfaces/python/source/workflows/graphrag.md
@@ -128,7 +128,6 @@ from infomap.tl.graphrag import run_graphrag_communities
 
 result = run_graphrag_communities(
     input_dir=input_dir,
-    silent=True,
     seed=123,
     num_trials=5,
 )
@@ -215,7 +214,6 @@ output_dir = work_dir / "output"
 result_with_output = run_graphrag_communities(
     input_dir=input_dir,
     output_dir=output_dir,
-    silent=True,
     seed=123,
     num_trials=5,
 )

--- a/interfaces/python/source/working-with-infomap/visualizing-and-exporting.md
+++ b/interfaces/python/source/working-with-infomap/visualizing-and-exporting.md
@@ -238,7 +238,7 @@ g = nx.karate_club_graph()
 communities = infomap.find_communities(
     g,
     module_attribute="infomap_module",
-    seed=123, num_trials=10, silent=True,
+    seed=123, num_trials=10,
 )
 nx.write_graphml(g, "karate_infomap.graphml")
 print(f"Found {len(communities)} communities")

--- a/test/python/test_errors.py
+++ b/test/python/test_errors.py
@@ -16,6 +16,8 @@ Pins three contracts:
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from infomap import (
@@ -166,3 +168,38 @@ def test_export_before_run_raises_not_run_error(make_infomap):
 
     with pytest.raises(NotRunError, match="Run Infomap"):
         annotate_networkx_graph(graph, im)
+
+
+def test_run_time_parse_message_fragments_still_appear_in_engine_source():
+    """Guard against silent drift of the run-time parse-error classifier.
+
+    ``errors._classify_run_message`` recognizes an *input* parse failure
+    surfacing from ``run()`` by matching hand-maintained fragments of the C++
+    engine's error strings (``_PARSE_MESSAGE_PREFIXES`` /
+    ``_PARSE_MESSAGE_SUBSTRINGS``). If the engine rewords one of those
+    messages, the fragment stops matching and the failure silently downgrades
+    from :class:`NetworkParseError` to a bare :class:`InfomapError` -- with no
+    other test failing, because the classifier still runs, just less
+    specifically. This asserts every fragment still occurs verbatim somewhere
+    in the C++ sources, so a rewording breaks the build and points here.
+    """
+    src_root = Path(__file__).resolve().parents[2] / "src"
+    if not src_root.is_dir():
+        pytest.skip("C++ sources not available in this layout")
+
+    sources = "\n".join(
+        path.read_text(encoding="utf-8", errors="replace")
+        for path in src_root.rglob("*")
+        if path.suffix in {".cpp", ".h"}
+    )
+    fragments = (
+        errors_module._PARSE_MESSAGE_PREFIXES
+        + errors_module._PARSE_MESSAGE_SUBSTRINGS
+    )
+    missing = [fragment for fragment in fragments if fragment not in sources]
+    assert not missing, (
+        f"run-time parse-error fragments no longer found in src/: {missing}. "
+        "The engine likely reworded a message; update errors._PARSE_MESSAGE_* "
+        "to match, or run() input failures will classify as InfomapError "
+        "instead of NetworkParseError."
+    )

--- a/test/scripts/check_binding_defaults.py
+++ b/test/scripts/check_binding_defaults.py
@@ -20,6 +20,13 @@ fails loud. A tri-state "unset" literal (Python ``None``, R ``NULL``) carries
 no scalar to compare and is skipped -- that is how a parameter opts a language
 out of the engine default (e.g. R ``NULL`` for the multilayer relax limits).
 
+It also checks *completeness* on the Python surface: every numeric value-typed
+parameter must either declare a 'defaults' entry or be listed as intentionally
+optional. The drift comparison alone iterates only the 'defaults' entries that
+already exist, so it cannot catch a numeric parameter that was never added --
+one that would silently render as ``T | None = None`` and drop its documented
+engine default.
+
 Usage:  check_binding_defaults.py <path-to-Infomap-binary>
 """
 
@@ -43,6 +50,31 @@ INTENTIONAL_FLAG_DIVERGENCES = {
     "--fast-hierarchical-solution": "Optional int (None = unset) vs the CLI repeated -F flag.",
     "--verbose": "Integer verbosity_level (default level 1) vs the CLI repeated -v flag.",
 }
+
+# Numeric value-typed parameters that intentionally render as an unset ``None``
+# on the Python surface (``param: int | None = None``) instead of surfacing the
+# engine default, so they are deliberately absent from overrides 'defaults'.
+# Each entry documents why. The completeness check below fails loud on any
+# *other* numeric parameter missing from 'defaults': that one would silently
+# render as ``T | None = None`` and drop its documented engine default. Adding a
+# numeric parameter to the engine therefore forces a conscious choice -- give it
+# a 'defaults' entry, or list it here as intentionally optional.
+INTENTIONAL_OPTIONAL_VALUE_PARAMS = {
+    "--weight-threshold": "Optional link-weight cutoff; unset means no filtering.",
+    "--node-limit": "Optional node-id cap; unset reads all nodes.",
+    "--matchable-multilayer-ids": "Optional; unset disables cross-network state-id matching.",
+    "--clu-level": "Optional depth; unset uses the engine default level.",
+    "--trial-offset": "Optional distributed-shard offset; unset is single-process.",
+    "--preferred-number-of-modules": "Optional soft preference; unset disables it.",
+    "--preferred-number-of-levels": "Optional soft preference; unset disables it.",
+    "--core-level-limit": "Optional reapply cap; unset uses the engine default.",
+    "--tune-iteration-limit": "Optional iteration cap; unset uses the engine default.",
+    "--num-random-moves": "Optional; unset disables random-move merging.",
+    "--max-degree-for-random-moves": "Optional; unset means no degree cap.",
+}
+
+# The engine longTypes that render as a numeric Python default (int/float).
+_NUMERIC_LONG_TYPES = {"integer", "number", "probability"}
 
 
 def _as_bool(value: str) -> bool:
@@ -79,9 +111,36 @@ def main() -> int:
     # flags, so a policy entry (per-parameter, group, or cliOnlyParameters)
     # naming a stale or misspelled flag fails here in the fast tier -- the unit
     # tests can only synthesize the catalog from the policy's own flag set.
-    ParameterCatalog(parameters, overrides)
+    catalog_obj = ParameterCatalog(parameters, overrides)
 
     drift: list[str] = []
+
+    # Completeness: every numeric value-typed parameter rendered on the Python
+    # surface must either declare a 'defaults' entry (checked below for drift)
+    # or be listed as intentionally optional. Without this, a newly added engine
+    # parameter that nobody wired into 'defaults' silently renders as
+    # ``T | None = None`` -- its documented default lost -- and the drift loop
+    # (which only iterates *existing* 'defaults' entries) cannot see the gap.
+    python_hidden = catalog_obj.hidden_bindings.get("python", set())
+    python_defaults = {
+        flag for flag, langs in overrides["defaults"].items() if "python" in langs
+    }
+    for param in catalog_obj.parameters:
+        if param.render_policy != "value":
+            continue  # flags and special render policies handle defaults elsewhere
+        if param.long_type not in _NUMERIC_LONG_TYPES:
+            continue  # string/path values legitimately default to None (unset)
+        if param.flag in python_hidden:
+            continue  # not part of the generated Python signature
+        if param.flag in python_defaults:
+            continue  # concrete default surfaced; drift loop covers it
+        if param.flag in INTENTIONAL_OPTIONAL_VALUE_PARAMS:
+            continue
+        drift.append(
+            f"{param.flag} [python]: numeric value parameter has no 'defaults' "
+            "entry and is not listed as intentionally optional; it would render "
+            "as 'T | None = None' and drop its engine default"
+        )
     for flag, per_language in overrides["defaults"].items():
         param = catalog.get(flag)
         if param is None:
@@ -123,7 +182,7 @@ def main() -> int:
         print(
             "\nUpdate interfaces/parameters/overrides.json 'defaults' to match the "
             "engine, or add an intentional divergence to INTENTIONAL_FLAG_DIVERGENCES "
-            "in this script with a reason.",
+            "/ INTENTIONAL_OPTIONAL_VALUE_PARAMS in this script with a reason.",
             file=sys.stderr,
         )
         return 1

--- a/test/scripts/check_binding_defaults.py
+++ b/test/scripts/check_binding_defaults.py
@@ -73,6 +73,19 @@ INTENTIONAL_OPTIONAL_VALUE_PARAMS = {
     "--max-degree-for-random-moves": "Optional; unset means no degree cap.",
 }
 
+# Parameters that exist only in feature-enabled builds (guarded by
+# ``#if INFOMAP_FEATURE_*`` in src/io/ParameterCatalog.cpp). The bindings are
+# generated from a standard build that omits them, so they are deliberately
+# outside the binding surface and carry no overrides entries -- but the CI
+# 'native' binary may enable the feature, so ``--print-json-parameters`` lists
+# them here. Exclude them from the completeness check; a new feature parameter
+# that reaches this list fails loud until it is added (or genuinely bound).
+FEATURE_GATED_PARAMS = {
+    "--lossy",
+    "--lambda",
+    "--test-feature",
+}
+
 # The engine longTypes that render as a numeric Python default (int/float).
 _NUMERIC_LONG_TYPES = {"integer", "number", "probability"}
 
@@ -126,6 +139,8 @@ def main() -> int:
         flag for flag, langs in overrides["defaults"].items() if "python" in langs
     }
     for param in catalog_obj.parameters:
+        if param.flag in FEATURE_GATED_PARAMS:
+            continue  # feature-build-only; outside the standard binding surface
         if param.render_policy != "value":
             continue  # flags and special render policies handle defaults elsewhere
         if param.long_type not in _NUMERIC_LONG_TYPES:


### PR DESCRIPTION
## Summary

Follow-up to the Python API / parameter-catalog / docs work, addressing findings from a review of that surface. Three changes, no behavior change to the shipped API:

- **Binding-default completeness guard** (`test/scripts/check_binding_defaults.py`). The guard previously only compared the binding defaults that *already* existed in `overrides.json` `defaults`, so a newly added numeric engine parameter that nobody wired in there would silently render as `T | None = None` and drop its documented engine default — with no check failing. Added a completeness pass: every numeric value-typed parameter on the Python surface must either declare a `defaults` entry or be listed in a new `INTENTIONAL_OPTIONAL_VALUE_PARAMS` allowlist (with a reason), mirroring the existing `INTENTIONAL_FLAG_DIVERGENCES` mechanism.
- **Parse-message drift guard** (`test/python/test_errors.py`). `errors._classify_run_message` routes `run()`-time input failures to `NetworkParseError` by matching hand-maintained fragments of the C++ engine's error strings. If the engine reworded a message, the fragment would stop matching and the failure would quietly downgrade to a bare `InfomapError` with no test failing. Added a guard asserting every fragment still occurs verbatim in the C++ sources.
- **Docs tidy.** Dropped a redundant `silent=True` from the `find_communities` / `run_graphrag_communities` helper examples — both default `silent=True` internally, and the explicit kwarg cut against the quiet-by-default narrative the rest of the docs cleanup established.

## Verification

Test execution (pytest / ctest) was **not run** — the compiled extension is not built in this environment and pytest is unavailable. Static verification done instead:

- `python -m ast` parse of both changed Python files — OK.
- Simulated the parse-message drift guard against `src/`: all 7 fragments (`Can't parse`, `Cannot parse`, `Cannot open input file`, `Can't open file`, `Unrecognized heading`, `JSON parse error`, `read permissions`) found — passes.
- Cross-checked the completeness allowlist against the generated `_options.py`: all 12 numeric fields that render as `| None = None` are accounted for — 11 in the allowlist, `fast_hierarchical_solution` covered by its `repeated_short` render policy and its existing `defaults` entry — so the new pass reports no drift on the current catalog.

Recommend a CI run to confirm the `fast;core` ctest and `test_errors.py::fast` leg.

## Notes

- The completeness guard is intentionally scoped to numeric (`integer`/`number`/`probability`) value parameters; string/path parameters legitimately default to `None` (unset) and are excluded.
- Both guards are additive; no source or generated files change, so no regeneration is required.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LcqzuowM9AZe7ozd65hZmZ)_