### PR TITLE
fix(python): close the infomap.run() advanced-tier deprecation gap

### DIFF
--- a/interfaces/python/source/the-infomap-class.md
+++ b/interfaces/python/source/the-infomap-class.md
@@ -71,6 +71,24 @@ The two consistent shifts: building a network is a {class}`~infomap.Network`
 reading results goes through the immutable {class}`~infomap.Result`
 (see {doc}`/working-with-infomap/results-and-iteration`).
 
+## Migrating deprecated keyword arguments
+
+Advanced engine keywords still work on `Infomap()` and `infomap.run()` in 2.x,
+but they are pending-deprecated and leave those signatures in 3.0 (issue #741):
+passing one directly emits a (default-silent) `PendingDeprecationWarning`. Each
+falls into one of three groups, with a sanctioned replacement:
+
+| Deprecated keyword | Where it moves |
+|---|---|
+| Advanced tuning flags -- `regularized`, `core_loop_limit`, `flow_model`, and the like | carry them on the {class}`~infomap.Options` object: `run(g, options=Options(regularized=True))` |
+| Output-artifact flags -- `no_file_output`, `tree`, `clu`, `out_name` | write from the {class}`~infomap.Result` instead: `result.write_tree(path)`, `result.write_clu(path)`, or `network.write_pajek(path)` |
+| Console flags -- `silent`, `verbose` | use logging: `infomap.enable_log()` for the engine log, and `infomap.enable_log(logging.DEBUG)` to raise its verbosity |
+
+The `options` carrier accepts an {class}`~infomap.Options` instance or a plain
+mapping; both are warning-free. Only bare keyword arguments typed directly on the
+call are flagged, so the common options (`seed`, `num_trials`, `two_level`,
+`directed`, `markov_time`) stay on the signature and are never deprecated.
+
 ## Removed accessors
 
 The redesign dropped a few camelCase passthroughs. Their replacements:

--- a/interfaces/python/src/infomap/_run.py
+++ b/interfaces/python/src/infomap/_run.py
@@ -24,6 +24,8 @@ from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from ._options import _warn_advanced_tier_kwargs
+
 if TYPE_CHECKING:
     from .result import Result
 
@@ -204,6 +206,13 @@ def run(
     there; see :meth:`Network.run`). The ``infomap`` command-line interface
     keeps its verbose default.
 
+    Advanced engine options passed as bare keyword arguments (for example a
+    direct ``regularized=True``) are pending-deprecated on this signature and
+    leave it in 3.0 (issue #741); carry them via ``options`` instead -- either an
+    :class:`Options` instance or a plain mapping -- which is the sanctioned,
+    warning-free path. The common options (``seed``, ``num_trials``,
+    ``two_level``, ``directed``, ``markov_time``) stay on the signature.
+
     Keyword arguments go to the engine; the input adapters always build with
     their defaults (e.g. networkx reads the ``"weight"`` edge attribute, a
     SciPy matrix is treated as undirected). For non-default input building -- a
@@ -246,6 +255,15 @@ def run(
     from .network import Network
 
     resolved = _resolve_options(options, overrides)
+    # Advanced-tier keywords are pending-deprecated on the run() signature and
+    # move off it in 3.0 (issue #741). Warn only on bare **overrides typed
+    # directly on this call; an Options or mapping `options` carrier is the
+    # sanctioned path and stays silent. The helper's caller-frame check sees the
+    # user's frame here (frame 2 is run()'s caller), so an in-package caller of
+    # run() is not flagged and the later Infomap(**resolved) -- reached from
+    # inside the package -- does not double-warn.
+    if overrides:
+        _warn_advanced_tier_kwargs(overrides, "init")
     # Keys the user actually supplied (kwargs + a mapping `options`), used to
     # reject adapter-only arguments below. An Options *instance* is excluded on
     # purpose: its to_kwargs() carries every field (e.g. directed=None) the user

--- a/scripts/parameter_catalog.py
+++ b/scripts/parameter_catalog.py
@@ -345,6 +345,40 @@ class ParameterCatalog:
                             f"overrides.{section}[{flag!r}] names unknown language "
                             f"{language!r}; known languages: {sorted(languages)}"
                         )
+        # `choices` is keyed by CLI flag but maps to a plain list of allowed
+        # values (flag -> list[str]), not a per-language dict, so it is validated
+        # separately from the sections above.
+        for flag, values in self.overrides.get("choices", {}).items():
+            if flag not in known_flags:
+                raise RuntimeError(
+                    f"overrides.choices lists unknown flag {flag!r} (not in the "
+                    "parameter catalog, bindingOnly, or cliOnlyParameters)"
+                )
+            if not isinstance(values, list) or not all(
+                isinstance(value, str) for value in values
+            ):
+                raise RuntimeError(
+                    f"overrides.choices[{flag!r}] must be a list of strings"
+                )
+        # `bindingOnly` is keyed by binding language and lists parameters that
+        # exist only on that surface. Validate the language keys and reject stray
+        # entry keys so a typo fails loud instead of silently building a binding
+        # no generator consumes (issue #755).
+        allowed_entry_keys = {"name", "flag", "type", "default", "reason"}
+        for language, entries in self.overrides.get("bindingOnly", {}).items():
+            if language not in languages:
+                raise RuntimeError(
+                    f"overrides.bindingOnly names unknown language {language!r}; "
+                    f"known languages: {sorted(languages)}"
+                )
+            for entry in entries:
+                unknown = set(entry) - allowed_entry_keys
+                if unknown:
+                    raise RuntimeError(
+                        f"overrides.bindingOnly[{language!r}] entry {entry.get('name', entry)!r} "
+                        f"has unknown keys {sorted(unknown)}; allowed: "
+                        f"{sorted(allowed_entry_keys)}"
+                    )
 
     def _validate_policy(self) -> None:
         # Fail loud on typos and incomplete decisions: the policy is the 3.0

--- a/scripts/parameter_catalog.py
+++ b/scripts/parameter_catalog.py
@@ -163,7 +163,7 @@ class Parameter:
     def uses_generic_spec(self) -> bool:
         return self.render_policy in {"flag", "value"}
 
-    def binding_default(self, language: str) -> dict[str, str]:
+    def binding_default(self, language: str) -> str | None:
         return self.overrides.get("defaults", {}).get(self.flag, {}).get(language)
 
     def python_default_value(self) -> str:

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Union
@@ -160,7 +161,13 @@ def make_infomap():
     def _make_infomap(
         *, seed: int = 123, num_trials: int = 1, silent: bool = True, **kwargs
     ) -> Infomap:
-        return Infomap(seed=seed, num_trials=num_trials, silent=silent, **kwargs)
+        # This helper deliberately builds the supported stateful Infomap compat
+        # surface for feature tests, so advanced-tier kwargs are exercised on
+        # purpose. The pending-deprecation those emit is asserted in
+        # test_deprecations.py; here it is only noise, so silence it.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", PendingDeprecationWarning)
+            return Infomap(seed=seed, num_trials=num_trials, silent=silent, **kwargs)
 
     return _make_infomap
 

--- a/test/python/test_api.py
+++ b/test/python/test_api.py
@@ -13,6 +13,7 @@ from infomap._bindings import InfomapWrapper
 pytestmark = pytest.mark.fast
 
 
+@pytest.mark.filterwarnings("ignore::PendingDeprecationWarning")
 def test_run_with_empty_initial_partition_overrides_persisted_partition(make_infomap):
     baseline = make_infomap()
     baseline.add_links([(1, 2), (1, 3), (2, 3), (2, 4)])
@@ -334,7 +335,7 @@ def test_from_options_uses_package_construct_args(monkeypatch):
 
 def test_run_with_options_forwards_to_run(monkeypatch):
     captured = {}
-    im = infomap_module.Infomap(silent=True, no_file_output=True)
+    im = infomap_module.Infomap(silent=True)
 
     def fake_run(self, **kwargs):
         captured["kwargs"] = kwargs

--- a/test/python/test_bulk_construction_routing.py
+++ b/test/python/test_bulk_construction_routing.py
@@ -36,14 +36,14 @@ def spy(monkeypatch):
 
 @pytest.mark.fast
 def test_list_links_route_to_bulk_addLinks(spy):
-    im = Infomap(silent=True, no_file_output=True)
+    im = Infomap(silent=True)
     im.add_links([(1, 2), (1, 3)])
     assert spy == {"addLinks": 1, "addLinksFromNumpy2D": 0}
 
 
 @pytest.mark.fast
 def test_numpy_links_route_to_bulk_numpy(spy):
-    im = Infomap(silent=True, no_file_output=True)
+    im = Infomap(silent=True)
     im.add_links(np.array([[1, 2, 1.0], [2, 3, 2.0]]))
     assert spy == {"addLinks": 0, "addLinksFromNumpy2D": 1}
 
@@ -96,10 +96,10 @@ def test_multilayer_bulk_routing(
 
         monkeypatch.setattr(owner, name, make(name), raising=True)
 
-    getattr(Infomap(silent=True, no_file_output=True), method)(list_in)
+    getattr(Infomap(silent=True), method)(list_in)
     assert calls[bulk] == 1, "list input must route to the bulk C++ constructor"
     assert calls[singular] == 0, "list input must NOT loop per-element in Python"
 
-    getattr(Infomap(silent=True, no_file_output=True), method)(numpy_in)
+    getattr(Infomap(silent=True), method)(numpy_in)
     assert calls[bulk_numpy] == 1, "numpy input must route to the FromNumpy2D constructor"
     assert calls[singular] == 0

--- a/test/python/test_collaborators.py
+++ b/test/python/test_collaborators.py
@@ -7,7 +7,7 @@ from infomap import Infomap, Network
 
 @pytest.mark.fast
 def test_network_builder_is_used_and_builds():
-    im = Infomap(silent=True, no_file_output=True)
+    im = Infomap(silent=True)
     assert isinstance(im._network, Network)
     im.add_node(1, "a")
     im.add_node(2)
@@ -20,7 +20,7 @@ def test_network_builder_is_used_and_builds():
 
 @pytest.mark.fast
 def test_repr_html_and_summary_render():
-    im = Infomap(silent=True, no_file_output=True)
+    im = Infomap(silent=True)
     im.add_links([(1, 2), (2, 3), (3, 1)])
     im.run()
     html = im._repr_html_()
@@ -37,7 +37,7 @@ def test_repr_html_and_summary_render():
 
 @pytest.mark.fast
 def test_multilayer_builder_is_used_and_builds():
-    im = Infomap(silent=True, no_file_output=True)
+    im = Infomap(silent=True)
     # The unified Network owns the multilayer verbs too (no separate builder).
     assert isinstance(im._network, Network)
     im.add_multilayer_intra_links([(1, 1, 2), (1, 2, 1), (2, 2, 3), (2, 3, 2)])

--- a/test/python/test_deprecations.py
+++ b/test/python/test_deprecations.py
@@ -20,7 +20,7 @@ from infomap import Infomap, Options, run
 
 
 def _two_triangles(**kwargs) -> Infomap:
-    im = Infomap(silent=True, no_file_output=True, num_trials=2, **kwargs)
+    im = Infomap(silent=True, num_trials=2, **kwargs)
     for source, target in [(0, 1), (1, 2), (2, 0), (2, 3), (3, 4), (4, 5), (5, 3)]:
         im.add_link(source, target)
     return im
@@ -95,7 +95,7 @@ def test_deprecated_accessor_emits_no_warning():
 def test_build_from_graph_accessor_silent():
     scipy_sparse = pytest.importorskip("scipy.sparse")
     matrix = scipy_sparse.csr_matrix([[0, 1, 0], [1, 0, 1], [0, 1, 0]])
-    im = Infomap(silent=True, no_file_output=True)
+    im = Infomap(silent=True)
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
         im.add_scipy_sparse_matrix(matrix)
@@ -164,6 +164,10 @@ def test_advanced_tier_kwargs_emit_no_deprecation_warning_and_work():
     tools escalate by default) and keep working."""
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
+        # Advanced-tier kwargs on the stateful surface do emit the softer
+        # PendingDeprecationWarning by design; this test is only about the
+        # louder DeprecationWarning, so ignore the pending one here.
+        warnings.simplefilter("ignore", PendingDeprecationWarning)
         im = _two_triangles(core_loop_limit=5, flow_model="undirected")
         result = im.run(markov_time=1.0, core_loop_limit=5)
     assert result.num_top_modules >= 1

--- a/test/python/test_deprecations.py
+++ b/test/python/test_deprecations.py
@@ -223,3 +223,26 @@ def test_advanced_tier_kwarg_silent_through_options_and_adapters():
             options=Options(regularized=True, core_loop_limit=5),
         )
     assert _pending(records) == []
+
+
+@pytest.mark.fast
+def test_functional_run_direct_advanced_kwarg_emits_pending():
+    """A non-default advanced-tier kwarg typed directly on the functional
+    infomap.run() front door emits a PendingDeprecationWarning naming the
+    keyword. The front door funnels through Infomap(**resolved) from inside the
+    package, so run() flags the user's own kwargs itself (issue #741)."""
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        run([(0, 1), (1, 2), (2, 0)], regularized=True)
+    assert any("regularized" in message for message in _pending(records))
+
+
+@pytest.mark.fast
+def test_functional_run_mapping_options_stays_silent():
+    """A plain-mapping options carrier is blessed exactly like Options(...):
+    advanced kwargs carried through it do not warn -- only bare keyword
+    overrides do."""
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        run([(0, 1), (1, 2), (2, 0)], options={"regularized": True})
+    assert _pending(records) == []

--- a/test/python/test_fluent_chaining.py
+++ b/test/python/test_fluent_chaining.py
@@ -60,7 +60,7 @@ def test_network_fluent_chain_builds_and_runs():
 
 @pytest.mark.fast
 def test_infomap_single_layer_mutators_do_not_return_self():
-    im = Infomap(silent=True, no_file_output=True)
+    im = Infomap(silent=True)
     assert im.add_node(1) is not im
     assert im.add_nodes([2, 3]) is not im
     assert im.add_state_node(10, 1) is not im
@@ -76,12 +76,12 @@ def test_infomap_single_layer_mutators_do_not_return_self():
 
 @pytest.mark.fast
 def test_infomap_multilayer_mutators_do_not_return_self():
-    a = Infomap(silent=True, no_file_output=True)
+    a = Infomap(silent=True)
     assert a.add_multilayer_intra_link(1, 1, 2) is not a
     assert a.add_multilayer_intra_links([(1, 2, 3)]) is not a
     assert a.add_multilayer_inter_link(1, 1, 2) is not a
     assert a.add_multilayer_inter_links([(2, 1, 1)]) is not a
-    b = Infomap(silent=True, no_file_output=True)
+    b = Infomap(silent=True)
     assert b.add_multilayer_link((0, 1), (1, 2)) is not b
     assert b.add_multilayer_links([((0, 3), (1, 2))]) is not b
 
@@ -91,7 +91,7 @@ def test_infomap_mutators_match_released_core_returns():
     # The released API returned the underlying SWIG call's result, routed now
     # through the shared Core. add_node returns whatever the binding returns
     # (an id or None), never self.
-    im = Infomap(silent=True, no_file_output=True)
+    im = Infomap(silent=True)
     assert not isinstance(im.add_node(3), Infomap)
     # remove_link mirrors network().removeLink, a bool: True if a link existed.
     im.add_link(3, 4)
@@ -101,7 +101,7 @@ def test_infomap_mutators_match_released_core_returns():
 
 @pytest.mark.fast
 def test_infomap_builds_and_runs_without_chaining():
-    im = Infomap(silent=True, no_file_output=True, seed=1)
+    im = Infomap(silent=True, seed=1)
     im.add_links([(1, 2), (2, 3), (3, 1), (3, 4), (4, 5), (5, 6), (6, 4)])
     im.add_node(7, "isolated-ish")
     im.set_name(1, "a")

--- a/test/python/test_from_graph_constructors.py
+++ b/test/python/test_from_graph_constructors.py
@@ -8,7 +8,7 @@ from infomap import Infomap, Network
 
 @pytest.mark.fast
 def test_node_id_to_label_initialized_empty():
-    im = Infomap(silent=True, no_file_output=True)
+    im = Infomap(silent=True)
     assert im.node_id_to_label == {}
 
 
@@ -25,7 +25,7 @@ def test_network_node_id_to_label_initialized_empty():
 
 @pytest.mark.fast
 def test_add_networkx_graph_sets_node_id_to_label():
-    im = Infomap(silent=True, no_file_output=True)
+    im = Infomap(silent=True)
     G = nx.Graph([("a", "b"), ("a", "c")])
     mapping = im.add_networkx_graph(G)
     assert mapping == {0: "a", 1: "b", 2: "c"}  # still returned (unchanged)
@@ -38,7 +38,7 @@ def test_add_scipy_sparse_matrix_sets_node_id_to_label():
 
     sparse = pytest.importorskip("scipy.sparse")
     A = sparse.csr_matrix(np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]]))
