### PR TITLE
Python API review: warning fixes and docs de-duplication for the 2.15/3.0 transition

### DIFF
--- a/interfaces/python/source/api/infomap.rst
+++ b/interfaces/python/source/api/infomap.rst
@@ -183,9 +183,8 @@ Full reference
    (``get_modules``, ``modules``, ``codelength``, ``to_dataframe``, …), and
    their example bodies show the legacy ``im.<accessor>`` form for reference
    only. In new code, read these off the :class:`Result` that ``run()`` returns
-   instead -- e.g. ``result = im.run(); result.modules()`` -- and mind the shape
-   shift: ``im.modules`` is a property, ``result.modules()`` a method. See
-   :doc:`/the-infomap-class` for the full migration table.
+   instead (see the note at the top of this page for the shape shift and the
+   migration table).
 
 .. autoclass:: Infomap
    :members:

--- a/interfaces/python/source/citing.md
+++ b/interfaces/python/source/citing.md
@@ -2,8 +2,7 @@
 
 When you use Infomap in published work, cite **both** the 2008 PNAS paper (which
 introduced the map equation) and the MapEquation software package (which
-identifies the implementation and version, for reproducibility). These are the
-canonical references for the method and the tool.
+identifies the implementation and version, for reproducibility).
 
 The survey {cite:p}`smiljanic2026survey` is the best single reference for the
 wider map-equation framework, its flow models, and its extensions. Cite it too

--- a/interfaces/python/source/concepts/choosing-a-method.md
+++ b/interfaces/python/source/concepts/choosing-a-method.md
@@ -171,13 +171,11 @@ genuinely mean different things; knowing your network tells you which to trust.
 
 ## API pointers
 
-- {func}`infomap.run` returns an immutable {class}`~infomap.Result`; pass
-  `directed=True` for directed-flow treatment and `two_level=True` for a flat
-  partition.
-- {func}`infomap.find_communities` returns a NetworkX-style `list[set]`, and
-  {func}`infomap.find_igraph_communities` returns an `igraph.VertexClustering`, so
-  an Infomap result plugs into igraph's own inspection and plotting utilities
-  alongside Louvain and Leiden.
+{func}`infomap.run` returns an immutable {class}`~infomap.Result` (pass
+`directed=True` for directed flow, `two_level=True` for a flat partition).
+{func}`infomap.find_communities` and {func}`infomap.find_igraph_communities`
+return NetworkX- and igraph-native cluster objects, so an Infomap result drops
+into those libraries' own tooling alongside Louvain and Leiden.
 
 ## Going deeper
 

--- a/interfaces/python/source/concepts/flow-and-random-walks.md
+++ b/interfaces/python/source/concepts/flow-and-random-walks.md
@@ -184,19 +184,13 @@ $\tau = 0.15$ restores ergodicity so every node stays reachable.
 
 ## API pointers
 
-- {func}`infomap.run` is the entry point; pass `directed=True` to use the
-  directed flow model with unrecorded teleportation. It returns a
-  {class}`~infomap.Result`.
-- {meth}`infomap.Network.from_networkx` loads a `networkx.DiGraph` (or `Graph`)
-  for non-default options; passing the graph straight to {func}`infomap.run`
-  works for the common case.
-- {meth}`infomap.Network.add_link` adds individual edges programmatically.
-- {meth}`infomap.Result.nodes` iterates per-node views; each exposes `.node_id`,
-  `.module_id`, and `.flow`.
-- {meth}`infomap.Result.to_dataframe` returns `flow`, `module_id`, `node_id`
-  (and more) as a pandas DataFrame in one call.
-- {attr}`infomap.Result.codelength` is the map-equation value at the partition
-  found, in bits per step.
+{func}`infomap.run` is the entry point — pass `directed=True` for the directed
+flow model with unrecorded teleportation — and returns a
+{class}`~infomap.Result`; build non-default or programmatic input with
+{meth}`~infomap.Network.from_networkx` and {meth}`~infomap.Network.add_link`.
+The result's flow-bearing accessors ({meth}`~infomap.Result.nodes`,
+{meth}`~infomap.Result.to_dataframe`, {attr}`~infomap.Result.codelength`) are
+covered in {doc}`/working-with-infomap/results-and-iteration`.
 
 ## Going deeper
 

--- a/interfaces/python/source/concepts/hierarchy-and-the-multilevel-map.md
+++ b/interfaces/python/source/concepts/hierarchy-and-the-multilevel-map.md
@@ -267,21 +267,13 @@ partition or a one-level description.
 
 ## API pointers
 
