### PR TITLE
Python API: agent-usability polish (docs traps, deprecation signals, clearer errors)

### DIFF
--- a/interfaces/python/source/api/infomap.rst
+++ b/interfaces/python/source/api/infomap.rst
@@ -26,8 +26,9 @@ docstrings, follows underneath.
    ``codelength``, …) are **deprecated and leave in 3.0** -- read the
    equivalently named members off the returned :class:`Result` instead. Mind the
    shape shift: ``im.modules`` is a property, while ``result.modules()`` is a
-   method. These accessors emit no runtime warning today, so nothing flags the
-   mistake; see :doc:`/the-infomap-class` for the full migration table. For
+   method. These accessors emit a silent-by-default ``PendingDeprecationWarning``
+   (surface it with ``-W``); see :doc:`/the-infomap-class` for the full
+   migration table. For
    one-shot use, prefer :func:`infomap.run`; the stateful class remains the way
    to build incrementally and to write the native output files.
 

--- a/interfaces/python/source/faq.md
+++ b/interfaces/python/source/faq.md
@@ -148,6 +148,21 @@ colouring or feeding another algorithm. `result.to_dataframe([...])` returns a
 pandas DataFrame with node id, module id, flow, and hierarchical path, better for
 filtering, grouping, and export. See {doc}`Reading the Result <working-with-infomap/results-and-iteration>`.
 
+### Why are `result.modules()` keys integers instead of my node labels?
+
+`infomap.run(graph)` maps your node labels to internal integer ids, so
+`result.modules()` and `node.node_id` are keyed by those ids. The mapping is kept
+on `result.names` (`{internal_id: label}` for graph inputs) -- relabel with no
+rebuild:
+
+```python
+named = {result.names.get(n, n): m for n, m in result.modules().items()}
+```
+
+`result.to_dataframe()` already includes a `name` column, and
+`infomap.find_communities(graph)` returns a `list[set]` in your original labels.
+See {doc}`Building a network <working-with-infomap/inputs>`.
+
 ### How do I export results to Gephi or to `.tree` / `.clu` files?
 
 For Gephi, annotate the graph with `infomap.to_networkx(result)` (or `to_igraph`)

--- a/interfaces/python/source/faq.md
+++ b/interfaces/python/source/faq.md
@@ -38,6 +38,18 @@ same names are properties -- another reason to read results off the returned
 `Result`, not the instance.) See
 {doc}`Reading the Result <working-with-infomap/results-and-iteration>`.
 
+### Why does `result.modules` give a bound method, or `result.modules().items` fail?
+
+Collections are **methods** -- call `result.modules()`, not `result.modules`.
+Accessing it without parentheses returns the method object, so
+`result.modules.items()` raises `AttributeError: 'function' object has no
+attribute 'items'`. And `result.modules()` returns a `{node_id: module_id}`
+dict: iterate `result.modules().items()`. Code ported from the stateful
+instance can also raise `TypeError: cannot unpack non-iterable int object` --
+its `modules` was a *property* that yielded `(node_id, module_id)` pairs, but
+iterating the `Result`'s dict yields keys, so unpack `result.modules().items()`
+instead. See {doc}`Reading the Result <working-with-infomap/results-and-iteration>`.
+
 ### How do I see Infomap's progress or engine log in Python?
 
 The Python API is quiet by default. Call `infomap.enable_log()` once to route the

--- a/interfaces/python/source/the-infomap-class.md
+++ b/interfaces/python/source/the-infomap-class.md
@@ -50,9 +50,9 @@ The on-instance result accessors (`im.get_modules()`, `im.codelength`,
 `im.nodes`) still work and are backed by that result, but they are **deprecated
 and leave in 3.0** -- read the equivalently named members off the returned
 {class}`~infomap.Result` instead. Mind the shape shift: `im.modules` is a
-property, while `result.modules()` is a method. These accessors emit no runtime
-warning today, so nothing flags the mistake; the migration table below maps each
-one across.
+property, while `result.modules()` is a method. These accessors emit a
+silent-by-default `PendingDeprecationWarning` (surface it with `-W`); the
+migration table below maps each one across.
 
 ## Migrating to the functional API
 

--- a/interfaces/python/source/the-infomap-class.md
+++ b/interfaces/python/source/the-infomap-class.md
@@ -46,8 +46,13 @@ print(result.modules())
 ```
 
 `im.run()` returns the same {class}`~infomap.Result` the functional API returns.
-The on-instance accessors (`im.get_modules()`, `im.codelength`, `im.nodes`) still
-work and are backed by that result.
+The on-instance result accessors (`im.get_modules()`, `im.codelength`,
+`im.nodes`) still work and are backed by that result, but they are **deprecated
+and leave in 3.0** -- read the equivalently named members off the returned
+{class}`~infomap.Result` instead. Mind the shape shift: `im.modules` is a
+property, while `result.modules()` is a method. These accessors emit no runtime
+warning today, so nothing flags the mistake; the migration table below maps each
+one across.
 
 ## Migrating to the functional API
 

--- a/interfaces/python/source/working-with-infomap/inputs.md
+++ b/interfaces/python/source/working-with-infomap/inputs.md
@@ -66,8 +66,8 @@ Two one-shot helpers return native types instead of a
 {class}`~infomap.Result`: {func}`infomap.find_communities` (a NetworkX-style
 ``list[set]``) and {func}`infomap.find_igraph_communities` (an
 ``igraph.VertexClustering``). Both accept ``trials`` (a convenience alias for
-``num_trials``) and default to ``10`` — a robust default for a single call;
-pass ``trials`` or ``num_trials``, not both.
+``num_trials``) and, like {func}`infomap.run`, default to ``num_trials=1`` —
+raise it for research runs. Pass ``trials`` or ``num_trials``, not both.
 
 The ``from_*`` constructors deliberately name their input-reading arguments in
 each library's own idiom rather than forcing one spelling across sources, and

--- a/interfaces/python/source/working-with-infomap/inputs.md
+++ b/interfaces/python/source/working-with-infomap/inputs.md
@@ -119,9 +119,20 @@ result = infomap.run(g_str, two_level=True, seed=123)
 print(result.to_dataframe(["name", "module_id"]).to_string(index=False))
 ```
 