-    im = Infomap(silent=True, no_file_output=True)
+    im = Infomap(silent=True)
     mapping = im.add_scipy_sparse_matrix(A)
     assert mapping == {0: 0, 1: 1, 2: 2}  # {internal_id: external_id}
     assert im.node_id_to_label == mapping
@@ -46,7 +46,7 @@ def test_add_scipy_sparse_matrix_sets_node_id_to_label():
 
 @pytest.mark.fast
 def test_add_edge_index_sets_node_id_to_label():
-    im = Infomap(silent=True, no_file_output=True)
+    im = Infomap(silent=True)
     mapping = im.add_edge_index([[0, 1, 2], [1, 2, 0]])
     assert mapping == {0: 0, 1: 1, 2: 2}
     assert im.node_id_to_label == mapping

--- a/test/python/test_igraph.py
+++ b/test/python/test_igraph.py
@@ -394,6 +394,7 @@ def test_find_igraph_communities_rejects_trial_and_vertex_weight_conflicts():
         infomap.find_igraph_communities(graph, vertex_weights=[1, 1])
 
 
+@pytest.mark.filterwarnings("ignore::PendingDeprecationWarning")
 def test_find_igraph_communities_accepts_num_trials_alone(monkeypatch):
     # `num_trials` (the engine option name) is accepted on its own, matching
     # the networkx helper; only passing it *together* with `trials` conflicts.

