### PR TITLE
fix(python): accept os.PathLike consistently across file-reading entry points

### DIFF
--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import warnings
 from collections import namedtuple
@@ -1062,12 +1063,14 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
     # Input
     # ----------------------------------------
 
-    def read_file(self, filename: str, accumulate: bool = True) -> None:
+    def read_file(
+        self, filename: str | os.PathLike[str], accumulate: bool = True
+    ) -> None:
         """Read network data from file.
 
         Parameters
         ----------
-        filename : str
+        filename : str or os.PathLike
         accumulate : bool, optional
             If the network data should be accumulated to already added
             nodes and links. Default ``True``.
@@ -1078,7 +1081,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             If the file cannot be opened or its content cannot be parsed.
         """
         with _engine_log_routing(), _translate_engine_errors(NetworkParseError):
-            self._core.readInputData(filename, accumulate)
+            self._core.readInputData(os.fsdecode(filename), accumulate)
 
     def add_node(
         self,

--- a/interfaces/python/src/infomap/_run.py
+++ b/interfaces/python/src/infomap/_run.py
@@ -10,9 +10,9 @@ Dispatch by input type:
   ``Network`` owns its ``Core``; we render the options, drive the engine, and
   stamp a ``Result`` bound to the ``Network``).
 - ``networkx.Graph`` / ``igraph.Graph`` / SciPy sparse matrix / a ``(2, E)``
-  edge index (ndarray or tensor) / a ``str``/``Path`` network file / an iterable
-  of ``(u, v[, w])`` links -> build an :class:`infomap.Infomap`, load via the
-  matching adapter, then ``im.run()``.
+  edge index (ndarray or tensor) / a ``str``/``os.PathLike`` network file / an
+  iterable of ``(u, v[, w])`` links -> build an :class:`infomap.Infomap`, load
+  via the matching adapter, then ``im.run()``.
 
 The options are passed as the keyword ``options`` (an :class:`Options`
 instance or mapping) and/or as keyword ``**overrides``; overrides win.
@@ -20,9 +20,9 @@ instance or mapping) and/or as keyword ``**overrides``; overrides win.
 
 from __future__ import annotations
 
