### PR TITLE
feat(python): add Result.summary() and Result.to_series()

### DIFF
--- a/interfaces/python/source/working-with-infomap/results-and-iteration.md
+++ b/interfaces/python/source/working-with-infomap/results-and-iteration.md
@@ -275,6 +275,31 @@ degenerate solution landscape where more trials are warranted. The karate club's
 community structure is pronounced enough that every trial finds the same
 codelength; large noisy networks spread wider.
 
+### Collecting a sweep into a table
+
+Sweeps over parameters or networks are the common case: vary a knob, keep the
+per-run metrics. {meth}`~infomap.Result.summary` returns those scalars as a
+plain dict whose keys match the `Result` property names, so each run drops
+straight into a one-row-per-run `pandas.DataFrame` — add your own
+swept-parameter columns alongside:
+
+```{code-cell} python
+records = []
+for markov_time in (0.75, 1.0, 1.5):
+    r = infomap.run(g, markov_time=markov_time, seed=123, num_trials=10)
+    records.append({"markov_time": markov_time, **r.summary()})
+
+sweep = pd.DataFrame(records)
+sweep[["markov_time", "codelength", "num_top_modules", "num_levels"]]
+```
+
+The same shape covers a sweep over several networks (add a `network` column) or
+repeated seeds (add a `seed` column, then `sweep.groupby("markov_time").agg(...)`
+to reduce trials to a mean and spread). {meth}`~infomap.Result.to_series` is the
+pandas-native single row, so `pandas.DataFrame([r.to_series() for r in results])`
+builds the same table. Both read only the eagerly captured scalars, so — unlike
+`to_dataframe()` — they never go stale after a re-run.
+
 ## Pitfalls
 
 - **A `Result` goes stale if its network runs again.** Reading `nodes()` or
@@ -302,6 +327,9 @@ codelength; large noisy networks spread wider.
   `module_id`, and `flow`.
 - {meth}`infomap.Result.to_dataframe` exports a table with columns `node_id`,
   `module_id`, `flow`, `path`, `name`.
+- {meth}`infomap.Result.summary` returns the scalar metrics as a
+  `{name: value}` dict — one row per run for building a sweep table with pandas.
+- {meth}`infomap.Result.to_series` is that same row as a `pandas.Series`.
 
 ## Going deeper
 

--- a/interfaces/python/src/infomap/__init__.py
+++ b/interfaces/python/src/infomap/__init__.py
@@ -9,7 +9,8 @@ Call :func:`infomap.run` on a network and read the immutable :class:`Result`::
     result = infomap.run(graph, seed=123, num_trials=20)
     result.codelength        # scalar metrics are properties (no parentheses)
     result.modules()         # collections are methods -> {node_id: module_id}
-    result.to_dataframe()    # columns: node_id, module_id, flow, path, name
+    result.to_dataframe()    # per-node table: node_id, module_id, flow, path, name
+    result.summary()         # {metric: value} scalar row, one per run for a sweep table
 
 ``run`` accepts a NetworkX or igraph graph, a SciPy sparse matrix, a ``(2, E)``
 edge index, a network file path, an iterable of ``(u, v[, w])`` links, or a

--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -1673,12 +1673,24 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         return _repr_text(self)
 
     def summary(self):
-        """Return a compact dictionary with network and result state.
+        """Return a compact dictionary describing this instance's state.
 
-        Before :meth:`run`, the summary contains loaded network counts and
-        higher-order state-node information. After :meth:`run`, it also
-        includes module counts, codelength components, entropy rate, and elapsed
-        time.
+        A *state card* for the stateful builder (it also backs the notebook
+        HTML repr). Before :meth:`run` it holds loaded network counts and
+        higher-order state-node information, with ``status`` set to
+        ``"not run"``; after :meth:`run` it also includes module counts,
+        codelength components, entropy rate, and elapsed time. Module counts use
+        the short card keys (``top_modules``, ``levels``, ``leaf_modules``).
+
+        This is not :meth:`Result.summary`. For a finished run's result metrics
+        as a one-row-per-run record -- keyed by the :class:`Result` property
+        names (``num_top_modules``, ``num_levels``), the shape for collecting a
+        sweep into a :class:`pandas.DataFrame` -- read ``summary()`` off the
+        ``Result`` that :meth:`run` returns instead.
+
+        See Also
+        --------
+        Result.summary : the returned run's result metrics as a sweep row.
         """
         return _summary_data(self)
 

--- a/interfaces/python/src/infomap/result.py
+++ b/interfaces/python/src/infomap/result.py
@@ -865,6 +865,14 @@ class Result(_ResultWritersMixin):
         column reads the same as the attribute you would read off a single
         result (``df["codelength"]`` mirrors ``result.codelength``).
 
+        This is distinct from :meth:`Infomap.summary`. That method describes the
+        stateful *instance* -- network counts and run ``status``, available even
+        before a run -- and keys its module counts with the shorter card names
+        (``top_modules``, ``levels``). ``Result.summary`` reports only a finished
+        run's result metrics, keyed by the ``Result`` property names
+        (``num_top_modules``, ``num_levels``); it is the shape to collect into a
+        sweep table.
+
         Only the eagerly captured O(1) scalars are included, so ``summary`` is
         cheap and stays valid for the life of the ``Result``: it never walks
         the tree and never raises :class:`~infomap.StaleResultError`, even
@@ -883,6 +891,7 @@ class Result(_ResultWritersMixin):
         --------
         to_series : the same record as a :class:`pandas.Series`.
         to_dataframe : the per-node table for a single result.
+        Infomap.summary : the stateful instance's state card (different keys).
 
         Examples
         --------

--- a/interfaces/python/src/infomap/result.py
+++ b/interfaces/python/src/infomap/result.py
@@ -843,6 +843,102 @@ class Result(_ResultWritersMixin):
         """
         return self._effective_num_modules_cached(depth)
 