--- a/test/python/test_logging.py
+++ b/test/python/test_logging.py
@@ -23,7 +23,13 @@ import pytest
 from infomap import Infomap, disable_log, enable_log
 
 
-pytestmark = pytest.mark.fast
+# These tests drive the engine log -> Python logging routing, deliberately
+# using silent=False to produce engine output; the pending deprecation on the
+# silent keyword is expected here (it is asserted in test_deprecations.py).
+pytestmark = [
+    pytest.mark.fast,
+    pytest.mark.filterwarnings("ignore::PendingDeprecationWarning"),
+]
 
 
 def _engine_stdout(capfd) -> str:

--- a/test/python/test_multilayer.py
+++ b/test/python/test_multilayer.py
@@ -1,6 +1,13 @@
 import pytest
 
 
+# These tests build and run multilayer networks through the stateful Infomap
+# compat surface (no_infomap / matchable_multilayer_ids), so the pending
+# deprecation on advanced-tier kwargs is expected here; it is asserted in
+# test_deprecations.py.
+pytestmark = pytest.mark.filterwarnings("ignore::PendingDeprecationWarning")
+
+
 def test_matchable_multilayer_ids_with_python_read_file(
     make_infomap, example_network_path
 ):

--- a/test/python/test_network.py
+++ b/test/python/test_network.py
@@ -31,7 +31,7 @@ def test_standalone_network_matches_infomap_delegated_build():
     net_modules = net._core.numTopModules()
 
     # Same graph via Infomap's delegated building verbs, same settings.
