### PR TITLE
docs(python): tidy residual review-campaign findings before 2.15/3.0

### DIFF
--- a/interfaces/python/source/flow-models/memory-and-state.md
+++ b/interfaces/python/source/flow-models/memory-and-state.md
@@ -299,7 +299,7 @@ a state network are:
 | `add_state_node(state_id, node_id)` | {meth}`infomap.Network.add_state_node` | Declare one state node (a context) on a physical node |
 | `add_state_nodes(state_nodes)` | {meth}`infomap.Network.add_state_nodes` | Declare many state nodes at once |
 | `directed` | {func}`infomap.run` | Follow link direction; a bare `Network` defaults to undirected flow, unlike the `DiGraph` route, which enables it automatically |
-| `states=True` | {meth}`infomap.Result.modules`, {meth}`infomap.Result.nodes`, {meth}`infomap.Result.to_dataframe` | Return state-node assignments. On a higher-order network `modules(states=False)` raises (a physical node can belong to several modules, so its module id is ambiguous); `nodes`/`to_dataframe` with `states=False` instead return physical nodes and warn that `node_id` is not unique |
+| `states=True` | {meth}`infomap.Result.modules`, {meth}`infomap.Result.nodes`, {meth}`infomap.Result.to_dataframe` | Return state-node assignments. On a higher-order network `modules(states=False)` raises (a physical node can belong to several modules, so its module id is ambiguous); `nodes`/`to_dataframe` with `states=False` instead return physical nodes, whose `node_id` is then not unique |
 
 ## API pointers
 

--- a/interfaces/python/source/working-with-infomap/inputs.md
+++ b/interfaces/python/source/working-with-infomap/inputs.md
@@ -81,9 +81,6 @@ argument and directedness therefore differ by source:
 | SciPy sparse | `weighted` (bool) | `directed=` (default `False`) |
 | `(2, E)` edge index | `edge_weight` (array) | `directed=` (default `True`) |
 
-SciPy and edge-index inputs default differently (undirected vs directed), so
-set ``directed=`` explicitly on them when direction matters.
-
 ## NetworkX
 
 ```{code-cell} python

--- a/interfaces/python/source/working-with-infomap/visualizing-and-exporting.md
+++ b/interfaces/python/source/working-with-infomap/visualizing-and-exporting.md
@@ -14,7 +14,7 @@ kernelspec:
 
 ```{admonition} At a glance
 :class: tip
-This chapter covers the docs visualisation helper, the in-memory
+The docs visualisation helper, the in-memory
 graph export (`to_networkx` / `to_igraph` for GraphML and, via NetworkX, GEXF),
 and the native `.tree` / `.clu` formats written straight off the
 {class}`~infomap.Result`.
@@ -151,9 +151,7 @@ come back as numbers when the file is read — Gephi's numeric colour scales and
 sorting work directly.
 
 Because the graph is rebuilt from the result, your original graph's node
-attributes are *not* carried over. To keep them, annotate your own graph in
-place with {func}`infomap.find_communities` (see below) or
-{func}`infomap.io.export.annotate_networkx_graph`.
+attributes are *not* carried over.
 
 Open the GraphML file in Gephi, select **Appearance → Nodes → Partition**, and
 choose `infomap_module` to colour the graph by community.

--- a/scripts/generate_binding_options.py
+++ b/scripts/generate_binding_options.py
@@ -463,7 +463,7 @@ def _python_engine_default_doc(param) -> str:
     Options whose Python default is a ``None`` sentinel render no flag unless
     set, so the reference shows ``= None`` and hides the concrete value the
     engine falls back to (e.g. ``clu_level`` -> 1, ``node_limit`` -> 0 meaning
-    "no limit"). Surface the catalog default so an agent reading the parameter
+    "no limit"). Surface the catalog default so a reader of the parameter
     reference isn't left guessing. Restricted to numeric defaults to avoid
     noise on choice/string options.
     """
@@ -497,7 +497,7 @@ def _options_doc_policy_note(policy: dict) -> str:
     """A short note for the Options docstring flagging fields that are not a
     first-class engine option on the Python library surface.
 
-    An agent steered to ``inspect.getdoc(infomap.Options)`` as the parameter
+    Someone reading ``inspect.getdoc(infomap.Options)`` as the parameter
     reference would otherwise read args-only / removed / alias fields (``tree``,
     ``silent``, ``out_name``, ``threads`` ...) as usable library knobs. Reuse the
     policy's own replacement guidance so the note stays in step with the facade
@@ -510,7 +510,7 @@ def _options_doc_policy_note(policy: dict) -> str:
     if action == "args-only" and (policy or {}).get("inertWithoutOutputDir"):
         # The standard inert output flags (tree, clu, output, ...) all share
         # one long replacement string; repeating it per field bloats the
