### PR TITLE
Post-landing review: run() over-correction fixes, terser API-pointers, corrected examples

### DIFF
--- a/examples/python/evaluate-partition.py
+++ b/examples/python/evaluate-partition.py
@@ -61,5 +61,5 @@ print(
 )
 
 # Output:
-# Partition one with 3 modules -> codelength: 2.5555555555555554
-# Partition two with 2 modules -> codelength: 2.60715482741224
+# Partition one with 3 modules -> codelength: 2.55555556 bits
+# Partition two with 2 modules -> codelength: 2.60715483 bits

--- a/examples/python/simple.py
+++ b/examples/python/simple.py
@@ -48,7 +48,7 @@ for node in result.nodes():
         node.name,
     )
 
-print("\n#path flow enter_flow exit_flow is_leaf")
+print("\n#path flow enter_flow exit_flow kind")
 for node in result.tree(states=True):
     print(
         node.path,

--- a/examples/python/state-network.py
+++ b/examples/python/state-network.py
@@ -26,7 +26,7 @@ print(
     f"{result.codelength:.8f} bits"
 )
 
-print("\n#node_id module")
+print("\n#state_id module_id")
 for node, module in result.modules(states=True).items():
     print(node, module)
 

--- a/interfaces/python/source/flow-models/bipartite.md
+++ b/interfaces/python/source/flow-models/bipartite.md
@@ -201,9 +201,9 @@ Set {attr}`~infomap.Infomap.bipartite_start_id` (or
 {attr}`~infomap.Network.bipartite_start_id`) to `n` before running: every node id
 `>= n` is a type-B node, ids below are type-A; link opposite types with
 {meth}`~infomap.Network.add_link`. {meth}`~infomap.Result.modules` covers both
-types. The option `hide_bipartite_nodes=True` omits type-B nodes from the written
-output files (`.tree`, `.clu`, …) — useful when only the type-A assignments
-matter — without changing what {meth}`~infomap.Result.modules` returns.
+types. The bipartite engine options (`hide_bipartite_nodes`,
+`skip_adjust_bipartite_flow`, `bipartite_teleportation`) are listed in the
+Options table below.
 
 ## Options
 

--- a/interfaces/python/source/flow-models/metadata.md
+++ b/interfaces/python/source/flow-models/metadata.md
@@ -283,11 +283,10 @@ while the bridge pair {3, 4} forms its own cluster in the centre.
 
 Declare a node's attribute with {meth}`~infomap.Network.set_meta_data`
 (`set_meta_data(node_id, meta_category)` — one integer category per node, before
-the run). Carry the metadata engine options via {class}`~infomap.Options`:
-`meta_data_rate` sets $\eta$, the weight of the attribute codebook term (default
-`1.0`; `0` suppresses metadata influence); `meta_data` reads `node_id category`
-pairs from a file; and `meta_data_unweighted` treats all nodes as equally
-visited. The result's metadata term is {attr}`~infomap.Result.meta_entropy`.
+the run). The metadata engine options (`meta_data_rate`, `meta_data`,
+`meta_data_unweighted`) are carried via {class}`~infomap.Options` and listed in
+the Options table below. The result's metadata term is
+{attr}`~infomap.Result.meta_entropy`.
 
 ## Options
 

--- a/interfaces/python/source/working-with-infomap/running-and-options.md
+++ b/interfaces/python/source/working-with-infomap/running-and-options.md
@@ -386,18 +386,12 @@ for name, graph in [("ring of cliques", G_ring), ("karate club", G_karate)]:
 
 ## API pointers
 
-The options in this chapter are fields of {class}`~infomap.Options`, the
-canonical way to configure a run: `infomap.run(input, options=Options(...))`
-(or {meth}`infomap.Network.run` with `options=`). Five common options —
-`seed`, `num_trials`, `two_level`, `directed`, and `markov_time` — are also
-accepted as direct keyword arguments to {func}`infomap.run`. Any other option
-can be passed as a bare keyword to {func}`infomap.run` too (it forwards to
-`Options`); prefer `Options` for a reusable or validated configuration. On the
-stateful {class}`infomap.Infomap` constructor and `run` method the advanced
-options remain accepted as keywords but are pending-deprecated on those
-signatures and leave them in 3.0 (see {doc}`/api/deprecations`). After a run the
-metrics live on the returned {class}`~infomap.Result`; see
-{doc}`results-and-iteration` for the metric properties and partition accessors.
+{class}`~infomap.Options` is the canonical option carrier: {func}`infomap.run`
+and {meth}`infomap.Network.run` both take `options=`. On the stateful
+{class}`infomap.Infomap` the advanced keywords stay accepted but are
+pending-deprecated and leave the signature in 3.0 ({doc}`/api/deprecations`).
+After a run, metrics and partition accessors live on the returned
+{class}`~infomap.Result` ({doc}`results-and-iteration`).
 
 The most-used options — all fields of {class}`~infomap.Options`, with the five
 common ones also accepted directly on {func}`infomap.run`:

--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -181,7 +181,13 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
     """
 
     def _init_from_options(self, args, options):
-        _warn_inert_output_options(options, args)
+        # engine_emits: a classic silent=False construction leaves the engine
+        # writing to stdout for life, where verbosity_level is effective (so it
+        # is not flagged inert). Read the raw option before the routed override
+        # below strips silent.
+        _warn_inert_output_options(
+            options, args, engine_emits=options.silent is False
+        )
         # In routed log mode (handlers on the "infomap" logger), logging is
         # the emission control: strip --silent from the constructor args (the
         # C++ engine composes constructor + run args additively, so a --silent
@@ -2271,7 +2277,13 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
 
     def _run_from_options(self, args, initial_partition, options):
         kwargs = options.to_kwargs()
-        _warn_inert_output_options(options, args)
+        # engine_emits: whether this instance's engine emits at all. It was
+        # baked --silent (or not) at construction and cannot be undone per run,
+        # so a non-silent instance makes verbosity_level effective regardless of
+        # this run's silent default.
+        _warn_inert_output_options(
+            options, args, engine_emits=not self._engine_constructed_silent
+        )
         if _is_log_routed():
             # Warn once per instance: a run loop would otherwise repeat the
             # same advisory on every call and train the user to ignore it.

--- a/interfaces/python/src/infomap/_run.py
+++ b/interfaces/python/src/infomap/_run.py
@@ -86,10 +86,9 @@ def _reject_unknown_options(resolved: dict) -> None:
     raise TypeError(
         "infomap.run() got unknown option(s): "
         + ", ".join(rendered)
-        + ". Only seed, num_trials, two_level, directed and markov_time are "
-        "direct keyword options; carry any other engine option via "
-        "options=Options(...). See inspect.getdoc(infomap.Options) for the "
-        "full list of option names."
+        + ". Any engine option can be passed as a keyword (or carried via "
+        "options=Options(...)); see inspect.getdoc(infomap.Options) for the "
+        "option names."
     )
 
 
@@ -101,7 +100,9 @@ def _reject_unknown_options(resolved: dict) -> None:
 _WRITER_EFFECTIVE_ARGS_ONLY = frozenset({"hide_bipartite_nodes"})
 
 
-def _warn_inert_output_options(options: Any, args: Any) -> None:
+def _warn_inert_output_options(
+    options: Any, args: Any, *, engine_emits: bool = False
+) -> None:
     """Warn when output-artifact options are set but cannot take effect.
 
     The args-only options (``tree``, ``ftree``, ``clu``, ``clu_level``,
@@ -152,18 +153,20 @@ def _warn_inert_output_options(options: Any, args: Any) -> None:
     # replacement text. ``silent`` is handled by the dedicated, context-aware
     # advisories on the Infomap/Network paths, so it is intentionally omitted.
     #
-    # verbosity_level is NOT inert under routed DEBUG logging: there
-    # apply_engine_log_overrides un-silences the engine and keeps a user-chosen
-    # level, so the -vv/-vvv detail records actually surface. Warning "no effect"
-    # in exactly the mode where it works -- and advising its removal -- would be
-    # the same mistake that was fixed for hide_bipartite_nodes, so drop it from
-    # the check there.
+    # verbosity_level is inert only while the engine stays silent. It becomes
+    # effective whenever the engine actually emits: classic silent=False (stdout
+    # output, where -v/-vv/-vvv sets the detail level) or a DEBUG-enabled routed
+    # logger (where apply_engine_log_overrides un-silences and keeps a
+    # user-chosen level). The caller passes engine_emits for the silent=False
+    # case; is_routed()+DEBUG is checked here. Warning "no effect" in a mode
+    # where it works -- and advising its removal -- would be the same mistake
+    # that was fixed for hide_bipartite_nodes, so drop it from the check there.
     import logging
 
     from ._logging import is_routed, logger as _engine_logger
 
     removable = ["verbosity_level", "print_config_fingerprint"]
-    if is_routed() and _engine_logger.isEnabledFor(logging.DEBUG):
+    if engine_emits or (is_routed() and _engine_logger.isEnabledFor(logging.DEBUG)):
         removable.remove("verbosity_level")
     inert_removed = [
         (name, _ADVANCED_TIER_KWARGS[name][3])
@@ -321,9 +324,7 @@ def _reject_adapter_kwargs(kind: str, user_keys: set) -> None:
         f"infomap.run() forwards keyword arguments to the engine, but {names} "
         f"{verb} how the {kind} input is read, not the engine. Build the "
         f"network explicitly and run it, e.g. "
-        f"infomap.run({constructor}(..., {misdirected[0]}=...), num_trials=10). "
-        f"run() builds input with default settings; Network.from_* is the path "
-        f"for non-default input."
+        f"infomap.run({constructor}(..., {misdirected[0]}=...), num_trials=10)."
     )
     if "directed" in misdirected:
         # `directed` names the adapter's edge orientation, not the engine's

--- a/interfaces/python/src/infomap/network.py
+++ b/interfaces/python/src/infomap/network.py
@@ -444,7 +444,10 @@ class Network(_NetworkWritersMixin):
                     stacklevel=2,
                 )
 
