### PR TITLE
Python API: agent-usability improvements for the 3.0 surface

### DIFF
--- a/examples/notebooks/options-guide.ipynb
+++ b/examples/notebooks/options-guide.ipynb
@@ -23,7 +23,7 @@
     "\n",
     "- keyword arguments: `Infomap(two_level=True, num_trials=20)`\n",
     "- a raw flag string: `Infomap(args=\"--two-level --num-trials 20\")`\n",
-    "- a reusable `InfomapOptions` object passed as `options=` to `infomap.run(...)`\n",
+    "- a reusable `Options` object passed as `options=` to `infomap.run(...)`\n",
     "\n",
     "This guide uses keyword arguments. The last section lists every option with its\n",
     "flag, default, and description, generated from the installed package so it always\n",
@@ -1352,14 +1352,14 @@
     "with every flag, default, and description, use any of these:\n",
     "\n",
     "```python\n",
-    "from infomap import InfomapOptions\n",
-    "help(InfomapOptions)\n",
+    "from infomap import Options\n",
+    "help(Options)\n",
     "```\n",
     "\n",
     "From the command line, `infomap --help` lists the common options, `infomap -hh`\n",
     "adds the advanced ones, and `infomap --print-json-parameters` prints the full\n",
     "machine-readable catalog. The {doc}`API options reference </api/options>` renders\n",
