### PR TITLE
Close remaining Python API agent-usability traps (run() guards, logging, docs)

### DIFF
--- a/examples/notebooks/4.3 Solution Landscape.ipynb
+++ b/examples/notebooks/4.3 Solution Landscape.ipynb
@@ -91,7 +91,7 @@
     "    \"\"\"\n",
     "\n",
     "    print(f\"Find communities in {networkName} with Infomap...\", end=\"\")\n",
-    "    im = infomap.Infomap(f\"-s {seed} --silent --two-level\")\n",
+    "    im = infomap.Infomap(seed=seed, two_level=True)\n",
     "    im.read_file(networkName)\n",
     "    result = im.run()\n",
     "\n",

--- a/examples/notebooks/9.2 Map Equation Similarity.ipynb
+++ b/examples/notebooks/9.2 Map Equation Similarity.ipynb
@@ -54,7 +54,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = infomap.run(G, two_level=True, num_trials=10, seed=123)\n",
+    "im = infomap.Infomap(two_level=True, num_trials=10, seed=123)\n",
+    "im.add_links(G.edges(data=\"weight\"))\n",
+    "result = im.run()\n",
     "modules = result.modules()"
    ]
   },

--- a/examples/notebooks/options-guide.ipynb
+++ b/examples/notebooks/options-guide.ipynb
@@ -21,11 +21,14 @@
     "`--two-level` is the keyword `two_level=True` in Python and the matching argument\n",
     "in R. In Python you can set options three ways:\n",
     "\n",
-    "- keyword arguments: `Infomap(two_level=True, num_trials=20)`\n",
+    "- the common keyword arguments `seed`, `num_trials`, `two_level`, `directed`,\n",
+    "  and `markov_time` — these stay on `infomap.run(...)` / `Infomap(...)`\n",
+    "- a reusable `Options` object passed as `options=` to `infomap.run(...)` — the\n",
+    "  home for every other (advanced) option; passing those as bare keyword\n",
+    "  arguments is pending-deprecated and leaves the signature in 3.0\n",
     "- a raw flag string: `Infomap(args=\"--two-level --num-trials 20\")`\n",
-    "- a reusable `Options` object passed as `options=` to `infomap.run(...)`\n",
     "\n",
-    "This guide uses keyword arguments. The last section lists every option with its\n",
+    "This guide passes advanced options through the `options=` carrier. The last section lists every option with its\n",
     "flag, default, and description, generated from the installed package so it always\n",
     "matches your version."
    ]
@@ -60,8 +63,8 @@
     "## Reproducible runs\n",
     "\n",
     "Set a `seed` and a meaningful `num_trials` so results are reproducible and stable.\n",