-When you need the integer-to-label mapping itself, build a
-{class}`~infomap.Network`: its {attr}`~infomap.Network.node_id_to_label` records
-it.
+When you want the assignment as a ``{label: module_id}`` dict, relabel
+{meth}`result.modules() <infomap.Result.modules>` through
+{attr}`result.names <infomap.Result.names>` -- the ``{internal_id: label}``
+mapping the loader records for graph inputs -- with no rebuild:
+
+```{code-cell} python
+result = infomap.run(g_str, seed=123)
+named = {result.names.get(nid, nid): mid for nid, mid in result.modules().items()}
+print("Named assignments:", named)
+```
+
+For label types that are not stored as node names (tuples, frozensets), build a
+{class}`~infomap.Network` and read its
+{attr}`~infomap.Network.node_id_to_label` instead:
 
 ```{code-cell} python
 from infomap import Network, run

--- a/interfaces/python/source/working-with-infomap/running-and-options.md
+++ b/interfaces/python/source/working-with-infomap/running-and-options.md
@@ -453,6 +453,10 @@ logging.getLogger("infomap").addHandler(my_handler)
 logging.getLogger("infomap").setLevel(logging.INFO)
 ```
 
+`silent=` and `verbose=` are pending-deprecated and leave the API in 3.0;
+`enable_log()` is the forward path for the engine log. The `silent=` behavior
+described below is documented for existing code.
+
 How the routing behaves:
 
 - **Logging is the control.** With handlers attached, every engine run emits

--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -118,7 +118,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
     :class:`~infomap.Result`:
 
     >>> from infomap import Infomap
-    >>> im = Infomap(silent=True)
+    >>> im = Infomap()
     >>> im.add_node(1)
     >>> im.add_node(2)
     >>> im.add_link(1, 2)
@@ -130,7 +130,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
     Read a network file and inspect a few metrics on the result:
 
     >>> from infomap import Infomap
-    >>> im = Infomap(silent=True, num_trials=10)
+    >>> im = Infomap(num_trials=10)
     >>> im.read_file("ninetriangles.net")
     >>> result = im.run()
     >>> result.codelength
@@ -143,7 +143,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
     or :meth:`Result.nodes` (per-node views):
 
     >>> from infomap import Infomap
-    >>> im = Infomap(silent=True)
+    >>> im = Infomap()
     >>> im.add_links(((1, 2), (1, 3), (2, 3), (4, 5), (4, 6), (5, 6), (3, 4)))
     >>> result = im.run()
     >>> for node_id, module_id in sorted(result.modules().items()):

--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -42,6 +42,7 @@ from ._logging import disable_log, enable_log
 from ._logging import engine_log_routing as _engine_log_routing
 from ._logging import is_routed as _is_log_routed
 from ._results import _InfomapResultsMixin
+from ._results import _install_accessor_deprecations
 from ._results import entropy, perplexity, plogp
 from .errors import NetworkParseError, _translate_engine_errors
 from .result import Result, TreeNode, build_result
@@ -2409,7 +2410,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         --------
 
         >>> from infomap import Infomap, Options
