### PR TITLE
Allow naming state nodes via addStateNode, wire through Python/R

### DIFF
--- a/interfaces/R/generated/infomap.R
+++ b/interfaces/R/generated/infomap.R
@@ -16559,12 +16559,42 @@ attr(`StateNetwork_addStateNode__SWIG_1`, 'returnType') = '_p_std__pairT_std__ma
 attr(`StateNetwork_addStateNode__SWIG_1`, "inputTypes") = c('_p_infomap__StateNetwork', 'integer', 'integer')
 class(`StateNetwork_addStateNode__SWIG_1`) = c("SWIGFunction", class('StateNetwork_addStateNode__SWIG_1'))
 
+# Start of StateNetwork_addStateNode
+
+`StateNetwork_addStateNode__SWIG_2` = function(self, id, physId, name, .copy = FALSE)
+{
+  if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
+  id = as.integer(id);
+  
+  if(length(id) > 1) {
+    warning("using only the first element of id");
+  };
+  
+  physId = as.integer(physId);
+  
+  if(length(physId) > 1) {
+    warning("using only the first element of physId");
+  };
+  
+  name = as(name, "character"); 
+  ;ans = .Call('R_swig_StateNetwork_addStateNode__SWIG_2', self, id, physId, name, as.logical(.copy), PACKAGE='infomap');
+  ans <- if (is.null(ans)) ans
+  else new("_p_std__pairT_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t__iterator_bool_t", ref=ans);
+  
+  ans
+  
+}
+
+attr(`StateNetwork_addStateNode__SWIG_2`, 'returnType') = '_p_std__pairT_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t__iterator_bool_t'
+attr(`StateNetwork_addStateNode__SWIG_2`, "inputTypes") = c('_p_infomap__StateNetwork', 'integer', 'integer', 'character')
+class(`StateNetwork_addStateNode__SWIG_2`) = c("SWIGFunction", class('StateNetwork_addStateNode__SWIG_2'))
+
 `StateNetwork_addStateNode` <- function(...) {
   argtypes <- mapply(class, list(...));
   argv <- list(...);
   argc <- length(argtypes);
   f <- NULL;
-# dispatch functions 2
+# dispatch functions 3
   if (argc == 2) {
     if (( extends(argtypes[1], '_p_infomap__StateNetwork') || is.null(argv[[1]]) ) && ( extends(argtypes[2], '_p_infomap__StateNetwork__StateNode') && length(argv[[2]]) == 1 )) {
       f <- StateNetwork_addStateNode__SWIG_0; 
@@ -16572,6 +16602,10 @@ class(`StateNetwork_addStateNode__SWIG_1`) = c("SWIGFunction", class('StateNetwo
   } else if (argc == 3) {
     if (( extends(argtypes[1], '_p_infomap__StateNetwork') || is.null(argv[[1]]) ) && ( (is.integer(argv[[2]]) || is.numeric(argv[[2]])) && length(argv[[2]]) == 1 ) && ( (is.integer(argv[[3]]) || is.numeric(argv[[3]])) && length(argv[[3]]) == 1 )) {
       f <- StateNetwork_addStateNode__SWIG_1; 
+    }
+  } else if (argc == 4) {
+    if (( extends(argtypes[1], '_p_infomap__StateNetwork') || is.null(argv[[1]]) ) && ( (is.integer(argv[[2]]) || is.numeric(argv[[2]])) && length(argv[[2]]) == 1 ) && ( (is.integer(argv[[3]]) || is.numeric(argv[[3]])) && length(argv[[3]]) == 1 ) && ( is.character(argv[[4]]) && length(argv[[4]]) == 1 )) {
+      f <- StateNetwork_addStateNode__SWIG_2; 
     }
   };
   if (is.null(f)) {
@@ -23797,7 +23831,7 @@ class(`InfomapWrapper_addPhysicalNode__SWIG_1`) = c("SWIGFunction", class('Infom
 # Dispatch function
 # Start of InfomapWrapper_addStateNode
 
-`InfomapWrapper_addStateNode` = function(self, id, physId)
+`InfomapWrapper_addStateNode__SWIG_0` = function(self, id, physId)
 {
   if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
   id = as.integer(id);
@@ -23812,14 +23846,62 @@ class(`InfomapWrapper_addPhysicalNode__SWIG_1`) = c("SWIGFunction", class('Infom
     warning("using only the first element of physId");
   };
   
-  ;.Call('R_swig_InfomapWrapper_addStateNode', self, id, physId, PACKAGE='infomap');
+  ;.Call('R_swig_InfomapWrapper_addStateNode__SWIG_0', self, id, physId, PACKAGE='infomap');
   
 }
 
-attr(`InfomapWrapper_addStateNode`, 'returnType') = 'void'
-attr(`InfomapWrapper_addStateNode`, "inputTypes") = c('_p_infomap__InfomapWrapper', 'integer', 'integer')
-class(`InfomapWrapper_addStateNode`) = c("SWIGFunction", class('InfomapWrapper_addStateNode'))
+attr(`InfomapWrapper_addStateNode__SWIG_0`, 'returnType') = 'void'
+attr(`InfomapWrapper_addStateNode__SWIG_0`, "inputTypes") = c('_p_infomap__InfomapWrapper', 'integer', 'integer')
+class(`InfomapWrapper_addStateNode__SWIG_0`) = c("SWIGFunction", class('InfomapWrapper_addStateNode__SWIG_0'))
 
+# Start of InfomapWrapper_addStateNode
+
+`InfomapWrapper_addStateNode__SWIG_1` = function(self, id, physId, name)
+{
+  if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
+  id = as.integer(id);
+  
+  if(length(id) > 1) {
+    warning("using only the first element of id");
+  };
+  
+  physId = as.integer(physId);
+  
+  if(length(physId) > 1) {
+    warning("using only the first element of physId");
+  };
+  
+  name = as(name, "character"); 
+  ;.Call('R_swig_InfomapWrapper_addStateNode__SWIG_1', self, id, physId, name, PACKAGE='infomap');
+  
+}
+
+attr(`InfomapWrapper_addStateNode__SWIG_1`, 'returnType') = 'void'
+attr(`InfomapWrapper_addStateNode__SWIG_1`, "inputTypes") = c('_p_infomap__InfomapWrapper', 'integer', 'integer', 'character')
+class(`InfomapWrapper_addStateNode__SWIG_1`) = c("SWIGFunction", class('InfomapWrapper_addStateNode__SWIG_1'))
+
+`InfomapWrapper_addStateNode` <- function(...) {
+  argtypes <- mapply(class, list(...));
+  argv <- list(...);
+  argc <- length(argtypes);
+  f <- NULL;
+# dispatch functions 2
+  if (argc == 3) {
+    if (( extends(argtypes[1], '_p_infomap__InfomapWrapper') || is.null(argv[[1]]) ) && ( (is.integer(argv[[2]]) || is.numeric(argv[[2]])) && length(argv[[2]]) == 1 ) && ( (is.integer(argv[[3]]) || is.numeric(argv[[3]])) && length(argv[[3]]) == 1 )) {
+      f <- InfomapWrapper_addStateNode__SWIG_0; 
+    }
+  } else if (argc == 4) {
+    if (( extends(argtypes[1], '_p_infomap__InfomapWrapper') || is.null(argv[[1]]) ) && ( (is.integer(argv[[2]]) || is.numeric(argv[[2]])) && length(argv[[2]]) == 1 ) && ( (is.integer(argv[[3]]) || is.numeric(argv[[3]])) && length(argv[[3]]) == 1 ) && ( is.character(argv[[4]]) && length(argv[[4]]) == 1 )) {
+      f <- InfomapWrapper_addStateNode__SWIG_1; 
+    }
+  };
+  if (is.null(f)) {
+    stop("cannot find overloaded function for InfomapWrapper_addStateNode with argtypes (",toString(argtypes),")");
+  };
+  f(...);
+}
+
+# Dispatch function
 # Start of InfomapWrapper_addLink
 
 `InfomapWrapper_addLink__SWIG_0` = function(self, sourceId, targetId, weight)

--- a/interfaces/R/generated/infomap_wrap.cpp
+++ b/interfaces/R/generated/infomap_wrap.cpp
@@ -33911,6 +33911,68 @@ R_swig_StateNetwork_addStateNode__SWIG_1 ( SEXP self, SEXP id, SEXP physId, SEXP
 
 
 SWIGEXPORT SEXP
+R_swig_StateNetwork_addStateNode__SWIG_2 ( SEXP self, SEXP id, SEXP physId, SEXP name, SEXP s_swig_copy)
+{
+  {
+    SwigValueWrapper< std::pair< std::map< unsigned int,infomap::StateNetwork::StateNode,std::less< unsigned int >,std::allocator< std::pair< unsigned int const,infomap::StateNetwork::StateNode > > >::iterator,bool > > result;
+    infomap::StateNetwork *arg1 = 0 ;
+    unsigned int arg2 ;
+    unsigned int arg3 ;
+    std::string arg4 ;
+    void *argp1 = 0 ;
+    int res1 = 0 ;
+    int val2 ;
+    int ecode2 = 0 ;
+    int val3 ;
+    int ecode3 = 0 ;
+    unsigned int r_nprotect = 0;
+    SEXP r_ans = R_NilValue ;
+    VMAXTYPE r_vmax = vmaxget() ;
+    
+    res1 = SWIG_R_ConvertPtr(self, &argp1, SWIGTYPE_p_infomap__StateNetwork, 0 |  0 );
+    if (!SWIG_IsOK(res1)) {
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "StateNetwork_addStateNode" "', argument " "1"" of type '" "infomap::StateNetwork *""'"); 
+    }
+    arg1 = reinterpret_cast< infomap::StateNetwork * >(argp1);
+    ecode2 = SWIG_AsVal_int(id, &val2);
+    if (!SWIG_IsOK(ecode2)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "StateNetwork_addStateNode" "', argument " "2"" of type '" "unsigned int""'");
+    } 
+    arg2 = static_cast< unsigned int >(val2);
+    ecode3 = SWIG_AsVal_int(physId, &val3);
+    if (!SWIG_IsOK(ecode3)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "StateNetwork_addStateNode" "', argument " "3"" of type '" "unsigned int""'");
+    } 
+    arg3 = static_cast< unsigned int >(val3);
+    {
+      std::string *ptr = (std::string *)0;
+      int res = SWIG_AsPtr_std_string(name, &ptr);
+      if (!SWIG_IsOK(res) || !ptr) {
+        SWIG_exception_fail(SWIG_ArgError((ptr ? res : SWIG_TypeError)), "in method '" "StateNetwork_addStateNode" "', argument " "4"" of type '" "std::string""'"); 
+      }
+      arg4 = *ptr;
+      if (SWIG_IsNewObj(res)) delete ptr;
+    }
+    {
+      try {
+        result = (arg1)->addStateNode(arg2,arg3,SWIG_STD_MOVE(arg4));
+      } catch (const std::exception& e) {
+        SWIG_exception(SWIG_RuntimeError, e.what());
+      }
+    }
+    r_ans = SWIG_R_NewPointerObj((new std::pair< infomap::StateNetwork::NodeMap::iterator,bool >(result)), SWIGTYPE_p_std__pairT_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t__iterator_bool_t, SWIG_POINTER_OWN |  0 );
+    vmaxset(r_vmax);
+    if(r_nprotect)  Rf_unprotect(r_nprotect);
+    
+    return r_ans;
+    fail: SWIGUNUSED;
+  }
+  Rf_error("%s %s", SWIG_ErrorType(SWIG_lasterror_code), SWIG_lasterror_msg);
+  return R_NilValue;
+}
+
+
+SWIGEXPORT SEXP
 R_swig_StateNetwork_addNode__SWIG_0 ( SEXP self, SEXP id, SEXP s_swig_copy)
 {
   {
@@ -47642,7 +47704,7 @@ R_swig_InfomapWrapper_addPhysicalNode__SWIG_1 ( SEXP self, SEXP id)
 
 
 SWIGEXPORT SEXP
-R_swig_InfomapWrapper_addStateNode ( SEXP self, SEXP id, SEXP physId)
+R_swig_InfomapWrapper_addStateNode__SWIG_0 ( SEXP self, SEXP id, SEXP physId)
 {
   {
     infomap::InfomapWrapper *arg1 = 0 ;
@@ -47676,6 +47738,67 @@ R_swig_InfomapWrapper_addStateNode ( SEXP self, SEXP id, SEXP physId)
     {
       try {
         (arg1)->addStateNode(arg2,arg3);
+      } catch (const std::exception& e) {
+        SWIG_exception(SWIG_RuntimeError, e.what());
+      }
+    }
+    r_ans = R_NilValue;
+    vmaxset(r_vmax);
+    if(r_nprotect)  Rf_unprotect(r_nprotect);
+    
+    return r_ans;
+    fail: SWIGUNUSED;
+  }
+  Rf_error("%s %s", SWIG_ErrorType(SWIG_lasterror_code), SWIG_lasterror_msg);
+  return R_NilValue;
+}
+
+
+SWIGEXPORT SEXP
+R_swig_InfomapWrapper_addStateNode__SWIG_1 ( SEXP self, SEXP id, SEXP physId, SEXP name)
+{
+  {
+    infomap::InfomapWrapper *arg1 = 0 ;
+    unsigned int arg2 ;
+    unsigned int arg3 ;
+    std::string arg4 ;
+    void *argp1 = 0 ;
+    int res1 = 0 ;
+    int val2 ;
+    int ecode2 = 0 ;
+    int val3 ;
+    int ecode3 = 0 ;
+    unsigned int r_nprotect = 0;
+    SEXP r_ans = R_NilValue ;
+    VMAXTYPE r_vmax = vmaxget() ;
+    
+    res1 = SWIG_R_ConvertPtr(self, &argp1, SWIGTYPE_p_infomap__InfomapWrapper, 0 |  0 );
+    if (!SWIG_IsOK(res1)) {
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapWrapper_addStateNode" "', argument " "1"" of type '" "infomap::InfomapWrapper *""'"); 
+    }
+    arg1 = reinterpret_cast< infomap::InfomapWrapper * >(argp1);
+    ecode2 = SWIG_AsVal_int(id, &val2);
+    if (!SWIG_IsOK(ecode2)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "InfomapWrapper_addStateNode" "', argument " "2"" of type '" "unsigned int""'");
+    } 
+    arg2 = static_cast< unsigned int >(val2);
+    ecode3 = SWIG_AsVal_int(physId, &val3);
+    if (!SWIG_IsOK(ecode3)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "InfomapWrapper_addStateNode" "', argument " "3"" of type '" "unsigned int""'");
+    } 
+    arg3 = static_cast< unsigned int >(val3);
+    {
+      std::string *ptr = (std::string *)0;
+      int res = SWIG_AsPtr_std_string(name, &ptr);
+      if (!SWIG_IsOK(res) || !ptr) {
+        SWIG_exception_fail(SWIG_ArgError((ptr ? res : SWIG_TypeError)), "in method '" "InfomapWrapper_addStateNode" "', argument " "4"" of type '" "std::string""'"); 
+      }
+      arg4 = *ptr;
+      if (SWIG_IsNewObj(res)) delete ptr;
+    }
+    {
+      try {
+        (arg1)->addStateNode(arg2,arg3,SWIG_STD_MOVE(arg4));
       } catch (const std::exception& e) {
         SWIG_exception(SWIG_RuntimeError, e.what());
       }
@@ -50304,6 +50427,7 @@ SWIGINTERN R_CallMethodDef CallEntries[] = {
    {"R_swig_InfoNode_getInfomapRoot__SWIG_0", (DL_FUNC) &R_swig_InfoNode_getInfomapRoot__SWIG_0, 1},
    {"R_swig_InfoNode_begin__SWIG_0", (DL_FUNC) &R_swig_InfoNode_begin__SWIG_0, 2},
    {"R_swig_new_InfomapModuleIterator__SWIG_1", (DL_FUNC) &R_swig_new_InfomapModuleIterator__SWIG_1, 2},
+   {"R_swig_StateNetwork_addStateNode__SWIG_2", (DL_FUNC) &R_swig_StateNetwork_addStateNode__SWIG_2, 5},
    {"R_swig_delete_map_uint_vector_uint", (DL_FUNC) &R_swig_delete_map_uint_vector_uint, 1},
    {"R_swig_InfoNode_getInfomapRoot__SWIG_1", (DL_FUNC) &R_swig_InfoNode_getInfomapRoot__SWIG_1, 1},
    {"R_swig_InfoNode_begin__SWIG_1", (DL_FUNC) &R_swig_InfoNode_begin__SWIG_1, 2},
@@ -50946,7 +51070,9 @@ SWIGINTERN R_CallMethodDef CallEntries[] = {
    {"R_swig_FlowData_enterFlow_set", (DL_FUNC) &R_swig_FlowData_enterFlow_set, 2},
    {"R_swig_Config_printStateNetwork_get", (DL_FUNC) &R_swig_Config_printStateNetwork_get, 2},
    {"R_swig_InfomapLeafIteratorPhysical_modularCentrality", (DL_FUNC) &R_swig_InfomapLeafIteratorPhysical_modularCentrality, 2},
+   {"R_swig_InfomapWrapper_addStateNode__SWIG_0", (DL_FUNC) &R_swig_InfomapWrapper_addStateNode__SWIG_0, 3},
    {"R_swig_deque_uint_pop_front", (DL_FUNC) &R_swig_deque_uint_pop_front, 1},
+   {"R_swig_InfomapWrapper_addStateNode__SWIG_1", (DL_FUNC) &R_swig_InfomapWrapper_addStateNode__SWIG_1, 4},
    {"R_swig_delete_DeltaFlow", (DL_FUNC) &R_swig_delete_DeltaFlow, 1},
    {"R_swig_new_DeltaFlow__SWIG_0", (DL_FUNC) &R_swig_new_DeltaFlow__SWIG_0, 3},
    {"R_swig_InfoNode_calculatePath", (DL_FUNC) &R_swig_InfoNode_calculatePath, 2},
@@ -51292,7 +51418,6 @@ SWIGINTERN R_CallMethodDef CallEntries[] = {
    {"R_swig_new_InfomapConfigInfomapBase__SWIG_2", (DL_FUNC) &R_swig_new_InfomapConfigInfomapBase__SWIG_2, 1},
    {"R_swig_InfomapBase_writeCsvTree__SWIG_1", (DL_FUNC) &R_swig_InfomapBase_writeCsvTree__SWIG_1, 3},
    {"R_swig_InfomapBase_elapsedTime", (DL_FUNC) &R_swig_InfomapBase_elapsedTime, 2},
-   {"R_swig_InfomapWrapper_addStateNode", (DL_FUNC) &R_swig_InfomapWrapper_addStateNode, 3},
    {"R_swig_Config_clusterDataIsHard_get", (DL_FUNC) &R_swig_Config_clusterDataIsHard_get, 2},
    {"R_swig_new_InfomapConfigInfomapBase__SWIG_3", (DL_FUNC) &R_swig_new_InfomapConfigInfomapBase__SWIG_3, 1},
    {"R_swig_InfomapBase_writeCsvTree__SWIG_2", (DL_FUNC) &R_swig_InfomapBase_writeCsvTree__SWIG_2, 2},

--- a/interfaces/R/infomap/R/Infomap.R
+++ b/interfaces/R/infomap/R/Infomap.R
@@ -307,18 +307,27 @@ InfomapClass <- R6::R6Class(
     #' @description Add a state node.
     #' @param state_id Integer state node id.
     #' @param node_id Integer physical node id.
-    add_state_node = function(state_id, node_id) {
-      private$.swig$addStateNode(as.integer(state_id), as.integer(node_id))
+    #' @param name Optional name of the state node itself, as opposed to the
+    #'   physical node.
+    add_state_node = function(state_id, node_id, name = NULL) {
+      id <- as.integer(state_id)
+      phys_id <- as.integer(node_id)
+      if (!is.null(name)) {
+        private$.swig$addStateNode(id, phys_id, as.character(name))
+      } else {
+        private$.swig$addStateNode(id, phys_id)
+      }
       invisible(self)
     },
 
     #' @description Add many state nodes at once.
-    #' @param state_nodes A list of `c(state_id, node_id)` vectors, or a
-    #'   named list/vector mapping `state_id` to `node_id`.
+    #' @param state_nodes A list of `c(state_id, node_id)` or
+    #'   `c(state_id, node_id, name)` vectors, or a named list/vector mapping
+    #'   `state_id` to `node_id`.
     add_state_nodes = function(state_nodes) {
       if (is.null(names(state_nodes))) {
         for (entry in state_nodes) {
-          self$add_state_node(entry[[1L]], entry[[2L]])
+          do.call(self$add_state_node, as.list(entry))
         }
       } else {
         for (state_str in names(state_nodes)) {
@@ -841,7 +850,13 @@ InfomapClass <- R6::R6Class(
       has_layer <- length(layer_id) == 1L &&
         layer_id %in% igraph::vertex_attr_names(g)
 
-      vertex_names <- igraph::V(g)$name
+      # Only a real igraph "name" attribute should become a state node's name;
+      # unlike physical nodes (named below with a stringified-id fallback),
+      # state names are optional metadata, so an absent attribute must leave
+      # them unset rather than assigning synthetic "1", "2", ... names.
+      raw_vertex_names <- igraph::V(g)$name
+
+      vertex_names <- raw_vertex_names
       if (is.null(vertex_names)) {
         vertex_names <- as.character(seq_len(igraph::vcount(g)))
       }
@@ -874,7 +889,11 @@ InfomapClass <- R6::R6Class(
         # Multilayer state network.
         layers <- as.integer(igraph::vertex_attr(g, layer_id))
         for (i in seq_len(igraph::vcount(g))) {
-          self$add_state_node(vertex_ids[i], phys[i])
+          if (is.character(raw_vertex_names)) {
+            self$add_state_node(vertex_ids[i], phys[i], name = raw_vertex_names[i])
+          } else {
+            self$add_state_node(vertex_ids[i], phys[i])
+          }
         }
 
         if (isTRUE(multilayer_inter_intra_format)) {
@@ -929,7 +948,11 @@ InfomapClass <- R6::R6Class(
       } else if (has_phys) {
         # State network without explicit layer info.
         for (i in seq_len(igraph::vcount(g))) {
-          self$add_state_node(vertex_ids[i], phys[i])
+          if (is.character(raw_vertex_names)) {
+            self$add_state_node(vertex_ids[i], phys[i], name = raw_vertex_names[i])
+          } else {
+            self$add_state_node(vertex_ids[i], phys[i])
+          }
         }
         self$add_links(cbind(edges[, 1L], edges[, 2L], weights))
       } else {

--- a/interfaces/R/infomap/tests/testthat/test-igraph.R
+++ b/interfaces/R/infomap/tests/testthat/test-igraph.R
@@ -87,3 +87,30 @@ test_that("as_communities rejects graphs that do not match imported igraph verti
     "same igraph graph"
   )
 })
+
+test_that("add_igraph preserves per-state names for state networks", {
+  skip_if_not_installed("igraph")
+
+  g <- igraph::make_graph(c(1, 2, 2, 1), directed = TRUE)
+  igraph::V(g)$name <- c("state-a", "state-b")
+  igraph::V(g)$phys_id <- c("alpha", "beta")
+
+  im <- Infomap(silent = TRUE)
+  im$add_igraph(g)
+
+  expect_equal(im$get_state_name(1L), "state-a")
+  expect_equal(im$get_state_name(2L), "state-b")
+})
+
+test_that("add_igraph does not synthesize state names when vertices are unnamed", {
+  skip_if_not_installed("igraph")
+
+  g <- igraph::make_graph(c(1, 2, 2, 1), directed = TRUE)
+  igraph::V(g)$phys_id <- c("alpha", "beta")
+
+  im <- Infomap(silent = TRUE)
+  im$add_igraph(g)
+
+  expect_null(im$get_state_name(1L))
+  expect_null(im$get_state_name(2L))
+})

--- a/interfaces/R/infomap/tests/testthat/test-state-names.R
+++ b/interfaces/R/infomap/tests/testthat/test-state-names.R
@@ -88,3 +88,12 @@ test_that("as.data.frame omits state_name for first-order networks", {
   df <- as.data.frame(im)
   expect_false("state_name" %in% names(df))
 })
+
+test_that("add_state_node accepts an optional per-state name", {
+  im <- Infomap(silent = TRUE)
+  im$add_state_node(1L, 1L, name = "a")
+  im$add_state_node(2L, 1L)
+
+  expect_equal(im$get_state_name(1L), "a")
+  expect_null(im$get_state_name(2L))
+})

--- a/interfaces/python/generated/infomap_wrap.cpp
+++ b/interfaces/python/generated/infomap_wrap.cpp
@@ -39655,13 +39655,67 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_StateNetwork_addStateNode__SWIG_2(PyObject *self, Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  infomap::StateNetwork *arg1 = 0 ;
+  unsigned int arg2 ;
+  unsigned int arg3 ;
+  std::string arg4 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned int val2 ;
+  int ecode2 = 0 ;
+  unsigned int val3 ;
+  int ecode3 = 0 ;
+  SwigValueWrapper< std::pair< std::map< unsigned int,infomap::StateNetwork::StateNode,std::less< unsigned int >,std::allocator< std::pair< unsigned int const,infomap::StateNetwork::StateNode > > >::iterator,bool > > result;
+  
+  (void)self;
+  if ((nobjs < 4) || (nobjs > 4)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__StateNetwork, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "StateNetwork_addStateNode" "', argument " "1"" of type '" "infomap::StateNetwork *""'"); 
+  }
+  arg1 = reinterpret_cast< infomap::StateNetwork * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_int(swig_obj[1], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "StateNetwork_addStateNode" "', argument " "2"" of type '" "unsigned int""'");
+  } 
+  arg2 = static_cast< unsigned int >(val2);
+  ecode3 = SWIG_AsVal_unsigned_SS_int(swig_obj[2], &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "StateNetwork_addStateNode" "', argument " "3"" of type '" "unsigned int""'");
+  } 
+  arg3 = static_cast< unsigned int >(val3);
+  {
+    std::string *ptr = (std::string *)0;
+    int res = SWIG_AsPtr_std_string(swig_obj[3], &ptr);
+    if (!SWIG_IsOK(res) || !ptr) {
+      SWIG_exception_fail(SWIG_ArgError((ptr ? res : SWIG_TypeError)), "in method '" "StateNetwork_addStateNode" "', argument " "4"" of type '" "std::string""'"); 
+    }
+    arg4 = *ptr;
+    if (SWIG_IsNewObj(res)) delete ptr;
+  }
+  {
+    try {
+      result = (arg1)->addStateNode(arg2,arg3,SWIG_STD_MOVE(arg4));
+    } catch (const std::exception& e) {
+      SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+  }
+  resultobj = SWIG_NewPointerObj((new std::pair< infomap::StateNetwork::NodeMap::iterator,bool >(result)), SWIGTYPE_p_std__pairT_std__mapT_unsigned_int_infomap__StateNetwork__StateNode_std__lessT_unsigned_int_t_std__allocatorT_std__pairT_unsigned_int_const_infomap__StateNetwork__StateNode_t_t_t__iterator_bool_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_StateNetwork_addStateNode(PyObject *self, PyObject *args) {
   Py_ssize_t argc;
-  PyObject *argv[4] = {
+  PyObject *argv[5] = {
     0
   };
   
-  if (!(argc = SWIG_Python_UnpackTuple(args, "StateNetwork_addStateNode", 0, 3, argv))) SWIG_fail;
+  if (!(argc = SWIG_Python_UnpackTuple(args, "StateNetwork_addStateNode", 0, 4, argv))) SWIG_fail;
   --argc;
   if (argc == 2) {
     int _v = 0;
@@ -39697,12 +39751,38 @@ SWIGINTERN PyObject *_wrap_StateNetwork_addStateNode(PyObject *self, PyObject *a
       }
     }
   }
+  if (argc == 4) {
+    int _v = 0;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_infomap__StateNetwork, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_unsigned_SS_int(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        {
+          int res = SWIG_AsVal_unsigned_SS_int(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
+        if (_v) {
+          int res = SWIG_AsPtr_std_string(argv[3], (std::string**)(0));
+          _v = SWIG_CheckState(res);
+          if (_v) {
+            return _wrap_StateNetwork_addStateNode__SWIG_2(self, argc, argv);
+          }
+        }
+      }
+    }
+  }
   
 fail:
   SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'StateNetwork_addStateNode'.\n"
     "  Possible C/C++ prototypes are:\n"
     "    infomap::StateNetwork::addStateNode(infomap::StateNetwork::StateNode const &)\n"
-    "    infomap::StateNetwork::addStateNode(unsigned int,unsigned int)\n");
+    "    infomap::StateNetwork::addStateNode(unsigned int,unsigned int)\n"
+    "    infomap::StateNetwork::addStateNode(unsigned int,unsigned int,std::string)\n");
   return 0;
 }
 
@@ -57297,7 +57377,7 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_InfomapWrapper_addStateNode(PyObject *self, PyObject *args) {
+SWIGINTERN PyObject *_wrap_InfomapWrapper_addStateNode__SWIG_0(PyObject *self, Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   infomap::InfomapWrapper *arg1 = 0 ;
   unsigned int arg2 ;
@@ -57308,10 +57388,9 @@ SWIGINTERN PyObject *_wrap_InfomapWrapper_addStateNode(PyObject *self, PyObject 
   int ecode2 = 0 ;
   unsigned int val3 ;
   int ecode3 = 0 ;
-  PyObject *swig_obj[3] ;
   
   (void)self;
-  if (!SWIG_Python_UnpackTuple(args, "InfomapWrapper_addStateNode", 3, 3, swig_obj)) SWIG_fail;
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
   res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__InfomapWrapper, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapWrapper_addStateNode" "', argument " "1"" of type '" "infomap::InfomapWrapper *""'"); 
@@ -57338,6 +57417,123 @@ SWIGINTERN PyObject *_wrap_InfomapWrapper_addStateNode(PyObject *self, PyObject 
   return resultobj;
 fail:
   return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_InfomapWrapper_addStateNode__SWIG_1(PyObject *self, Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  infomap::InfomapWrapper *arg1 = 0 ;
+  unsigned int arg2 ;
+  unsigned int arg3 ;
+  std::string arg4 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned int val2 ;
+  int ecode2 = 0 ;
+  unsigned int val3 ;
+  int ecode3 = 0 ;
+  
+  (void)self;
+  if ((nobjs < 4) || (nobjs > 4)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__InfomapWrapper, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InfomapWrapper_addStateNode" "', argument " "1"" of type '" "infomap::InfomapWrapper *""'"); 
+  }
+  arg1 = reinterpret_cast< infomap::InfomapWrapper * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_int(swig_obj[1], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "InfomapWrapper_addStateNode" "', argument " "2"" of type '" "unsigned int""'");
+  } 
+  arg2 = static_cast< unsigned int >(val2);
+  ecode3 = SWIG_AsVal_unsigned_SS_int(swig_obj[2], &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "InfomapWrapper_addStateNode" "', argument " "3"" of type '" "unsigned int""'");
+  } 
+  arg3 = static_cast< unsigned int >(val3);
+  {
+    std::string *ptr = (std::string *)0;
+    int res = SWIG_AsPtr_std_string(swig_obj[3], &ptr);
+    if (!SWIG_IsOK(res) || !ptr) {
+      SWIG_exception_fail(SWIG_ArgError((ptr ? res : SWIG_TypeError)), "in method '" "InfomapWrapper_addStateNode" "', argument " "4"" of type '" "std::string""'"); 
+    }
+    arg4 = *ptr;
+    if (SWIG_IsNewObj(res)) delete ptr;
+  }
+  {
+    try {
+      (arg1)->addStateNode(arg2,arg3,SWIG_STD_MOVE(arg4));
+    } catch (const std::exception& e) {
+      SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_InfomapWrapper_addStateNode(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[5] = {
+    0
+  };
+  
+  if (!(argc = SWIG_Python_UnpackTuple(args, "InfomapWrapper_addStateNode", 0, 4, argv))) SWIG_fail;
+  --argc;
+  if (argc == 3) {
+    int _v = 0;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_infomap__InfomapWrapper, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_unsigned_SS_int(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        {
+          int res = SWIG_AsVal_unsigned_SS_int(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
+        if (_v) {
+          return _wrap_InfomapWrapper_addStateNode__SWIG_0(self, argc, argv);
+        }
+      }
+    }
+  }
+  if (argc == 4) {
+    int _v = 0;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_infomap__InfomapWrapper, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_unsigned_SS_int(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        {
+          int res = SWIG_AsVal_unsigned_SS_int(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
+        if (_v) {
+          int res = SWIG_AsPtr_std_string(argv[3], (std::string**)(0));
+          _v = SWIG_CheckState(res);
+          if (_v) {
+            return _wrap_InfomapWrapper_addStateNode__SWIG_1(self, argc, argv);
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'InfomapWrapper_addStateNode'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    infomap::InfomapWrapper::addStateNode(unsigned int,unsigned int)\n"
+    "    infomap::InfomapWrapper::addStateNode(unsigned int,unsigned int,std::string)\n");
+  return 0;
 }
 
 

--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -1205,7 +1205,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
                 else:
                     self.add_node(*node)
 
-    def add_state_node(self, state_id: int, node_id: int) -> None:
+    def add_state_node(self, state_id: int, node_id: int, name: str | None = None) -> None:
         """Add a state node.
 
         Notes
@@ -1218,8 +1218,13 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         state_id : int
         node_id : int
             Id of the physical node the state node should be added to.
+        name : str, optional
+            Name of the state node itself, as opposed to the physical node.
         """
-        self._core.addStateNode(state_id, node_id)
+        if name:
+            self._core.addStateNode(state_id, node_id, name)
+        else:
+            self._core.addStateNode(state_id, node_id)
 
     def add_state_nodes(self, state_nodes: Any) -> None:
         """Add state nodes.
@@ -1257,8 +1262,9 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         Parameters
         ----------
         state_nodes : iterable of tuples or dict of int: int
-            Iterable of tuples of the form ``(state_id, node_id)``
-            or dict of the form ``{state_id: node_id}``.
+            Iterable of tuples of the form ``(state_id, node_id)`` or
+            ``(state_id, node_id, name)``, or dict of the form
+            ``{state_id: node_id}``.
         """
         # Gate on the mapping protocol instead of catching AttributeError
         # around the loop: an AttributeError raised mid-iteration inside the

--- a/interfaces/python/src/infomap/_swig.py
+++ b/interfaces/python/src/infomap/_swig.py
@@ -3135,8 +3135,8 @@ class InfomapWrapper(InfomapBase):
     def addPhysicalNode(self, *args):
         return _infomap.InfomapWrapper_addPhysicalNode(self, *args)
 
-    def addStateNode(self, id, physId):
-        return _infomap.InfomapWrapper_addStateNode(self, id, physId)
+    def addStateNode(self, *args):
+        return _infomap.InfomapWrapper_addStateNode(self, *args)
 
     def addLink(self, *args):
         return _infomap.InfomapWrapper_addLink(self, *args)

--- a/interfaces/python/src/infomap/io/igraph.py
+++ b/interfaces/python/src/infomap/io/igraph.py
@@ -213,7 +213,8 @@ def add_igraph_graph(
             )
     elif is_state_network:
         for vertex_id in vertices:
-            infomap.add_state_node(vertex_id, phys[vertex_id])
+            name = names[vertex_id] if names is not None else None
+            infomap.add_state_node(vertex_id, phys[vertex_id], name=name)
     else:
         for vertex_id in vertices:
             name = names[vertex_id] if names is not None else None

--- a/interfaces/python/src/infomap/io/networkx.py
+++ b/interfaces/python/src/infomap/io/networkx.py
@@ -326,9 +326,12 @@ def add_networkx_graph(
                     1.0,
                 )
         else:
-            for state_label in nodes:
+            for state_label, state_name in g.nodes.data("name"):
+                node_name = state_label if is_string_id else state_name
                 infomap.add_state_node(
-                    node_map[state_label], phys_map[node_ids[state_label]]
+                    node_map[state_label],
+                    phys_map[node_ids[state_label]],
+                    name=node_name,
                 )
     else:
         for node, name in g.nodes.data("name"):

--- a/interfaces/python/src/infomap/network.py
+++ b/interfaces/python/src/infomap/network.py
@@ -546,7 +546,7 @@ class Network(_NetworkWritersMixin):
                     self.add_node(*node)
         return self
 
-    def add_state_node(self, state_id: int, node_id: int) -> Network:
+    def add_state_node(self, state_id: int, node_id: int, name: str | None = None) -> Network:
         """Add a state node.
 
         Parameters
@@ -554,8 +554,12 @@ class Network(_NetworkWritersMixin):
         state_id : int
         node_id : int
             Id of the physical node the state node should be added to.
+        name : str, optional
         """
-        self._core.addStateNode(state_id, node_id)
+        if name:
+            self._core.addStateNode(state_id, node_id, name)
+        else:
+            self._core.addStateNode(state_id, node_id)
         return self
 
     def add_state_nodes(self, state_nodes: Any) -> Network:
@@ -564,8 +568,9 @@ class Network(_NetworkWritersMixin):
         Parameters
         ----------
         state_nodes : iterable of tuples or dict of int: int
-            Iterable of tuples of the form ``(state_id, node_id)``
-            or dict of the form ``{state_id: node_id}``.
+            Iterable of tuples of the form ``(state_id, node_id)`` or
+            ``(state_id, node_id, name)``, or dict of the form
+            ``{state_id: node_id}``.
         """
         # Gate on the mapping protocol instead of catching AttributeError
         # around the loop: an AttributeError raised mid-iteration inside the

--- a/src/Infomap.h
+++ b/src/Infomap.h
@@ -115,6 +115,7 @@ public:
 
   void addPhysicalNode(unsigned int id, const std::string& name = "") { m_network.addPhysicalNode(id, name); }
   void addStateNode(unsigned int id, unsigned int physId) { m_network.addStateNode(id, physId); }
+  void addStateNode(unsigned int id, unsigned int physId, std::string name) { m_network.addStateNode(id, physId, std::move(name)); }
 
   void addLink(unsigned int sourceId, unsigned int targetId, double weight = 1.0) { m_network.addLink(sourceId, targetId, weight); }
   void addLink(unsigned int sourceId, unsigned int targetId, unsigned long weight) { m_network.addLink(sourceId, targetId, weight); }

--- a/src/core/StateNetwork.cpp
+++ b/src/core/StateNetwork.cpp
@@ -39,6 +39,12 @@ std::pair<StateNetwork::NodeMap::iterator, bool> StateNetwork::addStateNode(unsi
   return addStateNode(StateNode(id, physId));
 }
 
+std::pair<StateNetwork::NodeMap::iterator, bool> StateNetwork::addStateNode(unsigned int id, unsigned int physId, std::string name)
+{
+  m_higherOrderInputMethodCalled = true;
+  return addStateNode(StateNode(id, physId, std::move(name)));
+}
+
 std::pair<StateNetwork::NodeMap::iterator, bool> StateNetwork::addNode(unsigned int id)
 {
   return addStateNode(StateNode(id));

--- a/src/core/StateNetwork.h
+++ b/src/core/StateNetwork.h
@@ -161,6 +161,7 @@ public:
   // Mutators
   std::pair<NodeMap::iterator, bool> addStateNode(const StateNode& node);
   std::pair<NodeMap::iterator, bool> addStateNode(unsigned int id, unsigned int physId);
+  std::pair<NodeMap::iterator, bool> addStateNode(unsigned int id, unsigned int physId, std::string name);
   std::pair<NodeMap::iterator, bool> addNode(unsigned int id);
   std::pair<NodeMap::iterator, bool> addNode(unsigned int id, std::string name);
   std::pair<NodeMap::iterator, bool> addNode(unsigned int id, double weight);


### PR DESCRIPTION
Fixes mapequation/infomap#800.

## Summary
- `StateNode::name` already existed (populated when reading a `*States "name"` file section, readable via `getStateNames()`/`getStateName()`), but there was no way to set a state node's name programmatically, and it wasn't reachable from `InfomapWrapper` or the Python/R bindings.
- This PR adds `StateNetwork::addStateNode(id, physId, name)` to close that gap, mirroring the existing `addNode`/`addPhysicalNode` named-overload idiom, and wires it through `InfomapWrapper` and the Python/R bindings.
- Along the way, fixes the networkx/igraph importers, which were silently dropping per-state names when building a state network — they forwarded names for physical nodes but never for the state nodes themselves.

## Changes
- Add `StateNetwork::addStateNode(id, physId, name)` (`src/core/StateNetwork.h`/`.cpp`) and mirror it into `InfomapWrapper::addStateNode` (`src/Infomap.h`).
- Add `name: str | None = None` to `add_state_node` on both `Network` and the `Infomap` facade (Python); calls the 2-arg core overload when unset, so unnamed state networks incur no extra `std::string` construction.
- Forward per-state names in the networkx and igraph importers, matching how physical node names are already derived (the node label itself for string ids, a `"name"` attribute otherwise).
- Mirror the same optional `name` in R's `add_state_node`/`add_state_nodes`, and forward igraph vertex names in the state-network import branches — without reusing the numeric-id fallback used for physical names, since state names are optional metadata (an absent attribute must leave them unset, not synthesize `"1"`, `"2"`, ...).

## Follow-up
The multilayer networkx/igraph import paths (`add_multilayer_node`) are a separate method without name support, so multilayer state names are still dropped — filed as mapequation/infomap#798.

## Test plan
- [x] `make build-native` — compiles clean
- [x] `make test-python-swig-freshness test-r-swig-freshness` — tracked SWIG outputs fresh
- [x] `./infomap_cpp_network_tests --gtest_filter="*State*"` — 54 cases pass
- [x] Python: full `test/python` suite — 738 passed, 2 pre-existing skips
- [x] R: full `testthat` suite (added 4 new tests covering direct API + igraph import) — all pass