### PR TITLE
test(python): fail the test suite on unexpected warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,6 +200,20 @@ minversion = "7"
 # marker (e.g. a typo of the custom ones below) is an error, not a silent skip.
 # --strict-config: a typo in this section is an error rather than ignored.
 addopts = ["-ra", "--strict-markers", "--strict-config"]
+# A test marked xfail that unexpectedly passes is a failure, not a silent pass:
+# it means the reason for the xfail is gone and the marker should be removed.
+xfail_strict = true
+# Turn unexpected warnings into failures. The package deliberately exercises its
+# own deprecated 2.x surface across the suite as part of the 3.0 migration, so
+# its own Deprecation/PendingDeprecationWarning churn is tolerated; every other
+# warning category (unhandled UserWarning, RuntimeWarning, FutureWarning, ...)
+# now fails the run instead of scrolling past. Tests that assert a specific
+# deprecation still do so via pytest.warns / pytest.deprecated_call.
+filterwarnings = [
+  "error",
+  "ignore::DeprecationWarning",
+  "ignore::PendingDeprecationWarning",
+]
 testpaths = ["test/python"]
 # NUMBER lets doctests state floats at the precision that matters
 # (`>>> result.codelength` -> `3.3858`) instead of an abs(...) < tol dance.


### PR DESCRIPTION
Bucket 2 of the [Scientific Python guide](https://learn.scientific-python.org/development/) reconciliation (follow-up to #814, sibling of #815). Config-only, `pyproject.toml` `[tool.pytest.ini_options]` alone.

## What

- **`xfail_strict`** [PP305]: an `xfail` test that unexpectedly passes now fails, so a stale marker gets removed instead of silently masking a fixed case. (The suite currently uses no `xfail`, so this is a no-op safety net today.)
- **`filterwarnings`** [PP309]: turn unexpected warnings into errors.

## The scope decision

A full `filterwarnings = ["error"]` fails **172 tests** — the suite deliberately exercises the package's own deprecated 2.x API throughout, as part of the 3.0 migration (672 `PendingDeprecationWarning` + 19 `DeprecationWarning` occurrences). Adding 172 per-test marks would be churn that fights the migration.

So the pragmatic scope is:

```toml
filterwarnings = ["error", "ignore::DeprecationWarning", "ignore::PendingDeprecationWarning"]
```

This fails the run on any **other** unexpected warning — an unhandled `UserWarning`, `RuntimeWarning`, `FutureWarning`, `ResourceWarning`, etc. — while tolerating the migration's deprecation churn. Tests that assert a specific deprecation still do so via `pytest.warns` / `pytest.deprecated_call`.

Trade-off, documented in the config comment: it also tolerates *upstream* deprecations for now. That can be tightened to a full `error` once 3.0 removes the deprecated surface.

## Verification

- Full Python suite green under the committed ini config: `765 passed, 2 skipped`.
- Doctest modules green: `39 passed`.
- Confirmed the full-`error` alternative fails 172 tests (why the narrower scope).