-    im = Infomap(silent=True, no_file_output=True, seed=123, num_trials=5)
+    im = Infomap(silent=True, seed=123, num_trials=5)
     im.add_links(_LINKS)
     im.run()
 
@@ -50,7 +50,7 @@ def test_multilayer_standalone_matches_infomap_delegated_build():
     net.add_multilayer_inter_links(inter)
     net._core.run(_RUN_ARGS)
 
-    im = Infomap(silent=True, no_file_output=True, seed=123, num_trials=5)
+    im = Infomap(silent=True, seed=123, num_trials=5)
     im.add_multilayer_intra_links(intra)
     im.add_multilayer_inter_links(inter)
     im.run()
@@ -112,7 +112,7 @@ def test_default_constructor_makes_owned_core():
 
 
 def test_shared_core_is_used_when_passed():
-    im = Infomap(silent=True, no_file_output=True)
+    im = Infomap(silent=True)
     net = Network(core=im._core)
     assert net._core is im._core
     net.add_link(1, 2)

--- a/test/python/test_network_input_contract.py
+++ b/test/python/test_network_input_contract.py
@@ -36,6 +36,7 @@ def test_json_standard_matches_in_memory(
     )
 
 
+@pytest.mark.filterwarnings("ignore::PendingDeprecationWarning")
 def test_json_embedded_meta_matches_set_meta_data(
     make_infomap, network_fixture_path, canonical_modules
 ):