-- {attr}`infomap.Result.num_levels` gives the tree depth Infomap discovered
-  (alias `max_depth`), so you can read the number of levels without walking the
-  tree.
-- {attr}`infomap.Result.num_top_modules` counts the modules at level 1, the
-  coarsest partition.
-- {meth}`infomap.Result.modules` returns a `{node_id: module_id}` dict. Its
-  `depth` selects the level:
-  - `depth=1` (default) gives the top modules.
-  - `depth=2, 3, …` give progressively finer levels.
-  - `depth=-1` gives the leaf (finest) modules.
-- {meth}`infomap.Result.effective_num_modules` gives the flow-weighted effective
-  number of modules at a `depth`, which helps when module sizes are uneven and a
-  plain count overstates them.
-- The engine option `two_level=True` restricts the search to two levels.
-  **Leave it off** for the full hierarchical result.
+All on {class}`~infomap.Result`: {attr}`~infomap.Result.num_levels` (alias
+{attr}`~infomap.Result.max_depth`), {attr}`~infomap.Result.num_top_modules`,
+{meth}`~infomap.Result.modules` (pass `depth=k`, or `depth=-1` for the leaf
+level), and {meth}`~infomap.Result.effective_num_modules`; see
+{doc}`/working-with-infomap/results-and-iteration`. The engine option
+`two_level=True` restricts the search to two levels — leave it off for the full
+hierarchy.
 
 ## Going deeper
 

--- a/interfaces/python/source/concepts/the-map-equation.md
+++ b/interfaces/python/source/concepts/the-map-equation.md
@@ -194,17 +194,14 @@ module because naming it shortens the overall code.
 
 ## API pointers
 
-- {func}`infomap.run` is the entry point; pass `two_level=True` to constrain the
-  search to a flat (non-hierarchical) partition. It returns a
-  {class}`~infomap.Result`.
-- `result.codelength` is the per-step description length in bits for the best
-  partition found; `result.one_level_codelength` is the cost with no modules, and
-  `result.relative_codelength_savings` reports the gain between them.
-- `result.num_top_modules` counts the top-level modules; `result.modules()`
-  returns a `{node_id: module_id}` mapping.
-- `preferred_number_of_modules=k` softly steers the search toward `k` modules.
-  It is not one of the direct `run` keywords; carry it via
-  `options=infomap.Options(preferred_number_of_modules=k)`.
+The codelength metrics this chapter defines all live on
+{class}`~infomap.Result`: {attr}`~infomap.Result.codelength`,
+{attr}`~infomap.Result.one_level_codelength`,
+{attr}`~infomap.Result.relative_codelength_savings`, plus
+{attr}`~infomap.Result.num_top_modules` and {meth}`~infomap.Result.modules`;
+see {doc}`/working-with-infomap/results-and-iteration`. {func}`infomap.run`
+takes `two_level=True` for a flat partition, and steers the module count softly
+with `preferred_number_of_modules` (carried via {class}`~infomap.Options`).
 
 ## Going deeper
 

--- a/interfaces/python/source/flow-models/bipartite.md
+++ b/interfaces/python/source/flow-models/bipartite.md
@@ -197,19 +197,13 @@ weak cross-cluster links.
 
 ## API pointers
 
-- {attr}`infomap.Infomap.bipartite_start_id` declares the first node id of the
-  type-B block: assign `im.bipartite_start_id = n` and every node with id `>= n`
-  is a type-B node, ids below are type-A. Set it before
-  {meth}`~infomap.Infomap.run`. {attr}`infomap.Network.bipartite_start_id` is the
-  same property on a {class}`~infomap.Network`.
-- {meth}`infomap.Network.add_link` adds a weighted edge between any two node ids;
-  for bipartite networks the source and target should be opposite types.
-- {meth}`infomap.Result.modules` returns a `{node_id: module_id}` dict covering
-  both types.
-- The option `hide_bipartite_nodes=True` omits type-B nodes from written
-  output files (`.tree`, `.clu`, …), which helps when only the type-A
-  assignments matter (projecting a user partition, say). It does not filter
-  {meth}`infomap.Result.modules`, which always covers both types.
+Set {attr}`~infomap.Infomap.bipartite_start_id` (or
+{attr}`~infomap.Network.bipartite_start_id`) to `n` before running: every node id
+`>= n` is a type-B node, ids below are type-A; link opposite types with
+{meth}`~infomap.Network.add_link`. {meth}`~infomap.Result.modules` covers both
+types. The option `hide_bipartite_nodes=True` omits type-B nodes from the written
+output files (`.tree`, `.clu`, …) — useful when only the type-A assignments
+matter — without changing what {meth}`~infomap.Result.modules` returns.
 
 ## Options
 

--- a/interfaces/python/source/flow-models/memory-and-state.md
+++ b/interfaces/python/source/flow-models/memory-and-state.md
@@ -303,48 +303,14 @@ a state network are:
 
 ## API pointers
 
