### PR TITLE
fix(python): consolidate the file-path contract across all surfaces

### DIFF
--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -221,9 +221,9 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         no_self_links: bool = False,
         node_limit: int | None = None,
         matchable_multilayer_ids: int | None = None,
-        cluster_data: str | None = None,
+        cluster_data: str | os.PathLike[str] | None = None,
         assign_to_neighbouring_module: bool = False,
-        meta_data: str | None = None,
+        meta_data: str | os.PathLike[str] | None = None,
         meta_data_rate: float = 1.0,
         meta_data_unweighted: bool = False,
         no_infomap: bool = False,
@@ -238,12 +238,12 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         print_all_trials: bool = False,
         no_overwrite: bool = False,
         print_config_fingerprint: bool = False,
-        timing_json: str | None = None,
-        summary_json: str | None = None,
-        manifest_json: str | None = None,
+        timing_json: str | os.PathLike[str] | None = None,
+        summary_json: str | os.PathLike[str] | None = None,
+        manifest_json: str | os.PathLike[str] | None = None,
         memory_report: bool = False,
         trial_offset: int | None = None,
-        trial_results: str | None = None,
+        trial_results: str | os.PathLike[str] | None = None,
         no_final_output: bool = False,
         verbosity_level: int = 1,
         silent: bool = True,
@@ -344,7 +344,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
 
             .. versionchanged:: 2.15
                 Pass it via ``Options``; moves off this signature in 3.0.
-        cluster_data : str, optional
+        cluster_data : str or os.PathLike, optional
             Read an initial partition from a clu file or a hierarchy from a tree/ftree
             file. Tree input may use physical or state nodes for higher-order networks.
 
@@ -356,7 +356,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
 
             .. versionchanged:: 2.15
                 Pass it via ``Options``; moves off this signature in 3.0.
-        meta_data : str, optional
+        meta_data : str or os.PathLike, optional
             Read metadata to encode from a clu-format file.
 
             .. versionchanged:: 2.15
@@ -507,18 +507,18 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             .. deprecated:: 2.15
                 This keyword leaves the ``Infomap`` signature in 3.0. A print-and-exit
                 CLI diagnostic; run the infomap binary.
-        timing_json : str, optional
+        timing_json : str or os.PathLike, optional
             Write machine-readable run timing JSON to this path. Use - for stdout.
 
             .. versionchanged:: 2.15
                 Pass it via ``Options``; moves off this signature in 3.0.
-        summary_json : str, optional
+        summary_json : str or os.PathLike, optional
             Write machine-readable final run summary JSON to this path. Use - for
             stdout.
 
             .. versionchanged:: 2.15
                 Pass it via ``Options``; moves off this signature in 3.0.
-        manifest_json : str, optional
+        manifest_json : str or os.PathLike, optional
             Write a machine-readable run manifest JSON to this path. Use - for stdout.
 
             .. versionchanged:: 2.15
@@ -535,7 +535,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
 
             .. versionchanged:: 2.15
                 Pass it via ``Options``; moves off this signature in 3.0.
-        trial_results : str, optional
+        trial_results : str or os.PathLike, optional
             Write this shard's per-trial results (codelengths, seeds, best-tree
             reference, fingerprints) as JSON to this path, for deterministic merging of
             distributed shard runs into a final solution.
@@ -838,9 +838,9 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         no_self_links: bool = False,
         node_limit: int | None = None,
         matchable_multilayer_ids: int | None = None,
-        cluster_data: str | None = None,
+        cluster_data: str | os.PathLike[str] | None = None,
         assign_to_neighbouring_module: bool = False,
-        meta_data: str | None = None,
+        meta_data: str | os.PathLike[str] | None = None,
         meta_data_rate: float = 1.0,
         meta_data_unweighted: bool = False,
         no_infomap: bool = False,
@@ -855,12 +855,12 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         print_all_trials: bool = False,
         no_overwrite: bool = False,
         print_config_fingerprint: bool = False,
-        timing_json: str | None = None,
-        summary_json: str | None = None,
-        manifest_json: str | None = None,
+        timing_json: str | os.PathLike[str] | None = None,
+        summary_json: str | os.PathLike[str] | None = None,
+        manifest_json: str | os.PathLike[str] | None = None,
         memory_report: bool = False,
         trial_offset: int | None = None,
-        trial_results: str | None = None,
+        trial_results: str | os.PathLike[str] | None = None,
         no_final_output: bool = False,
         verbosity_level: int = 1,
         silent: bool = False,

--- a/interfaces/python/src/infomap/_options.py
+++ b/interfaces/python/src/infomap/_options.py
@@ -266,6 +266,65 @@ def _validate_option_choices(options):
             )
 
 