-        _warn_inert_output_options(resolved, args)
+        # engine_emits stays False: a Network's engine is --silent for its
+        # whole lifetime (see the advisory above), so verbosity_level can never
+        # take effect here and is correctly flagged inert.
+        _warn_inert_output_options(resolved, args, engine_emits=False)
 
         rendered_args = _construct_args(args, **resolved.to_kwargs())
         # classify=True mirrors Infomap.run(): input failures surfacing at

--- a/test/python/test_run_agent_fixes.py
+++ b/test/python/test_run_agent_fixes.py
@@ -275,6 +275,31 @@ def test_verbosity_level_via_options_warns():
     assert any("no effect" in str(r.message) for r in _user_warnings(records))
 
 
+def test_verbosity_level_not_flagged_inert_when_engine_emits():
+    # With silent=False the engine writes to stdout for life, where
+    # verbosity_level IS effective (-v/-vv/-vvv sets the detail). Flagging it
+    # "no effect" there would be the routed-DEBUG false positive (fixed in
+    # test_logging) all over again, so it must stay quiet -- on the functional
+    # front door and the stateful construct+run path alike.
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        run(_LINKS, seed=1, options=Options(verbosity_level=3, silent=False))
+    assert not any(
+        "verbosity_level" in str(r.message) and "no effect" in str(r.message)
+        for r in _user_warnings(records)
+    )
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        im = Infomap(silent=False, verbosity_level=3)
+        im.add_links(_LINKS)
+        im.run()
+    assert not any(
+        "verbosity_level" in str(r.message) and "no effect" in str(r.message)
+        for r in _user_warnings(records)
+    )
+
+
 def test_print_config_fingerprint_via_options_warns():
     with warnings.catch_warnings(record=True) as records:
         warnings.simplefilter("always")


### PR DESCRIPTION
## Summary

Follow-up review of what the Python-API v3 campaign landed. Three small, self-contained cleanups (one commit each):

- **`fix(python)`** — three residual over-corrections on the `run()` front door:
  - `verbosity_level` was warned "no effect on the Python library surface" even when `silent=False` un-silences the engine (classic stdout mode), where `-v/-vv/-vvv` *is* the detail control — the routed-DEBUG false positive left unaddressed for the classic un-silence path. An `engine_emits` signal now carves it out; default-silent runs still warn.
  - the unknown-option `TypeError` claimed only `seed, num_trials, two_level, directed, markov_time` are accepted as keywords, contradicting the documented behaviour that any engine option forwards as a bare keyword (`run(g, regularized=True)` works). Reworded to match.
  - the misdirected-adapter-kwarg `TypeError` repeated its own worked example as a trailing sentence; trimmed.
- **`docs(python)`** — three `## API pointers` tails still recapped the body / duplicated the chapter's Options table, against the chapter-template rule; reduced to link indexes.
- **`docs(python)`** — a stale `# Output:` comment and two mislabeled column headers in the example scripts.

The 2.15 → 3.0 deprecation story is untouched (2.15 is not yet released); nothing here changes deprecation timing or the warning tiers.

## Verification

- `python -m pytest test/python/` → **669 passed, 55 skipped** (added a regression test pinning the `verbosity_level` carve-out on both the functional and construct-then-run paths).
- `ruff check` clean on the changed package sources and examples.
- Ran all three edited example scripts against the built extension; the comments/headers now match the real output.

## Notes

Two adjacent items left as maintainer judgment calls (not included here):
- `_warn_inert_output_options` re-fires on every `run()` — no warn-once guard, unlike its sibling silent-advisories. A guard only helps instance/`Network` reuse (the functional `run()` builds a fresh instance per call) and adds state to two classes.
- `net.run(silent=False)` warns, but `im.run(silent=False)` on a silent-constructed instance is silently inert — decide whether to add the advisory to the `Infomap` path or drop it from `Network`.

Deliberately unchanged (verified intentional): the `PendingDeprecationWarning` / `DeprecationWarning` tier split (documented in `RELEASING.md`) and the generated, CI-tested numeric option domains.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQjAYYoXTiJFmzFoBtSoxA)_