-**Declaring state nodes**
-
-```python
-net = Network()
-net.add_state_node(state_id, node_id)
-```
-
-Creates a state node with a unique integer `state_id` mapped to the physical
-node `node_id`.
-If the physical node does not yet exist, `add_state_node` creates it. Use
-{meth}`infomap.Network.set_name` afterwards for a human-readable label.
-
-**Adding state-level links**
-
-```python
-net.add_link(source_id, target_id, weight=1.0)
-```
-
-Links connect *state nodes*, not physical nodes. The same `add_link` serves both
-first-order and higher-order networks; in a state-node network `source_id` and
-`target_id` refer to state node ids.
-
-**Querying results**
-
-```python
-result = run(net)
-result.have_memory                            # True when state nodes were added
-
-# For memory networks, pass states=True
-state_modules = result.modules(states=True)   # {state_id: module_id}
-
-# Group state nodes by their physical node to find overlap
-for node in result.nodes(states=True):
-    node.node_id    # physical node id
-    node.state_id   # state node id
-    node.module_id  # module assignment for this state node
-    node.flow       # state-node visit frequency
-```
-
-Because a physical node has one entry per state node in
-`result.nodes(states=True)`, collecting all its module assignments requires
-grouping by `node_id`, as shown in the worked example.
+Build state nodes with {meth}`~infomap.Network.add_state_node` and link them with
+{meth}`~infomap.Network.add_link` (both take state ids; add labels with
+{meth}`~infomap.Network.set_name`). Read a higher-order run off
+{class}`~infomap.Result`: {attr}`~infomap.Result.have_memory`, and
+{meth}`~infomap.Result.modules` / {meth}`~infomap.Result.nodes` with
+`states=True` (each node exposes `.node_id`, `.state_id`, `.module_id`, `.flow`;
+group by `node_id` for overlap, as in the worked example above). See
+{doc}`/working-with-infomap/results-and-iteration` for the accessors.
 
 ## Going deeper
 

--- a/interfaces/python/source/flow-models/metadata.md
+++ b/interfaces/python/source/flow-models/metadata.md
@@ -281,20 +281,13 @@ while the bridge pair {3, 4} forms its own cluster in the centre.
 
 ## API pointers
 
-- {meth}`infomap.Network.set_meta_data` declares the attribute for a node:
-  `set_meta_data(node_id, meta_category)`. Each node takes one integer category
-  label; call it once per node before the run.
-- `meta_data_rate` (an engine option carried via `Options` to {func}`infomap.run`,
-  default `1.0`; no effect unless you declare metadata) sets $\eta$, the weight of
-  the attribute codebook term. Pass `meta_data_rate=0` to suppress all metadata
-  influence.
-- {attr}`infomap.Result.meta_entropy` is the metadata entropy term of the best
-  partition, in bits per step.
-
-Two further engine options:
-- `meta_data` is a path to a metadata file listing `node_id category` pairs.
-- `meta_data_unweighted`, when `True`, ignores node visit frequencies when
-  computing the metadata codebook and treats all nodes as equally visited.
+Declare a node's attribute with {meth}`~infomap.Network.set_meta_data`
+(`set_meta_data(node_id, meta_category)` — one integer category per node, before
+the run). Carry the metadata engine options via {class}`~infomap.Options`:
+`meta_data_rate` sets $\eta$, the weight of the attribute codebook term (default
+`1.0`; `0` suppresses metadata influence); `meta_data` reads `node_id category`
+pairs from a file; and `meta_data_unweighted` treats all nodes as equally
+visited. The result's metadata term is {attr}`~infomap.Result.meta_entropy`.
 
 ## Options
 

--- a/interfaces/python/source/robustness/incomplete-data.md
+++ b/interfaces/python/source/robustness/incomplete-data.md
@@ -238,12 +238,10 @@ The common keywords (`num_trials`, `seed`, `two_level`, `directed`) compose
 freely alongside it, e.g.
 `infomap.run(g, options=infomap.Options(regularized=True), num_trials=20, seed=123)`.
 
-- {attr}`infomap.Result.codelength` is the map equation value for the winning
-  partition; with regularization it reflects the Bayesian-corrected description
-  length.
-- {attr}`infomap.Result.num_top_modules` is the number of top-level modules
-  found.
-- {meth}`infomap.Result.modules` returns a `{node_id: module_id}` dict.
+The run metrics — {attr}`~infomap.Result.codelength` (Bayesian-corrected under
+regularization), {attr}`~infomap.Result.num_top_modules`, and
+{meth}`~infomap.Result.modules` — are covered in
+{doc}`/working-with-infomap/results-and-iteration`.
 
 ## Going deeper
 

--- a/interfaces/python/source/the-infomap-class.md
+++ b/interfaces/python/source/the-infomap-class.md
@@ -99,15 +99,12 @@ falls into one of three groups, with a recommended replacement:
 | Console flags -- `silent`, `verbosity_level` | use logging: `infomap.enable_log()` for the engine log, and `infomap.enable_log(logging.DEBUG)` to raise its verbosity |
 
 The `options` carrier accepts an {class}`~infomap.Options` instance or a plain
-mapping, and is accepted on `Infomap()`, {meth}`Infomap.run`,
-{meth}`Network.run`, and {func}`infomap.run` alike — for example
+mapping and works the same on `Infomap()`, {meth}`Infomap.run`,
+{meth}`Network.run`, and {func}`infomap.run` — for example
 `im.run(options=Options(regularized=True))` gives the stateful builder the same
