### PR TITLE
build(python): enable ruff isort (I) import sorting

### DIFF
--- a/examples/notebooks/benchmark-performance.ipynb
+++ b/examples/notebooks/benchmark-performance.ipynb
@@ -38,9 +38,10 @@
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
-    "import pandas as pd\n",
-    "import numpy as np\n",
+    "\n",
     "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
     "\n",
     "# --- configuration ---\n",
     "RUN_BENCHMARK = (\n",

--- a/examples/notebooks/options-guide.ipynb
+++ b/examples/notebooks/options-guide.ipynb
@@ -47,12 +47,13 @@
    },
    "outputs": [],
    "source": [
+    "from pathlib import Path\n",
+    "\n",
     "import infomap\n",
-    "from infomap import Infomap\n",
+    "import matplotlib.pyplot as plt\n",
     "import networkx as nx\n",
     "import pandas as pd\n",
-    "import matplotlib.pyplot as plt\n",
-    "from pathlib import Path"
+    "from infomap import Infomap"
    ]
   },
   {

--- a/examples/python/infomap-networkx.py
+++ b/examples/python/infomap-networkx.py
@@ -3,7 +3,6 @@ import pathlib
 import matplotlib.colors as colors
 import matplotlib.pyplot as plt
 import networkx as nx
-
 from infomap import run
 
 """

--- a/examples/python/infomap-sklearn.py
+++ b/examples/python/infomap-sklearn.py
@@ -1,8 +1,7 @@
 import networkx as nx
 import numpy as np
-from sklearn.model_selection import ParameterGrid
-
 from infomap import Network, Options
+from sklearn.model_selection import ParameterGrid
 
 # Build the network once, then re-run it with different options.
 net = Network.from_networkx(nx.karate_club_graph())

--- a/interfaces/python/src/infomap/__init__.py
+++ b/interfaces/python/src/infomap/__init__.py
@@ -55,25 +55,53 @@ See https://mapequation.org/infomap-python-docs/ for the full documentation.
 
 # The error taxonomy is pure Python and importable without the compiled
 # bindings, so it lives outside the guarded block below.
-from .errors import (
-    __all__ as _ERRORS_ALL,
-    InfomapError as InfomapError,
-    NetworkParseError as NetworkParseError,
-    NotRunError as NotRunError,
-    StaleResultError as StaleResultError,
-)
 from ._version import (
     __author__ as __author__,
+)
+from ._version import (
     __classifiers__ as __classifiers__,
+)
+from ._version import (
     __description__ as __description__,
+)
+from ._version import (
     __email__ as __email__,
+)
+from ._version import (
     __homepage__ as __homepage__,
+)
+from ._version import (
     __issues__ as __issues__,
+)
+from ._version import (
     __keywords__ as __keywords__,
+)
+from ._version import (
     __license__ as __license__,
+)
+from ._version import (
     __repo__ as __repo__,
+)
+from ._version import (
     __url__ as __url__,
+)
+from ._version import (
     __version__ as __version__,
+)
+from .errors import (
+    InfomapError as InfomapError,
+)
+from .errors import (
+    NetworkParseError as NetworkParseError,
+)
+from .errors import (
+    NotRunError as NotRunError,
+)
+from .errors import (
+    StaleResultError as StaleResultError,
+)
+from .errors import (
+    __all__ as _ERRORS_ALL,
 )
 
 _VERSION_ALL = [
@@ -100,13 +128,12 @@ __all__.extend(_ERRORS_ALL)
 # stays usable even before the compiled bindings are built.
 
 try:
-    from ._facade import __all__ as _FACADE_ALL
-    from ._facade import *  # noqa: F401,F403
-    from ._options import _construct_args as _construct_args
-
     from . import datasets as datasets
     from . import io as io
     from . import tl as tl
+    from ._facade import *  # noqa: F401,F403
+    from ._facade import __all__ as _FACADE_ALL
+    from ._options import _construct_args as _construct_args
 
     __all__.extend(_FACADE_ALL)
     __all__.append("datasets")

--- a/interfaces/python/src/infomap/__main__.py
+++ b/interfaces/python/src/infomap/__main__.py
@@ -2,6 +2,5 @@ import sys
 
 from . import main
 
-
 if __name__ == "__main__":
     sys.exit(main())

--- a/interfaces/python/src/infomap/_bindings.py
+++ b/interfaces/python/src/infomap/_bindings.py
@@ -5,5 +5,4 @@ from ._swig import *  # noqa: F401,F403
 from ._swig import _drain_log_queue as _drain_log_queue
 from ._swig import _set_log_callback as _set_log_callback
 
-
 __all__ = [name for name in globals() if not name.startswith("_")]

--- a/interfaces/python/src/infomap/_core.py
+++ b/interfaces/python/src/infomap/_core.py
@@ -16,20 +16,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from .errors import _translate_engine_errors
-
+from ._bindings import InfomapIterator as InfomapIterator
+from ._bindings import InfomapIteratorPhysical as InfomapIteratorPhysical
+from ._bindings import InfomapLeafIterator as InfomapLeafIterator
+from ._bindings import InfomapLeafIteratorPhysical as InfomapLeafIteratorPhysical
+from ._bindings import InfomapLeafModuleIterator as InfomapLeafModuleIterator
 from ._bindings import InfomapWrapper  # noqa: F401  (the only engine import)
-from ._bindings import build_info as build_info  # module-level engine function
-from ._bindings import run as run  # module-level engine function (CLI driver)
-
-# Engine log-sink hooks, re-exported through this single boundary for
-# infomap._logging: install/remove the process-global line sink, and drain
-# lines queued by non-GIL-holding threads after an engine call returns. Kept
-# under their private (underscore) names so the re-export uses the redundant
-# ``_x as _x`` alias a type checker treats as an explicit re-export -- a renamed
-# alias reads as an unexported private symbol (pyright reportPrivateImportUsage).
-from ._bindings import _drain_log_queue as _drain_log_queue
-from ._bindings import _set_log_callback as _set_log_callback
 
 # Documented tree-walking iterator/node types returned by ``Infomap.tree`` /
 # ``leaf_modules`` and the physical variants (source/api/iterators.rst). They are
@@ -39,11 +31,18 @@ from ._bindings import _set_log_callback as _set_log_callback
 # (vector_*, Config, StateNetwork, FlowModel, FlowData, ...) are deliberately
 # NOT re-exported.
 from ._bindings import InfoNode as InfoNode
-from ._bindings import InfomapIterator as InfomapIterator
-from ._bindings import InfomapIteratorPhysical as InfomapIteratorPhysical
-from ._bindings import InfomapLeafIterator as InfomapLeafIterator
-from ._bindings import InfomapLeafIteratorPhysical as InfomapLeafIteratorPhysical
-from ._bindings import InfomapLeafModuleIterator as InfomapLeafModuleIterator
+
+# Engine log-sink hooks, re-exported through this single boundary for
+# infomap._logging: install/remove the process-global line sink, and drain
+# lines queued by non-GIL-holding threads after an engine call returns. Kept
+# under their private (underscore) names so the re-export uses the redundant
+# ``_x as _x`` alias a type checker treats as an explicit re-export -- a renamed
+# alias reads as an unexported private symbol (pyright reportPrivateImportUsage).
+from ._bindings import _drain_log_queue as _drain_log_queue
+from ._bindings import _set_log_callback as _set_log_callback
+from ._bindings import build_info as build_info  # module-level engine function
+from ._bindings import run as run  # module-level engine function (CLI driver)
+from .errors import _translate_engine_errors
 
 
 class Core:

--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -6,24 +6,27 @@ from collections.abc import Mapping
 from contextlib import contextmanager
 from typing import Any
 
-from ._core import Core
-from ._core import apply_initial_partition
-from ._core import build_info as _engine_build_info
-from ._core import run as _cli_run
-
 # Documented tree-walking iterator/node types returned by ``Infomap.tree`` /
 # ``leaf_modules`` / the physical variants (source/api/iterators.rst). Surfaced
 # at the package top level so ``from infomap import InfoNode`` and
 # ``isinstance(node, infomap.InfomapIterator)`` keep working. Reached through the
 # ``_core`` boundary, never ``_swig``/``_bindings`` directly.
 from ._core import (
-    InfoNode,
+    Core,
     InfomapIterator,
     InfomapIteratorPhysical,
     InfomapLeafIterator,
     InfomapLeafIteratorPhysical,
     InfomapLeafModuleIterator,
+    InfoNode,
+    apply_initial_partition,
 )
+from ._core import build_info as _engine_build_info
+from ._core import run as _cli_run
+from ._logging import apply_engine_log_overrides as _apply_engine_log_overrides
+from ._logging import disable_log, enable_log
+from ._logging import engine_log_routing as _engine_log_routing
+from ._logging import is_routed as _is_log_routed
 from ._network_input import add_bulk_links as _add_bulk_links
 from ._network_input import first_order_unpacker as _first_order_unpacker
 from ._network_input import flat_multilayer_unpacker as _flat_multilayer_unpacker
@@ -39,31 +42,35 @@ from ._options import (
     _merge_options,
     _warn_advanced_tier_kwargs,
 )
-from ._logging import apply_engine_log_overrides as _apply_engine_log_overrides
-from ._logging import disable_log, enable_log
-from ._logging import engine_log_routing as _engine_log_routing
-from ._logging import is_routed as _is_log_routed
-from ._results import _InfomapResultsMixin
-from ._results import _install_accessor_deprecations
-from ._results import _warn_method_deprecated
-from ._results import entropy, perplexity, plogp
-from .errors import NetworkParseError, _translate_engine_errors
-from .result import Result, TreeNode, build_result
+from ._results import (
+    _InfomapResultsMixin,
+    _install_accessor_deprecations,
+    _warn_method_deprecated,
+    entropy,
+    perplexity,
+    plogp,
+)
+from ._run import _warn_inert_output_options, run
 from ._summary import (
     repr_html as _repr_html,
+)
+from ._summary import (
     repr_text as _repr_text,
+)
+from ._summary import (
     summary_data as _summary_data,
 )
+from .errors import NetworkParseError, _translate_engine_errors
 from .io.edge_index import add_edge_index as _add_edge_index
+from .io.export import to_igraph, to_networkx
 from .io.igraph import add_igraph_graph as _add_igraph_graph
 from .io.igraph import find_igraph_communities
 from .io.networkx import add_networkx_graph as _add_networkx_graph
 from .io.networkx import find_communities
-from .io.export import to_igraph, to_networkx
 from .io.scipy import add_scipy_sparse_matrix as _add_scipy_sparse_matrix
 from .io.writers import _InfomapWritersMixin
 from .network import Network
-from ._run import _warn_inert_output_options, run
+from .result import Result, TreeNode, build_result
 
 
 def _package_construct_args():

--- a/interfaces/python/src/infomap/_run.py
+++ b/interfaces/python/src/infomap/_run.py
@@ -163,7 +163,8 @@ def _warn_inert_output_options(
     # that was fixed for hide_bipartite_nodes, so drop it from the check there.
     import logging
 
-    from ._logging import is_routed, logger as _engine_logger
+    from ._logging import is_routed
+    from ._logging import logger as _engine_logger
 
     removable = ["verbosity_level", "print_config_fingerprint"]
     if engine_emits or (is_routed() and _engine_logger.isEnabledFor(logging.DEBUG)):

--- a/interfaces/python/src/infomap/datasets/__init__.py
+++ b/interfaces/python/src/infomap/datasets/__init__.py
@@ -20,7 +20,8 @@ per-run options are applied after the construction options.
 
 from __future__ import annotations
 
-from importlib.resources import as_file as _as_file, files as _files
+from importlib.resources import as_file as _as_file
+from importlib.resources import files as _files
 
 from .._core import Core as _Core
 from ..network import Network as _Network  # public return type of every loader below

--- a/interfaces/python/src/infomap/export.py
+++ b/interfaces/python/src/infomap/export.py
@@ -9,10 +9,20 @@ from __future__ import annotations
 
 from .io.export import (
     annotate_igraph_graph as annotate_igraph_graph,
+)
+from .io.export import (
     annotate_networkx_graph as annotate_networkx_graph,
+)
+from .io.export import (
     to_igraph as to_igraph,
+)
+from .io.export import (
     to_networkx as to_networkx,
+)
+from .io.export import (
     write_gexf as write_gexf,
+)
+from .io.export import (
     write_graphml as write_graphml,
 )
 

--- a/interfaces/python/src/infomap/graphrag.py
+++ b/interfaces/python/src/infomap/graphrag.py
@@ -9,9 +9,17 @@ from __future__ import annotations
 
 from .tl.graphrag import (
     GraphRAGGraph as GraphRAGGraph,
+)
+from .tl.graphrag import (
     GraphRAGRunResult as GraphRAGRunResult,
+)
+from .tl.graphrag import (
     read_graphrag as read_graphrag,
+)
+from .tl.graphrag import (
     run_graphrag_communities as run_graphrag_communities,
+)
+from .tl.graphrag import (
     write_graphrag_communities as write_graphrag_communities,
 )
 

--- a/interfaces/python/src/infomap/io/__init__.py
+++ b/interfaces/python/src/infomap/io/__init__.py
@@ -16,10 +16,20 @@ from __future__ import annotations
 
 from .export import (
     annotate_igraph_graph as annotate_igraph_graph,
+)
+from .export import (
     annotate_networkx_graph as annotate_networkx_graph,
+)
+from .export import (
     to_igraph as to_igraph,
+)
+from .export import (
     to_networkx as to_networkx,
+)
+from .export import (
     write_gexf as write_gexf,
+)
+from .export import (
     write_graphml as write_graphml,
 )
 

--- a/interfaces/python/src/infomap/io/writers.py
+++ b/interfaces/python/src/infomap/io/writers.py
@@ -27,7 +27,6 @@ from typing import TYPE_CHECKING
 
 from ..errors import _translate_engine_errors
 
-
 if TYPE_CHECKING:
     from .._core import Core
 

--- a/interfaces/python/src/infomap/merge.py
+++ b/interfaces/python/src/infomap/merge.py
@@ -30,8 +30,8 @@ import json
 import os
 import shutil
 import sys
-from typing import TypedDict
 from collections.abc import Iterable, Sequence
+from typing import TypedDict
 
 __all__ = ["merge_trial_results", "MergeError", "MergeSummary"]
 

--- a/interfaces/python/src/infomap/network.py
+++ b/interfaces/python/src/infomap/network.py
@@ -32,18 +32,19 @@ from typing import TYPE_CHECKING, Any
 from ._core import Core, apply_initial_partition
 from ._logging import engine_log_routing as _engine_log_routing
 from ._logging import is_routed as _is_log_routed
-from .errors import NetworkParseError, _translate_engine_errors
-from .io.writers import _NetworkWritersMixin
 from ._network_input import add_bulk_links as _add_bulk_links
 from ._network_input import first_order_unpacker as _first_order_unpacker
 from ._network_input import flat_multilayer_unpacker as _flat_multilayer_unpacker
 from ._network_input import paired_multilayer_unpacker as _paired_multilayer_unpacker
 from ._run import _UNSET
+from .errors import NetworkParseError, _translate_engine_errors
+from .io.writers import _NetworkWritersMixin
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     import igraph  # pyright: ignore[reportMissingImports]  # optional dep, no stubs
     import networkx
-    from collections.abc import Mapping
 
     from ._options import Options
     from .result import Result

--- a/interfaces/python/src/infomap/result.py
+++ b/interfaces/python/src/infomap/result.py
@@ -41,9 +41,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from ._optional import require_pandas
-from .errors import InfomapError, StaleResultError, _translate_engine_errors
-from .io.writers import _ResultWritersMixin
-from ._summary import repr_html as _summary_repr_html
 from ._results import (
     _DATAFRAME_COLUMN_ALIASES,
     _DEFAULT_TO_DATAFRAME_COLUMNS,
@@ -52,6 +49,9 @@ from ._results import (
     _unknown_dataframe_column_error,
     perplexity,
 )
+from ._summary import repr_html as _summary_repr_html
+from .errors import InfomapError, StaleResultError, _translate_engine_errors
+from .io.writers import _ResultWritersMixin
 
 # Legacy Infomap instance-mirror accessor names, mapped to their Result form. A
 # caller that learned the pre-Result API -- or hits the method/property flip
@@ -95,12 +95,12 @@ if TYPE_CHECKING:
     import networkx
     import pandas
 
-    from ._facade import Infomap
     from ._core import (
         InfomapIterator,
         InfomapIteratorPhysical,
         InfomapLeafModuleIterator,
     )
+    from ._facade import Infomap
 
 # build_result is internal plumbing shared by Infomap.run and Network.run;
 # only the result types are public API.

--- a/interfaces/python/src/infomap/shell.py
+++ b/interfaces/python/src/infomap/shell.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 import infomap
+
 from . import Infomap, MultilayerNode, Options
 from ._summary import summary_data as _summary_data
 
@@ -64,7 +65,8 @@ def create_namespace(network_file=None):
 def launch_shell(namespace, banner, *, use_ipython=True):
     if use_ipython:
         try:
-            from IPython import start_ipython  # pyright: ignore[reportMissingImports]  # optional dep, no stubs
+            # optional dep, no stubs
+            from IPython import start_ipython  # pyright: ignore[reportMissingImports]
         except ImportError:
             pass
         else:

--- a/interfaces/python/src/infomap/tl/__init__.py
+++ b/interfaces/python/src/infomap/tl/__init__.py
@@ -10,9 +10,17 @@ from ..errors import InfomapError
 # third-party imports, so this keeps ``import infomap`` dependency-free.
 from .graphrag import (
     GraphRAGGraph as GraphRAGGraph,
+)
+from .graphrag import (
     GraphRAGRunResult as GraphRAGRunResult,
+)
+from .graphrag import (
     read_graphrag as read_graphrag,
+)
+from .graphrag import (
     run_graphrag_communities as run_graphrag_communities,
+)
+from .graphrag import (
     write_graphrag_communities as write_graphrag_communities,
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,8 +169,8 @@ extend-exclude = [
 # The main one here is B905 -- zip() without strict= -- fixed by asserting the
 # equal-length invariant (strict=True) on the paired-array call sites.
 # pyupgrade (UP): modernize syntax to the >=3.11 floor (PEP 585/604
-# annotations, etc.).
-extend-select = ["B", "UP"]
+# annotations, etc.). isort (I): keep imports sorted and grouped.
+extend-select = ["B", "UP", "I"]
 
 [tool.ruff.lint.per-file-ignores]
 "build/py/*.py" = [

--- a/scripts/build_config.py
+++ b/scripts/build_config.py
@@ -8,7 +8,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 # Single source of truth for the C++ language standard across every build
 # surface: the native/Python flag lists below embed it, and the JS/Emscripten
 # build reads it back via the `field` / `make-export` interfaces. Bump here only.

--- a/scripts/check_cpp_stream_policy.py
+++ b/scripts/check_cpp_stream_policy.py
@@ -13,7 +13,6 @@ import re
 import sys
 from pathlib import Path
 
-
 DEFAULT_SCAN_PATTERNS = (
     "src/**/*.h",
     "src/**/*.cpp",

--- a/scripts/generate_binding_options.py
+++ b/scripts/generate_binding_options.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from parameter_catalog import GROUPS, ParameterCatalog
 from render_parameter_policy import render as render_parameter_policy_md
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 OVERRIDES = REPO_ROOT / "interfaces" / "parameters" / "overrides.json"
 

--- a/scripts/generate_js_metadata.py
+++ b/scripts/generate_js_metadata.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 from parameter_catalog import ParameterCatalog
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 OVERRIDES = REPO_ROOT / "interfaces" / "parameters" / "overrides.json"
 

--- a/scripts/generate_python_swig.py
+++ b/scripts/generate_python_swig.py
@@ -8,7 +8,6 @@ import subprocess
 import tempfile
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 INTERFACE_FILE = REPO_ROOT / "interfaces" / "swig" / "Infomap.i"
 REQUIRED_SWIG_VERSION = "4.4.1"

--- a/scripts/generate_r_swig.py
+++ b/scripts/generate_r_swig.py
@@ -8,7 +8,6 @@ import subprocess
 import tempfile
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 INTERFACE_FILE = REPO_ROOT / "interfaces" / "swig" / "Infomap.i"
 REQUIRED_SWIG_VERSION = "4.4.1"

--- a/scripts/notebook_manifest.py
+++ b/scripts/notebook_manifest.py
@@ -7,7 +7,6 @@ import sys
 import tomllib
 from pathlib import Path
 
-
 SUITE_TIERS = {
     "smoke": {"smoke"},
     "full": {"smoke", "full"},

--- a/scripts/parameter_catalog.py
+++ b/scripts/parameter_catalog.py
@@ -4,7 +4,6 @@ import json
 from dataclasses import dataclass
 from typing import Any
 
-
 GROUPS = ("Input", "Output", "Algorithm", "Accuracy")
 
 def resolve_policy_decision(

--- a/scripts/patch_macos_torch_libomp_rpath.py
+++ b/scripts/patch_macos_torch_libomp_rpath.py
@@ -9,7 +9,6 @@ import zipfile
 from pathlib import Path
 from shutil import which
 
-
 TORCH_LIBOMP_RPATH = "@loader_path/../torch/lib"
 VENDORED_LIBOMP_RPATH = "@loader_path/.dylibs"
 LIBOMP_LOAD_NAME = "@rpath/libomp.dylib"

--- a/scripts/prepare_npm_package.py
+++ b/scripts/prepare_npm_package.py
@@ -5,7 +5,6 @@ import json
 import shutil
 from pathlib import Path
 
-
 KEEP_PACKAGE_FIELDS = [
     "name",
     "version",

--- a/scripts/stage_r_package.py
+++ b/scripts/stage_r_package.py
@@ -27,7 +27,6 @@ import shutil
 import sys
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_SKELETON = REPO_ROOT / "interfaces" / "R" / "infomap"
 DEFAULT_GENERATED = REPO_ROOT / "interfaces" / "R" / "generated"

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,11 @@
+import importlib.util
 import os
 import sys
-import importlib.util
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
-
 
 REPO_ROOT = Path(__file__).resolve().parent
 SWIG_CPP_SOURCE = REPO_ROOT / "interfaces" / "python" / "generated" / "infomap_wrap.cpp"

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import importlib.util
 import warnings
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from collections.abc import Iterable
 
 import pytest
 from infomap import Infomap

--- a/test/python/test_add_links.py
+++ b/test/python/test_add_links.py
@@ -2,7 +2,6 @@ import math
 
 import pytest
 
-
 pytestmark = pytest.mark.fast
 
 

--- a/test/python/test_add_multilayer_intra_inter_links.py
+++ b/test/python/test_add_multilayer_intra_inter_links.py
@@ -1,6 +1,5 @@
 import pytest
 
-
 pytestmark = pytest.mark.fast
 
 

--- a/test/python/test_add_multilayer_links.py
+++ b/test/python/test_add_multilayer_links.py
@@ -1,7 +1,6 @@
 import pytest
 from infomap import MultilayerNode
 
-
 pytestmark = pytest.mark.fast
 
 

--- a/test/python/test_anndata.py
+++ b/test/python/test_anndata.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-import pytest
-
 import infomap
+import pytest
 
 ad = pytest.importorskip("anndata")
 pd = pytest.importorskip("pandas")

--- a/test/python/test_api.py
+++ b/test/python/test_api.py
@@ -1,14 +1,12 @@
 import importlib.resources
-from operator import itemgetter
 import tomllib
-
-import networkx as nx
-import pytest
+from operator import itemgetter
 
 import infomap as infomap_module
 import infomap._summary as summary_module
+import networkx as nx
+import pytest
 from infomap._bindings import InfomapWrapper
-
 
 pytestmark = pytest.mark.fast
 

--- a/test/python/test_build_config.py
+++ b/test/python/test_build_config.py
@@ -3,7 +3,6 @@ import importlib.util
 import re
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 BUILD_CONFIG_PATH = REPO_ROOT / "scripts" / "build_config.py"
 PYTHON_MK_PATH = REPO_ROOT / "mk" / "python.mk"

--- a/test/python/test_bulk_construction_routing.py
+++ b/test/python/test_bulk_construction_routing.py
@@ -5,7 +5,6 @@ performance invariant through the facade decomposition.
 
 import numpy as np
 import pytest
-
 from infomap import Infomap
 from infomap._bindings import InfomapWrapper
 

--- a/test/python/test_collaborators.py
+++ b/test/python/test_collaborators.py
@@ -1,7 +1,6 @@
 """Focused unit tests for the facade's collaborator decomposition (SP1)."""
 
 import pytest
-
 from infomap import Infomap, Network
 
 

--- a/test/python/test_compare_native_benchmarks.py
+++ b/test/python/test_compare_native_benchmarks.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import pytest
 
-
 pytestmark = pytest.mark.fast
 
 

--- a/test/python/test_core_boundary.py
+++ b/test/python/test_core_boundary.py
@@ -2,7 +2,6 @@
 and Infomap no longer inherits the SWIG wrapper."""
 
 import pytest
-
 from infomap import Infomap
 from infomap._bindings import InfomapWrapper
 from infomap._core import Core

--- a/test/python/test_deprecations.py
+++ b/test/python/test_deprecations.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import warnings
 
 import pytest
-
 from infomap import Infomap, Options, run
 
 

--- a/test/python/test_disconnected_nodes.py
+++ b/test/python/test_disconnected_nodes.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import networkx as nx
 import pytest
 
-
 pytestmark = pytest.mark.fast
 
 

--- a/test/python/test_docs_examples_surface.py
+++ b/test/python/test_docs_examples_surface.py
@@ -22,7 +22,6 @@ from pathlib import Path
 
 import pytest
 
-
 pytestmark = pytest.mark.fast
 
 REPO_ROOT = Path(__file__).resolve().parents[2]

--- a/test/python/test_docs_surface.py
+++ b/test/python/test_docs_surface.py
@@ -17,11 +17,9 @@ import importlib
 import re
 from pathlib import Path
 
-import pytest
-
 import infomap
 import infomap.merge
-
+import pytest
 
 pytestmark = pytest.mark.fast
 

--- a/test/python/test_errors.py
+++ b/test/python/test_errors.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-
 from infomap import (
     Infomap,
     InfomapError,
@@ -27,11 +26,12 @@ from infomap import (
     NetworkParseError,
     NotRunError,
     StaleResultError,
-    errors as errors_module,
     run,
 )
+from infomap import (
+    errors as errors_module,
+)
 from infomap.result import _StaleResultError
-
 
 pytestmark = pytest.mark.fast
 

--- a/test/python/test_export.py
+++ b/test/python/test_export.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import networkx as nx
 import pytest
-
 from infomap import Infomap
 from infomap.export import (
     annotate_igraph_graph,
@@ -12,7 +11,6 @@ from infomap.export import (
     write_gexf,
     write_graphml,
 )
-
 
 pytestmark = pytest.mark.fast
 

--- a/test/python/test_facade_generated_block.py
+++ b/test/python/test_facade_generated_block.py
@@ -9,7 +9,6 @@ import inspect
 from pathlib import Path
 
 import pytest
-
 from infomap import Infomap
 from infomap._options import _OPTION_FIELD_NAMES
 
@@ -47,7 +46,10 @@ def test_generated_signatures_are_annotated():
     import inspect
 
     from infomap import Infomap, Result
-    from infomap._options import FlowModel, OutputFormat  # noqa: F401  (generated aliases)
+    from infomap._options import (  # noqa: F401  (generated aliases)
+        FlowModel,
+        OutputFormat,
+    )
 
     init_signature = inspect.signature(Infomap.__init__)
     run_signature = inspect.signature(Infomap.run)

--- a/test/python/test_finders_options.py
+++ b/test/python/test_finders_options.py
@@ -11,12 +11,10 @@ finder staying quiet without forcing ``no_file_output``.
 
 from __future__ import annotations
 
-import networkx as nx
-import pytest
-
 import infomap
 import infomap._facade as facade
-
+import networkx as nx
+import pytest
 
 pytestmark = pytest.mark.fast
 

--- a/test/python/test_flow.py
+++ b/test/python/test_flow.py
@@ -2,7 +2,6 @@ import re
 
 import pytest
 
-
 pytestmark = pytest.mark.fast
 
 

--- a/test/python/test_fluent_chaining.py
+++ b/test/python/test_fluent_chaining.py
@@ -7,9 +7,7 @@ call's result (an id / bool / None), routed through the shared ``Core``.
 """
 
 import pytest
-
 from infomap import Infomap, Network
-
 
 # --- Network is fluent: every mutator returns self -----------------------------
 

--- a/test/python/test_from_graph_constructors.py
+++ b/test/python/test_from_graph_constructors.py
@@ -2,7 +2,6 @@
 
 import networkx as nx
 import pytest
-
 from infomap import Infomap, Network
 
 

--- a/test/python/test_graphrag.py
+++ b/test/python/test_graphrag.py
@@ -2,7 +2,6 @@ import json
 
 import pytest
 
-
 pytestmark = pytest.mark.fast
 
 

--- a/test/python/test_igraph.py
+++ b/test/python/test_igraph.py
@@ -5,13 +5,11 @@ import subprocess
 import sys
 from types import SimpleNamespace
 
-import pytest
-
 import infomap
 import infomap._facade as facade
+import pytest
 from infomap import _optional
 from infomap.io.igraph import _import_igraph, add_igraph_graph
-
 
 pytestmark = pytest.mark.fast
 

--- a/test/python/test_inert_output_options.py
+++ b/test/python/test_inert_output_options.py
@@ -14,10 +14,8 @@ from __future__ import annotations
 import warnings
 
 import pytest
-
 from infomap import Infomap, Network, Options, find_communities, run
 from infomap._run import _warn_inert_output_options
-
 
 pytestmark = pytest.mark.fast
 

--- a/test/python/test_iterators.py
+++ b/test/python/test_iterators.py
@@ -3,7 +3,6 @@ from operator import itemgetter
 import networkx as nx
 import pytest
 
-
 pytestmark = pytest.mark.fast
 
 

--- a/test/python/test_logging.py
+++ b/test/python/test_logging.py
@@ -19,9 +19,7 @@ import sys
 import warnings
 
 import pytest
-
 from infomap import Infomap, Options, disable_log, enable_log, run
-
 
 # These tests drive the engine log -> Python logging routing, deliberately
 # using silent=False to produce engine output; the pending deprecation on the

--- a/test/python/test_merge.py
+++ b/test/python/test_merge.py
@@ -9,7 +9,6 @@ import json
 from pathlib import Path
 
 import pytest
-
 from infomap.merge import MergeError, MergeSummary, merge_trial_results
 
 

--- a/test/python/test_multilayer.py
+++ b/test/python/test_multilayer.py
@@ -1,6 +1,5 @@
 import pytest
 
-
 # These tests build and run multilayer networks through the stateful Infomap
 # compat surface (no_infomap / matchable_multilayer_ids), so the pending
 # deprecation on advanced-tier kwargs is expected here; it is asserted in

--- a/test/python/test_multilayer_relax_to_self.py
+++ b/test/python/test_multilayer_relax_to_self.py
@@ -1,6 +1,5 @@
 import pytest
 
-
 pytestmark = pytest.mark.fast
 
 

--- a/test/python/test_multilevel_modules.py
+++ b/test/python/test_multilevel_modules.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 
 import pytest
 
-
 pytestmark = pytest.mark.fast
 
 

--- a/test/python/test_native_benchmark_script.py
+++ b/test/python/test_native_benchmark_script.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import pytest
 
-
 pytestmark = pytest.mark.fast
 
 

--- a/test/python/test_network.py
+++ b/test/python/test_network.py
@@ -12,7 +12,6 @@ against the identical graph built and run through ``Infomap``.
 """
 
 import pytest
-
 from infomap import Infomap, MultilayerNode, Network
 
 pytestmark = pytest.mark.fast

--- a/test/python/test_network_input_contract.py
+++ b/test/python/test_network_input_contract.py
@@ -1,6 +1,5 @@
 import pytest
 
-
 pytestmark = pytest.mark.fast
 
 

--- a/test/python/test_networkx.py
+++ b/test/python/test_networkx.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-import networkx as nx
-import pytest
-
 import infomap
 import infomap._facade as facade
-
+import networkx as nx
+import pytest
 
 pytestmark = pytest.mark.fast
 

--- a/test/python/test_no_swig_leak.py
+++ b/test/python/test_no_swig_leak.py
@@ -18,9 +18,8 @@ other module must talk to the engine through ``Core``.
 import ast
 from pathlib import Path
 
-import pytest
-
 import infomap
+import pytest
 from infomap import Infomap
 
 PACKAGE_DIR = Path(infomap.__file__).parent

--- a/test/python/test_node_renumbering.py
+++ b/test/python/test_node_renumbering.py
@@ -1,6 +1,5 @@
 import pytest
 
-
 pytestmark = pytest.mark.fast
 
 

--- a/test/python/test_option_domains.py
+++ b/test/python/test_option_domains.py
@@ -16,7 +16,6 @@ is covered.
 from __future__ import annotations
 
 import pytest
-
 from infomap import Infomap, Network, Options, datasets, run
 from infomap._options import _OPTION_DOMAINS, _validate_option_domains
 

--- a/test/python/test_option_paths.py
+++ b/test/python/test_option_paths.py
@@ -15,11 +15,9 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-import pytest
-
 import infomap
+import pytest
 from infomap import Infomap, Options
-
 
 pytestmark = pytest.mark.fast
 

--- a/test/python/test_optional_deps.py
+++ b/test/python/test_optional_deps.py
@@ -10,9 +10,7 @@ from __future__ import annotations
 import importlib
 
 import pytest
-
 from infomap import _optional
-
 
 pytestmark = pytest.mark.fast
 

--- a/test/python/test_options_alias.py
+++ b/test/python/test_options_alias.py
@@ -7,10 +7,9 @@ Settings alias has been removed.
 import dataclasses
 import warnings
 
-import pytest
-
 import infomap
-from infomap import Options, InfomapOptions
+import pytest
+from infomap import InfomapOptions, Options
 
 
 @pytest.mark.fast

--- a/test/python/test_output.py
+++ b/test/python/test_output.py
@@ -4,7 +4,6 @@ import json
 
 import pytest
 
-
 pytestmark = pytest.mark.fast
 
 

--- a/test/python/test_parameter_catalog.py
+++ b/test/python/test_parameter_catalog.py
@@ -1,7 +1,6 @@
 import sys
 from pathlib import Path
 
-
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
 from parameter_catalog import ParameterCatalog  # noqa: E402

--- a/test/python/test_parameter_policy.py
+++ b/test/python/test_parameter_policy.py
@@ -25,7 +25,6 @@ from pathlib import Path
 
 import pytest
 
-
 pytestmark = pytest.mark.fast
 
 REPO_ROOT = Path(__file__).resolve().parents[2]

--- a/test/python/test_public_types.py
+++ b/test/python/test_public_types.py
@@ -7,9 +7,8 @@ back. A curated ``__all__`` once dropped them, silently breaking
 with no deprecation period. Pin them so the package surface can't regress again.
 """
 
-import pytest
-
 import infomap
+import pytest
 
 # Each is ``.. autoclass``-ed in source/api/iterators.rst.
 DOCUMENTED_TYPES = [

--- a/test/python/test_result.py
+++ b/test/python/test_result.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-
 from infomap import Infomap, Result, datasets, run
 
 

--- a/test/python/test_result_agent_fixes.py
+++ b/test/python/test_result_agent_fixes.py
@@ -11,7 +11,6 @@ Result cannot write.
 from __future__ import annotations
 
 import pytest
-
 from infomap import Infomap, InfomapError, StaleResultError, datasets, run
 
 pytestmark = pytest.mark.fast

--- a/test/python/test_result_parity.py
+++ b/test/python/test_result_parity.py
@@ -10,7 +10,6 @@ drift.
 from __future__ import annotations
 
 import pytest
-
 from infomap import Infomap
 
 pytest.importorskip("pandas")

--- a/test/python/test_result_writers.py
+++ b/test/python/test_result_writers.py
@@ -13,9 +13,7 @@ import os
 from pathlib import Path
 
 import pytest
-
 from infomap import Network, Options, StaleResultError, run
-
 
 pytestmark = pytest.mark.fast
 

--- a/test/python/test_run_agent_fixes.py
+++ b/test/python/test_run_agent_fixes.py
@@ -18,7 +18,6 @@ import warnings
 
 import networkx as nx
 import pytest
-
 from infomap import Infomap, Network, Options, find_communities, run
 from infomap.result import Result
 

--- a/test/python/test_run_functional.py
+++ b/test/python/test_run_functional.py
@@ -12,13 +12,11 @@ from __future__ import annotations
 import sys
 import warnings
 
+import infomap
 import networkx as nx
 import pytest
-
-import infomap
 from infomap import Infomap, Network
 from infomap.result import Result, _StaleResultError
-
 
 pytestmark = pytest.mark.fast
 

--- a/test/python/test_run_signature.py
+++ b/test/python/test_run_signature.py
@@ -17,9 +17,8 @@ import inspect
 import json
 from pathlib import Path
 
-import pytest
-
 import infomap
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 

--- a/test/python/test_shell.py
+++ b/test/python/test_shell.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-
 from infomap import shell
 
 

--- a/test/python/test_signature_catalog.py
+++ b/test/python/test_signature_catalog.py
@@ -13,7 +13,6 @@ set-equality invariant independently of the generator.
 import inspect
 
 import pytest
-
 from infomap import Infomap
 from infomap._options import _OPTION_FIELD_NAMES
 

--- a/test/python/test_torch_interop.py
+++ b/test/python/test_torch_interop.py
@@ -4,7 +4,6 @@ import textwrap
 
 import pytest
 
-
 pytestmark = [pytest.mark.crash]
 
 

--- a/test/python/test_wrapper_args.py
+++ b/test/python/test_wrapper_args.py
@@ -3,11 +3,9 @@ import shlex
 import subprocess
 import sys
 
-import pytest
-
 import infomap as infomap_module
+import pytest
 from infomap._bindings import InfomapWrapper
-
 
 pytestmark = pytest.mark.fast
 

--- a/test/scripts/schema_validation.py
+++ b/test/scripts/schema_validation.py
@@ -5,9 +5,9 @@ from functools import cache
 from pathlib import Path
 from typing import Any
 
+from jsonschema import Draft202012Validator
 from referencing import Registry, Resource
 from referencing.jsonschema import DRAFT202012
-from jsonschema import Draft202012Validator
 
 
 def _repo_root() -> Path:


### PR DESCRIPTION
Bucket 2 formatting wave, PR 2 of 3 (pyupgrade → **isort** → ruff-format). Mechanical. **Stacked on #817** (base branch = `chore/ruff-pyupgrade`), so this diff shows only the import-ordering changes; review/merge #817 first.

## What

Adds `isort` (`I`) and applies it — imports sorted and grouped across 90 files (package, tests, examples, scripts). Almost entirely mechanical import-ordering churn.

**One manual adjustment** (`shell.py`): the optional `from IPython import start_ipython` carried a same-line `# pyright: ignore[reportMissingImports]` on a line long enough that isort wrapped it to multi-line — which detached the ignore from the module reference and surfaced a pyright error. Moving the explanatory comment to its own line keeps the import (with its ignore) on a single line under the length limit, so it survives isort and stays pyright-clean.

## Generated-file handling

`_options.py` stays excluded from ruff. `_facade.py`'s imports (top of file) are reordered, but its spliced signature block (far below) is untouched, so binding-options freshness holds.

## Verification

- `binding-options` freshness green — generated files intact.
- `ruff check` clean (excluding notebooks); pyright clean.
- Full suite `765 passed, 2 skipped`.