+_OPTION_PATHS = (
+    "cluster_data",
+    "meta_data",
+    "timing_json",
+    "summary_json",
+    "manifest_json",
+    "trial_results",
+)
+
+
+# Free-string value options, rendered verbatim into the argument string.
+_OPTION_FREE_STRINGS = (
+    "out_name",
+    "num_threads",
+    "threads",
+)
+
+
+def _normalize_option_paths(options):
+    """Decode path-typed option values (os.PathLike -> str) in place.
+
+    The path-typed options follow the package-wide file-path contract
+    (str | os.PathLike, decoded with os.fsdecode like the file readers
+    and writers); the rendered argument string needs plain str. A value
+    that is not path-like gets a TypeError naming the option here,
+    instead of a confusing engine parse error downstream.
+    """
+    for name in _OPTION_PATHS:
+        value = options.get(name)
+        if value is None or isinstance(value, str):
+            continue
+        try:
+            options[name] = os.fsdecode(value)
+        except TypeError:
+            raise TypeError(
+                f"{name}={value!r} is not a valid path: pass a str or "
+                "os.PathLike."
+            ) from None
+
+
+def _validate_option_arg_strings(options):
+    """Reject string values the rendered argument string cannot carry.
+
+    Rendered options travel to the engine as a whitespace-separated
+    argument string with no quoting support, so a value containing
+    whitespace would be silently split into separate tokens (a
+    cluster_data path 'my file.clu' reads as 'my'). Reject it here,
+    naming the option and the reason.
+    """
+    for name in _OPTION_PATHS + _OPTION_FREE_STRINGS:
+        value = options.get(name)
+        if isinstance(value, str) and any(ch.isspace() for ch in value):
+            raise ValueError(
+                f"{name}={value!r} contains whitespace, which the engine "
+                "argument string cannot carry (arguments are split on "
+                "whitespace, with no quoting). Use a whitespace-free value."
+            )
+
+
 _INPUT_OPTION_SPECS = (
     ("flag", "skip_adjust_bipartite_flow", "--skip-adjust-bipartite-flow", None),
     ("flag", "bipartite_teleportation", "--bipartite-teleportation", None),
@@ -436,13 +495,13 @@ class Options(metaclass=_OptionsMeta):
         Construct state ids from node ids and layer ids that stay comparable across
         networks. Set at least to the largest layer id among networks to match. Valid
         range: >= 1.
-    cluster_data : str, optional
+    cluster_data : str or os.PathLike, optional
         Read an initial partition from a clu file or a hierarchy from a tree/ftree file.
         Tree input may use physical or state nodes for higher-order networks.
     assign_to_neighbouring_module : bool, optional
         With --cluster-data, assign nodes missing module ids to a neighboring node's
         module when possible.
-    meta_data : str, optional
+    meta_data : str or os.PathLike, optional
         Read metadata to encode from a clu-format file.
     meta_data_rate : float, optional
         With --meta-data, set the metadata encoding rate. The default encodes metadata
@@ -507,11 +566,11 @@ class Options(metaclass=_OptionsMeta):
 
         Not a Python library option; it leaves the surface in 3.0. A print-and-exit CLI
         diagnostic; run the infomap binary.
-    timing_json : str, optional
+    timing_json : str or os.PathLike, optional
         Write machine-readable run timing JSON to this path. Use - for stdout.
-    summary_json : str, optional
+    summary_json : str or os.PathLike, optional
         Write machine-readable final run summary JSON to this path. Use - for stdout.
-    manifest_json : str, optional
+    manifest_json : str or os.PathLike, optional
         Write a machine-readable run manifest JSON to this path. Use - for stdout.
     memory_report : bool, optional
         Include peak RSS and best-effort bytes per node/link estimates in timing JSON.
@@ -520,7 +579,7 @@ class Options(metaclass=_OptionsMeta):
         Global index of the first trial this process runs; trial i uses seed = base_seed
         + (trial_offset + i). Default 0 (single-process behavior). Valid range: >= 0.
         Engine default: 0.
-    trial_results : str, optional
+    trial_results : str or os.PathLike, optional
         Write this shard's per-trial results (codelengths, seeds, best-tree reference,
         fingerprints) as JSON to this path, for deterministic merging of distributed
         shard runs into a final solution.
@@ -694,9 +753,9 @@ class Options(metaclass=_OptionsMeta):
     no_self_links: bool = False
     node_limit: int | None = None
     matchable_multilayer_ids: int | None = None
-    cluster_data: str | None = None
+    cluster_data: str | os.PathLike[str] | None = None
     assign_to_neighbouring_module: bool = False
-    meta_data: str | None = None
+    meta_data: str | os.PathLike[str] | None = None
     meta_data_rate: float = 1.0
     meta_data_unweighted: bool = False
     no_infomap: bool = False
@@ -712,12 +771,12 @@ class Options(metaclass=_OptionsMeta):
     print_all_trials: bool = False
     no_overwrite: bool = False
     print_config_fingerprint: bool = False
-    timing_json: str | None = None
-    summary_json: str | None = None
-    manifest_json: str | None = None
+    timing_json: str | os.PathLike[str] | None = None
+    summary_json: str | os.PathLike[str] | None = None
+    manifest_json: str | os.PathLike[str] | None = None
     memory_report: bool = False
     trial_offset: int | None = None
-    trial_results: str | None = None
+    trial_results: str | os.PathLike[str] | None = None
     no_final_output: bool = False
     verbosity_level: int = 1
     silent: bool = True
@@ -768,12 +827,20 @@ class Options(metaclass=_OptionsMeta):
     max_degree_for_random_moves: int = 2
 
     def __post_init__(self):
-        # Validate at construction so a bad value fails where it is
-        # written, not later at the to_args() render funnel. to_args()
-        # revalidates the merged result, so overrides are covered too.
+        # Normalize the path-typed options (os.PathLike -> str) before
+        # validating, so validation, repr, equality and rendering all
+        # see plain strings. Then validate at construction so a bad
+        # value fails where it is written, not later at the to_args()
+        # render funnel. to_args() revalidates the merged result, so
+        # overrides are covered too.
         options = self.to_kwargs()
+        _normalize_option_paths(options)
+        for name in _OPTION_PATHS:
+            if options[name] is not getattr(self, name):
+                object.__setattr__(self, name, options[name])
         _validate_option_domains(options)
         _validate_option_choices(options)