--- a/test/python/test_networkx.py
+++ b/test/python/test_networkx.py
@@ -168,7 +168,7 @@ def test_add_networkx_multigraph_with_parallel_edges_and_self_loop():
     graph.add_edge("d", "a")
     graph.add_edge("a", "a")  # self-loop
 
-    im = infomap.Infomap(silent=True, no_file_output=True, seed=123, num_trials=1)
+    im = infomap.Infomap(silent=True, seed=123, num_trials=1)
     mapping = im.add_networkx_graph(graph)
     result = im.run()
 
@@ -201,7 +201,7 @@ def test_find_communities_partitions_multilayer_network_nodes():
 
 
 def test_add_networkx_graph_empty_returns_empty_mapping():
-    im = infomap.Infomap(silent=True, no_file_output=True)
+    im = infomap.Infomap(silent=True)
     assert im.add_networkx_graph(nx.Graph()) == {}
 
 
@@ -217,12 +217,12 @@ def test_add_networkx_multilayer_diagonal_link_raises():
     graph.add_node("b-layer-2", node_id=2, layer_id=2)
     graph.add_edge("a-layer-1", "b-layer-2")
 
-    im = infomap.Infomap(silent=True, no_file_output=True)
+    im = infomap.Infomap(silent=True)
     with pytest.raises(ValueError, match="diagonal"):
         im.add_networkx_graph(graph)
 
     # The documented workaround (full multilayer format) accepts the same graph.
-    im_full = infomap.Infomap(silent=True, no_file_output=True)
+    im_full = infomap.Infomap(silent=True)
     mapping = im_full.add_networkx_graph(graph, multilayer_inter_intra_format=False)
     assert set(mapping.values()) == set(graph.nodes)
 
@@ -236,7 +236,7 @@ def test_add_networkx_layer_id_without_node_id_raises_clear_error():
     graph.add_node("b", layer_id=2)
     graph.add_edge("a", "b")
 
-    im = infomap.Infomap(silent=True, no_file_output=True)
+    im = infomap.Infomap(silent=True)
     with pytest.raises(ValueError, match="node_id"):
         im.add_networkx_graph(graph)
 
@@ -294,7 +294,7 @@ def test_find_communities_accepts_meta_attribute():
 def test_infomap_add_networkx_graph_accepts_meta_attribute():
     graph = _nx_with_meta({0: "a", 1: "b", 2: "a", 3: "a", 4: "b", 5: "b"})
     im = infomap.Infomap(
-        silent=True, no_file_output=True, seed=1, num_trials=5, meta_data_rate=1.0
+        silent=True, seed=1, num_trials=5, meta_data_rate=1.0
     )
     im.add_networkx_graph(graph, meta_attribute="ct")
     result = im.run()
@@ -314,7 +314,7 @@ def test_label_to_internal_id_enumerates_mixed_int_and_string():
 
 def test_add_networkx_graph_handles_mixed_int_string_labels():
     graph = nx.Graph([(1, "a"), ("a", 2)])
-    im = infomap.Infomap(silent=True, no_file_output=True, seed=1, num_trials=1)
+    im = infomap.Infomap(silent=True, seed=1, num_trials=1)
     mapping = im.add_networkx_graph(graph)
     assert set(mapping.values()) == {1, "a", 2}
     assert im.run().num_top_modules >= 1
@@ -385,6 +385,7 @@ def test_find_communities_rejects_trials_and_num_trials_conflict():
         ({"num_trials": 3}, 3),      # the engine option (back-compat)
     ],
 )
+@pytest.mark.filterwarnings("ignore::PendingDeprecationWarning")
 def test_find_communities_resolves_num_trials(monkeypatch, kwargs, expected):
     captured = {}
     real_infomap = facade.Infomap

--- a/test/python/test_networkx.py
+++ b/test/python/test_networkx.py
@@ -178,7 +178,8 @@ def test_add_networkx_multigraph_with_parallel_edges_and_self_loop():
 
     # The functional entry point accepts the same MultiGraph directly.
     functional = infomap.run(
-        graph, silent=True, no_file_output=True, seed=123, num_trials=1
+        graph,
+        options={"silent": True, "no_file_output": True, "seed": 123, "num_trials": 1},
     )
     assert sum(1 for _ in functional.nodes()) == graph.number_of_nodes()
 

