### PR TITLE
build(python): enable ruff flake8-bugbear (B) rules

### DIFF
--- a/interfaces/python/src/infomap/_network_input.py
+++ b/interfaces/python/src/infomap/_network_input.py
@@ -70,7 +70,7 @@ def split_optional_weight_rows(
             )
 
         values, weight = unpack(row, row_length)
-        for column, value in zip(columns, values):
+        for column, value in zip(columns, values, strict=True):
             column.append(value)
         weights.append(weight)
 

--- a/interfaces/python/src/infomap/io/export.py
+++ b/interfaces/python/src/infomap/io/export.py
@@ -70,7 +70,7 @@ def _node_attributes(
 def _flow_by_state_id(infomap: Any) -> dict[int, float]:
     # Read through the engine core, not the deprecated Infomap.nodes property.
     node_data = infomap._core.get_node_data(1, True)
-    return dict(zip(list(node_data.state_id), list(node_data.flow)))
+    return dict(zip(list(node_data.state_id), list(node_data.flow), strict=True))
 
 
 def _mapped_assignments(

--- a/interfaces/python/src/infomap/io/igraph.py
+++ b/interfaces/python/src/infomap/io/igraph.py
@@ -106,7 +106,7 @@ def _node_ids(values):
         # id. Detect that here and name the colliding labels instead of silently
         # merging two vertices into one physical node.
         labels_by_id: dict[int, Any] = {}
-        for label, _node_id in zip(values, ids):
+        for label, _node_id in zip(values, ids, strict=True):
             seen = labels_by_id.setdefault(_node_id, label)
             if repr(seen) != repr(label):
                 raise ValueError(
@@ -272,7 +272,7 @@ def add_igraph_graph(
             )
         # add_igraph_graph registers one node per vertex using the vertex index
         # as the (state) id, so meta is keyed by vertex index.
-        apply_node_meta_data(infomap, zip(vertices, meta_values))
+        apply_node_meta_data(infomap, zip(vertices, meta_values, strict=True))
 
     if names is None:
         return {vertex_id: vertex_id for vertex_id in vertices}

--- a/interfaces/python/src/infomap/result.py
+++ b/interfaces/python/src/infomap/result.py
@@ -709,7 +709,7 @@ class Result(_ResultWritersMixin):
             raise InfomapError(_HIGHER_ORDER_MODULES_MESSAGE)
         snapshot = self._snapshot(depth, states)
         ids = snapshot.state_id if states else snapshot.node_id
-        return dict(zip(ids, snapshot.module_id))
+        return dict(zip(ids, snapshot.module_id, strict=True))
 
     def nodes(self, depth: int = 1, *, states: bool = False) -> Iterator[TreeNode]:
         """Iterate leaf :class:`TreeNode` views, depth first from the root.
@@ -1067,7 +1067,7 @@ class Result(_ResultWritersMixin):
         names = self._names
 
         data = {}
-        for requested, resolved in zip(requested_columns, resolved_columns):
+        for requested, resolved in zip(requested_columns, resolved_columns, strict=True):
             data[requested] = self._column(resolved, requested, snapshot, names)
 
         dataframe = pandas.DataFrame(data, columns=requested_columns)
@@ -1153,7 +1153,7 @@ class Result(_ResultWritersMixin):
             state_names = self._state_names
             return [
                 state_names.get(sid) or names.get(nid, nid)
-                for sid, nid in zip(snapshot.state_id, snapshot.node_id)
+                for sid, nid in zip(snapshot.state_id, snapshot.node_id, strict=True)
             ]
         if resolved in _SNAPSHOT_COLUMNS:
             return list(getattr(snapshot, resolved))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,12 @@ extend-exclude = [
   "interfaces/python/src/infomap/_swig.py",
 ]
 
+[tool.ruff.lint]
+# flake8-bugbear (B) on top of the default E/F rules: likely-bug patterns.
+# The main one here is B905 -- zip() without strict= -- fixed by asserting the
+# equal-length invariant (strict=True) on the paired-array call sites.
+extend-select = ["B"]
+
 [tool.ruff.lint.per-file-ignores]
 "build/py/*.py" = [
   "F401",
@@ -167,6 +173,10 @@ extend-exclude = [
   "F821",
   "F405",
 ]
+# Tests access a property/attribute purely to trigger its side effect (a
+# deprecation warning, a boundary check), which B018 flags as a useless
+# expression. That access is the point of the test, so ignore B018 there.
+"test/python/*" = ["B018"]
 
 [tool.pyright]
 # Type-check the hand-written package only. The SWIG-generated _swig.py is

--- a/test/python/test_api.py
+++ b/test/python/test_api.py
@@ -302,7 +302,7 @@ def test_result_summaries_collect_into_one_row_per_run_dataframe():
 
     df = pd.DataFrame(
         {"markov_time": mt, **result.summary()}
-        for mt, result in zip(markov_times, results)
+        for mt, result in zip(markov_times, results, strict=True)
     )
 
     assert len(df) == len(markov_times)

--- a/test/python/test_result.py
+++ b/test/python/test_result.py
@@ -22,7 +22,7 @@ def test_get_node_data_single_traversal_matches_get_modules():
     im = _two_triangles()
     im.run()
     nd = im._core.get_node_data(1, False)
-    by_node = dict(zip(list(nd.node_id), list(nd.module_id)))
+    by_node = dict(zip(list(nd.node_id), list(nd.module_id), strict=True))
     assert by_node == im.get_modules(1, False)
 
 
@@ -31,7 +31,7 @@ def test_get_node_data_camelcase_swig_accessor_still_works():
     im = _two_triangles()
     im.run()
     nd = im._core.getNodeData(1, False)
-    assert dict(zip(list(nd.node_id), list(nd.module_id))) == im.get_modules(1, False)
+    assert dict(zip(list(nd.node_id), list(nd.module_id), strict=True)) == im.get_modules(1, False)
 
 
 @pytest.mark.fast
@@ -193,11 +193,11 @@ def test_to_dataframe_state_name_column_distinguishes_state_nodes(
     )
 
     # The "state_name" column carries the per-state-node name.
-    assert dict(zip(df["state_id"], df["state_name"])) == _STATES_NET_STATE_NAMES
+    assert dict(zip(df["state_id"], df["state_name"], strict=True)) == _STATES_NET_STATE_NAMES
     # The "name" column is unchanged: the physical name keyed by node_id.
     assert all(
         name == _STATES_NET_PHYSICAL_NAMES[node_id]
-        for node_id, name in zip(df["node_id"], df["name"])
+        for node_id, name in zip(df["node_id"], df["name"], strict=True)
     )
     # State nodes 1 and 4 are both physical node 1: the physical name collapses
     # them to "i", while state_name keeps them distinct.


### PR DESCRIPTION
Bucket 2 of the [Scientific Python guide](https://learn.scientific-python.org/development/) reconciliation (PR 1 of the follow-ups to #814). Semantic, small diff — kept separate from the mechanical formatting PRs.

## What

Adds `flake8-bugbear` (`B`) to the ruff rule set. All findings are `B905` — `zip()` without an explicit `strict=`. Every flagged call site pairs two arrays from a **common source** (the same `snapshot`, `node_data`, or vertex set), so equal length is an invariant; passing `strict=True` asserts it and turns a silent zip-to-shortest into an error if it ever breaks.

- 7 source sites (`result.py`, `io/igraph.py`, `io/export.py`, `_network_input.py`) → `strict=True`
- 5 test sites (`test_result.py`, `test_api.py`) → `strict=True`
- `B018` (useless expression) is ignored under `test/python/` — those tests access a property/attribute purely to trigger a side effect (deprecation warning, boundary check), which is the point of the test.

## Verification

- `ruff check` clean on the CI lint scope (`src/infomap` + `examples/python`) and repo-wide excluding the deliberately hand-linted notebooks.
- Full Python suite green: `765 passed, 2 skipped`. Every `strict=True` invariant holds, so no site was actually ragged.

Notebooks carry a few `B` findings but are excluded from every gate (pre-commit hook + CI lint scope), consistent with the existing "linted deliberately, not as a drive-by" stance.