-carrier. A bare keyword argument set to a non-default value still overrides the
-carrier. On the functional {func}`infomap.run` and {meth}`Network.run`, bare
-keywords forward to `Options` without a deprecation; on the stateful `Infomap()`
-constructor and {meth}`Infomap.run` the advanced options are pending-deprecated
-on the signature. The common options (`seed`, `num_trials`, `two_level`,
-`directed`, `markov_time`) stay on every signature and are never deprecated.
+carrier — and a bare keyword set to a non-default value overrides it. The common
+options (`seed`, `num_trials`, `two_level`, `directed`, `markov_time`) stay on
+every signature and are never deprecated.
 
 ## Removed accessors
 

--- a/interfaces/python/source/workflows/graphrag.md
+++ b/interfaces/python/source/workflows/graphrag.md
@@ -248,24 +248,16 @@ communities[["id", "level", "size", "entity_ids"]]
 
 ## API pointers
 
-- {func}`infomap.tl.graphrag.read_graphrag` translates entity/relationship
-  DataFrames or Parquet paths into a `GraphRAGGraph` with mapped node ids. Key
-  parameters: `entity_id_col`, `entity_title_col`, `source_col`, `target_col`,
-  `weight_col`, `endpoint_col` (`"title"` or `"id"`).
-- {func}`infomap.tl.graphrag.run_graphrag_communities` is the one-call pipeline: it
-  reads tables, runs Infomap, and optionally writes outputs. It returns a
-  `GraphRAGRunResult` with `.result`, `.infomap`, `.graph`, `.nodes`, and
-  `.communities`. Read run metrics such as `codelength` and the module counts off
-  `.result` (the immutable `Result`, e.g. `run_result.result.codelength`) rather than
-  the deprecated accessors on `.infomap`.
-- {func}`infomap.tl.graphrag.write_graphrag_communities` writes a pre-run Infomap
-  result to disk as GraphRAG-compatible Parquet tables.
-- {class}`infomap.tl.graphrag.GraphRAGGraph` holds the entity/relationship tables,
-  the edge arrays, and the bidirectional entity-id ↔ node-id mappings.
-- {class}`infomap.tl.graphrag.GraphRAGRunResult` bundles the `Infomap` object, the
-  `GraphRAGGraph`, and the two output DataFrames.
-- {attr}`infomap.Result.codelength` and {attr}`infomap.Result.num_top_modules`
-  report the quality and structure of the solution after a run.
+The `infomap.tl.graphrag` helpers:
+{func}`~infomap.tl.graphrag.read_graphrag` builds a
+{class}`~infomap.tl.graphrag.GraphRAGGraph` from entity/relationship tables or
+Parquet paths; {func}`~infomap.tl.graphrag.run_graphrag_communities` is the
+one-call pipeline, returning a {class}`~infomap.tl.graphrag.GraphRAGRunResult`
+(read run metrics off its `.result` — the immutable {class}`~infomap.Result`,
+e.g. `run_result.result.codelength` — not the deprecated accessors on
+`.infomap`); and {func}`~infomap.tl.graphrag.write_graphrag_communities` writes a
+finished result back to GraphRAG-compatible Parquet. The `Result` metrics are
+covered in {doc}`/working-with-infomap/results-and-iteration`.
 
 ## Going deeper
 

--- a/interfaces/python/source/workflows/hpc.md
+++ b/interfaces/python/source/workflows/hpc.md
@@ -311,21 +311,16 @@ sacct -j <job-id> --format=JobID,State,ExitCode,Elapsed,MaxRSS
 
 ## API pointers
 
-- {func}`infomap.run` is the main entry point. `num_trials` and `seed` are
-  direct keyword arguments; the parallelism options `num_threads`,
-  `parallel_trials`, `trial_offset`, and `trial_results` are carried via
-  {class}`~infomap.Options` (`infomap.run(input, options=Options(...))`), as
-  they leave the bare signature in 3.0 (see {doc}`/api/deprecations`).
-- `result.codelength` is the codelength of the best solution found.
-- `result.modules()` returns a `{node_id: module_id}` mapping for the top-level
-  partition.
-- {func}`infomap.merge.merge_trial_results` is the programmatic equivalent of
-  `python -m infomap.merge`.
-- {doc}`/working-with-infomap/running-and-options` covers the search and
-  flow-model options (`seed`, `num_trials`, `directed`, `markov_time`, …); the
-  parallelism options used here (`parallel_trials`, `inner_parallelization`,
-  `num_threads`, `trial_offset`) are documented on this page and in the
-  {doc}`Options reference </api/options>`.
+{func}`infomap.run` takes `num_trials` and `seed` directly; the parallelism
+options `num_threads`, `parallel_trials`, `trial_offset`, and `trial_results` are
+carried via {class}`~infomap.Options` (they leave the bare signature in 3.0, see
+{doc}`/api/deprecations`). {func}`infomap.merge.merge_trial_results` is the
+programmatic equivalent of `python -m infomap.merge`. Read run metrics
+({attr}`~infomap.Result.codelength`, {meth}`~infomap.Result.modules`, …) off the
+{class}`~infomap.Result` — see
+{doc}`/working-with-infomap/results-and-iteration`; the search and flow-model
+options are in {doc}`/working-with-infomap/running-and-options` and the
+{doc}`Options reference </api/options>`.
 
 ## Going deeper
 