+import os
 import warnings
 from collections.abc import Iterable, Mapping
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -441,7 +441,7 @@ def run(
     Parameters
     ----------
     input : Network, Infomap, networkx.Graph, igraph.Graph, scipy sparse matrix, \
-            (2, E) array/tensor, str or Path, or iterable of links
+            (2, E) array/tensor, str or os.PathLike, or iterable of links
         The network to partition. See the module docstring for the dispatch
         table.
     options : Options, mapping, or None, optional
@@ -574,10 +574,10 @@ def run(
         )
 
     # 2. A network file path.
-    if isinstance(input, (str, Path)):
+    if isinstance(input, (str, os.PathLike)):
         _reject_adapter_kwargs("file", user_keys)
         im = Infomap(args=args, **resolved)
-        im.read_file(str(input))
+        im.read_file(input)
         return im.run(initial_partition=initial_partition)
 
     # 3. A networkx graph.

--- a/interfaces/python/src/infomap/network.py
+++ b/interfaces/python/src/infomap/network.py
@@ -151,7 +151,7 @@ class Network(_NetworkWritersMixin):
             Accumulate onto already added nodes and links. Default ``True``.
         """
         net = cls()
-        net.read_file(str(path), accumulate=accumulate)
+        net.read_file(path, accumulate=accumulate)
         return net
 
     @classmethod
@@ -469,12 +469,14 @@ class Network(_NetworkWritersMixin):
     # Input
     # ----------------------------------------
 
-    def read_file(self, filename: str, accumulate: bool = True) -> Network:
+    def read_file(
+        self, filename: str | os.PathLike[str], accumulate: bool = True
+    ) -> Network:
         """Read network data from file.
 
         Parameters
         ----------
-        filename : str
+        filename : str or os.PathLike
         accumulate : bool, optional
             If the network data should be accumulated to already added
             nodes and links. Default ``True``.
@@ -485,7 +487,7 @@ class Network(_NetworkWritersMixin):
             If the file cannot be opened or its content cannot be parsed.
         """
         with _engine_log_routing(), _translate_engine_errors(NetworkParseError):
-            self._core.readInputData(filename, accumulate)
+            self._core.readInputData(os.fsdecode(filename), accumulate)
         return self
 
     # ----------------------------------------

--- a/interfaces/python/src/infomap/tl/graphrag.py
+++ b/interfaces/python/src/infomap/tl/graphrag.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
@@ -70,7 +71,7 @@ def _import_parquet_stack():
 
 def _read_table(table_or_path):
     pd = _import_parquet_stack()
-    if isinstance(table_or_path, (str, Path)):
+    if isinstance(table_or_path, (str, os.PathLike)):
         return pd.read_parquet(table_or_path)
     return table_or_path
 
@@ -148,8 +149,8 @@ def _register_node(
 
 
 def read_graphrag(
-    entities: "str | Path | pandas.DataFrame",
-    relationships: "str | Path | pandas.DataFrame",
+    entities: "str | os.PathLike[str] | pandas.DataFrame",
+    relationships: "str | os.PathLike[str] | pandas.DataFrame",
     *,
     entity_id_col: str = "id",
     entity_title_col: str = "title",
@@ -168,9 +169,9 @@ def read_graphrag(
 
     Parameters
     ----------
-    entities : str, pathlib.Path, or pandas.DataFrame
+    entities : str, os.PathLike, or pandas.DataFrame
         Entity table, or a path to a Parquet file containing it.
-    relationships : str, pathlib.Path, or pandas.DataFrame
+    relationships : str, os.PathLike, or pandas.DataFrame
         Relationship table, or a path to a Parquet file containing it.
     entity_id_col : str, optional
         Entity table column with unique entity ids. Default ``"id"``.
@@ -603,7 +604,7 @@ def _build_tables(im, graph: GraphRAGGraph):
 
 
 def write_graphrag_communities(
-    im: Infomap | Result, *, graph: GraphRAGGraph, output: str | Path
+    im: Infomap | Result, *, graph: GraphRAGGraph, output: str | os.PathLike[str]
 ) -> "tuple[pandas.DataFrame, pandas.DataFrame]":
     """Write GraphRAG-compatible community tables from a finished run.
 
@@ -617,7 +618,7 @@ def write_graphrag_communities(
         and avoids reaching back into the stateful instance.
     graph : GraphRAGGraph
         The graph returned by :func:`read_graphrag` for the same network.
-    output : str or pathlib.Path
+    output : str or os.PathLike
         Output directory, or a ``.parquet`` path for the communities table
         (its parent directory is then used for the nodes table). Writes
         ``infomap_nodes.parquet`` and ``communities.parquet``.
@@ -647,8 +648,8 @@ def write_graphrag_communities(
 
 def run_graphrag_communities(
     *,
-    input_dir: str | Path,
-    output_dir: str | Path | None = None,
+    input_dir: str | os.PathLike[str],
+    output_dir: str | os.PathLike[str] | None = None,
     args: str | None = None,
     entities_name: str = "entities.parquet",
     relationships_name: str = "relationships.parquet",
@@ -671,9 +672,9 @@ def run_graphrag_communities(
 
     Parameters
     ----------
-    input_dir : str or pathlib.Path
+    input_dir : str or os.PathLike
         Directory containing the entity and relationship Parquet files.
-    output_dir : str or pathlib.Path, optional
+    output_dir : str or os.PathLike, optional
         Where to write ``infomap_nodes.parquet``, ``communities.parquet``,
         and the run summary ``infomap_run.json``. If ``None``, nothing is
         written and only the in-memory result is returned.

--- a/test/python/test_graphrag.py
+++ b/test/python/test_graphrag.py
@@ -87,6 +87,29 @@ def _add_graphrag_links(im, graph):
     im.add_links(np.column_stack(columns))
 
 
+class _FsPathOnly:
+    """A generic ``os.PathLike`` that is not a ``pathlib.Path``."""
+
+    def __init__(self, path):
+        self._path = path
+
+    def __fspath__(self):
+        return str(self._path)
+
+    def __str__(self):
+        return "<not-the-path>"
+
+
+def test_read_graphrag_accepts_generic_pathlike(tmp_path):
+    from infomap.graphrag import read_graphrag
+
+    entities_path, relationships_path = _write_graphrag_fixture(tmp_path)
+
+    graph = read_graphrag(_FsPathOnly(entities_path), _FsPathOnly(relationships_path))
+
+    assert graph.sources.tolist() == [1, 2, 3, 4, 5, 6, 3]
+
+
 def test_read_graphrag_factorizes_titles_from_entities_first(tmp_path):
     from infomap.graphrag import read_graphrag
 

--- a/test/python/test_run_functional.py
+++ b/test/python/test_run_functional.py
@@ -182,6 +182,59 @@ def test_run_file_matches_oo(example_network_path):
     assert result.codelength == pytest.approx(3.385830820341408, abs=1e-4)
 
 
+class _FsPathOnly:
+    """A generic ``os.PathLike`` that is not a ``pathlib.Path``.
+
+    ``__str__`` deliberately disagrees with ``__fspath__``: any consumer that
+    converts with ``str()`` instead of ``os.fspath()`` reads a bogus path.
+    """
+
+    def __init__(self, path):
+        self._path = path
+
+    def __fspath__(self):
+        return str(self._path)
+
+    def __str__(self):
+        return "<not-the-path>"
+
+
+def test_run_accepts_generic_pathlike(example_network_path):
+    path = example_network_path("ninetriangles.net")
+    settings = {"silent": True, "num_trials": 1, "seed": 123}
+
+    result = infomap.run(_FsPathOnly(path), **settings)
+    expected = infomap.run(path, **settings)
+    assert result.codelength == pytest.approx(expected.codelength)
+
+
+def test_infomap_read_file_accepts_pathlike(example_network_path):
+    path = example_network_path("ninetriangles.net")
+
+    im = Infomap(silent=True, num_trials=1, seed=123)
+    im.read_file(_FsPathOnly(path))
+    im.run()
+
+    expected = _oo_codelength(
+        lambda im: im.read_file(str(path)), silent=True, num_trials=1, seed=123
+    )
+    assert im.codelength == pytest.approx(expected)
+
+
+def test_network_read_file_accepts_pathlike(example_network_path):
+    path = example_network_path("ninetriangles.net")
+
+    net = Network().read_file(_FsPathOnly(path))
+    assert net.num_nodes == Network().read_file(str(path)).num_nodes
+
+
+def test_network_from_file_accepts_generic_pathlike(example_network_path):
+    path = example_network_path("ninetriangles.net")
+
+    net = Network.from_file(_FsPathOnly(path))
+    assert net.num_nodes == Network.from_file(str(path)).num_nodes
+
+
 def test_run_network_matches_oo():
     net = Network()
     net.add_links(_LINKS)


### PR DESCRIPTION
The path-accepting surface disagreed with itself:

| Entry point | Documented | Actually accepted |
|---|---|---|
| `infomap.run(path)` | str or Path | strict `isinstance(input, (str, Path))` |
| `Network.from_file` | str or os.PathLike | anything, but converted with `str()` |
| `Infomap.read_file` / `Network.read_file` | str | str only — a `Path` raised TypeError in the SWIG layer |
| `read_graphrag` / `_read_table` | str or pathlib.Path | strict `(str, Path)` — a generic PathLike fell through to the DataFrame branch (AttributeError) |

`str()` is also the wrong conversion for the documented `from_file` contract: `os.fspath()`/`os.fsdecode()` is the PathLike protocol, and a PathLike whose `__str__` differs from `__fspath__` read a bogus path.

## Change

Consolidate on **`str | os.PathLike`** everywhere. The two `read_file` methods convert with `os.fsdecode()` at the lowest common entry to the engine; `from_file` and the `run()` dispatch pass the value through; graphrag widens its `isinstance` to `os.PathLike`. Docstrings and type annotations updated to `str | os.PathLike[str]` throughout (matching `from_file`'s existing annotation style), including graphrag's `output`/`input_dir` which already handled PathLike via `Path(...)` but were annotated `str | Path`.

Not breaking — a pure widening. `fsdecode(Path) == str(Path)` and `str` passes through untouched, so every call that works today behaves identically; the previous TypeError/AttributeError cases now work. The only theoretical behavior shift: an object that both implements `__fspath__` and is an iterable of links would switch branches in the `run()` dispatch — that type does not occur in practice.

## Tests

Five new tests cover all entry points (`run`, both `read_file`s, `from_file`, `read_graphrag`) through a generic `os.PathLike` helper whose `__str__` deliberately disagrees with `__fspath__`, pinning the fspath contract rather than just the widening. All five failed before the fix (dispatch TypeError, SWIG TypeError, wrong-path read, DataFrame-branch AttributeError).

## Verification

- Rebased on current master; `read_file`'s new engine-error translation (`_engine_log_routing` + `_translate_engine_errors`) and `run()`'s `args=args` pass-through preserved in the conflict resolution.
- `test/python`: 743 passed after `make build-python` + `make dev-python-install`, ruff clean, pyright clean (pre-push hook).
- No wrapper/SWIG/packaging surface touched; pure Python package sources.
