### PR TITLE
fix(python): re-export engine log hooks under their private names

### DIFF
--- a/interfaces/python/src/infomap/_core.py
+++ b/interfaces/python/src/infomap/_core.py
@@ -22,11 +22,14 @@ from ._bindings import InfomapWrapper  # noqa: F401  (the only engine import)
 from ._bindings import build_info as build_info  # module-level engine function
 from ._bindings import run as run  # module-level engine function (CLI driver)
 
-# Engine log-sink hooks, re-exported through this single boundary
-# for infomap._logging: install/remove the process-global line sink, and drain
-# lines queued by non-GIL-holding threads after an engine call returns.
-from ._bindings import _drain_log_queue as drain_log_queue  # noqa: F401
-from ._bindings import _set_log_callback as set_log_callback  # noqa: F401
+# Engine log-sink hooks, re-exported through this single boundary for
+# infomap._logging: install/remove the process-global line sink, and drain
+# lines queued by non-GIL-holding threads after an engine call returns. Kept
+# under their private (underscore) names so the re-export uses the redundant
+# ``_x as _x`` alias a type checker treats as an explicit re-export -- a renamed
+# alias reads as an unexported private symbol (pyright reportPrivateImportUsage).
+from ._bindings import _drain_log_queue as _drain_log_queue
+from ._bindings import _set_log_callback as _set_log_callback
 
 # Documented tree-walking iterator/node types returned by ``Infomap.tree`` /
 # ``leaf_modules`` and the physical variants (source/api/iterators.rst). They are

--- a/interfaces/python/src/infomap/_logging.py
+++ b/interfaces/python/src/infomap/_logging.py
@@ -49,7 +49,8 @@ def _sync_engine_routing() -> None:
     """Install or remove the engine-to-logging bridge for the next engine call."""
     # Imported lazily: _core imports _bindings at module load, and this module
     # is imported by the facade/network layers that _core must not depend on.
-    from ._core import drain_log_queue, set_log_callback
+    from ._core import _drain_log_queue as drain_log_queue
+    from ._core import _set_log_callback as set_log_callback
 
     global _installed
     should_route = bool(logger.handlers)
@@ -65,7 +66,7 @@ def _sync_engine_routing() -> None:
 
 def _drain() -> None:
     if _installed:
-        from ._core import drain_log_queue
+        from ._core import _drain_log_queue as drain_log_queue
 
         drain_log_queue()
 


### PR DESCRIPTION
## Summary

Fixes the red `master` CI. The full-scope Python type check (`make test-python-typecheck`, pyright 1.1.411 — its Python 3.14 leg) failed with three `reportPrivateImportUsage` errors in `interfaces/python/src/infomap/_logging.py`:

```
"drain_log_queue"/"set_log_callback" is not exported from module "._core"
```

`_core.py` re-exported the engine log hooks with a *renamed* alias (`from ._bindings import _drain_log_queue as drain_log_queue`), which pyright doesn't treat as an explicit re-export, so the names read as unexported private symbols. The full-scope check only runs on `master` push (PRs use the narrower quick-mode check), so it slipped through.

The fix re-exports the hooks with the redundant `_x as _x` alias pyright recognizes — the same pattern `._bindings` already uses for these symbols — and imports the private names in `_logging`, aliasing them locally to the names the function bodies already use. Pure alias rename; runtime log routing is unchanged.

## Verification

Reproduced the CI environment locally (built the extension + put the package on the env path like the editable install, pyright 1.1.411):

- Before: the exact three `reportPrivateImportUsage` errors from CI
- After: `0 errors, 0 warnings, 0 informations`
- `ruff check` on the changed files: clean
- `test/python/test_logging.py`: 16 passed
- Runtime end-to-end: engine log routed to the `infomap` logger (44 records captured), `enable_log`/`disable_log` work

## Notes

The JS bindings were already fresh — `make test-js-metadata` and `make test-binding-options-freshness` both pass with no diff, and the `javascript` CI job is green — so no binding regeneration was needed despite the branch name.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CoW9DNsGeXTUnGQKrzb3Xb)_