+    def summary(self) -> dict[str, Any]:
+        """Return the result's scalar metrics as a plain ``dict``.
+
+        A one-row-per-run record for collecting a sweep into a table: write
+        the loop as you normally would and drop each summary into pandas,
+        adding your own swept-parameter columns alongside::
+
+            records = []
+            for markov_time in (0.5, 1.0, 2.0):
+                result = infomap.run(graph, markov_time=markov_time, seed=123)
+                records.append({"markov_time": markov_time, **result.summary()})
+            df = pandas.DataFrame(records)
+
+        The keys match the scalar :class:`Result` property names, so each
+        column reads the same as the attribute you would read off a single
+        result (``df["codelength"]`` mirrors ``result.codelength``).
+
+        Only the eagerly captured O(1) scalars are included, so ``summary`` is
+        cheap and stays valid for the life of the ``Result``: it never walks
+        the tree and never raises :class:`~infomap.StaleResultError`, even
+        after the bound engine has re-run. The tree-derived ``effective_num_*``
+        metrics and the per-trial :attr:`codelengths` are intentionally left
+        out (read them off their properties when needed), as is the metadata
+        codelength -- add ``result.meta_codelength`` yourself for a metadata
+        run.
+
+        Returns
+        -------
+        dict
+            ``{metric_name: value}`` for the scalar result metrics.
+
+        See Also
+        --------
+        to_series : the same record as a :class:`pandas.Series`.
+        to_dataframe : the per-node table for a single result.
+
+        Examples
+        --------
+        >>> import infomap
+        >>> result = infomap.run(infomap.datasets.two_triangles(), seed=123)
+        >>> summary = result.summary()
+        >>> summary["num_top_modules"]
+        2
+        >>> summary["codelength"] == result.codelength
+        True
+        >>> "num_levels" in summary
+        True
+        """
+        return {
+            "codelength": self._codelength,
+            "num_top_modules": self._num_top_modules,
+            "num_non_trivial_top_modules": self._num_non_trivial_top_modules,
+            "num_leaf_modules": self._num_leaf_modules,
+            "num_levels": self._num_levels,
+            "relative_codelength_savings": self._relative_codelength_savings,
+            "index_codelength": self._index_codelength,
+            "module_codelength": self._module_codelength,
+            "one_level_codelength": self._one_level_codelength,
+            "entropy_rate": self._entropy_rate,
+            "num_nodes": self._num_nodes,
+            "num_links": self._num_links,
+            "elapsed_time": self._elapsed_time,
+        }
+
+    def to_series(self) -> "pandas.Series":
+        """Return the result's scalar metrics as a :class:`pandas.Series`.
+
+        The pandas-native form of :meth:`summary`: a one-row record indexed by
+        metric name, so a sweep collects into one row per run with
+
+        ::
+
+            pandas.DataFrame([result.to_series() for result in results])
+
+        Like :meth:`summary`, this reads only the eager scalars, so it stays
+        valid after the bound engine re-runs.
+
+        Returns
+        -------
+        pandas.Series
+            The :meth:`summary` mapping as a Series indexed by metric name.
+
+        Raises
+        ------
+        ImportError
+            If pandas is not installed. Install it with
+            ``python -m pip install "infomap[pandas]"``.
+
+        See Also
+        --------
+        summary : the same record as a plain ``dict``.
+        to_dataframe : the per-node table for a single result.
+        """
+        pandas = require_pandas("the Series accessor")
+        return pandas.Series(self.summary())
+
     def to_dataframe(
         self,
         columns: Sequence[str] | None = None,

--- a/interfaces/python/src/infomap/result.py
+++ b/interfaces/python/src/infomap/result.py
@@ -300,6 +300,11 @@ class Result(_ResultWritersMixin):
     ``Infomap`` rebuilds the C++ result tree, so node-level access on the old
     ``Result`` raises. Eager scalars (``codelength``, ``num_top_modules``, ...)
     stay valid.
+
+    For a sweep, :meth:`summary` returns the scalar metrics as a dict (one row
+    per run, so ``pandas.DataFrame(r.summary() for r in results)`` builds a
+    table) and :meth:`to_series` gives the pandas-native row; both read only the
+    eager scalars and stay valid after a re-run.
     """
 
     __slots__ = (

--- a/skills/infomap/references/python.md
+++ b/skills/infomap/references/python.md
@@ -78,7 +78,8 @@ import infomap
 result = infomap.run(graph, seed=123, num_trials=20)   # graph, file path, matrix, edge index, or links
 print(result.codelength, result.num_top_modules)       # scalars: properties (no parentheses)
 modules = result.modules()                              # {node_id: module_id} (method: parentheses)
-df = result.to_dataframe()                              # columns: node_id, module_id, flow, path, name
+df = result.to_dataframe()                              # per-node table: node_id, module_id, flow, path, name
+row = result.summary()                                  # {metric: value} scalar row (one per run; keys = property names)
 ```
 
 Confirm exact method names and option coverage against the installed package and published docs for the user's version; do not copy version-sensitive examples verbatim.
@@ -94,3 +95,20 @@ To write the mapequation.org native files in Python, call the writers on the `Re
 - `network.write_state_network(path)` — the internal state/multilayer network
 
 The `tree`, `clu`, `output`, `out_name`, and `no_file_output` **option flags are inert on the Python library surface**: setting them via `Options` writes no file and only emits a `UserWarning` (they act only through the raw `args` escape hatch together with an output directory). Write from the `Result`/`Network` instead.
+
+## Sweeps (many runs → one table)
+
+There is no sweep helper; users write their own loop. Do not invent one. The blessed pattern is a `Result` per run plus `result.summary()` (a `{metric: value}` dict keyed by the `Result` property names) collected into a tidy one-row-per-run `pandas.DataFrame` — the scikit-learn `pd.DataFrame(records)` idiom:
+
+```python
+import infomap, pandas as pd
+
+records = []
+for markov_time in (0.75, 1.0, 1.5):                    # or: for graph in graphs / for seed in seeds
+    r = infomap.run(graph, markov_time=markov_time, seed=123, num_trials=20)
+    records.append({"markov_time": markov_time, **r.summary()})   # add the swept params yourself
+
+sweep = pd.DataFrame(records)                           # columns: markov_time + codelength, num_top_modules, ...
+```
+
+`result.to_series()` is the pandas-native single row (`pd.DataFrame([r.to_series() for r in results])`). `summary()`/`to_series()` read only the eager scalars, so they never raise on a re-run; they omit the lazy `effective_num_*`, the per-trial `codelengths`, and `meta_codelength` — add those columns explicitly if a sweep needs them.

--- a/skills/infomap/references/python.md
+++ b/skills/infomap/references/python.md
@@ -112,3 +112,5 @@ sweep = pd.DataFrame(records)                           # columns: markov_time +
 ```
 
 `result.to_series()` is the pandas-native single row (`pd.DataFrame([r.to_series() for r in results])`). `summary()`/`to_series()` read only the eager scalars, so they never raise on a re-run; they omit the lazy `effective_num_*`, the per-trial `codelengths`, and `meta_codelength` — add those columns explicitly if a sweep needs them.
+
+Do not confuse `result.summary()` (this method, on a `Result`) with `im.summary()` on the stateful `Infomap` instance. The instance method is a network/run *state card* — it works before a run and keys module counts with the short card names (`status`, `top_modules`, `levels`), not the `Result` property names. For a sweep table, always collect `Result.summary()` (`num_top_modules`, `num_levels`, …).

--- a/test/python/test_api.py
+++ b/test/python/test_api.py
@@ -233,6 +233,83 @@ def test_to_dataframe_rejects_unknown_columns(make_infomap, example_network_path
         im.to_dataframe(columns=["node_id", "modul_id"])
 
 
+def test_result_summary_returns_scalar_metrics_matching_properties():
+    result = infomap_module.run(infomap_module.datasets.two_triangles(), seed=123)
+
+    summary = result.summary()
+
+    assert isinstance(summary, dict)
+    assert set(summary) == {
+        "codelength",
+        "num_top_modules",
+        "num_non_trivial_top_modules",
+        "num_leaf_modules",
+        "num_levels",
+        "relative_codelength_savings",
+        "index_codelength",
+        "module_codelength",
+        "one_level_codelength",
+        "entropy_rate",
+        "num_nodes",
+        "num_links",
+        "elapsed_time",
+    }
+    # Every value mirrors the eponymous Result property, and is a plain scalar
+    # (no tuples/dicts) so a DataFrame column stays a real numeric column.
+    for name, value in summary.items():
+        assert value == getattr(result, name)
+        assert isinstance(value, (int, float))
+
+
+def test_result_summary_stays_valid_after_rerun(make_infomap):
+    im = make_infomap()
+    im.add_links(((1, 2), (1, 3), (2, 3), (4, 5), (4, 6), (5, 6), (3, 4)))
+    result = im.run()
+
+    before = result.summary()
+    im.run()  # re-run: the Result is now stale for node-level access
+
+    # summary reads only the eager snapshot scalars, so it stays valid and
+    # never raises, unlike node-level access on a stale Result.
+    assert result.summary() == before
+    with pytest.raises(infomap_module.StaleResultError):
+        result.to_dataframe()
+
+
+def test_result_to_series_matches_summary():
+    pytest.importorskip("pandas")
+    import pandas as pd
+
+    result = infomap_module.run(infomap_module.datasets.two_triangles(), seed=123)
+
+    series = result.to_series()
+
+    assert isinstance(series, pd.Series)
+    assert dict(series) == result.summary()
+
+
+def test_result_summaries_collect_into_one_row_per_run_dataframe():
+    pytest.importorskip("pandas")
+    import pandas as pd
+
+    markov_times = (0.5, 1.0, 2.0)
+    results = [
+        infomap_module.run(
+            infomap_module.datasets.two_triangles(), markov_time=mt, seed=123
+        )
+        for mt in markov_times
+    ]
+
+    df = pd.DataFrame(
+        {"markov_time": mt, **result.summary()}
+        for mt, result in zip(markov_times, results)
+    )
+
+    assert len(df) == len(markov_times)
+    assert list(df.columns) == ["markov_time", *results[0].summary().keys()]
+    assert list(df["codelength"]) == [result.codelength for result in results]
+
+
 def test_get_dataframe_missing_pandas_message(monkeypatch, make_infomap):
     im = make_infomap(no_infomap=True)
     # pandas resolves lazily via require_pandas (infomap._optional); simulate


### PR DESCRIPTION
## Summary

Collecting per-run metrics from a sweep (over parameters or networks) into a table was entirely hand-rolled: `Result` exposed scalars only as individual properties, so every loop had to hand-transcribe each metric into a dict. This adds a small building block on `Result` so results drop straight into pandas — without a bespoke sweep DSL, keeping users on the familiar `pd.DataFrame(records)` idiom:

- `Result.summary() -> dict` — the run's scalar metrics as a one-row-per-run record, keyed by the `Result` property names (so `df["codelength"]` mirrors `result.codelength`). `pandas.DataFrame(r.summary() for r in results)` is the whole sweep table.
- `Result.to_series() -> pandas.Series` — the pandas-native form of that row (behind the optional-pandas guard).

Both read only the eagerly captured O(1) scalars, so they stay valid for the life of the `Result` and never raise `StaleResultError` (unlike node-level access after a re-run). The lazy `effective_num_*`, per-trial `codelengths`, and metadata codelength are intentionally omitted; read them off their properties when needed.

Docs / discoverability:
- `results-and-iteration.md`: a "Collecting a sweep into a table" section + API-pointer entries.
- `skills/infomap/references/python.md`: a "Sweeps" section and a `summary()` line in the minimal pattern.
- The `Result` class docstring and the package quick-start docstring point at `summary()`/`to_series()`.
- `Result.summary()` and `Infomap.summary()` now cross-reference each other and call out that they use different keys (`num_top_modules` vs `top_modules`), so the two are not conflated. No behaviour change to `Infomap.summary()`.

## Verification

Built the extension from the committed SWIG wrapper and ran against it:
- `test/python/test_api.py` (new `summary`/`to_series` tests + existing `Infomap.summary` tests) — pass.
- Doctests on `result.py` and `_facade.py` — pass.
- `test_docs_surface.py`, `test_docs_examples_surface.py`, `test_no_eager_optional_import.py`, `test_deprecations.py`, `test_collaborators.py` — pass.
- `ruff check` on the changed files — clean.
- Ran the docs sweep snippet against the build (markov_time 0.75 → 6 modules, 1.0/1.5 → 3).

Not run: the full Sphinx docs site (docs toolchain not installed locally). The `{code-cell}` snippet was executed directly, and the new `{meth}`/`{class}` cross-references target documented objects.

## Notes

- No `infomap.sweep(...)` helper by design — the building block keeps the user's own loop.
- `Result` is documented via `autoclass:: Result :members:`, so the new methods appear in the API reference automatically.
- Possible follow-up (not in this PR): reconcile `Infomap.summary()`'s key names with `Result.summary()` behind a deprecation cycle.