-        >>> im = Infomap(silent=True, num_trials=10)
+        >>> im = Infomap(num_trials=10)
         >>> im.add_links((
         ...     (1, 2), (1, 3), (2, 3),
         ...     (3, 4),
@@ -2465,7 +2466,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         >>> import networkx as nx
         >>> from infomap import Infomap
         >>> G = nx.Graph([("a", "b"), ("a", "c")])
-        >>> im = Infomap(silent=True)
+        >>> im = Infomap()
         >>> mapping = im.add_networkx_graph(G)
         >>> mapping
         {0: 'a', 1: 'b', 2: 'c'}
@@ -2493,7 +2494,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         >>> G.add_edge("d", "e")
         >>> G.add_edge("d", "f")
         >>> G.add_edge("e", "f")
-        >>> im = Infomap(silent=True)
+        >>> im = Infomap()
         >>> mapping = im.add_networkx_graph(G)
         >>> mapping
         {0: 'a', 1: 'b', 2: 'c', 3: 'd', 4: 'e', 5: 'f'}
@@ -2518,7 +2519,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         >>> G.add_node(32, node_id=3, layer_id=2)
         >>> G.add_edge(11, 21, weight=2)
         >>> G.add_edge(22, 32)
-        >>> im = Infomap(silent=True)
+        >>> im = Infomap()
         >>> mapping = im.add_networkx_graph(G)
         >>> result = im.run()
         >>> for node in sorted(result.nodes(states=True), key=lambda n: n.state_id):
@@ -2836,7 +2837,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         --------
 
         >>> from infomap import Infomap
-        >>> im = Infomap(silent=True, num_trials=10)
+        >>> im = Infomap(num_trials=10)
         >>> im.add_node(1, "Left 1")
         >>> im.add_node(2, "Left 2")
         >>> im.bipartite_start_id = 3
@@ -2871,7 +2872,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         --------
 
         >>> from infomap import Infomap, Options
-        >>> im = Infomap(silent=True)
+        >>> im = Infomap()
         >>> im.add_node(1)
         >>> im.add_node(2)
         >>> im.add_node(3)
@@ -2904,7 +2905,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         :meth:`run`.
 
         >>> from infomap import Infomap, MultilayerNode
-        >>> im = Infomap(silent=True)
+        >>> im = Infomap()
         >>> im.add_multilayer_intra_link(1, 1, 2)
         >>> im.add_multilayer_intra_link(2, 1, 3)
         >>> im.initial_partition = {(1, 1): 0, MultilayerNode(2, 1): 1}
@@ -3052,6 +3053,19 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             Use ``result = im.run(); result.elapsed_time``.
         """
         return self._core.elapsedTime()
+
+
+# The result-scalar accessors defined directly on Infomap (the mixin owns the
+# rest); wrap them to emit the same pending-deprecation warning. See
+# _results.py::_install_accessor_deprecations.
+_install_accessor_deprecations(
+    Infomap,
+    {
+        "codelength": "result.codelength",
+        "codelengths": "result.codelengths",
+        "elapsed_time": "result.elapsed_time",
+    },
+)
 
 
 def build_info():

--- a/interfaces/python/src/infomap/_results.py
+++ b/interfaces/python/src/infomap/_results.py
@@ -1,11 +1,80 @@
 from __future__ import annotations
 
+import functools
+import os
+import sys
+import warnings
 from collections.abc import Sequence
 from math import log2
 from typing import TYPE_CHECKING, Any
 
 from ._optional import require_pandas
 from .errors import _translate_engine_errors
+
+_PACKAGE_PREFIX = os.path.dirname(os.path.abspath(__file__)) + os.sep
+
+
+def _emit_accessor_deprecation(member: str, replacement: str) -> None:
+    """Emit the pending-deprecation warning for a legacy on-instance accessor.
+
+    The legacy result mirror on ``Infomap`` stays usable through 2.x and leaves
+    in 3.0 (#742). Like the advanced-tier keyword warning, this is a
+    ``PendingDeprecationWarning`` -- silent under the default filter, so it nags
+    no one until 3.0 nears, but it surfaces under ``-W`` and for tools that
+    escalate warnings. The caller-frame check keeps internal readers (the
+    summary card, ``_repr_html_``, any in-package reuse) quiet, so only user
+    code is flagged.
+    """
+    # frame 0 = this function, frame 1 = the accessor wrapper, frame 2 = the
+    # code that read the accessor (property __get__ is C-level, so it adds no
+    # Python frame for either methods or properties).
+    caller = sys._getframe(2)
+    if caller.f_code.co_filename.startswith(_PACKAGE_PREFIX):
+        return
+    warnings.warn(
+        f"Infomap.{member} is deprecated and leaves in 3.0; read {replacement} "
+        "off the Result returned by im.run() instead.",
+        PendingDeprecationWarning,
+        stacklevel=3,
+    )
+
+
+def _wrap_accessor(func, member: str, replacement: str):
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        _emit_accessor_deprecation(member, replacement)
+        return func(self, *args, **kwargs)
+
+    return wrapper
+
+
+def _install_accessor_deprecations(cls, replacements) -> None:
+    """Wrap each deprecated accessor named in ``replacements`` so it emits the
+    pending-deprecation warning before delegating to the original.
+
+    Data-driven (mirroring ``_ADVANCED_TIER_KWARGS`` for the keyword surface) so
+    the deprecated members and their replacements live in one table. Members not
+    defined directly on ``cls`` are skipped. ``functools.wraps`` preserves each
+    member's ``__doc__`` (with its ``.. deprecated::`` note) and signature for
+    ``help()``/autodoc and IDE introspection.
+    """
+    for member, replacement in replacements.items():
+        attr = cls.__dict__.get(member)
+        if attr is None:
+            continue
+        if isinstance(attr, property):
+            setattr(
+                cls,
+                member,
+                property(
+                    _wrap_accessor(attr.fget, member, replacement),
+                    attr.fset,
+                    attr.fdel,
+                    attr.__doc__,
+                ),
+            )
+        elif callable(attr):
+            setattr(cls, member, _wrap_accessor(attr, member, replacement))
 
 
 if TYPE_CHECKING:
@@ -283,14 +352,14 @@ class _InfomapResultsMixin:
         --------
 
         >>> from infomap import Infomap
-        >>> im = Infomap(silent=True)
+        >>> im = Infomap()
         >>> im.read_file("twotriangles.net")
         >>> _ = im.run()
         >>> im.get_modules()
         {1: 1, 2: 1, 3: 1, 4: 2, 5: 2, 6: 2}
 
         >>> from infomap import Infomap
-        >>> im = Infomap(silent=True)
+        >>> im = Infomap()
         >>> im.read_file("states.net")
         >>> _ = im.run()
         >>> im.get_modules(states=True)
@@ -344,7 +413,7 @@ class _InfomapResultsMixin:
         --------
 
         >>> from infomap import Infomap
-        >>> im = Infomap(silent=True, num_trials=10)
+        >>> im = Infomap(num_trials=10)
         >>> im.read_file("ninetriangles.net")
         >>> _ = im.run()
         >>> for modules in sorted(im.get_multilevel_modules().values()):
@@ -378,7 +447,7 @@ class _InfomapResultsMixin:
         (3, 9)
 
         >>> from infomap import Infomap
-        >>> im = Infomap(silent=True)
+        >>> im = Infomap()
         >>> im.read_file("states.net")
         >>> _ = im.run()
         >>> for node, modules in im.get_multilevel_modules(states=True).items():
@@ -435,7 +504,7 @@ class _InfomapResultsMixin:
         Examples
         --------
         >>> from infomap import Infomap
-        >>> im = Infomap(silent=True, num_trials=5)
+        >>> im = Infomap(num_trials=5)
         >>> im.read_file("twotriangles.net")
         >>> _ = im.run()
         >>> for node_id, module_id in im.modules:
@@ -697,7 +766,7 @@ class _InfomapResultsMixin:
         --------
 
         >>> from infomap import Infomap
-        >>> im = Infomap(silent=True)
+        >>> im = Infomap()
         >>> im.read_file("twotriangles.net")
         >>> _ = im.run()
         >>> im.get_dataframe(columns=["path", "flow", "name", "node_id"], states=True)
@@ -977,7 +1046,7 @@ class _InfomapResultsMixin:
         --------
 
         >>> from infomap import Infomap
-        >>> im = Infomap(silent=True)
+        >>> im = Infomap()
         >>> im.read_file("twotriangles.net")
         >>> _ = im.run()
         >>> for link in im.get_links():
@@ -1032,7 +1101,7 @@ class _InfomapResultsMixin:
         --------
 
         >>> from infomap import Infomap
-        >>> im = Infomap(silent=True)
+        >>> im = Infomap()
         >>> im.read_file("twotriangles.net")
         >>> _ = im.run()
         >>> for link in im.links:
@@ -1071,7 +1140,7 @@ class _InfomapResultsMixin:
         --------
 
         >>> from infomap import Infomap
-        >>> im = Infomap(silent=True)
+        >>> im = Infomap()
         >>> im.read_file("twotriangles.net")
         >>> _ = im.run()
         >>> for link in im.flow_links:
@@ -1391,7 +1460,7 @@ class _InfomapResultsMixin:
         --------
 
         >>> from infomap import Infomap
-        >>> im = Infomap(silent=True)
+        >>> im = Infomap()
         >>> im.read_file("twotriangles.net")
         >>> _ = im.run()
         >>> f"{im.entropy_rate:.5f}"
@@ -1445,3 +1514,52 @@ class _InfomapResultsMixin:
             Use ``result = im.run(); result.meta_entropy``.
         """
         return self._core.getMetaCodelength(True)
+
+
+# The legacy result-mirror accessors on the stateful Infomap, mapped to the
+# Result member that replaces each. Kept in step with the docstring
+# ``.. deprecated::`` notes above and with result.py's _LEGACY_ACCESSOR_HINTS
+# (which redirects the same names typed on a Result). The non-deprecated
+# network-info properties (num_nodes, num_links, num_physical_nodes) are
+# intentionally absent -- they stay on the surface.
+_LEGACY_RESULT_ACCESSORS = {
+    "get_modules": "result.modules()",
+    "get_multilevel_modules": "result.multilevel_modules()",
+    "modules": "result.modules()",
+    "multilevel_modules": "result.multilevel_modules()",
+    "get_tree": "result.tree()",
+    "get_nodes": "result.nodes()",
+    "tree": "result.tree(states=True)",
+    "physical_tree": "result.tree(states=False)",
+    "leaf_modules": "result.leaf_modules()",
+    "nodes": "result.nodes(states=True)",
+    "physical_nodes": "result.nodes(states=False)",
+    "get_dataframe": "result.to_dataframe()",
+    "to_dataframe": "result.to_dataframe()",
+    "get_name": "result.names[node_id]",
+    "get_names": "result.names",
+    "names": "result.names",
+    "get_state_names": "result.state_names",
+    "state_names": "result.state_names",
+    "get_links": "result.links()",
+    "links": "result.links()",
+    "flow_links": 'result.links(data="flow")',
+    "num_top_modules": "result.num_top_modules",
+    "num_non_trivial_top_modules": "result.num_non_trivial_top_modules",
+    "num_leaf_modules": "result.num_leaf_modules",
+    "get_effective_num_modules": "result.effective_num_modules()",
+    "effective_num_top_modules": "result.effective_num_top_modules",
+    "effective_num_leaf_modules": "result.effective_num_leaf_modules",
+    "max_depth": "result.max_depth",
+    "num_levels": "result.num_levels",
+    "have_memory": "result.have_memory",
+    "index_codelength": "result.index_codelength",
+    "module_codelength": "result.module_codelength",
+    "one_level_codelength": "result.one_level_codelength",
+    "relative_codelength_savings": "result.relative_codelength_savings",
+    "entropy_rate": "result.entropy_rate",
+    "meta_codelength": "result.meta_codelength",
+    "meta_entropy": "result.meta_entropy",
+}
+
+_install_accessor_deprecations(_InfomapResultsMixin, _LEGACY_RESULT_ACCESSORS)

--- a/interfaces/python/src/infomap/errors.py
+++ b/interfaces/python/src/infomap/errors.py
@@ -85,6 +85,17 @@ _PARSE_MESSAGE_SUBSTRINGS = (
     "read permissions",
 )
 
+# The engine's own empty-network error (src/io/Network.cpp) is file-oriented
+# ("read network" from a file), which is meaningless on the in-memory Python
+# library surface where input is built with add_*/run(...). Re-message it with a
+# build-the-network pointer. Matched verbatim; test_errors guards against drift.
+_EMPTY_NETWORK_MESSAGE = "No input file to read network"
+_EMPTY_NETWORK_GUIDANCE = (
+    "cannot run Infomap on an empty network: no nodes or links were added. "
+    "Build the network first -- e.g. infomap.run([(0, 1), (1, 2), (2, 0)]), or "
+    "add input with add_link(...)/add_links(...)/read_file(...) before run()."
+)
+
 
 def _classify_run_message(message: str) -> type[InfomapError] | None:
     if message.startswith(_PARSE_MESSAGE_PREFIXES):
@@ -111,5 +122,10 @@ def _translate_engine_errors(
         raise
     except RuntimeError as error:
         message = str(error)
+        # The engine's file-oriented empty-network error is meaningless on the
+        # in-memory library surface (build with add_*/run(...), not a file), so
+        # re-message it with a build-the-network pointer regardless of classify.
+        if message == _EMPTY_NETWORK_MESSAGE:
+            raise InfomapError(_EMPTY_NETWORK_GUIDANCE) from None
         error_class = (_classify_run_message(message) if classify else None) or default
         raise error_class(message) from None

--- a/interfaces/python/src/infomap/io/igraph.py
+++ b/interfaces/python/src/infomap/io/igraph.py
@@ -356,9 +356,10 @@ def find_igraph_communities(
         metadata; vertices with missing values are skipped. Raises
         :class:`ValueError` if the attribute does not exist.
     **infomap_options
-        Engine options passed to :class:`infomap.Infomap`. ``silent=True`` is
-        applied unless overridden. Prefer carrying non-common options via the
-        ``options=`` argument above (the 3.0-safe path).
+        Engine options passed to :class:`infomap.Infomap`. The engine is quiet
+        by default; call ``infomap.enable_log()`` for the log. Prefer carrying
+        non-common options via the ``options=`` argument above (the 3.0-safe
+        path).
 
     Returns
     -------
@@ -390,12 +391,12 @@ def find_igraph_communities(
 
     # Merge the options= carrier under the caller's bare keyword arguments (bare
     # kwargs win) and apply the `trials` alias. num_trials is left to the engine
-    # default (1), matching infomap.run(). The library surface writes no files
-    # without an output directory, so no_file_output is not forced.
+    # default (1), matching infomap.run(). The engine is quiet by default, so
+    # silent is not forced (a deprecated bare kwarg leaving in 3.0); no_file_output
+    # is not forced either (redundant without an output directory).
     engine_options = _resolve_options(options, infomap_options)
     if trials is not None:
         engine_options["num_trials"] = trials
-    engine_options = {"silent": True, **engine_options}
 
     infomap = Infomap(**engine_options)
     node_mapping = add_igraph_graph(

--- a/interfaces/python/src/infomap/io/networkx.py
+++ b/interfaces/python/src/infomap/io/networkx.py
@@ -85,14 +85,11 @@ def _run_networkx(
 ) -> tuple[Any, Any, dict[int, Any]]:
     from .._facade import Infomap
 
-    # dict[str, Any]: the caller's infomap_options carry arbitrary option value
-    # types, not just the silent bool. The library surface writes no files
-    # without an output directory, so no_file_output is not forced here (it is
-    # an inert, warned-about output flag like the others).
-    options: dict[str, Any] = {"silent": True}
-    options.update(infomap_options)
-
-    infomap = Infomap(**options)
+    # The Python API is quiet by default (Infomap defaults silent=True), so the
+    # finder does not force silent (a deprecated bare kwarg leaving in 3.0) or
+    # no_file_output (redundant: the library surface writes no files without an
+    # output directory). Both stay overridable through infomap_options.
+    infomap = Infomap(**infomap_options)
     node_mapping = add_networkx_graph(
         infomap,
         g,
@@ -174,9 +171,10 @@ def find_communities(
         Initial module assignment passed to :meth:`infomap.Infomap.run`.
         Keys may use the original NetworkX node labels.
     **infomap_options
-        Engine options passed to :class:`infomap.Infomap`. ``silent=True`` is
-        applied unless overridden. Prefer carrying non-common options via the
-        ``options=`` argument above (the 3.0-safe path).
+        Engine options passed to :class:`infomap.Infomap`. The engine is quiet
+        by default; call ``infomap.enable_log()`` for the log. Prefer carrying
+        non-common options via the ``options=`` argument above (the 3.0-safe
+        path).
 
     Returns
     -------

--- a/interfaces/python/src/infomap/network.py
+++ b/interfaces/python/src/infomap/network.py
@@ -73,7 +73,7 @@ class Network(_NetworkWritersMixin):
     ...     .add_link(4, 6)
     ...     .add_link(5, 6)
     ... )
-    >>> result = net.run(options={"silent": True})
+    >>> result = net.run()
     >>> result.num_top_modules
     2
     >>> for node_id, module_id in sorted(result.modules().items()):
@@ -88,7 +88,7 @@ class Network(_NetworkWritersMixin):
     A :class:`Network` can also be handed to :func:`infomap.run`:
 
     >>> from infomap import run
-    >>> result = run(net, silent=True)
+    >>> result = run(net)
     >>> result.num_top_modules
     2
 

--- a/interfaces/python/src/infomap/result.py
+++ b/interfaces/python/src/infomap/result.py
@@ -270,7 +270,7 @@ class Result(_ResultWritersMixin):
     Run Infomap and read the partition off the ``Result``:
 
     >>> from infomap import Infomap
-    >>> im = Infomap(silent=True)
+    >>> im = Infomap()
     >>> im.add_links(((1, 2), (1, 3), (2, 3), (4, 5), (4, 6), (5, 6), (3, 4)))
     >>> result = im.run()
     >>> result.num_top_modules

--- a/interfaces/python/src/infomap/tl/__init__.py
+++ b/interfaces/python/src/infomap/tl/__init__.py
@@ -179,8 +179,8 @@ def infomap(
     args : str, optional
         Raw Infomap CLI arguments passed to :class:`~infomap.Infomap`.
     **infomap_options
-        Keyword arguments passed to :class:`~infomap.Infomap`. ``silent=True``
-        is applied unless explicitly overridden.
+        Keyword arguments passed to :class:`~infomap.Infomap`. The engine is
+        quiet by default; call ``infomap.enable_log()`` for the log.
 
     Returns
     -------
@@ -207,13 +207,11 @@ def infomap(
     )
     _validate_adjacency_shape(matrix, n_obs=n_obs)
 
-    # dict[str, Any]: the caller's infomap_options carry arbitrary option value
-    # types, not just the silent bool. no_file_output is not forced -- it is
-    # redundant on the library surface (no output directory -> no files) and an
-    # inert output flag the API warns about.
-    options: dict[str, Any] = {"silent": True}
-    options.update(infomap_options)
-    im = Infomap(args=args, **options)
+    # The Python API is quiet by default (Infomap defaults silent=True), so the
+    # helper does not force silent (a deprecated bare kwarg leaving in 3.0) or
+    # no_file_output (redundant on the library surface: no output directory ->
+    # no files). Both stay overridable through infomap_options.
+    im = Infomap(args=args, **infomap_options)
     obs_names = list(adata.obs_names)
     # Use the internal impl rather than the deprecated public
     # add_scipy_sparse_matrix accessor the rest of the API steers away from.
@@ -246,7 +244,7 @@ def infomap(
             "neighbors_key": neighbors_key,
             "obsp": resolved_obsp,
             "args": args,
-            **options,
+            **infomap_options,
         },
         "n_modules": result.num_top_modules,
         "codelength": result.codelength,

--- a/test/python/test_anndata.py
+++ b/test/python/test_anndata.py
@@ -180,7 +180,6 @@ def test_tl_infomap_writes_metadata():
         "neighbors_key": None,
         "obsp": "connectivities",
         "args": "--silent",
-        "silent": True,
         "seed": 123,
         "num_trials": 1,
     }

--- a/test/python/test_deprecations.py
+++ b/test/python/test_deprecations.py
@@ -2,12 +2,18 @@
 the ``Result`` returned by :meth:`Infomap.run` and the ``Network`` / functional
 ``infomap.run`` builders.
 
-These members are deprecated by documentation only: each carries a
-``.. deprecated::`` note in its docstring, but they emit **no**
-``DeprecationWarning`` at runtime. Each deprecated member must therefore (a)
-still work and return the same value as its non-deprecated replacement, and (b)
-not raise under ``-W error::DeprecationWarning``. The package itself must also
-not emit any of these warnings during normal operation.
+The legacy result accessors emit a **silent-by-default**
+``PendingDeprecationWarning`` naming their ``Result`` replacement (the
+caller-frame guard keeps internal readers -- the summary card, ``_repr_html_``,
+in-package reuse -- quiet, so only user code is flagged). Each such member must
+therefore (a) still work and return the same value as its replacement, (b) emit
+that ``PendingDeprecationWarning`` when read from user code, and (c) never raise
+the louder ``DeprecationWarning`` that tools escalate by default. The package
+itself must emit neither warning during normal operation (construct, run, repr,
+summary).
+
+The build-from-graph accessors and config helpers stay documentation-only for
+now (no runtime warning); only the result mirror is instrumented.
 """
 
 from __future__ import annotations
@@ -20,7 +26,9 @@ from infomap import Infomap, Options, run
 
 
 def _two_triangles(**kwargs) -> Infomap:
-    im = Infomap(silent=True, num_trials=2, **kwargs)
+    # No silent= (advanced-tier, pending-deprecated); the API is quiet by
+    # default, so the helper stays warning-free at construction.
+    im = Infomap(num_trials=2, **kwargs)
     for source, target in [(0, 1), (1, 2), (2, 0), (2, 3), (3, 4), (4, 5), (5, 3)]:
         im.add_link(source, target)
     return im
@@ -31,9 +39,13 @@ def _two_triangles(**kwargs) -> Infomap:
 
 @pytest.mark.fast
 def test_no_self_warnings_on_import_construct_run_repr_summary():
-    """Constructing, running, repr() and summary() emit zero DeprecationWarnings."""
+    """Construct, run, repr() and summary() emit neither a DeprecationWarning nor
+    the accessors' PendingDeprecationWarning. The summary card and _repr_html_
+    read the legacy accessors internally, but the caller-frame guard keeps
+    in-package reads quiet."""
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
+        warnings.simplefilter("error", PendingDeprecationWarning)
         im = _two_triangles()
         im.run()
         repr(im)
@@ -50,6 +62,7 @@ def test_result_method_accessor_silent_and_matches():
     result = im.run()
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
+        warnings.simplefilter("ignore", PendingDeprecationWarning)
         legacy = im.get_modules()
     assert legacy == result.modules()
 
@@ -60,6 +73,7 @@ def test_result_property_accessor_silent_and_matches():
     result = im.run()
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
+        warnings.simplefilter("ignore", PendingDeprecationWarning)
         legacy = list(im.flow_links)
     assert legacy == list(result.links(data="flow"))
 
@@ -70,6 +84,7 @@ def test_result_metric_property_silent_and_matches():
     result = im.run()
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
+        warnings.simplefilter("ignore", PendingDeprecationWarning)
         legacy = im.codelength
         legacy_levels = im.num_levels
     assert legacy == result.codelength
@@ -77,15 +92,20 @@ def test_result_metric_property_silent_and_matches():
 
 
 @pytest.mark.fast
-def test_deprecated_accessor_emits_no_warning():
-    """Deprecated members are documentation-only: they emit no warning at all."""
+def test_deprecated_result_accessor_emits_pending_naming_replacement():
+    """A legacy result accessor read from user code emits a silent-by-default
+    PendingDeprecationWarning naming its Result replacement, and never the louder
+    DeprecationWarning."""
     im = _two_triangles()
     im.run()
     with warnings.catch_warnings(record=True) as records:
         warnings.simplefilter("always")
         im.get_modules()
-    deprecations = [r for r in records if issubclass(r.category, DeprecationWarning)]
-    assert deprecations == []
+    pending = [r for r in records if issubclass(r.category, PendingDeprecationWarning)]
+    assert any("result.modules()" in str(r.message) for r in pending)
+    # PendingDeprecationWarning is not a DeprecationWarning subclass, so the
+    # louder category that tools escalate by default stays silent.
+    assert not [r for r in records if issubclass(r.category, DeprecationWarning)]
 
 
 @pytest.mark.fast

--- a/test/python/test_errors.py
+++ b/test/python/test_errors.py
@@ -86,6 +86,20 @@ def test_unrecognized_option_raises_infomap_error():
         Infomap(args="--bogus-flag", silent=True)
 
 
+def test_empty_network_run_raises_clear_infomap_error():
+    """An empty network gets a build-the-network pointer, not the engine's
+    file-oriented "No input file to read network" -- meaningless on the
+    in-memory library surface."""
+    import infomap
+
+    with pytest.raises(InfomapError, match="empty network"):
+        Infomap().run()
+    with pytest.raises(InfomapError, match="empty network"):
+        infomap.run([])
+    with pytest.raises(InfomapError, match="empty network"):
+        Network().run()
+
+
 def test_read_file_missing_file_raises_network_parse_error(make_infomap):
     with pytest.raises(NetworkParseError, match="Cannot open file"):
         make_infomap().read_file("/nonexistent/network.net")
@@ -195,11 +209,16 @@ def test_run_time_parse_message_fragments_still_appear_in_engine_source():
     fragments = (
         errors_module._PARSE_MESSAGE_PREFIXES
         + errors_module._PARSE_MESSAGE_SUBSTRINGS
+        # The empty-network message is re-worded verbatim into a friendly
+        # build-the-network pointer; if the engine rewords it, the match stops
+        # firing and the raw file-oriented message leaks back to the user.
+        + (errors_module._EMPTY_NETWORK_MESSAGE,)
     )
     missing = [fragment for fragment in fragments if fragment not in sources]
     assert not missing, (
-        f"run-time parse-error fragments no longer found in src/: {missing}. "
-        "The engine likely reworded a message; update errors._PARSE_MESSAGE_* "
-        "to match, or run() input failures will classify as InfomapError "
-        "instead of NetworkParseError."
+        f"run-time engine message fragments no longer found in src/: {missing}. "
+        "The engine likely reworded a message; update errors._PARSE_MESSAGE_* / "
+        "_EMPTY_NETWORK_MESSAGE to match, or run() input failures will classify "
+        "as InfomapError instead of NetworkParseError (or the empty-network "
+        "error will lose its friendly re-message)."
     )

--- a/test/python/test_errors.py
+++ b/test/python/test_errors.py
@@ -28,6 +28,7 @@ from infomap import (
     NotRunError,
     StaleResultError,
     errors as errors_module,
+    run,
 )
 from infomap.result import _StaleResultError
 
@@ -90,12 +91,10 @@ def test_empty_network_run_raises_clear_infomap_error():
     """An empty network gets a build-the-network pointer, not the engine's
     file-oriented "No input file to read network" -- meaningless on the
     in-memory library surface."""
-    import infomap
-
     with pytest.raises(InfomapError, match="empty network"):
         Infomap().run()
     with pytest.raises(InfomapError, match="empty network"):
-        infomap.run([])
+        run([])
     with pytest.raises(InfomapError, match="empty network"):
         Network().run()
 

--- a/test/python/test_finders_options.py
+++ b/test/python/test_finders_options.py
@@ -65,8 +65,9 @@ def test_find_communities_carrier_carries_advanced_option(recorded):
 
 @pytest.mark.filterwarnings("ignore::PendingDeprecationWarning")
 def test_find_communities_carrier_keeps_engine_quiet_without_forcing_no_file_output(recorded):
-    # The finder keeps the engine quiet but no longer forces no_file_output --
-    # it is redundant on the library surface (no output directory -> no files).
+    # The finder no longer force-sets silent or no_file_output; the Options
+    # carrier already defaults silent True and no_file_output False, so the
+    # engine reaches run() quiet and file-free without the finder touching them.
     infomap.find_communities(_graph(), options=infomap.Options(regularized=True))
     assert recorded["silent"] is True
     assert recorded["no_file_output"] is False

--- a/test/python/test_igraph.py
+++ b/test/python/test_igraph.py
@@ -159,8 +159,10 @@ def test_find_igraph_communities_sets_directed_for_directed_graph(monkeypatch):
 
     assert clustering.membership == [0, 0]
     assert instances[0].directed is True
-    assert instances[0].options["silent"] is True
-    # no_file_output is no longer forced (redundant on the library surface).
+    # silent and no_file_output are no longer forced: the API is quiet by
+    # default and the library surface writes no files without an output
+    # directory, so the finder leaves both at the engine default.
+    assert "silent" not in instances[0].options
     assert "no_file_output" not in instances[0].options
     assert instances[0].options["num_trials"] == 3
 

--- a/test/python/test_networkx.py
+++ b/test/python/test_networkx.py
@@ -96,9 +96,11 @@ def test_find_communities_sets_directed_for_digraph(monkeypatch):
 
     assert communities == [{"source", "target"}]
     assert instances[0].directed is True
-    assert instances[0].options["silent"] is True
-    # no_file_output is no longer forced: the library surface writes no files
-    # without an output directory, so the finder leaves it at the engine default.
+    # silent and no_file_output are no longer forced: the API is quiet by
+    # default (Infomap defaults silent=True) and the library surface writes no
+    # files without an output directory, so the finder leaves both at the engine
+    # default rather than passing the deprecated flags.
+    assert "silent" not in instances[0].options
     assert "no_file_output" not in instances[0].options
     assert instances[0].initial_partition is None
 


### PR DESCRIPTION
## Summary

Follow-up polish making the Python API easier to use without stumbling — especially for AI agents consuming the surface — all on the 3.0-safe API. Grouped by commit:

- **Docs traps & steering** — fix the finder trial default in `inputs.md` (said "10, robust"; the code, FAQ, and skill all say `num_trials=1`, and the old wording discouraged raising it); add an FAQ entry keyed on the method-flip errors (`'function' object has no attribute 'items'`, `cannot unpack non-iterable int object`); flag the on-instance result accessors as deprecated & removed in 3.0 on the migration page; add a `silent=`/`verbose=` pending-deprecation callout to the logging how-to; drop the deprecated `silent=True` from the flagship class docstring examples.
- **Deprecation signal** — the legacy on-instance result accessors (`im.modules`, `im.codelength`, `im.get_modules()`, …) now emit a **silent-by-default** `PendingDeprecationWarning` naming their `Result` replacement, matching the advanced-tier keyword deprecation. A caller-frame guard keeps internal readers (the summary card, `_repr_html_`) quiet, so only user code is flagged.
- **Clearer error** — an empty-network run (`infomap.run([])`, `Network().run()`, `Infomap().run()`) now raises a build-the-network pointer instead of the engine's file-oriented "No input file to read network". Re-messaged at the error-translation boundary so multilayer networks (whose nodes/links generate at run time) are never false-flagged.
- **Label recovery** — document relabeling `result.modules()` through `result.names` on the functional path (no `Network` rebuild), in `inputs.md` and a symptom-keyed FAQ entry.
- **`silent=` hygiene** — stop force-seeding the deprecated `silent=True` in the `find_communities` / `find_igraph_communities` / `tl.infomap` helpers; they rely on the quiet-by-default engine and stay overridable.

No runtime behavior changes beyond the new (silent-by-default) warning and the friendlier empty-network message; output is byte-identical otherwise.

## Verification

- `make test-python-doctest` — 38 doctests pass.
- `pytest -m fast` — 451 passed, 1 skipped (full fast suite, with igraph installed).
- Docs-surface guards (`test_docs_surface`, `test_docs_examples_surface`), the deprecation, signature-catalog, and parameter-policy suites pass; `ruff check` clean.
- The empty-network re-message is drift-guarded against `src/` in `test_errors`.
- Not run: full `make build-docs` (Sphinx) in this environment — the doc changes are prose + docstrings using existing roles, and the executed doc cells were verified standalone.

## Notes

- The instance-accessor `PendingDeprecationWarning` is silent under the default warning filter (surfaces under `-W`); pytest does not escalate warnings, so CI stays green. `api/infomap.rst` and `the-infomap-class.md` were updated to state the accessors now emit it (replacing the "no runtime warning today" note).
- Deferred to the holistic 3.0 `silent` removal (a public-API change): `run_graphrag_communities(..., silent=...)` keeps its public `silent` parameter.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHZYwpqx45KSQH16YHhGCd)_