### PR TITLE
build: modernize CI/packaging toolchain and prune build-config rot

### DIFF
--- a/.github/actions/setup-ccache/action.yml
+++ b/.github/actions/setup-ccache/action.yml
@@ -31,7 +31,7 @@ runs:
 
     - name: Cache ccache directory
       if: runner.os != 'Windows'
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: ${{ github.workspace }}/.ccache
         key: ccache-${{ inputs.key-prefix }}-${{ github.sha }}

--- a/.github/actions/setup-js-build/action.yml
+++ b/.github/actions/setup-js-build/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Set up Node.js
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
-        node-version: 20
+        node-version: 24
         cache: npm
 
     - name: Set up Emscripten

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,15 @@ updates:
     labels:
       - dependencies
     open-pull-requests-limit: 5
+
+  - package-ecosystem: docker
+    directory: /docker
+    schedule:
+      interval: monthly
+    labels:
+      - dependencies
+    open-pull-requests-limit: 5
+    groups:
+      docker:
+        patterns:
+          - "*"

--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -44,6 +44,10 @@ env:
   # in this workflow. Keep in sync with the `release` extra in pyproject.toml
   # (bumped there by dependabot).
   CIBW_VERSION: "4.1.0"
+  # Single source of truth for the macOS deployment target used by the
+  # cibuildwheel jobs below. Keep in sync with mk/ci.mk (ci-export-github-env),
+  # which sets the same value for the make-based macOS builds.
+  MACOS_DEPLOYMENT_TARGET: "15.0"
 
 jobs:
   swig-freshness:
@@ -405,7 +409,7 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: >-
             CXX=/usr/bin/clang++
             FEATURES="${{ inputs.features }}"
-            MACOSX_DEPLOYMENT_TARGET=15.0
+            MACOSX_DEPLOYMENT_TARGET=${{ env.MACOS_DEPLOYMENT_TARGET }}
             CPPFLAGS="-I$(brew --prefix libomp)/include"
             LDFLAGS="-L$(brew --prefix libomp)/lib"
 
@@ -474,7 +478,7 @@ jobs:
             python -c "from infomap import Infomap; print(Infomap(silent=True).num_top_modules)"
           CIBW_ENVIRONMENT_MACOS: >-
             CXX=/usr/bin/clang++
-            MACOSX_DEPLOYMENT_TARGET=15.0
+            MACOSX_DEPLOYMENT_TARGET=${{ env.MACOS_DEPLOYMENT_TARGET }}
             CPPFLAGS="-I$(brew --prefix libomp)/include"
             LDFLAGS="-L$(brew --prefix libomp)/lib"
 

--- a/.github/workflows/deploy-redirect.yml
+++ b/.github/workflows/deploy-redirect.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   deploy:
     name: Deploy redirect
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     environment:
       name: github-pages

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ Baseline tools:
 
 - Python 3.11 or newer; use `python3` on macOS when `python` is unavailable
 - R 4.0 or newer for the R package; CI exercises both `release` and `oldrel`
-- Node.js 20 for the JavaScript worker package
+- Node.js 24 for the JavaScript worker package
 - `gcc` or `clang` with a working C++ toolchain
 - `swig` 4.4.1 only for refreshing tracked Python or R wrapper outputs
 - `em++` from Emscripten 5.0.5 for JavaScript worker builds

--- a/docker/notebook.Dockerfile
+++ b/docker/notebook.Dockerfile
@@ -1,4 +1,6 @@
-ARG BASE_CONTAINER=jupyter/scipy-notebook:python-3.11
+# Jupyter Docker Stacks moved from Docker Hub (jupyter/*) to Quay
+# (quay.io/jupyter/*) in 2023; the Docker Hub images are no longer updated.
+ARG BASE_CONTAINER=quay.io/jupyter/scipy-notebook:python-3.11
 FROM $BASE_CONTAINER
 
 USER root

--- a/mk/ci.mk
+++ b/mk/ci.mk
@@ -1,5 +1,8 @@
 .PHONY: ci-export-github-env
 