-    "This guide fixes `seed=123` and `num_trials=20`, and runs `silent=True` to keep the\n",
-    "notebook output short."
+    "This guide fixes `seed=123` and `num_trials=20`. The Python API is quiet by\n",
+    "default; call `infomap.enable_log()` to see the engine log."
    ]
   },
   {
@@ -115,7 +118,7 @@
     "| Cluster multilayer or temporal networks | `multilayer_relax_rate`, `multilayer_relax_to_self`, `multilayer_relax_limit` |\n",
     "| Bias the partition with node metadata | `meta_data`, `meta_data_rate` |\n",
     "| Start from, or only score, a partition | `cluster_data`, `no_infomap` |\n",
-    "| Choose what gets written | `tree`, `ftree`, `clu`, `output`, `out_name`, `no_file_output` |\n",
+    "| Choose what gets written | `result.write_tree` / `write_flow_tree` / `write_clu` |\n",
     "\n",
     "For run time and memory planning, see\n",
     "{doc}`benchmark-performance <benchmark-performance>`."
@@ -1186,7 +1189,7 @@
     "im = Infomap(seed=SEED, num_trials=NUM_TRIALS)\n",
     "im.read_file(\"data/jazz.net\")\n",
     "result = im.run()\n",
-    "im.write_clu(\"output/jazz.clu\")\n",
+    "result.write_clu(\"output/jazz.clu\")\n",
     "optimized = round(result.codelength, 4)\n",
     "\n",
     "scored = infomap.run(\n",
@@ -1209,19 +1212,27 @@
    "source": [
     "## Choosing the output\n",
     "\n",
-    "By default Infomap writes a `.tree` file. You can pick formats explicitly.\n",
+    "`infomap.run()` and `Infomap.run()` return their results in memory — on the\n",
+    "Python library surface they do **not** write files by default. Write the native\n",
+    "files straight off the `Result`:\n",
     "\n",
-    "- `tree`, `ftree`, and `clu` enable individual formats. `ftree` adds aggregated\n",
-    "  links between modules and is used by the Network Navigator.\n",
-    "- `output` selects several formats at once, for example\n",
-    "  `output=[\"clu\", \"tree\", \"ftree\"]`.\n",
-    "- `clu_level` chooses the depth for `.clu` output, `out_name` sets the base file\n",
-    "  name, and `no_file_output=True` keeps everything in memory.\n",
-    "- `silent` and `verbosity_level` control console output.\n",
+    "- `result.write_tree(path)` writes the `.tree` hierarchy, `result.write_flow_tree(path)`\n",
+    "  the `.ftree` variant (with aggregated links between modules, used by the\n",
+    "  Network Navigator), and `result.write_clu(path, depth_level=...)` the top-level\n",
+    "  (or chosen-depth) `.clu` assignment.\n",
+    "- `Network.write_pajek(path)` / `Network.write_state_network(path)` serialize the\n",
+    "  input network itself.\n",
     "\n",
-    "In a notebook you read metrics and node assignments from the `Result` object\n",
-    "that `run` returns, for example its `to_dataframe(...)`, and write files only\n",
-    "when another tool needs them."
+    "The option flags `tree`, `ftree`, `clu`, `output`, `out_name`, and\n",
+    "`no_file_output` are CLI-only: on the Python library surface they are inert (they\n",
+    "act only through the raw `args` escape hatch together with an output directory),\n",
+    "so setting them via `Options` writes nothing and emits a `UserWarning`. Console\n",
+    "output is controlled by logging — call `infomap.enable_log()` to see the engine\n",
+    "log.\n",
+    "\n",
+    "In a notebook you usually read metrics and node assignments from the `Result`\n",
+    "object that `run` returns, for example its `to_dataframe(...)`, and write files\n",
+    "only when another tool needs them."
    ]
   },
   {

--- a/examples/notebooks/run-infomap-on-graphrag-tables.ipynb
+++ b/examples/notebooks/run-infomap-on-graphrag-tables.ipynb
@@ -127,7 +127,6 @@
     "result = run_graphrag_communities(\n",
     "    input_dir=input_dir,\n",
     "    output_dir=output_dir,\n",
-    "    silent=True,\n",
     "    seed=123,\n",
     "    num_trials=5,\n",
     ")\n",

--- a/examples/python/infomap-sklearn.py
+++ b/examples/python/infomap-sklearn.py
@@ -2,7 +2,7 @@ import networkx as nx
 import numpy as np
 from sklearn.model_selection import ParameterGrid
 
-from infomap import Network
+from infomap import Network, Options
 
 # Build the network once, then re-run it with different options.
 net = Network.from_networkx(nx.karate_club_graph())
@@ -11,7 +11,7 @@ grid = ParameterGrid({"markov_time": np.linspace(0.8, 2, 5)})
 
 for params in grid:
     result = net.run(
-        options={"two_level": True, "num_trials": 10, **params}
+        options=Options(two_level=True, num_trials=10, markov_time=params["markov_time"])
     )
     print(
         f"markov_time={params['markov_time']:0.1f}: "

--- a/interfaces/python/source/faq.md
+++ b/interfaces/python/source/faq.md
@@ -56,7 +56,12 @@ The Python API is quiet by default. Call `infomap.enable_log()` once to route th
 engine log through the standard `logging` module
 (`infomap.enable_log(logging.DEBUG)` for more detail), and `infomap.disable_log()`
 to stop. Prefer this over the legacy `silent` keyword, which is pending-deprecated
-and leaves the API in 3.0. See
+and leaves the API in 3.0. One caveat: `enable_log()` covers the `Infomap` class
+and `infomap.run(...)` on an edge list, graph, or file path, but a pre-built
+`Network` (including the bundled {mod}`infomap.datasets`) runs silently for its
+whole lifetime, so `enable_log()` does not capture its run (a `UserWarning` says
+as much) -- run through `Infomap(...)` or pass the raw input to `infomap.run` for
+those. See
 {doc}`Running Infomap and tuning options <working-with-infomap/running-and-options>`.
 
 ### What does `infomap.find_communities` return, and how does it differ from `infomap.run`?

--- a/interfaces/python/source/workflows/graphrag.md
+++ b/interfaces/python/source/workflows/graphrag.md
@@ -254,7 +254,10 @@ communities[["id", "level", "size", "entity_ids"]]
   `weight_col`, `endpoint_col` (`"title"` or `"id"`).
 - {func}`infomap.tl.graphrag.run_graphrag_communities` is the one-call pipeline: it
   reads tables, runs Infomap, and optionally writes outputs. It returns a
-  `GraphRAGRunResult` with `.infomap`, `.graph`, `.nodes`, and `.communities`.
+  `GraphRAGRunResult` with `.result`, `.infomap`, `.graph`, `.nodes`, and
+  `.communities`. Read run metrics such as `codelength` and the module counts off
+  `.result` (the immutable `Result`, e.g. `result.result.codelength`) rather than
+  the deprecated accessors on `.infomap`.
 - {func}`infomap.tl.graphrag.write_graphrag_communities` writes a pre-run Infomap
   result to disk as GraphRAG-compatible Parquet tables.
 - {class}`infomap.tl.graphrag.GraphRAGGraph` holds the entity/relationship tables,

--- a/interfaces/python/source/workflows/hpc.md
+++ b/interfaces/python/source/workflows/hpc.md
@@ -116,7 +116,7 @@ make the pattern self-contained and executable.
 import infomap
 
 # A small network: two dense groups connected by a single bridge.
-# On a real network this would be a large file loaded with im.read_file().
+# On a real network the links would come from a file, e.g. Network.from_file("graph.net").
 edges = [
     # group A: nodes 0-3
     (0, 1), (1, 2), (2, 3), (3, 0), (0, 2), (1, 3),

--- a/interfaces/python/source/working-with-infomap/results-and-iteration.md
+++ b/interfaces/python/source/working-with-infomap/results-and-iteration.md
@@ -103,8 +103,9 @@ lazily on first access and then cached. The surface follows one convention:
 
 A `Result` from an earlier run of a reused stateful {class}`~infomap.Infomap`
 raises if you read its node data after a later `run()`. The eagerly captured
-scalar properties stay readable (the lazily computed `effective_num_*`
-properties must have been read at least once before the re-run).
+scalar properties stay readable (the lazily computed `effective_num_top_modules`
+and `effective_num_leaf_modules` properties, and the `effective_num_modules(depth)`
+method, must have been read at least once before the re-run).
 
 ### Summary statistics
 

--- a/interfaces/python/source/working-with-infomap/running-and-options.md
+++ b/interfaces/python/source/working-with-infomap/running-and-options.md
@@ -453,41 +453,14 @@ logging.getLogger("infomap").addHandler(my_handler)
 logging.getLogger("infomap").setLevel(logging.INFO)
 ```
 
-`silent=` and `verbose=` are pending-deprecated and leave the API in 3.0;
-`enable_log()` is the forward path for the engine log. The `silent=` behavior
-described below is documented for existing code.
-
-How the routing behaves:
-
-- **Logging is the control.** With handlers attached, every engine run emits
-  records — no `silent=False` needed, and `silent=` is ignored for emission.
-  Tune volume with logger/handler levels (`logging.WARNING` silences the
-  engine's INFO lines); remove the handlers to go back to classic stdout
-  output gated by `silent=`.
-- **Levels map naturally.** Default lines arrive at `INFO`. A logger enabled
-  for `DEBUG` (`infomap.enable_log(logging.DEBUG)`) automatically raises the
-  engine verbosity to `-vv`, so its detail lines arrive at `DEBUG`.
-- **Only handlers attached directly to `logging.getLogger("infomap")` count.**
-  `logging.basicConfig(...)` alone does not reroute the engine log — without
-  an `"infomap"` handler, `silent=False` prints to stdout exactly as before.
-- **Configure logging before creating a stateful engine.** The engine bakes
-  its silence in at construction, so an {class}`~infomap.Infomap` created
-  *before* logging was configured cannot emit records (its runs warn to
-  explain why). The one-shot {func}`infomap.run` always respects the current
-  logging configuration.
-- **Routed output is plain lines.** The colors and the live progress line are
-  terminal features; log records get one clean line each.
-- **{class}`~infomap.Network` engines are silent for their whole lifetime**
-  (see {meth}`Network.run <infomap.Network.run>`), so records come from the
-  stateful {class}`~infomap.Infomap` and non-`Network` {func}`infomap.run`
-  inputs. The `infomap` command-line interface is unaffected.
-- **`silent` is fixed at construction for the stateful engine.** Because the
-  engine bakes silence in when the {class}`~infomap.Infomap` is built, passing
-  `silent=False` to {meth}`Infomap.run <infomap.Infomap.run>` on an instance
-  constructed silent (the default) cannot re-enable the classic stdout log —
-  construct with `silent=False`, or route the log through logging. The one-shot
-  {func}`infomap.run` builds a fresh engine per call, so its `silent=` takes
-  effect there.
+{func}`~infomap.enable_log` (above) is the supported way to see the engine log;
+the `silent=` and `verbose=` keywords are pending-deprecated and leave the API
+in 3.0. One timing nuance if you route through logging: a stateful
+{class}`~infomap.Infomap` bakes its silence in at construction, so configure
+logging *before* you build one (its runs warn otherwise), whereas the one-shot
+{func}`infomap.run` always respects the current configuration.
+{class}`~infomap.Network` engines stay silent for their whole lifetime (see
+{meth}`Network.run <infomap.Network.run>`).
 
 ## Going deeper
 

--- a/interfaces/python/src/infomap/_core.py
+++ b/interfaces/python/src/infomap/_core.py
@@ -82,6 +82,16 @@ def apply_initial_partition(core: Any, module_ids) -> bool:
     """
     if module_ids is None:
         module_ids = {}
+    # Accept a dict (the documented form) or the SWIG map the engine
+    # round-trips through here (getInitialPartition() returns a map_uint_uint,
+    # not a dict); reject a non-mapping (a list, a scalar) up front with a clear
+    # message instead of a raw SWIG TypeError from setInitialPartition.
+    if not hasattr(module_ids, "items"):
+        raise TypeError(
+            "initial_partition must be a mapping of {node_id: module_id} "
+            "(or {(layer_id, node_id): module_id} for a multilayer network), "
+            f"not {type(module_ids).__name__}."
+        )
     if module_ids and any(isinstance(key, tuple) for key in module_ids):
         if not all(isinstance(key, tuple) for key in module_ids):
             raise ValueError(
@@ -100,5 +110,19 @@ def apply_initial_partition(core: Any, module_ids) -> bool:
             modules.append(int(module))
         core.setMultilayerInitialPartition(layer_ids, node_ids, modules)
         return True
+    # First-order path. Validate int-castability for a user dict (the engine's
+    # own SWIG map is already integer-keyed and passes straight through) so a
+    # malformed value -- e.g. a {node: (path,)} tuple -- raises a clear error
+    # instead of a raw SWIG TypeError from setInitialPartition.
+    if isinstance(module_ids, dict):
+        try:
+            module_ids = {
+                int(node): int(module) for node, module in module_ids.items()
+            }
+        except (TypeError, ValueError) as exc:
+            raise TypeError(
+                "initial_partition must map integer node/state ids to integer "
+                "module ids, e.g. {1: 0, 2: 0, 3: 1}."
+            ) from exc
     core.setInitialPartition(module_ids)
     return False

--- a/interfaces/python/src/infomap/_run.py
+++ b/interfaces/python/src/infomap/_run.py
@@ -139,6 +139,21 @@ def _is_edge_index(obj: Any) -> bool:
     return "int" in str(dtype).lower()
 
 
+def _is_pandas_dataframe(obj: Any) -> bool:
+    """A pandas ``DataFrame``, duck-typed to avoid importing pandas.
+
+    Iterating a ``DataFrame`` yields its *column labels*, not its rows, so it
+    must not fall through to the ``(u, v[, w])`` link-iterable branch (where it
+    would fail deep in ``add_links`` with a message about the column labels).
+    ``run()`` rejects it up front with a pointer to the tabular conversions.
+    """
+    return (
+        hasattr(obj, "itertuples")
+        and hasattr(obj, "columns")
+        and hasattr(obj, "to_numpy")
+    )
+
+
 # Adapter-only keyword arguments per input type. run() forwards keywords to the
 # *engine* (Infomap options); these instead configure how the *input* is read,
 # so they live on the matching Network.from_* constructor. Listing them lets
@@ -189,9 +204,10 @@ def _reject_adapter_kwargs(kind: str, user_keys: set) -> None:
     if not misdirected:
         return
     names = ", ".join(repr(name) for name in misdirected)
+    verb = "configures" if len(misdirected) == 1 else "configure"
     message = (
         f"infomap.run() forwards keyword arguments to the engine, but {names} "
-        f"configure how the {kind} input is read, not the engine. Build the "
+        f"{verb} how the {kind} input is read, not the engine. Build the "
         f"network explicitly and run it, e.g. "
         f"infomap.run({constructor}(..., {misdirected[0]}=...), num_trials=10). "
         f"run() builds input with default settings; Network.from_* is the path "
@@ -410,6 +426,33 @@ def run(
         im = Infomap(**resolved)
         im._add_edge_index_impl(input)
         return im.run(initial_partition=initial_partition)
+
+    # A dict is iterable, but iterating it yields only its keys and silently
+    # drops the values -- a ``{(u, v): weight}`` edge dict would lose its
+    # weights (partitioning a different, unweighted graph with no error), a
+    # ``{node: neighbors}`` adjacency dict would yield bare ids. Reject it here,
+    # before the link-iterable branch, with the explicit conversion.
+    if isinstance(input, Mapping):
+        raise TypeError(
+            "infomap.run() does not accept a dict: iterating one yields only "
+            "its keys, silently dropping the values. For a {(source, target): "
+            "weight} edge dict pass [(u, v, w) for (u, v), w in d.items()]; for "
+            "a {node: [neighbors]} adjacency dict, expand it to (source, "
+            "target) link tuples first (or build a Network)."
+        )
+
+    # A pandas DataFrame is iterable too, but iterating one yields its column
+    # labels, not its edge rows. Point at the documented tabular paths.
+    if _is_pandas_dataframe(input):
+        raise TypeError(
+            "infomap.run() does not accept a pandas DataFrame directly: "
+            "iterating one yields its column labels, not its edge rows. Pass "
+            "the edge columns as an array, e.g. "
+            "infomap.run(df[['source', 'target']].to_numpy()) (add a weight "
+            "column for weighted links), or infomap.run(df.itertuples("
+            "index=False)); for non-default building use "
+            "Network().add_links(df.to_numpy())."
+        )
 
     # 7. An iterable of (u, v[, w]) links.
     if isinstance(input, Iterable):

--- a/interfaces/python/src/infomap/datasets/__init__.py
+++ b/interfaces/python/src/infomap/datasets/__init__.py
@@ -20,10 +20,10 @@ per-run options are applied after the construction options.
 
 from __future__ import annotations
 
-from importlib.resources import as_file, files
+from importlib.resources import as_file as _as_file, files as _files
 
-from .._core import Core
-from ..network import Network
+from .._core import Core as _Core
+from ..network import Network  # public return type of every loader below
 
 __all__ = [
     "bipartite",
@@ -42,8 +42,8 @@ def _load(filename: str, *, extra_args: str = "") -> Network:
     args = "--silent --no-file-output"
     if extra_args:
         args = f"{args} {extra_args}"
-    net = Network(core=Core(args))
-    with as_file(files(__name__) / "data" / filename) as path:
+    net = Network(core=_Core(args))
+    with _as_file(_files(__name__) / "data" / filename) as path:
         net.read_file(str(path))
     return net
 

--- a/interfaces/python/src/infomap/network.py
+++ b/interfaces/python/src/infomap/network.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Any
 
 from ._core import Core, apply_initial_partition
 from ._logging import engine_log_routing as _engine_log_routing
+from ._logging import is_routed as _is_log_routed
 from .errors import NetworkParseError, _translate_engine_errors
 from .io.writers import _NetworkWritersMixin
 from ._network_input import add_bulk_links as _add_bulk_links
@@ -314,7 +315,23 @@ class Network(_NetworkWritersMixin):
         else:
             resolved = Options(**dict(options))
 
-        if resolved.silent is False:
+        if _is_log_routed():
+            # enable_log()/handlers on the "infomap" logger route the engine
+            # log, but a Network's Core is constructed --silent for its whole
+            # lifetime and that cannot be undone per run (the engine composes
+            # constructor + run args additively), so a routed run of a Network
+            # emits no records. Point the caller at a surface that can emit,
+            # mirroring the stale-silent advisory on the Infomap path.
+            warnings.warn(
+                "the 'infomap' logger has handlers, but a Network engine is "
+                "silent for its whole lifetime, so this run emits no log "
+                "records. For the engine log, run through Infomap(...) or pass "
+                "the input directly to infomap.run() (an edge list, graph, or "
+                "file path) instead.",
+                UserWarning,
+                stacklevel=2,
+            )
+        elif resolved.silent is False:
             warnings.warn(
                 "A Network engine is silent for its whole lifetime; "
                 "silent=False has no effect here. For the engine log, run "

--- a/skills/infomap/SKILL.md
+++ b/skills/infomap/SKILL.md
@@ -25,7 +25,7 @@ Identify the user's mode before answering:
 
 - Prefer **Python** for notebooks, scripts, NetworkX, python-igraph, SciPy sparse matrices, edge-index data, AnnData/Scanpy workflows, tabular outputs, and GraphML/GEXF export.
 - Prefer **R** for R-native analysis, R igraph workflows, R Markdown-style reports, and users who want `cluster_infomap()` or the R6 `Infomap` API.
-- Prefer **CLI** for file-based workflows, batch jobs, shell pipelines, native output files, or wrapper-independent runs.
+- Prefer **CLI** for file-based workflows, batch jobs, shell pipelines, or wrapper-independent runs. Native `.tree`/`.clu` output is not CLI-only — Python writes the same files via the `Result`/`Network` writers.
 
 When the user already chose an interface, stay there unless a different interface is clearly necessary.
 
@@ -50,8 +50,8 @@ When the user already chose an interface, stay there unless a different interfac
 ## Reference map
 
 - `references/method-selection.md`: survey-based guide from research problem to Infomap model.
-- `references/cli.md`: file-based CLI workflows and native outputs.
-- `references/python.md`: Python package workflows and integrations.
+- `references/cli.md`: file-based CLI workflows and CLI-driven native output.
+- `references/python.md`: Python package workflows, integrations, and writing native output files.
 - `references/r.md`: R package workflows and igraph interop.
 - `references/notebooks.md`: survey companion notebooks and Jupyter adaptation.
 - `references/reproducibility.md`: reporting, provenance, and method-section checklist.

--- a/skills/infomap/references/python.md
+++ b/skills/infomap/references/python.md
@@ -82,3 +82,15 @@ df = result.to_dataframe()                              # columns: node_id, modu
 ```
 
 Confirm exact method names and option coverage against the installed package and published docs for the user's version; do not copy version-sensitive examples verbatim.
+
+## Writing native output files
+
+To write the mapequation.org native files in Python, call the writers on the `Result` (partition artifacts) or the `Network` (input serializations) — not the option flags:
+
+- `result.write_tree(path)` — `.tree`
+- `result.write_flow_tree(path)` — `.ftree`
+- `result.write_clu(path, depth_level=1)` — `.clu` at a chosen hierarchy depth
+- `network.write_pajek(path)` — Pajek serialization of the input network
+- `network.write_state_network(path)` — the internal state/multilayer network
+
+The `tree`, `clu`, `output`, `out_name`, and `no_file_output` **option flags are inert on the Python library surface**: setting them via `Options` writes no file and only emits a `UserWarning` (they act only through the raw `args` escape hatch together with an output directory). Write from the `Result`/`Network` instead.

--- a/skills/infomap/references/reproducibility.md
+++ b/skills/infomap/references/reproducibility.md
@@ -37,7 +37,7 @@ Use these local benchmark results only as order-of-magnitude guidance. They were
 | first-order edge list | 16.9 MB | 0 | 1M | 5 | 16.68s | 17.55s | 41.40s |
 | state network | 19.2 MB | 400k | 800k | 1 | 10.62s | 11.51s | 26.49s |
 
-For large or repeated runs, prefer convergence-aware and parallel options over a fixed high trial count: `--converge` stops trials on a codelength plateau, `--parallel-trials` runs independent trials concurrently, and `--num-threads` auto-detects cpuset/SLURM/OpenMP limits. On HPC, shard trials across jobs with `--trial-offset`/`--trial-results` and merge with the `infomap.merge` helper (see `run-infomap-on-hpc.ipynb`).
+For large or repeated runs, prefer convergence-aware and parallel options over a fixed high trial count: `--converge` stops trials on a codelength plateau, `--parallel-trials` runs independent trials concurrently, and `--num-threads` auto-detects cpuset/SLURM/OpenMP limits. On HPC, shard trials across jobs with `--trial-offset`/`--trial-results` and merge the shards with `merge_trial_results` from `infomap.merge` (`from infomap.merge import merge_trial_results`) or the CLI `python -m infomap.merge` — `merge` is deliberately not imported into the top-level namespace (see `run-infomap-on-hpc.ipynb`). In the Python API these HPC scaling options (`converge`, `parallel_trials`, `num_threads`, `trial_offset`, `trial_results`) are advanced-tier: carry them via `options=infomap.Options(...)` (e.g. `options=Options(converge=True, parallel_trials=True, num_threads="auto")`), not as bare `run()` keywords.
 
 Practical gating:
 

--- a/test/python/test_logging.py
+++ b/test/python/test_logging.py
@@ -274,6 +274,20 @@ def test_enable_log_is_a_one_line_opt_in(capfd):
     assert _engine_stdout(capfd) == ""
 
 
+def test_network_run_under_routing_warns(infomap_log_handler):
+    # A Network's engine is constructed --silent for its whole lifetime and
+    # that cannot be undone per run, so a routed run (handlers on the "infomap"
+    # logger, e.g. after enable_log()) emits no records. It warns instead of
+    # going silently dark -- the bundled datasets are Networks, so this also
+    # covers infomap.run(dataset) under enable_log().
+    from infomap import Network
+
+    net = Network().add_link(1, 2).add_link(2, 3).add_link(1, 3)
+    with pytest.warns(UserWarning, match="emits no log records"):
+        net.run(options={"num_trials": 1, "seed": 1})
+    assert infomap_log_handler.records == []
+
+
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 def test_raising_log_handler_does_not_kill_the_run(infomap_log_handler):
     class RaisingHandler(logging.Handler):

--- a/test/python/test_run_functional.py
+++ b/test/python/test_run_functional.py
@@ -488,3 +488,41 @@ def test_run_rejects_networkx_meta_attribute_kwarg():
     graph.nodes["b"]["ct"] = 1
     with pytest.raises(TypeError, match="Network.from_networkx"):
         infomap.run(graph, meta_attribute="ct", silent=True)
+
+
+# -- input-dispatch guards for mapping / tabular inputs -----------------------
+
+
+def test_run_rejects_dict_input():
+    # A dict is iterable, but iterating it yields only its keys and drops the
+    # values -- a {(u, v): weight} edge dict would silently partition the
+    # unweighted graph. run() rejects it with the explicit conversion instead of
+    # quietly building a different network.
+    with pytest.raises(TypeError, match="does not accept a dict"):
+        infomap.run({(1, 2): 1.0, (2, 3): 1.0, (3, 1): 1.0})
+    with pytest.raises(TypeError, match="does not accept a dict"):
+        infomap.run({1: [2, 3], 2: [3]})
+
+
+def test_run_rejects_dataframe_input_and_conversions_work():
+    pd = pytest.importorskip("pandas")
+    # Iterating a DataFrame yields its column labels, not its edge rows, so
+    # run() rejects it up front with a pointer to the tabular conversions.
+    df = pd.DataFrame({"source": [1, 2, 3, 1], "target": [2, 3, 1, 3]})
+    with pytest.raises(TypeError, match="pandas DataFrame"):
+        infomap.run(df)
+    # The conversions the message points at still work.
+    assert isinstance(infomap.run(df.to_numpy(), num_trials=1, seed=1), Result)
+    assert isinstance(
+        infomap.run(df.itertuples(index=False), num_trials=1, seed=1), Result
+    )
+
+
+def test_run_initial_partition_rejects_non_mapping():
+    with pytest.raises(TypeError, match="must be a mapping"):
+        infomap.run(_LINKS, initial_partition=[0, 0, 0], num_trials=1, seed=1)
+
+
+def test_run_initial_partition_rejects_non_integer_values():
+    with pytest.raises(TypeError, match="integer node/state ids"):
+        infomap.run(_LINKS, initial_partition={1: (0, 0)}, num_trials=1, seed=1)


### PR DESCRIPTION
## Summary

Follow-up to the Python API agent-usability work: closes the remaining spots where an AI agent (or any user) stumbles, found by inventorying the `run()` input surface, the docs, the skill, and the example notebooks.

Behavior (`feat` / `chore`):
- `infomap.run()` now rejects a `dict` or a pandas `DataFrame` with a pointer to the right conversion. A `{(u, v): weight}` dict previously **dropped its weights silently** (iterating a dict yields keys), and a `DataFrame` failed deep in `add_links` because iterating one yields column labels — both are common agent inputs. The documented paths (`df.to_numpy()`, `df.itertuples()`, `Network().add_links(...)`) are unchanged.
- A malformed `initial_partition` (a list, or `{node: (path,)}`) now raises a clear `{node_id: module_id}` message instead of a raw SWIG `TypeError`. The engine's own map round-trips through the same path, so the guard is duck-typed and only coerces user dicts.
- `Network.run()` now warns when the `infomap` logger has handlers but the Network is silent for its whole lifetime (e.g. `enable_log()` + `infomap.run(<dataset>)`), so the log path no longer goes silently dark with no explanation.
- Minor: subject/verb agreement in the adapter-kwarg rejection; keep implementation imports out of the `infomap.datasets` namespace.

Docs / skill / notebooks (`docs`):
- **options-guide** notebook: output section now leads with `result.write_*` and marks the `tree`/`clu`/`output`/`out_name`/`no_file_output` flags as inert on the library surface; intro/setup prose steers advanced options through the `options=` carrier and drops `silent=`.
- **9.2**: fixed a `NameError` (`from_infomap` needed a stateful instance the migration removed; rebuilt via `add_links`, byte-identical partition).
- **faq / graphrag / hpc / running-and-options / results-and-iteration** and the **skill** references: `enable_log()` caveat for Networks, `.result` for graphrag metrics, `im.read_file` comment fix, compressed `silent=`, `effective_num_modules(depth)` is a method, native writers documented, `merge_trial_results` entry point, HPC options via `Options`.
- `silent=` / raw-args / dict-`options` forms dropped from the graphrag-tables and 4.3 notebooks and the sklearn example.

## Verification

- 639 fast Python tests + 12 doctests pass; `ruff` clean. New tests cover each `run()` input guard, the `initial_partition` validation, and the Network-under-routing advisory. The `test_docs_and_examples_avoid_the_deprecated_surface` guard passes.
- Every edited notebook cell's code was run with warnings-as-errors → **zero warnings**; `9.2`'s rebuilt cell yields a byte-identical partition; the sklearn example runs end-to-end; all touched `.ipynb` remain valid JSON with minimal diffs.
- **Not run** in this container (editable install blocked by the distro-managed `packaging`): the full Sphinx build and the notebook-execution harness. The doc changes are text-only within existing files using established cross-reference roles, and the changed notebook/example code paths were verified directly.

## Notes

- One flagged item was **deliberately skipped**: `examples/notebooks/_support.py`'s private `_run_networkx` import. It is notebook-internal scaffolding (not an agent-facing API surface), its bare-kwargs path does not actually warn (it is shielded in-package), and a rewrite would have to replicate the private `_to_internal_partition` conversion and risks silently changing four manual-tier notebooks that cannot be executed in this environment. Correctness of those notebooks outweighs the cleanup; it can be done later as a separate, notebook-verified change.
- FYI: GitHub reports a pre-existing Dependabot alert (1 high) on `master`, unrelated to this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_016usQPCF9Kp6sUSgDbXdntb)_