-        # reference an agent is told to read. State the rationale once in the
+        # reference users are pointed to. State the rationale once in the
         # class docstring and keep the per-field note to a short pointer.
         # ``hide_bipartite_nodes`` is args-only but writer-effective (no
         # inertWithoutOutputDir), so it falls through and keeps its own note.
@@ -1253,7 +1253,7 @@ _FACADE_OPTIONS_DOC = (
 # A kept keyword is permanent -- only its entry point relocates to Options in
 # 3.0 -- so its docstring uses ``.. versionchanged::`` rather than
 # ``.. deprecated::``. Marking a still-supported tuning knob "deprecated" makes
-# agents and linters (which read the directive token literally) steer users
+# tools and linters (which read the directive token literally) steer users
 # away from a valid option.
 _ADVANCED_TIER_KEEP_NOTE = "Pass it via `Options`; moves off this signature in 3.0."
 

--- a/scripts/render_parameter_policy.py
+++ b/scripts/render_parameter_policy.py
@@ -89,9 +89,9 @@ def render(catalog: ParameterCatalog) -> str:
             if decision["action"] != "keep":
                 cell = f"**{cell}**"
                 # Surface the per-language binding name when it differs from the
-                # CLI flag (e.g. --verbose -> Python/R verbosity_level), so an
-                # agent searching the policy by the name it types in code finds
-                # the entry instead of only the CLI spelling.
+                # CLI flag (e.g. --verbose -> Python/R verbosity_level), so
+                # someone searching the policy by the name they type in code
+                # finds the entry instead of only the CLI spelling.
                 rename = (
                     catalog.overrides.get("names", {}).get(flag, {}).get(surface)
                 )

--- a/skills/infomap/references/notebooks.md
+++ b/skills/infomap/references/notebooks.md
@@ -20,7 +20,7 @@ Use notebooks when the user wants to:
 
 Use scripts instead when the user wants batch runs, CI, parameter sweeps, or stable pipeline execution.
 
-Notebook runtimes can grow quickly when examples download data, build layouts, compare methods, or run many trials. Do not start Docker, Jupyter, full notebook execution, parameter sweeps, or long comparison notebooks unless the user asks. For validation, prefer running one small extracted cell or a reduced toy example first.
+Notebook runtimes can grow quickly when examples download data, build layouts, compare methods, or run many trials.
 
 ## Notebook topics
 


### PR DESCRIPTION
## Summary

A small follow-up pass on the Python API review campaign, tidying three residual findings ahead of the 2.15/3.0 transition:

- **Factual fix.** The memory-and-state options table claimed `nodes`/`to_dataframe` with `states=False` "return physical nodes and warn that `node_id` is not unique". No such warning is emitted — the physical nodes come back with a repeated `node_id`, silently. Reworded to the real behaviour.
- **Doc trims.** Removed residual duplicated notes and a filler lead-in the earlier de-duplication pass hadn't reached: a surviving "This chapter covers" opener and a `to_networkx` caveat already carried by the Pitfall (`visualizing-and-exporting.md`), a directedness note sandwiched between the table and the Pitfall (`inputs.md`), and a twice-stated Docker/Jupyter instruction (`notebooks.md` skill reference).
- **De-agent the generators.** `6b215cb` dropped "agent" framing from the published docs and package source but scoped itself to `interfaces/python` and left the option/policy generators. Reworded the remaining comments/docstrings in `generate_binding_options.py` and `render_parameter_policy.py` to neutral reader terms.

## Verification

- Built the extension and ran the Python suite: **669 passed, 55 skipped** (baseline and after the changes).
- Confirmed the corrected `states=False` behaviour against the built extension (physical nodes with a repeated `node_id`, no warning recorded).
- The generator edits touch comments/docstrings only — the generated `_options.py` / policy table are byte-identical.
- Spot-checked the campaign more broadly: deprecation version markers are 100% consistent (`.. deprecated:: 2.15` / removal in 3.0), the warning walk-backs (inert-output, silent-engine, directed/flow_model) settle correctly, and the example scripts run clean with accurate printed output.

## Notes

- Deliberately did **not** flip the legacy surface's `PendingDeprecationWarning` → `DeprecationWarning`. That silent-by-default soft landing is intentional and documented (`api/deprecations.rst`, `RELEASING.md`) and switching it would surface a deprecation warning for every existing caller the moment 2.15 lands.
- Left the "agent" framing that `6b215cb` kept on purpose: the skill under `skills/`, the `AGENTS.md` links in `README.rst`, and the test-internal names/docstrings.
- Minor FYI (no change made): `run_graphrag_communities(silent=)` emits a `DeprecationWarning` while the advanced-tier `silent=` uses `PendingDeprecationWarning`. Defensible — the graphrag `silent=` is effectively a no-op now — but it is the only remaining category asymmetry for `silent` if strict uniformity is wanted.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LskEbFsq1o955miG5qAp6Z)_