--- a/interfaces/python/source/workflows/scanpy.md
+++ b/interfaces/python/source/workflows/scanpy.md
@@ -216,19 +216,13 @@ sc.pl.umap(
 
 ## API pointers
 
-- {func}`infomap.tl.infomap` is the AnnData-aware helper. It reads
-  `adata.obsp["connectivities"]` by default and accepts `neighbors_key`, `obsp`,
-  and `adjacency` to point at a different graph. It writes a categorical column
-  to `adata.obs[key_added]` and metadata to `adata.uns[key_added]`.
-- {func}`infomap.run` partitions any SciPy sparse matrix directly (use
-  {meth}`infomap.Network.from_scipy_sparse_matrix` for non-default loading); reach
-  for it when you need hierarchical output or flow values.
-- {meth}`infomap.Result.modules` returns `{node_index: module_id}` and accepts
-  `depth` for sub-module assignments.
-- {attr}`infomap.Result.codelength` is the map equation value for the best
-  partition; it is also at `adata.uns[key_added]["codelength"]` after
-  `tl.infomap`.
-- {attr}`infomap.Result.num_top_modules` is the number of top-level modules.
+{func}`infomap.tl.infomap` is the AnnData-aware helper (it reads
+`adata.obsp["connectivities"]` by default and writes `adata.obs[key_added]` /
+`adata.uns[key_added]`, including `["codelength"]`); its keywords are below. For
+hierarchical output or flow values, partition the graph directly with
+{func}`infomap.run` (or {meth}`~infomap.Network.from_scipy_sparse_matrix` for
+non-default loading) and read the {class}`~infomap.Result` — see
+{doc}`/working-with-infomap/results-and-iteration`.
 
 Key `infomap.tl.infomap` keyword arguments:
 

--- a/interfaces/python/source/working-with-infomap/results-and-iteration.md
+++ b/interfaces/python/source/working-with-infomap/results-and-iteration.md
@@ -25,10 +25,6 @@ A {class}`~infomap.Result` holds more than labels. Each node carries a flow
 value, the share of the random walk that visits it, and the hierarchical tree
 records nested modules that a flat assignment vector cannot.
 
-This chapter covers the summary statistics, the assignment dict, the per-node
-view with flow, and the DataFrame export. It also explains why a single run may
-not be enough.
-
 ## Three layers of detail
 
 Think of the {class}`~infomap.Result` as three concentric layers of detail.
@@ -51,14 +47,13 @@ can filter, group, merge, and export.
 
 ## Why more than one trial
 
-Infomap keeps only the partition with the lowest codelength across the
-`num_trials` independent searches, and that partition is what the
-{class}`~infomap.Result` reports through `codelength`, `modules()`, and
-`nodes()`. A single trial can settle in a local minimum, so one run is fine for
-exploration but results you publish or act on warrant more; see
-{doc}`Running Infomap </working-with-infomap/running-and-options>` for why a
-single trial gets stuck and the full `num_trials` rule of thumb. The rest of this
-chapter is about *reading and comparing* the partition you get back.
+The {class}`~infomap.Result` reports the best (lowest-codelength) partition
+across the `num_trials` independent searches. One run is fine for exploration,
+but a single trial can settle in a local minimum, so results you publish or act
+on warrant more — see
+{doc}`Running Infomap </working-with-infomap/running-and-options>` for why and
+the full `num_trials` rule of thumb. The rest of this chapter is about *reading
+and comparing* the partition you get back.
 
 :::{toggle}
 **The solution landscape and degeneracy**

--- a/interfaces/python/src/infomap/_options.py
+++ b/interfaces/python/src/infomap/_options.py
@@ -848,13 +848,21 @@ class Options(metaclass=_OptionsMeta):
         _validate_option_domains(options)
         _validate_option_choices(options)
         if self.directed is not None and self.flow_model is not None:
-            warnings.warn(
-                f"both 'directed' and 'flow_model' are set; 'directed' "
-                f"takes precedence and flow_model={self.flow_model!r} is "
-                "ignored by the engine. Set only one (directed=True is shorthand for flow_model='directed').",
-                UserWarning,
-                stacklevel=_external_stacklevel(),
-            )
+            # Only warn on a genuine conflict. directed=True is shorthand for
+            # flow_model="directed" (False -> "undirected"), so pairing it with
+            # the matching flow_model is redundant but consistent -- warning
+            # there second-guesses valid input. Warn only when the two disagree,
+            # where 'directed' silently wins and the flow_model is really lost.
+            implied_flow_model = "directed" if self.directed else "undirected"
+            if self.flow_model != implied_flow_model:
+                warnings.warn(
+                    f"both 'directed' and 'flow_model' are set and disagree; "
+                    f"'directed' takes precedence and flow_model="
+                    f"{self.flow_model!r} is ignored by the engine. Set only "
+                    "one (directed=True is shorthand for flow_model='directed').",
+                    UserWarning,
+                    stacklevel=_external_stacklevel(),
+                )
         rendered_args = []
 
         if self.include_self_links is not None:

--- a/interfaces/python/src/infomap/_run.py
+++ b/interfaces/python/src/infomap/_run.py
@@ -151,9 +151,23 @@ def _warn_inert_output_options(options: Any, args: Any) -> None:
     # effect. Point at the real control using each option's catalog
     # replacement text. ``silent`` is handled by the dedicated, context-aware
     # advisories on the Infomap/Network paths, so it is intentionally omitted.
+    #
+    # verbosity_level is NOT inert under routed DEBUG logging: there
+    # apply_engine_log_overrides un-silences the engine and keeps a user-chosen
+    # level, so the -vv/-vvv detail records actually surface. Warning "no effect"
+    # in exactly the mode where it works -- and advising its removal -- would be
+    # the same mistake that was fixed for hide_bipartite_nodes, so drop it from
+    # the check there.
+    import logging
+
+    from ._logging import is_routed, logger as _engine_logger
+
+    removable = ["verbosity_level", "print_config_fingerprint"]
+    if is_routed() and _engine_logger.isEnabledFor(logging.DEBUG):
+        removable.remove("verbosity_level")
     inert_removed = [
         (name, _ADVANCED_TIER_KWARGS[name][3])
-        for name in ("verbosity_level", "print_config_fingerprint")
+        for name in removable
         if getattr(options, name) != getattr(_OPTION_DEFAULTS, name)
     ]
     if inert_removed:

--- a/interfaces/python/src/infomap/_run.py
+++ b/interfaces/python/src/infomap/_run.py
@@ -485,12 +485,6 @@ def run(
     (``infomap.enable_log(logging.DEBUG)`` for more detail). The ``infomap``
     command-line interface keeps its verbose default.
 
-    Advanced engine options can be passed either as bare keyword arguments (for
-    a one-off, e.g. ``regularized=True``) or via ``options`` -- an
-    :class:`Options` instance or a plain mapping, the reusable and validated
-    carrier and the full parameter reference. The two are equivalent; a keyword
-    argument takes precedence over the same field in ``options``.
-
     Keyword arguments go to the engine; the input adapters always build with
     their defaults (e.g. networkx reads the ``"weight"`` edge attribute, a
     SciPy matrix is treated as undirected). For non-default input building -- a

--- a/interfaces/python/src/infomap/network.py
+++ b/interfaces/python/src/infomap/network.py
@@ -352,8 +352,7 @@ class Network(_NetworkWritersMixin):
         seed, num_trials, two_level, directed, markov_time : optional
             The five common-tier engine options, accepted directly here to match
             :func:`infomap.run` and :meth:`infomap.Infomap.run`. A supplied value
-            overrides the ``options`` carrier; carry any other engine option via
-            ``options=Options(...)``.
+            overrides the ``options`` carrier.
         args : str, optional
             Raw Infomap arguments prepended before the rendered options.
         initial_partition : mapping, optional

--- a/interfaces/python/src/infomap/network.py
+++ b/interfaces/python/src/infomap/network.py
@@ -123,6 +123,12 @@ class Network(_NetworkWritersMixin):
         # (engine re-ran since) raises instead of reading freed memory. This is
         # the minimal engine contract Result needs, mirroring Infomap.
         self._generation = 0
+        # Warn at most once per Network that its engine is silent for its whole
+        # lifetime (routed logging / silent=False cannot re-enable it). A run
+        # loop -- e.g. a markov_time sweep over a bundled dataset under
+        # enable_log() -- would otherwise repeat the advisory on every call and
+        # train the user to ignore it, matching the Infomap path's guard.
+        self._warned_silent_advisory = False
 
     def __repr__(self) -> str:
         return f"Network(num_nodes={self.num_nodes}, num_links={self.num_links})"
@@ -406,31 +412,38 @@ class Network(_NetworkWritersMixin):
         if common or overrides:
             resolved = resolved.replace(**{**common, **overrides})
 
-        if _is_log_routed():
-            # enable_log()/handlers on the "infomap" logger route the engine
-            # log, but a Network's Core is constructed --silent for its whole
-            # lifetime and that cannot be undone per run (the engine composes
-            # constructor + run args additively), so a routed run of a Network
-            # emits no records. Point the caller at a surface that can emit,
-            # mirroring the stale-silent advisory on the Infomap path.
-            warnings.warn(
-                "the 'infomap' logger has handlers, but a Network engine is "
-                "silent for its whole lifetime, so this run emits no log "
-                "records. For the engine log, run through Infomap(...) or pass "
-                "the input directly to infomap.run() (an edge list, graph, or "
-                "file path) instead.",
-                UserWarning,
-                stacklevel=2,
-            )
-        elif resolved.silent is False:
-            warnings.warn(
-                "A Network engine is silent for its whole lifetime; "
-                "silent=False has no effect here. For the engine log, run "
-                "through Infomap(silent=False) or pass the input directly "
-                "to infomap.run().",
-                UserWarning,
-                stacklevel=2,
-            )
+        # Warn once per Network (see _warned_silent_advisory): the engine is
+        # silent for its whole lifetime, so both routed logging and an explicit
+        # silent=False are inert here. Repeating it every run would nag a sweep.
+        if not self._warned_silent_advisory:
+            if _is_log_routed():
+                # enable_log()/handlers on the "infomap" logger route the engine
+                # log, but a Network's Core is constructed --silent for its whole
+                # lifetime and that cannot be undone per run (the engine composes
+                # constructor + run args additively), so a routed run of a
+                # Network emits no records. Point the caller at a surface that
+                # can emit, mirroring the stale-silent advisory on the Infomap
+                # path.
+                self._warned_silent_advisory = True
+                warnings.warn(
+                    "the 'infomap' logger has handlers, but a Network engine is "
+                    "silent for its whole lifetime, so this run emits no log "
+                    "records. For the engine log, run through Infomap(...) or "
+                    "pass the input directly to infomap.run() (an edge list, "
+                    "graph, or file path) instead.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            elif resolved.silent is False:
+                self._warned_silent_advisory = True
+                warnings.warn(
+                    "A Network engine is silent for its whole lifetime; "
+                    "silent=False has no effect here. For the engine log, run "
+                    "through Infomap(silent=False) or pass the input directly "
+                    "to infomap.run().",
+                    UserWarning,
+                    stacklevel=2,
+                )
 
         _warn_inert_output_options(resolved, args)
 

--- a/test/python/test_logging.py
+++ b/test/python/test_logging.py
@@ -20,7 +20,7 @@ import warnings
 
 import pytest
 
-from infomap import Infomap, disable_log, enable_log
+from infomap import Infomap, Options, disable_log, enable_log, run
 
 
 # These tests drive the engine log -> Python logging routing, deliberately
@@ -142,6 +142,24 @@ def test_info_logger_keeps_default_engine_verbosity(infomap_log_handler):
 
     levels = {record.levelno for record in infomap_log_handler.records}
     assert levels == {logging.INFO}
+
+
+def test_verbosity_level_not_flagged_inert_under_routed_debug(infomap_log_handler):
+    # Regression: verbosity_level IS effective under routed DEBUG logging (the
+    # fixture enables it), so it must not trigger the "no effect on the Python
+    # library surface" advisory there. Warning in exactly the mode where the
+    # option works -- and advising its removal -- is the mistake that was fixed
+    # for hide_bipartite_nodes. Outside routed DEBUG it stays inert and still
+    # warns (test_run_agent_fixes.test_verbosity_level_via_options_warns).
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        run([(1, 2), (2, 3), (1, 3)], seed=1, options=Options(verbosity_level=3))
+    assert not any("no effect" in str(record.message) for record in records)
+    # Routing is genuinely engaged (guards against a vacuous pass): the run
+    # emitted DEBUG detail records rather than going to stdout.
+    assert any(
+        record.levelno == logging.DEBUG for record in infomap_log_handler.records
+    )
 
 
 def test_records_are_plain_lines_without_ansi(infomap_log_handler):

--- a/test/python/test_options_alias.py
+++ b/test/python/test_options_alias.py
@@ -5,6 +5,7 @@ Settings alias has been removed.
 """
 
 import dataclasses
+import warnings
 
 import pytest
 
@@ -54,6 +55,30 @@ def test_options_repr_shows_only_non_default_fields():
     assert repr(Options(num_trials=10)) == "Options(num_trials=10)"
     o = Options(num_trials=10, seed=1, flow_model="directed")
     assert eval(repr(o), {"Options": Options}) == o
+
+
+@pytest.mark.fast
+def test_directed_and_matching_flow_model_do_not_warn():
+    # directed=True is shorthand for flow_model="directed" (False -> undirected),
+    # so pairing them consistently is redundant but valid input -- to_args() must
+    # not second-guess it. Only a genuine disagreement warns (see below).
+    for directed, flow_model in ((True, "directed"), (False, "undirected")):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any warning fails the test
+            Options(directed=directed, flow_model=flow_model).to_args()
+
+
+@pytest.mark.fast
+def test_directed_conflicting_flow_model_warns():
+    # A real disagreement: 'directed' silently wins and the flow_model is lost,
+    # so the caller should hear about it.
+    with pytest.warns(UserWarning, match="disagree"):
+        Options(directed=True, flow_model="undirected").to_args()
+    with pytest.warns(UserWarning, match="disagree"):
+        Options(directed=False, flow_model="directed").to_args()
+    # A directed variant is distinct from plain "directed" and is dropped too.
+    with pytest.warns(UserWarning, match="disagree"):
+        Options(directed=True, flow_model="undirdir").to_args()
 
 
 @pytest.mark.fast

--- a/test/python/test_run_functional.py
+++ b/test/python/test_run_functional.py
@@ -10,6 +10,7 @@ honours the same run-generation guard as the ``Infomap``-backed one.
 from __future__ import annotations
 
 import sys
+import warnings
 
 import networkx as nx
 import pytest
@@ -133,13 +134,31 @@ def test_network_run_is_silent_by_default(capfd):
 def test_network_run_silent_false_warns():
     # A Network engine is constructed silent for its whole lifetime (a flag
     # cannot be switched off per run), so an explicit silent=False warns
-    # instead of being silently ignored.
+    # instead of being silently ignored. Each fresh Network warns once (the
+    # advisory is once-per-instance, see the guard below), whether run via
+    # net.run() or the functional infomap.run().
+    with pytest.warns(UserWarning, match="silent for its whole lifetime"):
+        Network().add_links(_LINKS).run(
+            options={"silent": False, "num_trials": 1, "seed": 1}
+        )
+
+    with pytest.warns(UserWarning, match="silent for its whole lifetime"):
+        infomap.run(
+            Network().add_links(_LINKS),
+            options={"silent": False, "num_trials": 1, "seed": 1},
+        )
+
+
+def test_network_silent_advisory_warns_once_per_instance():
+    # The silent-for-life advisory is guarded once per Network so a run loop
+    # (e.g. a sweep) does not repeat it every call and train the user to ignore
+    # warnings -- matching the Infomap path's once-per-instance guard.
     net = Network().add_links(_LINKS)
     with pytest.warns(UserWarning, match="silent for its whole lifetime"):
         net.run(options={"silent": False, "num_trials": 1, "seed": 1})
-
-    with pytest.warns(UserWarning, match="silent for its whole lifetime"):
-        infomap.run(net, options={"silent": False, "num_trials": 1, "seed": 1})
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any further warning fails the test
+        net.run(options={"silent": False, "num_trials": 1, "seed": 1})
 
 
 def test_run_networkx_matches_oo():


### PR DESCRIPTION
## Summary

A follow-up review pass over the 2.14 Python API redesign and its docs, ahead of the 2.15 deprecation cycle and the 3.0 removal. It tightens three warning behaviours that slipped through the campaign and trims documentation that re-describes or recaps itself. The deprecation model is unchanged.

**Warning fixes**

- `Network.run()` re-emitted the "engine is silent for its whole lifetime" advisory on *every* call (a `markov_time` sweep over a bundled dataset under `enable_log()` warned each iteration). Now warned once per `Network`, mirroring the Infomap path's `_warned_stale_silent` guard.
- `verbosity_level` was flagged "no effect on the Python library surface" even under routed DEBUG logging, where it *does* take effect — and the advice was to remove it. Now flagged only where it is genuinely inert (same class as the earlier `hide_bipartite_nodes` fix).
- `directed` + `flow_model` warned even when the two agree (`directed=True` with `flow_model="directed"`). Now only on a real conflict, where `directed` silently wins and the `flow_model` is lost.

**Docs**

- The remaining chapter "API pointers" tails are now link indexes rather than recaps, per the rule the chapter template sets: cross-cutting `Result` metrics/accessors point at `results-and-iteration`; chapter-specific knobs stay. Covers the concept, flow-model, and workflow/robustness chapters (e.g. `memory-and-state` went from a three-code-block walkthrough to an index).
- Trimmed a prose table-of-contents and a `num_trials` recap in `results-and-iteration`, a restated Options-carrier paragraph in `the-infomap-class`, a duplicated carrier/shape-shift note in the `run` docstrings and `api/infomap.rst`, and a redundant closing line in `citing`.

## Verification

- Full Python unit suite: **668 passed, 55 skipped** (`pytest test/python`). Added 4 regression tests for the warning fixes.
- `ruff check` clean on the changed source (`ruff format` left off, as configured).
- Docs built with Sphinx (`nb_execution_mode=off`): no cross-reference warnings on the touched pages.

## Notes

- The 2.15/3.0 transition is consistent: the legacy surface emits a silent-by-default `PendingDeprecationWarning`, markers read `.. deprecated:: 2.15`, removal is `3.0`, and 2.14.0 ships neither markers nor runtime warnings. Consistency, migration-table validity, and option-range parity with the C++ catalog were spot-checked and are clean.
- Left as-is after review (not chattiness): the `inputs` / `visualizing-and-exporting` Pitfalls and the `running-and-options` options section (concise gotcha re-flags / the chapter's own topic), and the `multilayer` / `temporal` API-pointers (distinguishing building-verb pointers plus a genuine `states=True` gotcha).
- Follow-up, structural (your call): the state-network worked example is duplicated between `concepts/state-nodes-and-higher-order-flow` and `flow-models/memory-and-state`.

---
_Generated by [Claude Code](https://claude.ai/code/session_014rXsDt28pW13xqve5agHao)_