### PR TITLE
test(python): harden pytest config and modernize the ruff hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.8
     hooks:
-      - id: ruff
+      - id: ruff-check
         name: ruff (lint)
         args: [--fix]
         # Notebooks are published-article companions with a couple of known

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 requires = [
   # >=77 for PEP 639 SPDX license support (the `license` expression below).
   "setuptools>=77",
-  "wheel",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -196,6 +195,11 @@ reportMissingModuleSource = false
 reportUnsupportedDunderAll = false
 
 [tool.pytest.ini_options]
+minversion = "7"
+# -ra: summarize skips/xfails at the end. --strict-markers: an unregistered
+# marker (e.g. a typo of the custom ones below) is an error, not a silent skip.
+# --strict-config: a typo in this section is an error rather than ignored.
+addopts = ["-ra", "--strict-markers", "--strict-config"]
 testpaths = ["test/python"]
 # NUMBER lets doctests state floats at the precision that matters
 # (`>>> result.codelength` -> `3.3858`) instead of an abs(...) < tol dance.


### PR DESCRIPTION
## Summary

Adopts the low-risk quick wins from the [Scientific Python development guide](https://learn.scientific-python.org/development/)'s `sp-repo-review` checks. All are config-only — no changes to the source tree, no test-tree churn.

Running `sp-repo-review` against the repo moved it from 30 → 36 passing checks with zero regressions. The six fixed here are the ones that are pure hygiene; the remaining findings are deliberate deviations (pyright instead of mypy, Make instead of nox/tox, ruff-format deferred to its own reformat commit) or churn items to weigh separately.

## Changes

- **pytest** (`[tool.pytest.ini_options]`): set `minversion`, and add `-ra` (skip/xfail summary), `--strict-markers`, and `--strict-config`. `--strict-markers` is a real safety net here — we register custom markers (`fast`/`slow`/`crash`/`perf`), and a typo of one now errors instead of silently registering a new marker and skipping. `--strict-config` turns a typo in the pytest section into an error. [PP302/306/307/308]
- **build-system**: drop `wheel` from `requires`; the setuptools backend provides it. [PP003]
- **pre-commit**: rename the ruff hook id from the legacy `ruff` to `ruff-check`. [PC192]

## Verification

- Full Python suite green under the new strict flags: `765 passed, 2 skipped`. Confirmed no test uses an unregistered marker (only `fast` among the custom set is used, and it is registered).
- `sp-repo-review` re-run confirms PP302, PP306, PP307, PP308, PP003, and PC192 now pass, with no previously-passing check regressing.
- `pyproject.toml` parses; TOML valid.

Not touched: ruff-format, `filterwarnings=error`, and isort/pyupgrade rule sets — all real but higher-churn, best done as their own deliberate commits.