-    "the same `InfomapOptions` fields as a searchable web page."
+    "the same `Options` fields as a searchable web page."
    ]
   },
   {

--- a/examples/notebooks/run-infomap-on-graphrag-tables.ipynb
+++ b/examples/notebooks/run-infomap-on-graphrag-tables.ipynb
@@ -29,7 +29,7 @@
     "\n",
     "import pandas as pd\n",
     "\n",
-    "from infomap.graphrag import read_graphrag, run_graphrag_communities\n",
+    "from infomap.tl.graphrag import read_graphrag, run_graphrag_communities\n",
     "\n",
     "try:\n",
     "    import igraph as ig\n",
@@ -132,7 +132,7 @@
     "    num_trials=5,\n",
     ")\n",
     "\n",
-    "result.infomap.codelength"
+    "result.result.codelength"
    ]
   },
   {

--- a/examples/python/file-io.py
+++ b/examples/python/file-io.py
@@ -36,16 +36,16 @@ for node_id, modules in result.multilevel_modules().items():
 
 pathlib.Path("output").mkdir(exist_ok=True)
 print(f"Writing top level modules to output/{name}.clu...")
-im.write(f"output/{name}.clu")
+result.write(f"output/{name}.clu")
 
 print(f"Writing second level modules to output/{name}_level2.clu...")
-im.write(f"output/{name}_level2.clu", depth_level=2)
+result.write(f"output/{name}_level2.clu", depth_level=2)
 
 print(f"Writing bottom level modules to output/{name}_level-1.clu...")
-im.write(f"output/{name}_level-1.clu", depth_level=-1)
+result.write(f"output/{name}_level-1.clu", depth_level=-1)
 
 print(f"Writing tree to output/{name}.tree...")
-im.write(f"output/{name}.tree")
+result.write(f"output/{name}.tree")
 
 print("Read back .clu file and only calculate codelength...")
 net2 = Network.from_file(filename)

--- a/interfaces/python/source/concepts/the-map-equation.md
+++ b/interfaces/python/source/concepts/the-map-equation.md
@@ -168,9 +168,10 @@ The club famously split into two factions, but Infomap minimises the description
 length of the flow, not a sociological label. Nodes on the boundary between the
 factions can form their own transitional cluster where the walker's affiliation
 is split, and naming it shortens the code, so Infomap often reports more than two
-modules here. To steer the search toward two modules, pass
-`preferred_number_of_modules=2`, a soft preference rather than a hard
-constraint.
+modules here. To steer the search toward two modules, carry
+`preferred_number_of_modules=2` via `Options` —
+`infomap.run(g, options=infomap.Options(preferred_number_of_modules=2))` — a soft
+preference rather than a hard constraint.
 ```
 
 ```{code-cell} python
@@ -202,6 +203,8 @@ module because naming it shortens the overall code.
 - `result.num_top_modules` counts the top-level modules; `result.modules()`
   returns a `{node_id: module_id}` mapping.
 - `preferred_number_of_modules=k` softly steers the search toward `k` modules.
+  It is not one of the direct `run` keywords; carry it via
+  `options=infomap.Options(preferred_number_of_modules=k)`.
 
 ## Going deeper
 

--- a/interfaces/python/source/faq.md
+++ b/interfaces/python/source/faq.md
@@ -98,8 +98,8 @@ filtering, grouping, and export. See {doc}`Reading the Result <working-with-info
 
 For Gephi, annotate the graph with `infomap.to_networkx(result)` (or `to_igraph`)
 and write it with `nx.write_graphml` / `nx.write_gexf`. For the native formats,
-the stateful `Infomap` writes them with `im.write_tree(path)` and
-`im.write_clu(path)`: `.clu` is one row per node, `.tree` carries the full
+write straight from the `Result` with `result.write_tree(path)` and
+`result.write_clu(path)`: `.clu` is one row per node, `.tree` carries the full
 hierarchy. See {doc}`Visualising and exporting <working-with-infomap/visualizing-and-exporting>`.
 
 ## Flow models and representations

--- a/interfaces/python/source/flow-models/metadata.md
+++ b/interfaces/python/source/flow-models/metadata.md
@@ -284,9 +284,10 @@ while the bridge pair {3, 4} forms its own cluster in the centre.
 - {meth}`infomap.Network.set_meta_data` declares the attribute for a node:
   `set_meta_data(node_id, meta_category)`. Each node takes one integer category
   label; call it once per node before the run.
-- `meta_data_rate` (an engine option on {func}`infomap.run`, default `1.0`; no
-  effect unless you declare metadata) sets $\eta$, the weight of the attribute
-  codebook term. Pass `meta_data_rate=0` to suppress all metadata influence.
+- `meta_data_rate` (an engine option carried via `Options` to {func}`infomap.run`,
+  default `1.0`; no effect unless you declare metadata) sets $\eta$, the weight of
+  the attribute codebook term. Pass `meta_data_rate=0` to suppress all metadata
+  influence.
 - {attr}`infomap.Result.meta_entropy` is the metadata entropy term of the best
   partition, in bits per step.
 
@@ -297,7 +298,8 @@ Two further engine options:
 
 ## Options
 
-Metadata influence is set by these engine options on {func}`infomap.run`:
+Metadata influence is set by these engine options, carried via `Options` to
+{func}`infomap.run`:
 
 | Option | Default | Effect |
 |---|---|---|

--- a/interfaces/python/source/flow-models/multilayer.md
+++ b/interfaces/python/source/flow-models/multilayer.md
@@ -428,9 +428,10 @@ assert n_links_self < n_links_default
 - {func}`infomap.datasets.multilayer`, {func}`infomap.datasets.multilayer_intra`,
   and {func}`infomap.datasets.multilayer_intra_inter` load the bundled example
   networks for the three file forms, ready to run.
-- `multilayer_relax_rate` (default `0.15`) is an engine option on
-  {func}`infomap.run`: the relax rate used when no explicit inter-layer links are
-  provided.
+- `multilayer_relax_rate` (default `0.15`) is an engine option carried via
+  `Options` to {func}`infomap.run`
+  (`options=Options(multilayer_relax_rate=...)`): the relax rate used when no
+  explicit inter-layer links are provided.
 - {meth}`infomap.Result.modules` needs `states=True` on multilayer networks to
   return state-node assignments; `states=False` raises an
   {class}`~infomap.InfomapError` on higher-order networks.
@@ -440,7 +441,8 @@ assert n_links_self < n_links_default
 
 ## Options
 
-The relax-rate model is controlled by these engine options on {func}`infomap.run`.
+The relax-rate model is controlled by these engine options, carried via `Options`
+to {func}`infomap.run` (`options=Options(...)`).
 They apply when Infomap simulates the coupling; with explicit inter-layer links
 only `multilayer_relax_to_self` still has an effect, deciding whether a
 node-aligned inter link attaches to the node's own copy or spreads over its

--- a/interfaces/python/source/flow-models/temporal.md
+++ b/interfaces/python/source/flow-models/temporal.md
@@ -236,8 +236,8 @@ generalises to higher-order and temporal networks {cite:p}`holmgren2023change`.
 - {meth}`infomap.Network.add_multilayer_link` adds a fully specified multilayer
   link `(layer, node) -> (layer, node)` when you want complete control over the
   state-node graph.
-- `multilayer_relax_rate` (an engine option on {func}`infomap.run`) sets the
-  inter-layer relax rate $r \in [0, 1]$ when you use `add_multilayer_intra_link`
+- `multilayer_relax_rate` (an engine option carried via `Options` to
+  {func}`infomap.run`) sets the inter-layer relax rate $r \in [0, 1]$ when you use `add_multilayer_intra_link`
   without explicit inter-layer links. 0.15–0.25 is a typical starting point.
 - `multilayer_relax_limit` restricts relaxation to layers within a given index
   distance, enforcing temporal ordering.
@@ -254,7 +254,8 @@ generalises to higher-order and temporal networks {cite:p}`holmgren2023change`.
 
 ## Options
 
-Temporal coupling is set by the multilayer engine options on {func}`infomap.run`:
+Temporal coupling is set by the multilayer engine options, carried via `Options`
+to {func}`infomap.run`:
 
 | Option | Default | Effect |
 |---|---|---|

--- a/interfaces/python/source/robustness/incomplete-data.md
+++ b/interfaces/python/source/robustness/incomplete-data.md
@@ -216,8 +216,9 @@ close to the planted five.
 
 ## API pointers
 
-Pass `regularized=True` to {func}`infomap.run` to activate the Bayesian map
-equation. One optional keyword controls the prior strength:
+Enable it via `options=infomap.Options(regularized=True)` on {func}`infomap.run`
+to activate the Bayesian map equation. One optional keyword controls the prior
+strength:
 
 - `regularized=True` enables the Bayesian regularized map equation, which adds a
   fully connected prior network to reduce overfitting to missing links. It works
@@ -233,8 +234,9 @@ equation. One optional keyword controls the prior strength:
   reason to trust community boundaries in sparse data ($C < 1$) or to suppress
   them harder ($C > 1$).
 
-All other engine options (`num_trials`, `seed`, `two_level`, `directed`, and so
-on) compose freely with `regularized=True`.
+The common keywords (`num_trials`, `seed`, `two_level`, `directed`) compose
+freely alongside it, e.g.
+`infomap.run(g, options=infomap.Options(regularized=True), num_trials=20, seed=123)`.
 
 - {attr}`infomap.Result.codelength` is the map equation value for the winning
   partition; with regularization it reflects the Bayesian-corrected description

--- a/interfaces/python/source/the-infomap-class.md
+++ b/interfaces/python/source/the-infomap-class.md
@@ -86,8 +86,12 @@ falls into one of three groups, with a sanctioned replacement:
 | Console flags -- `silent`, `verbose` | use logging: `infomap.enable_log()` for the engine log, and `infomap.enable_log(logging.DEBUG)` to raise its verbosity |
 
 The `options` carrier accepts an {class}`~infomap.Options` instance or a plain
-mapping; both are warning-free. Only bare keyword arguments typed directly on the
-call are flagged, so the common options (`seed`, `num_trials`, `two_level`,
+mapping, and is accepted on `Infomap()`, {meth}`Infomap.run`,
+{meth}`Network.run`, and {func}`infomap.run` alike — for example
+`im.run(options=Options(regularized=True))` gives the stateful builder the same
+warning-free path. A bare keyword argument set to a non-default value still
+overrides the carrier, and only bare keyword arguments typed directly on the call
+are flagged, so the common options (`seed`, `num_trials`, `two_level`,
 `directed`, `markov_time`) stay on the signature and are never deprecated.
 
 ## Removed accessors

--- a/interfaces/python/source/the-infomap-class.md
+++ b/interfaces/python/source/the-infomap-class.md
@@ -59,6 +59,7 @@ Each stateful pattern has a direct functional or `Network` equivalent:
 | Build incrementally | `im.add_node(...)`, `im.add_link(...)`, then `im.run()` | `net = Network(); net.add_node(...); net.add_link(...)`, then `infomap.run(net)` |
 | Reusable configuration | repeat the keyword arguments | `options = Options(**opts)`, then `infomap.run(g, options=options)` |
 | Top-level modules | `im.get_modules()` | `result.modules()` |
+| Iterate `(node_id, module_id)` pairs | `for k, v in im.modules:` | `for k, v in result.modules().items():` |
 | Modules at level *k* | `im.get_modules(depth_level=k)` | `result.modules(depth=k)` |
 | State-node modules | `im.get_modules(states=True)` | `result.modules(states=True)` |
 | Per-node flow | `for n in im.nodes: n.data.flow` | `for n in result.nodes(states=True): n.flow` (`im.nodes` iterates state nodes; plain `result.nodes()` gives physical nodes, identical for first-order networks) |

--- a/interfaces/python/source/workflows/hpc.md
+++ b/interfaces/python/source/workflows/hpc.md
@@ -15,8 +15,8 @@ kernelspec:
 ```{admonition} At a glance
 :class: tip
 Infomap trials are independent work units: run many in parallel on a
-single node with `parallel_trials`, or split them across a scheduler job
-array with `trial_offset` and merge the best result afterwards with
+single node with `options=Options(parallel_trials=True)`, or split them across a
+scheduler job array with `trial_offset` and merge the best result afterwards with
 `python -m infomap.merge`.
 ```
 
@@ -32,8 +32,9 @@ reasonable wall-clock time.
 Two strategies cover most HPC use cases:
 
 1. **Single-node parallelism.** Your scheduler gives you a node with many
-   cores. Run all trials on that node with `parallel_trials=True`.
-   `num_threads` controls the thread budget; left unset (its default, the same
+   cores. Run all trials on that node with
+   `options=Options(parallel_trials=True)`. `num_threads` (also carried on
+   `Options`) controls the thread budget; left unset (its default, the same
    as `"auto"`) it reads scheduler-set variables (`SLURM_CPUS_PER_TASK`,
    `OMP_NUM_THREADS`, cpuset) automatically.
 

--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -1,6 +1,7 @@
 import sys
 import warnings
 from collections import namedtuple
+from collections.abc import Mapping
 from contextlib import contextmanager
 
 from ._core import Core
@@ -33,6 +34,7 @@ from ._options import (
     Options,
     OutputFormat,
     _construct_args,
+    _merge_options,
     _warn_advanced_tier_kwargs,
 )
 from ._logging import apply_engine_log_overrides as _apply_engine_log_overrides
@@ -265,6 +267,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         prefer_modular_solution: bool = False,
         num_random_moves: int | None = None,
         max_degree_for_random_moves: int | None = None,
+        options: Options | Mapping | None = None,
     ) -> None:
         """Create a new Infomap instance.
 
@@ -276,6 +279,11 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         ----------
         args : str, optional
             Raw Infomap arguments to prepend before rendered keyword options.
+        options : Options, mapping, or None, optional
+            A reusable ``Options`` object (or a mapping) applied as the base
+            configuration; any keyword argument set to a non-default value overrides it.
+            This is the sanctioned, warning-free carrier for the advanced options that
+            leave the signature in 3.0.
         include_self_links : bool, optional
             Deprecated. Self-links are included by default; use no_self_links=True to
             exclude them.
@@ -907,7 +915,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
                 stacklevel=2,
             )
         _warn_advanced_tier_kwargs(locals(), "init")
-        options = Options._from_locals(locals())
+        options = _merge_options(options, Options._from_locals(locals()), "init")
         self._init_from_options(args, options)
 
     def run(
@@ -991,6 +999,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         prefer_modular_solution: bool = False,
         num_random_moves: int | None = None,
         max_degree_for_random_moves: int | None = None,
+        options: Options | Mapping | None = None,
     ) -> "Result":
         """Run Infomap.
 
@@ -1007,6 +1016,11 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             Raw Infomap arguments to prepend before rendered keyword options.
         initial_partition : dict, optional
             Initial partition to use for this run only. See initial_partition.
+        options : Options, mapping, or None, optional
+            A reusable ``Options`` object (or a mapping) applied as the base
+            configuration; any keyword argument set to a non-default value overrides it.
+            This is the sanctioned, warning-free carrier for the advanced options that
+            leave the signature in 3.0.
         include_self_links : bool, optional
             Deprecated. Self-links are included by default; use no_self_links=True to
             exclude them.
@@ -1647,7 +1661,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
                 stacklevel=2,
             )
         _warn_advanced_tier_kwargs(locals(), "run")
-        options = Options._from_locals(locals())
+        options = _merge_options(options, Options._from_locals(locals()), "run")
         return self._run_from_options(args, initial_partition, options)
     # === END generated ===
 
@@ -2391,7 +2405,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         Examples
         --------
 
-        >>> from infomap import Infomap
+        >>> from infomap import Infomap, Options
         >>> im = Infomap(silent=True, num_trials=10)
         >>> im.add_links((
         ...     (1, 2), (1, 3), (2, 3),
@@ -2402,10 +2416,10 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         >>> im.set_meta_data(4, 1)
         >>> im.set_meta_data(5, 0)
         >>> im.set_meta_data(6, 0)
-        >>> result = im.run(meta_data_rate=0)
+        >>> result = im.run(options=Options(meta_data_rate=0))
         >>> result.num_top_modules
         2
-        >>> result = im.run(meta_data_rate=2)
+        >>> result = im.run(options=Options(meta_data_rate=2))
         >>> result.num_top_modules
         3
 
@@ -2853,7 +2867,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         Examples
         --------
 
-        >>> from infomap import Infomap
+        >>> from infomap import Infomap, Options
         >>> im = Infomap(silent=True)
         >>> im.add_node(1)
         >>> im.add_node(2)
@@ -2869,7 +2883,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         ...     3: 1,
         ...     4: 1
         ... }
-        >>> result = im.run(no_infomap=True)
+        >>> result = im.run(options=Options(no_infomap=True))
         >>> result.codelength
         3.4056
 

--- a/interfaces/python/src/infomap/_options.py
+++ b/interfaces/python/src/infomap/_options.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import os
 import sys
 import warnings
-from dataclasses import dataclass, fields
+from collections.abc import Mapping
+from dataclasses import dataclass, fields, replace
 from typing import Literal
 
 
@@ -699,6 +700,46 @@ _OPTION_FIELD_NAMES = tuple(field.name for field in fields(Options))
 
 # Options is the canonical public name; InfomapOptions stays as a back-compat alias.
 InfomapOptions = Options
+
+
+_OPTION_DEFAULTS = Options()
+# The only facade keyword whose Infomap.run() default differs from
+# Infomap.__init__(): run() defaults silent to False. A keyword left at its
+# run-context default must defer to the options= carrier rather than
+# spuriously override it.
+_RUN_DEFAULT_OVERRIDES = {"silent": False}
+
+
+def _context_default(name, context):
+    if context == "run" and name in _RUN_DEFAULT_OVERRIDES:
+        return _RUN_DEFAULT_OVERRIDES[name]
+    return getattr(_OPTION_DEFAULTS, name)
+
+
+def _merge_options(base, keyword_options, context):
+    """Merge the ``options=`` carrier with the facade keyword options.
+
+    ``base`` is the ``options=`` argument to ``Infomap()`` / ``Infomap.run()``
+    (an :class:`Options`, a mapping, or ``None``); ``keyword_options`` is the
+    :class:`Options` built from the facade's per-keyword parameters. A keyword
+    left at its (context-appropriate) default defers to ``base``; a keyword
+    set to a non-default value is an explicit override and wins -- mirroring
+    the "overrides win over options" rule of :func:`infomap.run`.
+    """
+    if base is None:
+        return keyword_options
+    if isinstance(base, Mapping):
+        base = Options(**base)
+    elif not isinstance(base, Options):
+        raise TypeError(
+            "options must be an Options instance, a mapping, or None"
+        )
+    overrides = {
+        name: getattr(keyword_options, name)
+        for name in _OPTION_FIELD_NAMES
+        if getattr(keyword_options, name) != _context_default(name, context)
+    }
+    return replace(base, **overrides)
 
 
 def _construct_args(

--- a/interfaces/python/src/infomap/_options.py
+++ b/interfaces/python/src/infomap/_options.py
@@ -294,33 +294,86 @@ class Options:
         print non-modular statistics.
     out_name : str, optional
         Base name for output files, for example [out_directory]/[out-name].tree.
+
+        Args-only on the Python library surface. Use
+        Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or
+        Network.write_pajek/write_state_network. The flag only acts when an output
+        directory is passed via the raw args escape hatch.
     no_file_output : bool, optional
         Do not write output files.
+
+        Args-only on the Python library surface. Use
+        Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or
+        Network.write_pajek/write_state_network. The flag only acts when an output
+        directory is passed via the raw args escape hatch.
     tree : bool, optional
         Write the modular hierarchy to a tree file. Enabled by default when no other
         output format is selected.
+
+        Args-only on the Python library surface. Use
+        Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or
+        Network.write_pajek/write_state_network. The flag only acts when an output
+        directory is passed via the raw args escape hatch.
     ftree : bool, optional
         Write the modular hierarchy and aggregated links between nested modules to an
         ftree file. Used by Network Navigator.
+
+        Args-only on the Python library surface. Use
+        Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or
+        Network.write_pajek/write_state_network. The flag only acts when an output
+        directory is passed via the raw args escape hatch.
     clu : bool, optional
         Write top-level module ids for each node to a clu file.
+
+        Args-only on the Python library surface. Use
+        Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or
+        Network.write_pajek/write_state_network. The flag only acts when an output
+        directory is passed via the raw args escape hatch.
     clu_level : int, optional
         With --clu or --output clu, write module ids at this depth from the root. Use -1
         for bottom-level modules.
+
+        Args-only on the Python library surface. Use
+        Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or
+        Network.write_pajek/write_state_network. The flag only acts when an output
+        directory is passed via the raw args escape hatch.
     output : sequence of str, optional
         Write selected output formats as a comma-separated list without spaces, e.g. -o
         clu,tree,ftree. Options: clu, tree, ftree, newick, json, csv, network, states,
         flow.
+
+        Args-only on the Python library surface. Use
+        Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or
+        Network.write_pajek/write_state_network. The flag only acts when an output
+        directory is passed via the raw args escape hatch.
     hide_bipartite_nodes : bool, optional
         Hide bipartite nodes in output by projecting the solution to primary nodes.
+
+        Args-only on the Python library surface. Use
+        Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or
+        Network.write_pajek/write_state_network. The flag only acts when an output
+        directory is passed via the raw args escape hatch.
     print_all_trials : bool, optional
         Write each trial to separate output files. Has effect only when --num-trials is
         greater than 1.
+
+        Args-only on the Python library surface. Use
+        Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or
+        Network.write_pajek/write_state_network. The flag only acts when an output
+        directory is passed via the raw args escape hatch.
     no_overwrite : bool, optional
         Fail with an output error if any target output file already exists. By default
         existing files are replaced.
+
+        Args-only on the Python library surface. Use
+        Result.write_tree/write_flow_tree/write_clu (write_clu takes depth_level) or
+        Network.write_pajek/write_state_network. The flag only acts when an output
+        directory is passed via the raw args escape hatch.
     print_config_fingerprint : bool, optional
         Print the canonical configuration fingerprint and exit.
+
+        Not a Python library option; it leaves the surface in 3.0. A print-and-exit CLI
+        diagnostic; run the infomap binary.
     timing_json : str, optional
         Write machine-readable run timing JSON to this path. Use - for stdout.
     summary_json : str, optional
@@ -343,9 +396,17 @@ class Options:
     verbosity_level : int, optional
         Verbosity level on the console. 1 keeps the default output level, 2 renders -vv
         and so on.
+
+        Not a Python library option; it leaves the surface in 3.0. A DEBUG-enabled
+        'infomap' logger (infomap.enable_log(logging.DEBUG)) raises engine verbosity;
+        logger levels filter the records.
     silent : bool, optional
         Suppress console output. The Python API is quiet by default; construct with
         silent=False for the engine log. The command-line interface is unaffected.
+
+        Not a Python library option; it leaves the surface in 3.0. The Python API is
+        quiet by default; logging is the control. Attach handlers to
+        logging.getLogger('infomap') (e.g. infomap.enable_log()) for the engine log.
     two_level : bool, optional
         Optimize a two-level partition instead of the default multi-level hierarchy.
     flow_model : str, optional
@@ -468,6 +529,9 @@ class Options:
         partition, parallel trials, and inner parallelization.
     threads : str, optional
         Alias for --num-threads.
+
+        Not a Python library option; it leaves the surface in 3.0. Use num_threads;
+        threads is a redundant alias of the same engine option.
     prefer_modular_solution : bool, optional
         Prefer a modular solution even when one module gives a lower codelength.
     num_random_moves : int, optional

--- a/interfaces/python/src/infomap/_results.py
+++ b/interfaces/python/src/infomap/_results.py
@@ -1391,7 +1391,7 @@ class _InfomapResultsMixin:
         --------
 
         >>> from infomap import Infomap
-        >>> im = Infomap(silent=True, no_infomap=True)
+        >>> im = Infomap(silent=True)
         >>> im.read_file("twotriangles.net")
         >>> _ = im.run()
         >>> f"{im.entropy_rate:.5f}"

--- a/interfaces/python/src/infomap/_run.py
+++ b/interfaces/python/src/infomap/_run.py
@@ -169,10 +169,31 @@ def _reject_adapter_kwargs(kind: str, user_keys: set) -> None:
     raise TypeError(message)
 
 
+# Sentinel for the common-tier keyword parameters below: it lets run() tell "the
+# caller passed this option" from "left at its default", so a supplied value
+# overrides the ``options`` carrier while an untouched one defers to it. Typed
+# ``Any`` so the honest per-parameter annotations (``seed: int`` ...) still
+# type-check against this shared default; the ``<unset>`` repr keeps
+# ``inspect.signature(infomap.run)`` readable for IDE/agent introspection.
+class _Unset:
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return "<unset>"
+
+
+_UNSET: Any = _Unset()
+
+
 def run(
     input: Any,
     *,
     options: Any = None,
+    seed: int = _UNSET,
+    num_trials: int = _UNSET,
+    two_level: bool = _UNSET,
+    directed: bool | None = _UNSET,
+    markov_time: float = _UNSET,
     initial_partition: Any = None,
     **overrides: Any,
 ) -> "Result":
@@ -185,12 +206,35 @@ def run(
         The network to partition. See the module docstring for the dispatch
         table.
     options : Options, mapping, or None, optional
-        Base configuration. Keyword ``overrides`` take precedence.
+        Base configuration. Any keyword argument below takes precedence.
+    seed : int, optional
+        Random-number-generator seed for reproducible results (default 123).
+    num_trials : int, optional
+        Number of independent trials to run; the best solution is kept
+        (default 1).
+    two_level : bool, optional
+        Optimize a two-level partition instead of the default multilevel
+        hierarchy.
+    directed : bool, optional
+        Treat links as directed (shorthand for ``flow_model="directed"``).
+        For a graph, file, or link-iterable input this is an engine flag; for a
+        SciPy sparse matrix or a ``(2, E)`` edge index it names the input
+        adapter's orientation instead and is rejected here -- build the network
+        with ``Network.from_scipy_sparse_matrix(..., directed=True)`` /
+        ``Network.from_edge_index(..., directed=True)``, or pass
+        ``options=Options(flow_model="directed")``.
+    markov_time : float, optional
+        Scale link flow to change the cost of moving between modules; higher
+        values yield fewer modules.
     initial_partition : mapping, optional
         Initial module assignment for this run only.
     **overrides
-        Individual Infomap options (CLI-flag keyword arguments) that override
-        ``options``. These configure the *engine*, not how the input is read.
+        Any other Infomap engine option, as a keyword argument. These
+        advanced-tier options still work but are pending-deprecated on this
+        signature and leave it in 3.0 (issue #741); carry them via ``options``
+        (an :class:`Options` instance or a mapping) for the sanctioned,
+        warning-free path. They configure the *engine*, not how the input is
+        read.
 
     Returns
     -------
@@ -254,21 +298,39 @@ def run(
     from ._facade import Infomap
     from .network import Network
 
-    resolved = _resolve_options(options, overrides)
+    # The five common-tier options are first-class keyword parameters so they
+    # show up in inspect.signature(infomap.run) for IDE/agent introspection;
+    # every other engine option rides **overrides. Collect the common ones the
+    # caller actually supplied (still at _UNSET means "defer to options").
+    common = {
+        name: value
+        for name, value in (
+            ("seed", seed),
+            ("num_trials", num_trials),
+            ("two_level", two_level),
+            ("directed", directed),
+            ("markov_time", markov_time),
+        )
+        if value is not _UNSET
+    }
+
+    resolved = _resolve_options(options, {**overrides, **common})
     # Advanced-tier keywords are pending-deprecated on the run() signature and
     # move off it in 3.0 (issue #741). Warn only on bare **overrides typed
-    # directly on this call; an Options or mapping `options` carrier is the
-    # sanctioned path and stays silent. The helper's caller-frame check sees the
-    # user's frame here (frame 2 is run()'s caller), so an in-package caller of
-    # run() is not flagged and the later Infomap(**resolved) -- reached from
-    # inside the package -- does not double-warn.
+    # directly on this call; the common-tier parameters above never warn, and an
+    # Options or mapping `options` carrier is the sanctioned path and stays
+    # silent. The helper's caller-frame check sees the user's frame here (frame 2
+    # is run()'s caller), so an in-package caller of run() is not flagged and the
+    # later Infomap(**resolved) -- reached from inside the package -- does not
+    # double-warn.
     if overrides:
         _warn_advanced_tier_kwargs(overrides, "init")
-    # Keys the user actually supplied (kwargs + a mapping `options`), used to
-    # reject adapter-only arguments below. An Options *instance* is excluded on
-    # purpose: its to_kwargs() carries every field (e.g. directed=None) the user
-    # never set, which would false-positive the guard.
-    user_keys = set(overrides)
+    # Keys the user actually supplied (kwargs + common-tier params + a mapping
+    # `options`), used to reject adapter-only arguments below. An Options
+    # *instance* is excluded on purpose: its to_kwargs() carries every field
+    # (e.g. directed=None) the user never set, which would false-positive the
+    # guard.
+    user_keys = set(overrides) | set(common)
     if isinstance(options, Mapping):
         user_keys |= set(options)
 

--- a/interfaces/python/src/infomap/result.py
+++ b/interfaces/python/src/infomap/result.py
@@ -59,6 +59,20 @@ _LEGACY_ACCESSOR_HINTS = {
     "physical_tree": "result.tree()",
 }
 
+# Also accept the camelCase SWIG-style spellings (``result.getModules()``) an agent
+# may carry over from the low-level C++ core API, mapping each to the same Result
+# pointer as its snake_case twin.
+_LEGACY_ACCESSOR_HINTS.update(
+    {
+        "".join(
+            part.capitalize() if i else part
+            for i, part in enumerate(name.split("_"))
+        ): hint
+        for name, hint in list(_LEGACY_ACCESSOR_HINTS.items())
+        if name.startswith("get_")
+    }
+)
+
 if TYPE_CHECKING:
     import igraph  # pyright: ignore[reportMissingImports]  # optional dep, no stubs
     import networkx

--- a/scripts/generate_binding_options.py
+++ b/scripts/generate_binding_options.py
@@ -325,7 +325,8 @@ def generate_python(catalog: ParameterCatalog) -> str:
         "import os",
         "import sys",
         "import warnings",
-        "from dataclasses import dataclass, fields",
+        "from collections.abc import Mapping",
+        "from dataclasses import dataclass, fields, replace",
         "from typing import Literal",
         "",
         "",
@@ -510,6 +511,46 @@ def generate_python(catalog: ParameterCatalog) -> str:
             "",
             "# Options is the canonical public name; InfomapOptions stays as a back-compat alias.",
             "InfomapOptions = Options",
+            "",
+            "",
+            "_OPTION_DEFAULTS = Options()",
+            "# The only facade keyword whose Infomap.run() default differs from",
+            "# Infomap.__init__(): run() defaults silent to False. A keyword left at its",
+            "# run-context default must defer to the options= carrier rather than",
+            "# spuriously override it.",
+            '_RUN_DEFAULT_OVERRIDES = {"silent": False}',
+            "",
+            "",
+            "def _context_default(name, context):",
+            '    if context == "run" and name in _RUN_DEFAULT_OVERRIDES:',
+            "        return _RUN_DEFAULT_OVERRIDES[name]",
+            "    return getattr(_OPTION_DEFAULTS, name)",
+            "",
+            "",
+            "def _merge_options(base, keyword_options, context):",
+            '    """Merge the ``options=`` carrier with the facade keyword options.',
+            "",
+            "    ``base`` is the ``options=`` argument to ``Infomap()`` / ``Infomap.run()``",
+            "    (an :class:`Options`, a mapping, or ``None``); ``keyword_options`` is the",
+            "    :class:`Options` built from the facade's per-keyword parameters. A keyword",
+            "    left at its (context-appropriate) default defers to ``base``; a keyword",
+            "    set to a non-default value is an explicit override and wins -- mirroring",
+            '    the "overrides win over options" rule of :func:`infomap.run`.',
+            '    """',
+            "    if base is None:",
+            "        return keyword_options",
+            "    if isinstance(base, Mapping):",
+            "        base = Options(**base)",
+            "    elif not isinstance(base, Options):",
+            "        raise TypeError(",
+            '            "options must be an Options instance, a mapping, or None"',
+            "        )",
+            "    overrides = {",
+            "        name: getattr(keyword_options, name)",
+            "        for name in _OPTION_FIELD_NAMES",
+            "        if getattr(keyword_options, name) != _context_default(name, context)",
+            "    }",
+            "    return replace(base, **overrides)",
             "",
             "",
             "def _construct_args(",
@@ -879,6 +920,13 @@ _INERT_WITHOUT_OUTDIR_NOTE = (
     "`write_*` methods to write results)."
 )
 
+_FACADE_OPTIONS_DOC = (
+    "A reusable `Options` object (or a mapping) applied as the base "
+    "configuration; any keyword argument set to a non-default value overrides "
+    "it. This is the sanctioned, warning-free carrier for the advanced options "
+    "that leave the signature in 3.0."
+)
+
 # A kept keyword is permanent -- only its entry point relocates to Options in
 # 3.0 -- so its docstring uses ``.. versionchanged::`` rather than
 # ``.. deprecated::``. Marking a still-supported tuning knob "deprecated" makes
@@ -939,6 +987,7 @@ def generate_facade(catalog: ParameterCatalog) -> str:
     lines.append("        self,")
     lines.append("        args: str | None = None,")
     lines.extend(_render_facade_signature(names, index))
+    lines.append("        options: Options | Mapping | None = None,")
     lines.append("    ) -> None:")
     lines.append('        """Create a new Infomap instance.')
     lines.append("")
@@ -955,11 +1004,15 @@ def generate_facade(catalog: ParameterCatalog) -> str:
             "            ",
         )
     )
+    lines.append("        options : Options, mapping, or None, optional")
+    lines.extend(wrap_doc(_FACADE_OPTIONS_DOC, "            "))
     lines.extend(_render_facade_docstring_params(names, index))
     lines.append('        """')
     lines.extend(_PRETTY_WARNING_LINES)
     lines.append('        _warn_advanced_tier_kwargs(locals(), "init")')
-    lines.append("        options = Options._from_locals(locals())")
+    lines.append(
+        '        options = _merge_options(options, Options._from_locals(locals()), "init")'
+    )
     lines.append("        self._init_from_options(args, options)")
     lines.append("")
     # ---- run ----
@@ -968,6 +1021,7 @@ def generate_facade(catalog: ParameterCatalog) -> str:
     lines.append("        args: str | None = None,")
     lines.append("        initial_partition: dict | None = None,")
     lines.extend(_render_facade_signature(names, index, context="run"))
+    lines.append("        options: Options | Mapping | None = None,")
     lines.append('    ) -> "Result":')
     lines.append('        """Run Infomap.')
     lines.append("")
@@ -1000,6 +1054,8 @@ def generate_facade(catalog: ParameterCatalog) -> str:
             "            ",
         )
     )
+    lines.append("        options : Options, mapping, or None, optional")
+    lines.extend(wrap_doc(_FACADE_OPTIONS_DOC, "            "))
     lines.extend(_render_facade_docstring_params(names, index))
     lines.append("")
     lines.append("        Returns")
@@ -1013,7 +1069,9 @@ def generate_facade(catalog: ParameterCatalog) -> str:
     lines.append('        """')
     lines.extend(_PRETTY_WARNING_LINES)
     lines.append('        _warn_advanced_tier_kwargs(locals(), "run")')
-    lines.append("        options = Options._from_locals(locals())")
+    lines.append(
+        '        options = _merge_options(options, Options._from_locals(locals()), "run")'
+    )
     lines.append(
         "        return self._run_from_options(args, initial_partition, options)"
     )

--- a/scripts/generate_binding_options.py
+++ b/scripts/generate_binding_options.py
@@ -292,6 +292,30 @@ def _advanced_tier_kwarg_lines(catalog: ParameterCatalog) -> list[str]:
     return lines
 
 
+def _options_doc_policy_note(policy: dict) -> str:
+    """A short note for the Options docstring flagging fields that are not a
+    first-class engine option on the Python library surface.
+
+    An agent steered to ``inspect.getdoc(infomap.Options)`` as the parameter
+    reference would otherwise read args-only / removed / alias fields (``tree``,
+    ``silent``, ``out_name``, ``threads`` ...) as usable library knobs. Reuse the
+    policy's own replacement guidance so the note stays in step with the facade
+    docstrings and the runtime advanced-tier warning.
+    """
+    action = (policy or {}).get("action", "keep")
+    if action == "keep":
+        return ""
+    replacement = (policy or {}).get("replacement", "").strip()
+    lead = {
+        "args-only": "Args-only on the Python library surface.",
+        "remove": "Not a Python library option; it leaves the surface in 3.0.",
+        "alias": "Compatibility alias.",
+        "deprecate": "Deprecated.",
+        "hide": "Not exposed on the Python surface.",
+    }.get(action, "")
+    return f"{lead} {replacement}".strip()
+
+
 def generate_python(catalog: ParameterCatalog) -> str:
     grouped = catalog.grouped()
     include_self_links = catalog.binding_only_entry("python", "include_self_links")
@@ -386,6 +410,10 @@ def generate_python(catalog: ParameterCatalog) -> str:
             description = param.python_doc_description()
             lines.append(f"    {name} : {param.python_doc_type()}")
             lines.extend(wrap_doc(description, "        "))
+            note = _options_doc_policy_note(param.policy("python"))
+            if note:
+                lines.append("")
+                lines.extend(wrap_doc(note, "        "))
     lines.append("    include_self_links : bool, optional")
     lines.extend(
         wrap_doc(

--- a/skills/infomap/references/python.md
+++ b/skills/infomap/references/python.md
@@ -31,6 +31,8 @@ result = infomap.run(
 
 Passing those options as bare keyword arguments still works in 2.x but is pending-deprecated (it emits no visible warning today) and leaves the signature in 3.0. Generate `infomap.run(g, options=Options(regularized=True))`, not `infomap.run(g, regularized=True)`.
 
+`directed` is a direct engine kwarg only for graph, file, and link-iterable inputs. For a SciPy sparse matrix or a `(2, E)` edge index it names the *input adapter's* orientation, so `infomap.run(A, directed=True)` raises `TypeError`; build the network explicitly with `Network.from_scipy_sparse_matrix(A, directed=True)` / `Network.from_edge_index(ei, directed=True)`, or pass `options=Options(flow_model="directed")`.
+
 The Python API is quiet by default. Do not reach for `silent=` (also going away); to see the engine log, attach a handler to the `infomap` logger, e.g. `infomap.enable_log()`.
 
 ## Authority for current syntax

--- a/skills/infomap/references/python.md
+++ b/skills/infomap/references/python.md
@@ -31,6 +31,8 @@ result = infomap.run(
 
 Passing those options as bare keyword arguments still works in 2.x but is pending-deprecated (it emits no visible warning today) and leaves the signature in 3.0. Generate `infomap.run(g, options=Options(regularized=True))`, not `infomap.run(g, regularized=True)`.
 
+The `options=` carrier is accepted on the stateful `Infomap()` and `Infomap.run()` as well, not just `infomap.run()` and `Network.run()` — e.g. `im.run(options=Options(regularized=True))` — so the stateful builder has the same warning-free path (a bare keyword set to a non-default value still overrides the carrier).
+
 `directed` is a direct engine kwarg only for graph, file, and link-iterable inputs. For a SciPy sparse matrix or a `(2, E)` edge index it names the *input adapter's* orientation, so `infomap.run(A, directed=True)` raises `TypeError`; build the network explicitly with `Network.from_scipy_sparse_matrix(A, directed=True)` / `Network.from_edge_index(ei, directed=True)`, or pass `options=Options(flow_model="directed")`.
 
 The Python API is quiet by default. Do not reach for `silent=` (also going away); to see the engine log, attach a handler to the `infomap` logger, e.g. `infomap.enable_log()`.

--- a/skills/infomap/references/python.md
+++ b/skills/infomap/references/python.md
@@ -54,7 +54,7 @@ Use the published Python docs at `https://mapequation.org/infomap-python-docs/` 
 ## Choose the Python entry point
 
 - One-call partitioning from a graph, file, matrix, edge index, or link iterable: `infomap.run(input, seed=..., num_trials=...)`.
-- Just a node→community mapping keyed by the original NetworkX labels: `infomap.find_communities(graph, seed=..., num_trials=...)` (igraph counterpart: `infomap.find_igraph_communities`).
+- Just the partition in the graph's own node labels: `infomap.find_communities(graph, seed=..., num_trials=...)` returns a NetworkX-style `list[set]` of node labels — not a `{node: module}` dict. Its igraph counterpart `infomap.find_igraph_communities` returns an `igraph.VertexClustering` (keyed by vertex index), not the same shape. Both accept a `trials` alias and default to `num_trials=10` (not 1, unlike `run`).
 - Non-default input building (weights, directedness, state/multilayer): `Network.from_*(...)` then `.run(options=Options(...))`.
 - AnnData/Scanpy observation graphs: use the `infomap.tl` helper if the installed package exposes it.
 

--- a/test/python/test_docs_examples_surface.py
+++ b/test/python/test_docs_examples_surface.py
@@ -250,6 +250,7 @@ ALLOWLIST: dict[str, set[str]] = {
     "interfaces/python/source/the-infomap-class.md": {
         "codelength",
         "get_modules",
+        "modules",
         "nodes",
         "num_top_modules",
         "to_dataframe",

--- a/test/python/test_docs_examples_surface.py
+++ b/test/python/test_docs_examples_surface.py
@@ -28,6 +28,7 @@ pytestmark = pytest.mark.fast
 REPO_ROOT = Path(__file__).resolve().parents[2]
 EXAMPLES = REPO_ROOT / "examples" / "python"
 DOCS = REPO_ROOT / "interfaces" / "python" / "source"
+SRC = REPO_ROOT / "interfaces" / "python" / "src" / "infomap"
 
 # The legacy result/build/config mirror on Infomap (docs-only deprecated
 # since 2.14; see test_deprecations.py). Curated by hand: introspecting
@@ -299,4 +300,45 @@ def test_docs_and_examples_avoid_the_deprecated_surface():
     assert not violations, (
         "our own examples/docs teach the deprecated or advanced-tier "
         "surface:\n" + "\n".join(sorted(set(violations)))
+    )
+
+
+# The package's own source modules are the help()/autodoc surface, so their
+# docstrings (and code) must not pass an advanced-tier option directly either --
+# otherwise an agent reading help(Infomap.set_meta_data) learns the 3.0-breaking
+# bare-kwarg pattern. Only the advanced-kwarg rule applies here; the
+# instance-accessor rules do NOT, because the deprecated members are *defined*
+# and documented on their own in these files. The console-quieting
+# silent/verbosity_level knobs are excluded: they default to silent, do not emit
+# the pending-deprecation warning, and are covered by the separate
+# silent->logging migration.
+_CONSOLE_KWARGS = {"silent", "verbosity_level"}
+
+
+def _source_module_files() -> list[Path]:
+    # _swig.py is the low-level SWIG-generated binding, not an authored surface.
+    return [p for p in sorted(SRC.rglob("*.py")) if p.name != "_swig.py"]
+
+
+@pytest.mark.fast
+def test_source_docstrings_avoid_direct_advanced_kwargs():
+    if not SRC.is_dir():
+        pytest.skip("package source not available (wheel/sdist test run)")
+
+    advanced = _advanced_kwargs() - _CONSOLE_KWARGS
+    violations: list[str] = []
+    for path in _source_module_files():
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        rel = path.relative_to(REPO_ROOT)
+        for span in _call_argument_spans(text):
+            span = _strip_nested_option_calls(span)
+            for kwarg in _KWARG.findall(span):
+                if kwarg in advanced:
+                    violations.append(
+                        f"{rel}: advanced kwarg {kwarg}= passed directly "
+                        "(carry it via Options)"
+                    )
+    assert not violations, (
+        "source docstrings/code pass advanced-tier kwargs directly:\n"
+        + "\n".join(sorted(set(violations)))
     )

--- a/test/python/test_facade_generated_block.py
+++ b/test/python/test_facade_generated_block.py
@@ -19,8 +19,8 @@ FACADE = Path(__file__).resolve().parents[2] / (
 BEGIN = "# === BEGIN generated: Infomap option signatures"
 END = "# === END generated ==="
 
-NON_OPTION_INIT = {"self", "args", "pretty"}
-NON_OPTION_RUN = {"self", "args", "initial_partition", "pretty"}
+NON_OPTION_INIT = {"self", "args", "pretty", "options"}
+NON_OPTION_RUN = {"self", "args", "initial_partition", "pretty", "options"}
 
 
 @pytest.mark.fast

--- a/test/python/test_signature_catalog.py
+++ b/test/python/test_signature_catalog.py
@@ -23,8 +23,10 @@ from infomap._options import _OPTION_FIELD_NAMES
 # keeps working, hence absent from InfomapOptions. Any *new* extra parameter still fails.
 BACKWARD_COMPAT_EXTRA = {"pretty"}
 
-NON_OPTION_INIT = {"self", "args"} | BACKWARD_COMPAT_EXTRA
-NON_OPTION_RUN = {"self", "args", "initial_partition"} | BACKWARD_COMPAT_EXTRA
+# `options` is the reusable Options/mapping carrier accepted alongside the bare
+# keyword arguments; it is not itself an option field in the catalog.
+NON_OPTION_INIT = {"self", "args", "options"} | BACKWARD_COMPAT_EXTRA
+NON_OPTION_RUN = {"self", "args", "initial_partition", "options"} | BACKWARD_COMPAT_EXTRA
 
 
 @pytest.mark.fast


### PR DESCRIPTION
## Summary

Follow-up hardening of the Python API for the 3.0 surface, focused on the places where an API consumer — especially one reading `help()` / `inspect.signature` / `inspect.getdoc` — gets steered toward a deprecated or 3.0-breaking pattern:

- **`infomap.run()` surfaces the common tier.** The five common-tier options (`seed`, `num_trials`, `two_level`, `directed`, `markov_time`) are now explicit keyword parameters, so introspection reveals them and everything else is naturally channeled to `Options`. A shared `<unset>` sentinel keeps "passed" distinct from "left at default" (an explicit value overrides the `options=` carrier); `directed` stays routed through the adapter-kwarg guard.
- **`options=` carrier on the stateful `Infomap`.** `Infomap()` and `Infomap.run()` now accept an `options=` carrier (an `Options` or mapping), giving the stateful builder the same warning-free path for advanced options as `infomap.run()` / `Network.run()`. A non-default bare keyword still overrides the carrier.
- **`Options` docstring marks non-engine fields.** The generated `Options` docstring now flags the args-only / removed-in-3.0 fields (`tree`, `clu`, `out_name`, `no_file_output`, `silent`, `verbosity_level`, `threads`, `print_config_fingerprint`, …), so `inspect.getdoc(Options)` no longer presents them as first-class library knobs.
- **`Result` legacy hints cover camelCase.** `result.getModules()` (and the other SWIG-style spellings) now return a pointer to `result.modules()` instead of a bare `AttributeError`.
- **Docs / skill / examples consistency.** Routed advanced options through `Options` in prose and the FAQ; qualified that `directed` is an input-adapter setting for SciPy / edge-index inputs; added a correct `Options` example for `preferred_number_of_modules`; fixed the `im.modules` → `result.modules().items()` migration note; corrected the documented `find_communities` return type (`list[set]`, not a dict); and migrated the remaining example/notebook leaks to the Result/Options API.
- **Source-docstring cleanup + guard.** The docstrings that passed bare advanced kwargs (`set_meta_data`, `initial_partition`, `entropy_rate`) now route through `options=` (or drop the incidental kwarg), and a new test guards the source `help()`/autodoc surface against reintroducing the bare-kwarg pattern.

## Verification

- Full Python unit suite green: **614 passed, 3 skipped** (`-m "not slow and not perf"`).
- Doctests pass under **`-W error::PendingDeprecationWarning`** (no advanced-tier warnings emitted from the package's own docstrings).
- Binding-options freshness check (`generate_binding_options.py --check`) passes; regeneration touches only `_options.py` / `_facade.py`, with the R, JS, and `policy.md` outputs unchanged.
- `ruff check` clean on all changed Python; core-scope pyright shows no new findings.
- Behavior spot-checked empirically: options-vs-override precedence, adapter `directed` rejection for SciPy/edge-index, and carrier-silent vs bare-kwarg warnings.

## Notes

- Generated files (`_options.py` and the `_facade.py` signature block) were regenerated with `scripts/generate_binding_options.py`; the source of truth is the generator plus `interfaces/parameters/overrides.json`.
- Deliberately out of scope (deferred to a pre-3.0 release): flipping the advanced-tier `PendingDeprecationWarning` and the instance-accessor deprecations to a visible `DeprecationWarning`, and the matching once-3.0-nears docstring pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NTyDWMPx7aQ3iQe1Pki4vc)_