--- a/test/python/test_output.py
+++ b/test/python/test_output.py
@@ -75,6 +75,7 @@ def test_state_output_writers_include_state_columns(
     assert parsed["higherOrder"] is True
 
 
+@pytest.mark.filterwarnings("ignore::PendingDeprecationWarning")
 def test_json_metadata_values_remain_strings(
     make_infomap, output_dir, validate_json_schema
 ):

--- a/test/python/test_parameter_catalog.py
+++ b/test/python/test_parameter_catalog.py
@@ -192,3 +192,59 @@ def test_python_common_tier_matches_issue_738_decision(test_paths):
     assert common == sorted(
         ["--seed", "--num-trials", "--two-level", "--directed", "--markov-time"]
     )
+
+
+def test_parameter_catalog_rejects_unknown_choices_flag():
+    import pytest
+
+    parameters = [_minimal_param("--seed", required=True, longType="integer")]
+    overrides = {
+        "policy": _tier_policy("--seed"),
+        "choices": {"--seeed": ["a", "b"]},
+    }
+
+    with pytest.raises(RuntimeError, match=r"--seeed"):
+        ParameterCatalog(parameters, overrides)
+
+
+def test_parameter_catalog_rejects_non_list_choices():
+    import pytest
+
+    parameters = [_minimal_param("--seed", required=True, longType="integer")]
+    overrides = {
+        "policy": _tier_policy("--seed"),
+        "choices": {"--seed": "clu"},
+    }
+
+    with pytest.raises(RuntimeError, match="list of strings"):
+        ParameterCatalog(parameters, overrides)
+
+
+def test_parameter_catalog_rejects_unknown_binding_only_language():
+    import pytest
+
+    parameters = [_minimal_param("--seed", required=True, longType="integer")]
+    overrides = {
+        "policy": _tier_policy("--seed"),
+        "bindingOnly": {"cpp": [{"name": "foo", "flag": "--foo", "reason": "x"}]},
+    }
+
+    with pytest.raises(RuntimeError, match="cpp"):
+        ParameterCatalog(parameters, overrides)
+
+
+def test_parameter_catalog_rejects_unknown_binding_only_entry_key():
+    import pytest
+
+    parameters = [_minimal_param("--seed", required=True, longType="integer")]
+    overrides = {
+        "policy": _tier_policy("--seed"),
+        "bindingOnly": {
+            "python": [
+                {"name": "foo", "flag": "--foo", "reason": "x", "typ": "bool"}
+            ]
+        },
+    }
+
+    with pytest.raises(RuntimeError, match="typ"):
+        ParameterCatalog(parameters, overrides)

--- a/test/python/test_public_types.py
+++ b/test/python/test_public_types.py
@@ -36,7 +36,7 @@ def test_documented_iterator_types_in_dunder_all():
 
 @pytest.mark.fast
 def test_tree_returns_a_documented_iterator_type():
-    im = infomap.Infomap(silent=True, no_file_output=True)
+    im = infomap.Infomap(silent=True)
     im.add_link(0, 1)
     im.add_link(1, 2)
     im.run()
@@ -50,7 +50,7 @@ def test_treenode_is_importable_from_the_package():
     # the top level (for isinstance / type hints), like Result itself.
     assert hasattr(infomap, "TreeNode")
     assert "TreeNode" in infomap.__all__
-    im = infomap.Infomap(silent=True, no_file_output=True)
+    im = infomap.Infomap(silent=True)
     im.add_link(0, 1)
     assert isinstance(next(im.run().nodes()), infomap.TreeNode)
 

--- a/test/python/test_result.py
+++ b/test/python/test_result.py
@@ -6,7 +6,7 @@ from infomap import Infomap, Result
 
 
 def _two_triangles() -> Infomap:
-    im = Infomap(silent=True, no_file_output=True)
+    im = Infomap(silent=True)
     im.add_link(0, 1)
     im.add_link(1, 2)
     im.add_link(2, 0)
@@ -146,7 +146,7 @@ def test_result_nodes_yield_immutable_treenodes():
 
 @pytest.mark.fast
 def test_result_modules_raises_on_higher_order_without_states(network_fixture_path):
-    im = Infomap(silent=True, no_file_output=True)
+    im = Infomap(silent=True)
     im.read_file(str(network_fixture_path("states.net")))
     result = im.run()
     assert result.have_memory
@@ -169,7 +169,7 @@ _STATES_NET_PHYSICAL_NAMES = {1: "i", 2: "j", 3: "k", 4: "l", 5: "m"}
 
 @pytest.mark.fast
 def test_state_names_accessor_exposes_state_node_names(network_fixture_path):
-    im = Infomap(silent=True, no_file_output=True)
+    im = Infomap(silent=True)
     im.read_file(str(network_fixture_path("states.net")))
     result = im.run()
 
@@ -184,7 +184,7 @@ def test_to_dataframe_state_name_column_distinguishes_state_nodes(
     network_fixture_path,
 ):
     pytest.importorskip("pandas")
-    im = Infomap(silent=True, no_file_output=True)
+    im = Infomap(silent=True)
     im.read_file(str(network_fixture_path("states.net")))
     result = im.run()
 
@@ -214,7 +214,7 @@ def test_to_dataframe_state_name_column_distinguishes_state_nodes(
 @pytest.mark.fast
 def test_state_name_falls_back_to_physical_name_for_first_order(example_network_path):
     pytest.importorskip("pandas")
-    im = Infomap(silent=True, no_file_output=True)
+    im = Infomap(silent=True)
     im.read_file(str(example_network_path("twotriangles.net")))
     result = im.run()
 

--- a/test/python/test_result_parity.py
+++ b/test/python/test_result_parity.py
@@ -17,37 +17,37 @@ pytest.importorskip("pandas")
 
 
 def _simple(example_network_path) -> Infomap:
-    im = Infomap(silent=True, no_file_output=True, num_trials=5)
+    im = Infomap(silent=True, num_trials=5)
     im.read_file(str(example_network_path("twotriangles.net")))
     return im
 
 
 def _nine(example_network_path) -> Infomap:
-    im = Infomap(silent=True, no_file_output=True, num_trials=10)
+    im = Infomap(silent=True, num_trials=10)
     im.read_file(str(example_network_path("ninetriangles.net")))
     return im
 
 
 def _states(example_network_path) -> Infomap:
-    im = Infomap(silent=True, no_file_output=True)
+    im = Infomap(silent=True)
     im.read_file(str(example_network_path("states.net")))
     return im
 
 
 def _multilayer(example_network_path) -> Infomap:
-    im = Infomap(silent=True, no_file_output=True)
+    im = Infomap(silent=True)
     im.read_file(str(example_network_path("multilayer.net")))
     return im
 
 
 def _bipartite(example_network_path) -> Infomap:
-    im = Infomap(silent=True, no_file_output=True)
+    im = Infomap(silent=True)
     im.read_file(str(example_network_path("bipartite.net")))
     return im
 
 
 def _meta(example_network_path) -> Infomap:
-    im = Infomap(silent=True, no_file_output=True)
+    im = Infomap(silent=True)
     for source, target in [(0, 1), (1, 2), (2, 0), (2, 3), (3, 4), (4, 5), (5, 3)]:
         im.add_link(source, target)
     for node_id in range(6):

--- a/test/python/test_run_functional.py
+++ b/test/python/test_run_functional.py
@@ -72,7 +72,11 @@ def test_run_network_input_is_silent_by_default(capfd):
 
 def test_run_silent_false_override_prints_engine_log(capfd):
     _engine_log(capfd)
-    infomap.run(_LINKS, silent=False, num_trials=1, seed=1)
+    # Passing silent as a bare keyword is pending-deprecated (it moves to logging
+    # in 3.0); in 2.x it still overrides the default and prints the engine log.
+    # The warning-free carrier equivalents are covered by the two tests below.
+    with pytest.warns(PendingDeprecationWarning, match="silent"):
+        infomap.run(_LINKS, silent=False, num_trials=1, seed=1)
     assert _engine_log(capfd) != ""
 
 
@@ -132,7 +136,7 @@ def test_network_run_silent_false_warns():
         net.run(options={"silent": False, "num_trials": 1, "seed": 1})
 
     with pytest.warns(UserWarning, match="silent for its whole lifetime"):
-        infomap.run(net, silent=False, num_trials=1, seed=1)
+        infomap.run(net, options={"silent": False, "num_trials": 1, "seed": 1})
 
 
 def test_run_networkx_matches_oo():
@@ -266,11 +270,11 @@ def test_to_networkx_directed_flow_model_exports_digraph():
     # explicit flow_model="directed" exports a DiGraph exactly like
     # directed=True does.
     net = Network().add_links(_LINKS)
-    for options in ({"flow_model": "directed"}, {"directed": True}):
-        result = infomap.run(net, **options, **_SETTINGS)
+    for flow_option in ({"flow_model": "directed"}, {"directed": True}):
+        result = infomap.run(net, options={**flow_option, **_SETTINGS})
         assert isinstance(infomap.to_networkx(result), nx.DiGraph)
 
-    undirected = infomap.run(net, **_SETTINGS)
+    undirected = infomap.run(net, options=_SETTINGS)
     assert not isinstance(infomap.to_networkx(undirected), nx.DiGraph)
 
 

--- a/test/python/test_run_functional.py
+++ b/test/python/test_run_functional.py
@@ -106,7 +106,7 @@ def test_options_default_is_silent():
 
 def test_stateful_infomap_is_silent_by_default(capfd):
     _engine_log(capfd)  # drain log buffered by earlier (unflushed) tests
-    im = Infomap(num_trials=1, seed=1, no_file_output=True)
+    im = Infomap(num_trials=1, seed=1)
     im.add_links(_LINKS)
     im.run()
     assert _engine_log(capfd) == ""
@@ -114,7 +114,11 @@ def test_stateful_infomap_is_silent_by_default(capfd):
 
 def test_stateful_infomap_silent_false_prints_engine_log(capfd):
     _engine_log(capfd)
-    im = Infomap(silent=False, num_trials=1, seed=1, no_file_output=True)
+    # silent as a bare keyword is pending-deprecated (it moves to logging in
+    # 3.0) but still overrides the default in 2.x; the carrier/logging paths are
+    # the warning-free replacements.
+    with pytest.warns(PendingDeprecationWarning, match="silent"):
+        im = Infomap(silent=False, num_trials=1, seed=1)
     im.add_links(_LINKS)
     im.run()
     assert _engine_log(capfd) != ""

--- a/test/python/test_wrapper_args.py
+++ b/test/python/test_wrapper_args.py
@@ -52,9 +52,12 @@ def test_construct_args_deduplicates_no_self_links():
     assert tokens.count("--no-self-links") == 1
 
 
+@pytest.mark.filterwarnings("ignore::PendingDeprecationWarning")
 def test_run_forwards_variable_markov_options(monkeypatch):
+    # Deliberately forwards advanced-tier engine kwargs through the stateful
+    # run() to assert they reach the engine; the pending-deprecation is expected.
     captured = {}
-    im = infomap_module.Infomap(silent=True, no_file_output=True)
+    im = infomap_module.Infomap(silent=True)
 
     def fake_construct_args(args=None, **kwargs):
         captured["args"] = args
@@ -168,9 +171,9 @@ def test_cli_completion_invalid_shell_exits_without_traceback():
 
 def test_pretty_warns_when_passed_explicitly():
     with pytest.deprecated_call(match="pretty is deprecated and has no effect"):
-        infomap_module.Infomap(silent=True, no_file_output=True, pretty=True)
+        infomap_module.Infomap(silent=True, pretty=True)
 
-    im = infomap_module.Infomap(silent=True, no_file_output=True)
+    im = infomap_module.Infomap(silent=True)
     im.add_link(0, 1)
     with pytest.deprecated_call(match="pretty is deprecated and has no effect"):
         im.run(pretty=False)
@@ -182,7 +185,7 @@ def test_include_self_links_warning_points_at_caller():
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always", DeprecationWarning)
         infomap_module.Infomap(
-            silent=True, no_file_output=True, include_self_links=True
+            silent=True, include_self_links=True
         )
 
     matching = [w for w in caught if "include_self_links" in str(w.message)]


### PR DESCRIPTION
## Summary

The functional front door `infomap.run(...)` built `Infomap(**resolved)` from
*inside* the package, so the caller-frame guard in `_warn_advanced_tier_kwargs`
suppressed the advanced-tier `PendingDeprecationWarning` for kwargs typed
directly on `run()` (issue #741) — unlike `Infomap()` / `Infomap.run()`, which
warn. `run()` now flags the bare `**overrides` itself; an `Options` *or* a plain
mapping `options` carrier stays silent (the sanctioned path), and the later
`Infomap(**resolved)` does not double-warn.

Follow-ups surfaced while getting the surface clean:

- **Catalog hardening:** `scripts/parameter_catalog.py` now validates the
  `choices` and `bindingOnly` override sections (unknown flag / language / entry
  key fails loud, like the existing `names`/`defaults`/`docs` guard).
- **Migration docs:** a 3.0 keyword-migration table in the stateful-class guide
  (advanced tuning → `Options`, output artifacts → `Result`/`Network` writers,
  `silent`/`verbose` → logging).
- **Typing fix:** `binding_default`'s annotation corrected
  (`dict[str, str]` → `str | None`).
- **Test suite:** the suite's own functional-run sites now carry advanced kwargs
  via the `options` carrier, and the pre-existing pending-deprecation warning
  noise is cleared — dead `no_file_output=True` no-ops removed (verified: same
  result, no files written), and the tests that deliberately exercise the
  supported stateful compat surface are declared intentional.

## Verification

- Build: `pip install -e ".[test]"`.
- `pytest test/python` → **612 passed, 3 skipped**, and **0** `PendingDeprecationWarning`
  in the summary. Also clean under `-W error::PendingDeprecationWarning` (every
  pending warning is handled or deliberately asserted).
- `pytest --doctest-modules interfaces/python/src/infomap/_run.py` passes.
- Manual: `infomap.run(edges, regularized=True)` warns and points at the caller;
  `options=Options(regularized=True)` and `options={"regularized": True}` stay silent.
- pyright core (`pyrightconfig-core.json`) 0 errors; `ruff check` clean.

## Notes

- The `CHANGELOG.md` is release-please-generated from Conventional Commits, so it
  is intentionally not hand-edited.
- `find_communities` / `find_igraph_communities` are left out of the new warning
  on purpose: they are separate backward-compat helpers (return `list[set]`, not
  `Result`), and the deprecation is scoped to "the `Infomap()` and `run()` signatures".
- The stateful `Infomap`/`Infomap.run` keep no warning-free `options=` carrier by
  design (`run_with_options` is itself deprecated); the sanctioned carrier is the
  functional `infomap.run(input, options=...)` / `Network.run(options=...)`.
- Pre-existing full-scope pyright diagnostics in `_logging.py`
  (`reportPrivateImportUsage`) are untouched — unrelated subsystem, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DC5g7FiwNCWJaAejcNtf6C

---
_Generated by [Claude Code](https://claude.ai/code/session_01DC5g7FiwNCWJaAejcNtf6C)_