+        _validate_option_arg_strings(options)
 
     def __repr__(self) -> str:
         # Show only the fields set away from their defaults; the full
@@ -845,8 +912,10 @@ class Options(metaclass=_OptionsMeta):
             given.
         """
         options = self.to_kwargs()
+        _normalize_option_paths(options)
         _validate_option_domains(options)
         _validate_option_choices(options)
+        _validate_option_arg_strings(options)
         if self.directed is not None and self.flow_model is not None:
             # Only warn on a genuine conflict. directed=True is shorthand for
             # flow_model="directed" (False -> "undirected"), so pairing it with

--- a/interfaces/python/src/infomap/datasets/__init__.py
+++ b/interfaces/python/src/infomap/datasets/__init__.py
@@ -44,7 +44,7 @@ def _load(filename: str, *, extra_args: str = "") -> _Network:
         args = f"{args} {extra_args}"
     net = _Network(core=_Core(args))
     with _as_file(_files(__name__) / "data" / filename) as path:
-        net.read_file(str(path))
+        net.read_file(path)
     return net
 
 

--- a/interfaces/python/src/infomap/io/export.py
+++ b/interfaces/python/src/infomap/io/export.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import os
 import warnings
 from collections.abc import Mapping
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from .._optional import require_igraph, require_networkx
@@ -534,7 +534,7 @@ def to_igraph(
 def write_graphml(
     graph: networkx.Graph | igraph.Graph,
     im: Infomap | Result,
-    path: str | Path,
+    path: str | os.PathLike[str],
     **options: Any,
 ) -> None:
     """Write a GraphML file with Infomap result attributes on nodes.