+# The MACOSX_DEPLOYMENT_TARGET below is the make-based macOS build's copy of the
+# value also set in .github/workflows/_python-package.yml (env.MACOS_DEPLOYMENT_TARGET,
+# consumed by the cibuildwheel jobs). Keep the two in sync when bumping.
 ci-export-github-env:
 	@if [ "$(UNAME_S)" = "Darwin" ]; then \
 		if [ -n "$(BUILD_CONFIG_LIBOMP_PREFIX)" ]; then \

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -76,7 +76,6 @@ endif
 
 HEADERS := $(shell find src -name "*.h")
 SOURCES := $(shell find src -name "*.cpp")
-SWIG_FILES := $(shell find interfaces/swig -name "*.i")
 MK_FILES := $(wildcard mk/*.mk)
 BINDING_OPTIONS_SCRIPT := scripts/generate_binding_options.py
 BUILD_CONFIG_SCRIPT := scripts/build_config.py
@@ -155,6 +154,8 @@ help:
 		"  test-python-unit      Run pytest for test/python." \
 		"  test-python-doctest   Run Python doctests and ruff checks for the installed package." \
 		"  test-python-examples  Run the Python example smoke tests." \
+		"  test-python-typecheck  Type-check the whole Python package with pyright." \
+		"  test-python-typecheck-core  Type-check the core Python surface (pre-push / quick-mode scope)." \
 		"  test-python-notebooks-smoke  Run PR-safe tutorial notebook smoke tests with nbmake." \
 		"  test-python-notebooks-full   Run all CI-maintained tutorial notebooks with nbmake." \
 		"  test-python-swig-freshness  Verify tracked SWIG outputs are up to date." \
@@ -178,11 +179,15 @@ help:
 		"  format-native-check   Verify C++ sources are clang-format clean." \
 		"  format-r              Rewrite R sources with Air." \
 		"  format-r-check        Verify R sources are Air-format clean." \
+		"  format-python         Rewrite Python sources with Ruff." \
+		"  format-js             Rewrite JS/TS sources with Biome." \
 		"  tidy-native           Run clang-tidy over C++ source files." \
+		"  print-parameter-policy  Render the parameter-policy surface matrix as Markdown." \
 		"  dev-cpp-check         Run the fast C++ developer feedback suite." \
 		"  dev-bootstrap         Install Python dev dependencies, run npm ci, and install git hooks." \
 		"  hooks                 Install the pre-commit git hook (lint/format on commit)." \
 		"  dev-python-install    Install the built Python package in editable mode." \
+		"  dev-r-install         Install the staged R package into the user library." \
 		"  dev-python-notebooks-install Install notebook execution dependencies." \
 		"  clean                 Remove native, Python, and JS build outputs." \
 		"  clean-native          Remove native build artifacts, libraries, and CMake build dirs." \
@@ -192,7 +197,9 @@ help:
 		"" \
 		"Docs / Release" \
 		"  build-docs            Build the Python docs site into docs/ after installing the local package." \
+		"  check-docs-links      Verify external documentation links resolve (linkcheck; hits the network)." \
 		"  release-python-dist   Build local sdist and wheel artifacts from the repo root." \
+		"  release-r-dist        Build the R source tarball and platform binary into dist/R/." \
 		"  release-python-testpypi  Publish the built distributions to TestPyPI." \
 		"  release-python-pypi      Publish the built distributions to PyPI." \
 		"" \

--- a/mk/js.mk
+++ b/mk/js.mk
@@ -7,7 +7,11 @@ JS_WORKER_TARGET := build/js/$(WORKER_FILENAME)
 JS_NODE_TARGET := build/js/infomap.node.mjs
 JS_CLI_TARGET := build/js/infomap.cli.mjs
 JS_NODE_TEST := interfaces/js/test/node/test-node.mjs
-EMXX_NODE_FLAGS := -std=c++17 -O3 $(INFOMAP_VENDOR_CPPFLAGS) -s SINGLE_FILE=1 -s ALLOW_MEMORY_GROWTH=1 -s DISABLE_EXCEPTION_CATCHING=0 -s ENVIRONMENT=node -s MODULARIZE=1 -s EXPORT_ES6=1 -s INVOKE_RUN=0 -s EXIT_RUNTIME=0
+# -std tracks build_config.py via BUILD_CONFIG_CXX_STANDARD (exported by
+# common.mk), so the wasm builds stay on the same C++ standard as the native
+# and Python builds. -O3 is intentionally fixed: the published JS artifacts are
+# always release-optimized regardless of MODE.
+EMXX_NODE_FLAGS := -std=$(BUILD_CONFIG_CXX_STANDARD) -O3 $(INFOMAP_VENDOR_CPPFLAGS) -s SINGLE_FILE=1 -s ALLOW_MEMORY_GROWTH=1 -s DISABLE_EXCEPTION_CATCHING=0 -s ENVIRONMENT=node -s MODULARIZE=1 -s EXPORT_ES6=1 -s INVOKE_RUN=0 -s EXIT_RUNTIME=0
 PRE_WORKER_MODULE := interfaces/js/pre-worker-module.js
 JS_METADATA_DIR := interfaces/js/generated
 JS_PARAMETERS_JSON := $(JS_METADATA_DIR)/parameters.json
@@ -46,7 +50,7 @@ $(JS_WORKER_OUTPUT_FORMATS): $(JS_OUTPUT_FORMATS_JSON) interfaces/js/scripts/wri
 $(JS_WORKER_TARGET): $(SOURCES) $(HEADERS) $(PRE_WORKER_MODULES) $(MK_FILES) Makefile
 	@echo "Compiling Infomap to run in a worker in the browser..."
 	@mkdir -p $(dir $@)
-	$(EMXX) -std=c++17 -O3 $(INFOMAP_VENDOR_CPPFLAGS) -s SINGLE_FILE=1 -s ALLOW_MEMORY_GROWTH=1 -s DISABLE_EXCEPTION_CATCHING=0 -s ENVIRONMENT=worker $(foreach file,$(PRE_WORKER_MODULES),--pre-js $(file)) -o $@ $(SOURCES)
+	$(EMXX) -std=$(BUILD_CONFIG_CXX_STANDARD) -O3 $(INFOMAP_VENDOR_CPPFLAGS) -s SINGLE_FILE=1 -s ALLOW_MEMORY_GROWTH=1 -s DISABLE_EXCEPTION_CATCHING=0 -s ENVIRONMENT=worker $(foreach file,$(PRE_WORKER_MODULES),--pre-js $(file)) -o $@ $(SOURCES)
 
 test-js: build-js
 	$(RM) -r $(NPM_UNPACK_DIR) $(NPM_STAGE_DIR)/*.tgz $(NPM_PACK_JSON)

--- a/mk/r.mk
+++ b/mk/r.mk
@@ -10,7 +10,7 @@ R_TARBALL := $(R_DIST_DIR)/infomap_$(R_VERSION).tar.gz
 
 R_STAGE_SCRIPT := scripts/stage_r_package.py
 R_SWIG_SCRIPT := scripts/generate_r_swig.py
-R_SOURCE_FILES := $(filter-out $(R_SKELETON_DIR)/R/options.R $(R_SKELETON_DIR)/R/swig_bindings.R,$(wildcard $(R_SKELETON_DIR)/R/*.R))
+R_SOURCE_FILES := $(filter-out $(R_SKELETON_DIR)/R/options.R,$(wildcard $(R_SKELETON_DIR)/R/*.R))
 R_TEST_FILES := $(wildcard $(R_SKELETON_DIR)/tests/*.R) $(wildcard $(R_SKELETON_DIR)/tests/testthat/*.R)
 R_EXAMPLE_FILES := $(wildcard examples/R/*.R)
 R_FORMAT_TARGETS := \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
-  "setuptools>=68",
+  # >=77 for PEP 639 SPDX license support (the `license` expression below).
+  "setuptools>=77",
   "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/scripts/build_config.py
+++ b/scripts/build_config.py
@@ -9,6 +9,12 @@ import sys
 from pathlib import Path
 
 
+# Single source of truth for the C++ language standard across every build
+# surface: the native/Python flag lists below embed it, and the JS/Emscripten
+# build reads it back via the `field` / `make-export` interfaces. Bump here only.
+CXX_STANDARD = "c++17"
+
+
 FEATURE_REGISTRY = {
     "simd-log": {
         "define": "INFOMAP_USE_SIMD_LOG",
@@ -146,9 +152,9 @@ def _base_compile_flags(compiler_family):
         # otherwise), and it makes the Unicode pretty-output literals (•, →, ╰─)
         # encode correctly. mingw-gcc (R/Windows) and clang/Emscripten (JS)
         # already use a UTF-8 source charset, so this is MSVC-only.
-        return ["/std:c++17", "/utf-8"]
+        return [f"/std:{CXX_STANDARD}", "/utf-8"]
 
-    flags = ["-Wall", "-Wextra", "-pedantic", "-Wnon-virtual-dtor", "-std=c++17"]
+    flags = ["-Wall", "-Wextra", "-pedantic", "-Wnon-virtual-dtor", f"-std={CXX_STANDARD}"]
     if compiler_family == "clang":
         flags.append("-Wshadow")
     elif compiler_family == "gnu":
@@ -338,6 +344,7 @@ def resolve_build_config(
 
     return {
         "mode": mode,
+        "cxx_standard": CXX_STANDARD,
         "openmp": bool(openmp),
         # Report native_arch as effective only when flags were actually emitted —
         # i.e. release mode AND a compiler family that we know how to tune
@@ -372,6 +379,7 @@ def _field_value(config, field):
 # a single invocation instead of one process per field.
 MAKE_EXPORT_FIELDS = (
     ("BUILD_CONFIG_MODE", "mode"),
+    ("BUILD_CONFIG_CXX_STANDARD", "cxx_standard"),
     ("BUILD_CONFIG_OPENMP", "openmp"),
     ("BUILD_CONFIG_ENABLED_FEATURES", "enabled_features"),
     ("BUILD_CONFIG_PLATFORM", "platform"),
@@ -403,6 +411,7 @@ def main():
         "--field",
         choices=[
             "mode",
+            "cxx_standard",
             "openmp",
             "native_arch",
             "enabled_features",


### PR DESCRIPTION
## Summary

Follow-up to a build-system health review. No runtime/`src/` changes — this touches CI, packaging, Docker, and the Make/build-config layer only. Two commits:

- **`ci:` modernize workflows, Docker base, and packaging pins**
  - `setup-js-build`: Node 20 (EOL 2026-04-30) → **Node 24** (matches the npm publish jobs).
  - notebook image: deprecated Docker Hub `jupyter/scipy-notebook` → **`quay.io/jupyter/scipy-notebook`** (Docker Hub `jupyter/*` unmaintained since the 2023 move to Quay).
  - `pyproject` build-system: setuptools floor **68 → 77** so the PEP 639 SPDX `license` expression is actually supported by the declared minimum.
  - dependabot: add the **`docker`** ecosystem (`/docker`) so the four Dockerfile base images are monitored.
  - align `actions/cache` on **v6** in `setup-ccache` (python/r workflows already use v6); pin `deploy-redirect` to **`ubuntu-24.04`** (was the only non-pinned runner).

- **`build:` de-duplicate C++ standard and prune dead make config**
  - `build_config.py` is now the single source of truth for the C++ standard (`CXX_STANDARD`); `mk/js.mk` reads it via `BUILD_CONFIG_CXX_STANDARD` instead of hardcoding `-std=c++17` in the Emscripten node/worker builds.
  - `MACOSX_DEPLOYMENT_TARGET` de-duplicated via a workflow-level env var, with a cross-reference in `mk/ci.mk`.
  - remove dead `SWIG_FILES` var and the vestigial `swig_bindings.R` entry in `mk/r.mk`'s `filter-out`.
  - `make help` now lists previously-omitted user-facing targets (`format-python`, `format-js`, `dev-r-install`, `release-r-dist`, `test-python-typecheck[-core]`, `check-docs-links`, `print-parameter-policy`).

## Verification

- Full `make build-native` compiles + links; `./Infomap --version` → `2.15.0 compiled with OpenMP`.
- `make -n build-node` / `build-js` show `-std=c++17` expanded from `build_config.py` — single-sourcing proven end-to-end.
- `make help` exits 0 with every newly-listed target present; all 8 documented targets resolve (no phantom targets).
- `pyproject.toml` + all changed workflow/action YAML parse; `build_config.py` byte-compiles; `field cxx_standard` → `c++17`.
- Not run: full CI matrix, macOS cibuildwheel build, wasm/emsdk build, R and docs suites.

## Notes

- The floating `r-lib/*` and `actions/*-pages` actions were left unpinned: SHA-pinning needs verifiable commit hashes, and dependabot bumps them anyway.
- Notebook image kept on the `python-3.11` tag and existing pip shims (`backports.tarfile`, `importlib_metadata`) for minimal behavior change; these can likely be bumped/dropped separately once an image build confirms the current Quay base no longer needs them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3JHFjeKzDynUtJLoQijqd)_