@@ -550,7 +550,7 @@ def write_graphml(
     im : Infomap or Result
         A run :class:`~infomap.Infomap` instance, or the
         :class:`~infomap.Result` it returned (the result's engine is used).
-    path : str or pathlib.Path
+    path : str or os.PathLike
         Output file path.
     **options
         Passed through to :func:`annotate_networkx_graph` or
@@ -562,6 +562,7 @@ def write_graphml(
     -------
     None
     """
+    path = os.fsdecode(path)
     if _is_igraph_graph(graph):
         writer_options = {}
         writer_options.update(options.pop("writer_options", {}))
@@ -570,7 +571,7 @@ def write_graphml(
             im,
             **options,
         )
-        annotated_graph.write_graphml(str(path), **writer_options)
+        annotated_graph.write_graphml(path, **writer_options)
         return
 
     nx = _import_networkx()
@@ -587,7 +588,7 @@ def write_graphml(
 def write_gexf(
     graph: networkx.Graph,
     im: Infomap | Result,
-    path: str | Path,
+    path: str | os.PathLike[str],
     **options: Any,
 ) -> None:
     """Write a GEXF file with Infomap result attributes on NetworkX nodes.
@@ -602,7 +603,7 @@ def write_gexf(
     im : Infomap or Result
         A run :class:`~infomap.Infomap` instance, or the
         :class:`~infomap.Result` it returned (the result's engine is used).
-    path : str or pathlib.Path
+    path : str or os.PathLike
         Output file path.
     **options
         Passed through to :func:`annotate_networkx_graph` (e.g.
@@ -627,6 +628,7 @@ def write_gexf(
             "`write_graphml()` for igraph graphs or pass a NetworkX graph."
         )
 
+    path = os.fsdecode(path)
     nx = _import_networkx()
     writer_options = {}
     writer_options.update(options.pop("writer_options", {}))

--- a/interfaces/python/src/infomap/io/writers.py
+++ b/interfaces/python/src/infomap/io/writers.py
@@ -14,6 +14,10 @@ Three hosts share these mixins:
 Each host provides ``_writer_core()`` returning the engine core to write
 from; the default resolves ``self._core`` (Infomap, Network), and ``Result``
 overrides it with its stale-guard.
+
+Filenames follow the package-wide file-path contract: ``str | os.PathLike``,
+decoded with ``os.fsdecode`` -- the same conversion the file readers use, so
+the same path value works on both sides of a run.
 """
 
 from __future__ import annotations
@@ -79,7 +83,7 @@ class _ResultWritersMixin(_WritersBase):
         filename : str or os.PathLike
             The filename.
         """
-        filename = os.fspath(filename)
+        filename = os.fsdecode(filename)
         _, ext = os.path.splitext(filename)
         ext = ext[1:]  # remove the dot
 
@@ -145,7 +149,7 @@ class _ResultWritersMixin(_WritersBase):
             depth = depth_level if depth_level is not None else 1
         core = self._writer_core()
         with _translate_engine_errors():
-            core.writeClu(os.fspath(filename), states, depth)
+            core.writeClu(os.fsdecode(filename), states, depth)
 
     def write_tree(
         self, filename: str | os.PathLike[str], states: bool = False
@@ -167,7 +171,7 @@ class _ResultWritersMixin(_WritersBase):
         """
         core = self._writer_core()
         with _translate_engine_errors():
-            core.writeTree(os.fspath(filename), states)
+            core.writeTree(os.fsdecode(filename), states)
 
     def write_flow_tree(
         self, filename: str | os.PathLike[str], states: bool = False
@@ -189,7 +193,7 @@ class _ResultWritersMixin(_WritersBase):
         """
         core = self._writer_core()
         with _translate_engine_errors():
-            core.writeFlowTree(os.fspath(filename), states)
+            core.writeFlowTree(os.fsdecode(filename), states)
 
     def write_newick(
         self, filename: str | os.PathLike[str], states: bool = False
@@ -211,7 +215,7 @@ class _ResultWritersMixin(_WritersBase):
         """
         core = self._writer_core()
         with _translate_engine_errors():
-            core.writeNewickTree(os.fspath(filename), states)
+            core.writeNewickTree(os.fsdecode(filename), states)
 
     def write_json(
         self, filename: str | os.PathLike[str], states: bool = False
@@ -233,7 +237,7 @@ class _ResultWritersMixin(_WritersBase):
         """
         core = self._writer_core()
         with _translate_engine_errors():
-            core.writeJsonTree(os.fspath(filename), states)
+            core.writeJsonTree(os.fsdecode(filename), states)
 
     def write_csv(
         self, filename: str | os.PathLike[str], states: bool = False
@@ -255,7 +259,7 @@ class _ResultWritersMixin(_WritersBase):
         """
         core = self._writer_core()
         with _translate_engine_errors():
-            core.writeCsvTree(os.fspath(filename), states)
+            core.writeCsvTree(os.fsdecode(filename), states)
 
 
 class _NetworkWritersMixin(_WritersBase):
@@ -302,7 +306,7 @@ class _NetworkWritersMixin(_WritersBase):
         """
         core = self._writer_core()
         with _translate_engine_errors():
-            core.network().writeStateNetwork(os.fspath(filename))
+            core.network().writeStateNetwork(os.fsdecode(filename))
 
     def write_pajek(
         self, filename: str | os.PathLike[str], flow: bool = False
@@ -323,7 +327,7 @@ class _NetworkWritersMixin(_WritersBase):
         """
         core = self._writer_core()
         with _translate_engine_errors():
-            core.network().writePajekNetwork(os.fspath(filename), flow)
+            core.network().writePajekNetwork(os.fsdecode(filename), flow)
 
 
 class _InfomapWritersMixin(_ResultWritersMixin, _NetworkWritersMixin):

--- a/interfaces/python/src/infomap/merge.py
+++ b/interfaces/python/src/infomap/merge.py
@@ -71,12 +71,21 @@ class MergeError(Exception):
     """Raised when shard files are missing, inconsistent, or unmergeable."""
 
 
-def _expand_patterns(patterns: Iterable[str]) -> List[str]:
-    """Expand glob patterns (each item may itself be a comma-separated list)."""
+def _expand_patterns(patterns: Iterable[str | os.PathLike[str]]) -> List[str]:
+    """Expand glob patterns.
+
+    A ``str`` item may be a comma-separated list of patterns (CLI parity);
+    an ``os.PathLike`` item names exactly one pattern -- a comma in it is
+    part of the path.
+    """
     paths: List[str] = []
     seen = set()
     for raw in patterns:
-        for pattern in str(raw).split(","):
+        if isinstance(raw, str):
+            items = raw.split(",")
+        else:
+            items = [os.fsdecode(raw)]
+        for pattern in items:
             pattern = pattern.strip()
             if not pattern:
                 continue
@@ -206,7 +215,7 @@ def _write_clu_from_tree(tree_path: str, clu_path: str) -> None:
 
 
 def merge_trial_results(
-    patterns: Sequence[str],
+    patterns: Sequence[str | os.PathLike[str]],
     out_name: str | os.PathLike[str],
     formats: Sequence[str] = SUPPORTED_FORMATS,
     require_complete: bool = False,
@@ -215,8 +224,10 @@ def merge_trial_results(
 
     Parameters
     ----------
-    patterns : sequence of str
-        Shard result file paths or glob patterns (each may be comma-separated).
+    patterns : sequence of str or os.PathLike
+        Shard result file paths or glob patterns. A ``str`` may be a
+        comma-separated list of patterns; an ``os.PathLike`` names exactly
+        one pattern.
     out_name : str or os.PathLike
         Output basename; ``<out_name>.tree`` / ``<out_name>.clu`` are written.
     formats : sequence of str, optional
@@ -233,7 +244,7 @@ def merge_trial_results(
         winner tree path, the number of shards/trials, any ``missing`` indices,
         and the list of ``outputs`` written.
     """
-    out_name = os.fspath(out_name)
+    out_name = os.fsdecode(out_name)
     bad = [f for f in formats if f not in SUPPORTED_FORMATS]
     if bad:
         raise MergeError(

--- a/interfaces/python/src/infomap/tl/graphrag.py
+++ b/interfaces/python/src/infomap/tl/graphrag.py
@@ -300,7 +300,7 @@ def _output_paths(output):
             "communities": None,
         }
 
-    output_path = Path(output)
+    output_path = Path(os.fsdecode(output))
     if output_path.suffix.lower() == ".parquet":
         output_dir = output_path.parent
         communities_path = output_path
@@ -734,7 +734,7 @@ def run_graphrag_communities(
             stacklevel=2,
         )
 
-    input_path = Path(input_dir)
+    input_path = Path(os.fsdecode(input_dir))
     graph = read_graphrag(
         input_path / entities_name,
         input_path / relationships_name,

--- a/scripts/generate_binding_options.py
+++ b/scripts/generate_binding_options.py
@@ -417,6 +417,95 @@ def _option_choices_lines(catalog: ParameterCatalog) -> list[str]:
     return lines
 
 
+# Static runtime helpers: the path-typed options follow the package-wide
+# file-path contract (str | os.PathLike, decoded with os.fsdecode like the
+# file readers and writers), and -- together with the free-string options --
+# must survive the rendered argument string, which the engine splits on
+# whitespace with no quoting support. Normalize and validate at the Options
+# boundary so every entry point (Options()/Infomap()/run()/Network.run())
+# gets the same contract and a clear error instead of a silent misparse.
+_NORMALIZE_OPTION_PATHS_HELPER = [
+    "def _normalize_option_paths(options):",
+    '    """Decode path-typed option values (os.PathLike -> str) in place.',
+    "",
+    "    The path-typed options follow the package-wide file-path contract",
+    "    (str | os.PathLike, decoded with os.fsdecode like the file readers",
+    "    and writers); the rendered argument string needs plain str. A value",
+    "    that is not path-like gets a TypeError naming the option here,",
+    "    instead of a confusing engine parse error downstream.",
+    '    """',
+    "    for name in _OPTION_PATHS:",
+    "        value = options.get(name)",
+    "        if value is None or isinstance(value, str):",
+    "            continue",
+    "        try:",
+    "            options[name] = os.fsdecode(value)",
+    "        except TypeError:",
+    "            raise TypeError(",
+    '                f"{name}={value!r} is not a valid path: pass a str or "',
+    '                "os.PathLike."',
+    "            ) from None",
+]
+
+
+_VALIDATE_OPTION_ARG_STRINGS_HELPER = [
+    "def _validate_option_arg_strings(options):",
+    '    """Reject string values the rendered argument string cannot carry.',
+    "",
+    "    Rendered options travel to the engine as a whitespace-separated",
+    "    argument string with no quoting support, so a value containing",
+    "    whitespace would be silently split into separate tokens (a",
+    "    cluster_data path 'my file.clu' reads as 'my'). Reject it here,",
+    "    naming the option and the reason.",
+    '    """',
+    "    for name in _OPTION_PATHS + _OPTION_FREE_STRINGS:",
+    "        value = options.get(name)",
+    "        if isinstance(value, str) and any(ch.isspace() for ch in value):",
+    "            raise ValueError(",
+    '                f"{name}={value!r} contains whitespace, which the engine "',
+    '                "argument string cannot carry (arguments are split on "',
+    '                "whitespace, with no quoting). Use a whitespace-free value."',
+    "            )",
+]
+
+
+def _option_path_lines(catalog: ParameterCatalog) -> list[str]:
+    """The path-typed and free-string option tables plus their helpers.
+
+    ``_OPTION_PATHS`` lists the ``ArgType::path`` parameters (normalized with
+    ``os.fsdecode`` at construction); ``_OPTION_FREE_STRINGS`` lists the
+    unconstrained string parameters. Both are rendered verbatim into the
+    whitespace-split argument string, so both get the whitespace guard.
+    """
+    paths: list[str] = []
+    free_strings: list[str] = []
+    for group in GROUPS:
+        for param in catalog.grouped()[group]:
+            if not param.uses_generic_spec() or param.spec_kind != "value":
+                continue
+            if param.choices:
+                continue
+            if param.long_type == "path":
+                paths.append(param.name("python"))
+            elif param.long_type == "string":
+                free_strings.append(param.name("python"))
+
+    lines: list[str] = ["_OPTION_PATHS = ("]
+    lines.extend(f'    "{name}",' for name in paths)
+    lines.append(")")
+    lines.extend(["", ""])
+    lines.append("# Free-string value options, rendered verbatim into the argument string.")
+    lines.append("_OPTION_FREE_STRINGS = (")
+    lines.extend(f'    "{name}",' for name in free_strings)
+    lines.append(")")
+    lines.extend(["", ""])
+    lines.extend(_NORMALIZE_OPTION_PATHS_HELPER)
+    lines.extend(["", ""])
+    lines.extend(_VALIDATE_OPTION_ARG_STRINGS_HELPER)
+    lines.extend(["", ""])
+    return lines
+
+
 def _option_domain_lines(catalog: ParameterCatalog) -> list[str]:
     """The runtime numeric-domain table plus its validator.
 
@@ -566,6 +655,7 @@ def generate_python(catalog: ParameterCatalog) -> str:
     lines.extend(_advanced_tier_kwarg_lines(catalog))
     lines.extend(_option_domain_lines(catalog))
     lines.extend(_option_choices_lines(catalog))
+    lines.extend(_option_path_lines(catalog))
     for group in GROUPS:
         spec_name = f"_{group.upper()}_OPTION_SPECS"
         lines.append(f"{spec_name} = (")
@@ -692,12 +782,20 @@ def generate_python(catalog: ParameterCatalog) -> str:
         [
             "",
             "    def __post_init__(self):",
-            "        # Validate at construction so a bad value fails where it is",
-            "        # written, not later at the to_args() render funnel. to_args()",
-            "        # revalidates the merged result, so overrides are covered too.",
+            "        # Normalize the path-typed options (os.PathLike -> str) before",
+            "        # validating, so validation, repr, equality and rendering all",
+            "        # see plain strings. Then validate at construction so a bad",
+            "        # value fails where it is written, not later at the to_args()",
+            "        # render funnel. to_args() revalidates the merged result, so",
+            "        # overrides are covered too.",
             "        options = self.to_kwargs()",
+            "        _normalize_option_paths(options)",
+            "        for name in _OPTION_PATHS:",
+            "            if options[name] is not getattr(self, name):",
+            "                object.__setattr__(self, name, options[name])",
             "        _validate_option_domains(options)",
             "        _validate_option_choices(options)",
+            "        _validate_option_arg_strings(options)",
             "",
             "    def __repr__(self) -> str:",
             "        # Show only the fields set away from their defaults; the full",
@@ -769,8 +867,10 @@ def generate_python(catalog: ParameterCatalog) -> str:
             "            given.",
             '        """',
             "        options = self.to_kwargs()",
+            "        _normalize_option_paths(options)",
             "        _validate_option_domains(options)",
             "        _validate_option_choices(options)",
+            "        _validate_option_arg_strings(options)",
             "        if self.directed is not None and self.flow_model is not None:",
             "            # Only warn on a genuine conflict. directed=True is shorthand for",
             '            # flow_model="directed" (False -> "undirected"), so pairing it with',

--- a/scripts/parameter_catalog.py
+++ b/scripts/parameter_catalog.py
@@ -252,6 +252,10 @@ class Parameter:
             base = "float" if self.long_type in {"probability", "number"} else "int"
         elif self.long_type == "list":
             base = "list[str] | tuple[str, ...]"
+        elif self.long_type == "path":
+            # Path options follow the package-wide file-path contract: accept
+            # str | os.PathLike, decoded to str at the Options boundary.
+            base = "str | os.PathLike[str]"
         else:
             base = "str"
         return base if self.python_default_value() != "None" else f"{base} | None"
@@ -277,6 +281,8 @@ class Parameter:
             return "int, optional"
         if self.long_type in {"number", "probability"}:
             return "float, optional"
+        if self.long_type == "path":
+            return "str or os.PathLike, optional"
         return "str, optional"
 
     def python_doc_description(self) -> str:

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -149,6 +149,30 @@ def canonical_modules():
     return _canonical_modules
 
 
+class FsPathOnly:
+    """A generic ``os.PathLike`` that is not a ``pathlib.Path``.
+
+    ``__str__`` deliberately disagrees with ``__fspath__``: any consumer that
+    converts with ``str()`` instead of ``os.fspath()`` / ``os.fsdecode()``
+    reads a bogus path.
+    """
+
+    def __init__(self, path):
+        self._path = path
+
+    def __fspath__(self) -> str:
+        return str(self._path)
+
+    def __str__(self) -> str:
+        return "<not-the-path>"
+
+
+@pytest.fixture
+def fspath_only():
+    """Factory for a generic non-``Path`` ``os.PathLike`` with a lying ``__str__``."""
+    return FsPathOnly
+
+
 @pytest.fixture
 def output_dir(tmp_path: Path) -> Path:
     path = tmp_path / "output"

--- a/test/python/test_export.py
+++ b/test/python/test_export.py
@@ -189,6 +189,37 @@ def test_igraph_graphml_export_writes_vertex_attributes(tmp_path):
     assert all(value is not None for value in exported.vs["infomap_module"])
 
 
+def test_igraph_graphml_export_accepts_generic_pathlike(tmp_path, fspath_only):
+    ig = pytest.importorskip("igraph")
+    graph = ig.Graph(edges=[(0, 1), (2, 3)], directed=False)
+    im = _igraph_result(graph)
+    path = tmp_path / "generic.graphml"
+
+    write_graphml(graph, im, fspath_only(path))
+
+    assert path.stat().st_size > 0
+
+
+def test_networkx_graphml_export_accepts_generic_pathlike(tmp_path, fspath_only):
+    graph = nx.Graph([(1, 2), (2, 3), (10, 11), (11, 12)])
+    im, mapping = _networkx_result(graph)
+    path = tmp_path / "generic.graphml"
+
+    write_graphml(graph, im, fspath_only(path), node_mapping=mapping)
+
+    assert path.stat().st_size > 0
+
+
+def test_networkx_gexf_export_accepts_generic_pathlike(tmp_path, fspath_only):
+    graph = nx.Graph([(1, 2), (2, 3), (10, 11), (11, 12)])
+    im, mapping = _networkx_result(graph)
+    path = tmp_path / "generic.gexf"
+
+    write_gexf(graph, im, fspath_only(path), node_mapping=mapping)
+
+    assert path.stat().st_size > 0
+
+
 def test_igraph_export_copy_true_leaves_original_graph_unchanged():
     ig = pytest.importorskip("igraph")
     graph = ig.Graph(edges=[(0, 1)], directed=False)

--- a/test/python/test_graphrag.py
+++ b/test/python/test_graphrag.py
@@ -110,6 +110,26 @@ def test_read_graphrag_accepts_generic_pathlike(tmp_path):
     assert graph.sources.tolist() == [1, 2, 3, 4, 5, 6, 3]
 
 
+def test_write_graphrag_communities_accepts_generic_pathlike_output(tmp_path):
+    _require_parquet_stack()
+
+    from infomap import Infomap
+    from infomap.graphrag import read_graphrag, write_graphrag_communities
+
+    entities_path, relationships_path = _write_graphrag_fixture(tmp_path)
+    graph = read_graphrag(entities_path, relationships_path)
+
+    im = Infomap(silent=True, seed=123, num_trials=5)
+    _add_graphrag_links(im, graph)
+    im.run()
+
+    output_dir = tmp_path / "infomap"
+    write_graphrag_communities(im, graph=graph, output=_FsPathOnly(output_dir))
+
+    assert (output_dir / "communities.parquet").is_file()
+    assert (output_dir / "infomap_nodes.parquet").is_file()
+
+
 def test_read_graphrag_factorizes_titles_from_entities_first(tmp_path):
     from infomap.graphrag import read_graphrag
 

--- a/test/python/test_merge.py
+++ b/test/python/test_merge.py
@@ -6,6 +6,7 @@ extension or running Infomap.
 """
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -243,3 +244,33 @@ def test_merge_accepts_pathlike_out_name(tmp_path):
         str(tmp_path / "final.tree"),
         str(tmp_path / "final.clu"),
     ]
+
+
+def test_merge_accepts_generic_pathlike_patterns(tmp_path, fspath_only):
+    shard_json = _shard(
+        tmp_path, "a", offset=0, trials=[(0, 6.0)], best_tree_modules={1: 1}
+    )
+
+    summary = merge_trial_results(
+        [fspath_only(shard_json)], out_name=fspath_only(tmp_path / "final")
+    )
+
+    assert summary["num_shards"] == 1
+    assert (tmp_path / "final.tree").is_file()
+
+
+def test_merge_pathlike_pattern_is_a_literal_path_not_a_comma_list(tmp_path):
+    # A plain-string pattern keeps its CLI-parity comma splitting, but a
+    # PathLike names exactly one path -- a comma in it is part of the path.
+    shard_dir = tmp_path / "shards,batch-1"
+    shard_dir.mkdir()
+    shard_json = _shard(
+        shard_dir, "a", offset=0, trials=[(0, 6.0)], best_tree_modules={1: 1}
+    )
+
+    summary = merge_trial_results(
+        [Path(shard_json)], out_name=str(tmp_path / "final")
+    )
+
+    assert summary["num_shards"] == 1
+    assert (tmp_path / "final.tree").is_file()

--- a/test/python/test_option_paths.py
+++ b/test/python/test_option_paths.py
@@ -1,0 +1,128 @@
+"""Path-typed engine options share the package-wide file-path contract.
+
+The file-reading entry points accept ``str | os.PathLike`` and decode with
+``os.fsdecode`` (#809). The path-typed *options* (``cluster_data``,
+``meta_data``, the report JSON paths, ``trial_results``) travel to the engine
+through the rendered argument string instead, so they need the same
+acceptance plus one extra guard: the argument string is split on whitespace
+with no quoting support, so a path containing whitespace can never arrive
+intact and must be rejected up front with the reason -- not silently
+truncated into a confusing engine error.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+import infomap
+from infomap import Infomap, Options
+
+
+pytestmark = pytest.mark.fast
+
+_LINKS = [(1, 2), (1, 3), (2, 3), (3, 4), (4, 5), (4, 6), (5, 6)]
+
+
+@pytest.fixture
+def clu_file(tmp_path) -> Path:
+    clu = tmp_path / "partition.clu"
+    clu.write_text("# node module\n1 1\n2 1\n3 1\n4 2\n5 2\n6 2\n")
+    return clu
+
+
+def test_path_option_table_matches_the_catalog():
+    from infomap._options import _OPTION_PATHS
+
+    # The path-typed options, as declared ArgType::path in the C++ catalog.
+    # A new path option lands here via make build-binding-options; update the
+    # expectation when one is added.
+    assert set(_OPTION_PATHS) == {
+        "cluster_data",
+        "meta_data",
+        "timing_json",
+        "summary_json",
+        "manifest_json",
+        "trial_results",
+    }
+
+
+def test_options_normalize_pathlike_to_str(clu_file, fspath_only):
+    options = Options(cluster_data=fspath_only(clu_file))
+
+    assert options.cluster_data == str(clu_file)
+
+
+def test_options_normalize_bytes_to_str(clu_file):
+    options = Options(cluster_data=os.fsencode(clu_file))
+
+    assert options.cluster_data == str(clu_file)
+
+
+def test_options_replace_normalizes_pathlike(clu_file, fspath_only):
+    options = Options().replace(cluster_data=fspath_only(clu_file))
+
+    assert options.cluster_data == str(clu_file)
+
+
+def test_options_to_args_renders_the_real_path(clu_file, fspath_only):
+    args = Options(cluster_data=fspath_only(clu_file)).to_args()
+
+    assert str(clu_file) in args
+    assert "not-the-path" not in args
+
+
+def test_run_accepts_pathlike_cluster_data(clu_file, fspath_only):
+    expected = infomap.run(_LINKS, cluster_data=str(clu_file), no_infomap=True)
+
+    result = infomap.run(_LINKS, cluster_data=fspath_only(clu_file), no_infomap=True)
+
+    assert result.modules() == expected.modules()
+
+
+def test_infomap_constructor_accepts_pathlike_cluster_data(clu_file, fspath_only):
+    im = Infomap(silent=True, cluster_data=fspath_only(clu_file), no_infomap=True)
+    im.add_links(_LINKS)
+    result = im.run()
+
+    expected = infomap.run(_LINKS, cluster_data=str(clu_file), no_infomap=True)
+    assert result.modules() == expected.modules()
+
+
+def test_infomap_run_accepts_pathlike_cluster_data(clu_file, fspath_only):
+    im = Infomap(silent=True)
+    im.add_links(_LINKS)
+    result = im.run(cluster_data=fspath_only(clu_file), no_infomap=True)
+
+    expected = infomap.run(_LINKS, cluster_data=str(clu_file), no_infomap=True)
+    assert result.modules() == expected.modules()
+
+
+def test_non_path_option_value_rejected_with_option_name():
+    with pytest.raises(TypeError, match="cluster_data"):
+        Options(cluster_data=123)
+
+
+def test_whitespace_path_rejected_at_construction(tmp_path):
+    clu = tmp_path / "my partition.clu"
+    clu.write_text("1 1\n")
+
+    with pytest.raises(ValueError, match="whitespace"):
+        Options(cluster_data=str(clu))
+
+
+def test_whitespace_out_name_rejected(tmp_path):
+    # out_name is string-typed rather than path-typed, but it is rendered
+    # into the same whitespace-split argument string.
+    with pytest.raises(ValueError, match="whitespace"):
+        Options(out_name="my results")
+
+
+def test_whitespace_path_rejected_at_run(tmp_path):
+    clu = tmp_path / "my partition.clu"
+    clu.write_text("1 1\n")
+
+    with pytest.raises(ValueError, match="whitespace"):
+        infomap.run(_LINKS, cluster_data=str(clu), no_infomap=True)

--- a/test/python/test_result_writers.py
+++ b/test/python/test_result_writers.py
@@ -9,6 +9,7 @@ result-artifact writers (tree/ftree/clu/Newick/JSON/CSV) live on
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -125,6 +126,46 @@ def test_result_writers_accept_path_objects(run_result, tmp_path):
     target: Path = tmp_path / "pathlib.tree"
 
     result.write_tree(target)
+
+    assert target.stat().st_size > 0
+
+
+def test_result_writers_accept_generic_pathlike(run_result, tmp_path, fspath_only):
+    _, result = run_result
+    target: Path = tmp_path / "generic.tree"
+
+    result.write_tree(fspath_only(target))
+
+    assert target.stat().st_size > 0
+
+
+def test_result_writers_accept_bytes_paths(run_result, tmp_path):
+    # The readers decode with os.fsdecode (#809), which also accepts a bytes
+    # path; the writers must mirror it so the same path value works on both
+    # sides of a run instead of leaking a raw SWIG TypeError.
+    _, result = run_result
+    target: Path = tmp_path / "bytes.tree"
+
+    result.write_tree(os.fsencode(target))
+
+    assert target.stat().st_size > 0
+
+
+def test_result_generic_write_accepts_bytes_paths(run_result, tmp_path):
+    _, result = run_result
+    target: Path = tmp_path / "generic-bytes.tree"
+
+    result.write(os.fsencode(target))
+
+    assert target.stat().st_size > 0
+
+
+def test_network_writers_accept_bytes_paths(tmp_path):
+    net = Network()
+    net.add_links(_LINKS)
+    target: Path = tmp_path / "bytes.net"
+
+    net.write_pajek(os.fsencode(target))
 
     assert target.stat().st_size > 0
 


### PR DESCRIPTION
Completes what #809 started for the readers: every path-accepting surface in the Python package now shares one contract — `str | os.PathLike[str]`, decoded with `os.fsdecode`.

## Changes

- **Writers** (`io/writers.py`, all hosts): `os.fspath` → `os.fsdecode`, matching the readers, so the same path value works on both sides of a run. `write_tree(b"...")` no longer leaks a raw SWIG `TypeError`.
- **Path-typed options** (`cluster_data`, `meta_data`, `timing_json`, `summary_json`, `manifest_json`, `trial_results`): accept `os.PathLike`, normalized to `str` in `Options.__post_init__` so validation, repr, equality, and rendering all see plain strings. A non-path value gets a `TypeError` naming the option.
- **Whitespace guard**: the rendered engine argument string is split on whitespace with no quoting support (verified empirically — `"..."`, `'...'`, and `\ ` escapes all pass through literally), so a path or `out_name` containing whitespace can never arrive intact. It is now rejected at construction with the reason, instead of silently truncating (`cluster_data="/tmp/my file.clu"` previously read as `/tmp/my` and surfaced as a confusing engine error).
- **`io.export.write_graphml` / `write_gexf`**: `str | os.PathLike` annotations; the igraph branch converted with `str()`, which wrote a generic `PathLike` to its repr instead of its path.
- **`merge_trial_results`**: `patterns` accepts `os.PathLike`. A `PathLike` names exactly one literal path (a comma in it is part of the path); comma splitting stays as str-only CLI parity.
- **graphrag**: `input_dir`/`output` decoded with `os.fsdecode`; the `datasets` loaders pass their `Path` straight to `read_file`.

The option surface changes go through the generator per AGENTS.md: `scripts/parameter_catalog.py` maps `ArgType::path` to the annotation and doc type, and `scripts/generate_binding_options.py` emits the `_OPTION_PATHS` / `_OPTION_FREE_STRINGS` tables plus their normalize/validate helpers into `_options.py` and the facade signature block. Regenerated with `make build-binding-options`; the R/TS artifacts and `policy.md` are byte-identical.

## Verified

- 18 new tests, each observed failing before the fix (the pre-fix igraph export test literally wrote a file named `<not-the-path>` to the repo root): `test_option_paths.py` (new), plus additions to `test_result_writers.py`, `test_export.py`, `test_merge.py`, `test_graphrag.py`, and a shared `FsPathOnly` fixture in `conftest.py`.
- Full Python suite: 765 passed, 2 skipped.
- `make test-binding-options-freshness`: fresh.
- `make test-python-typecheck` (pyright): 0 errors.
- `test_path_option_table_matches_the_catalog` pins `_OPTION_PATHS` against the C++ catalog so a future `ArgType::path` parameter cannot drift past this contract.

## Not verified

- Whitespace paths through the raw `args` escape hatch are untouched and still misparse there; carrying them would need quoting support in the C++ argument tokenizer, which is out of scope here.
- R and JS surfaces: regenerated outputs are unchanged, so no behavior to verify.