### PR TITLE
build(python): measure and report test coverage

### DIFF
--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -262,8 +262,25 @@ jobs:
           INFOMAP_EXPECTED_FEATURES: ${{ inputs.features }}
 
       - name: Run Python unit tests
-        if: ${{ !matrix.smoke-only }}
+        if: ${{ !matrix.smoke-only && !matrix.run-full-suite }}
         run: make test-python-unit
+
+      # The full-suite leg has the [test]+[examples] extras, so it exercises the
+      # io/ and tl/ adapters -- the best leg to measure coverage on. Runs the
+      # same suite as test-python-unit, plus coverage.xml for the upload below.
+      - name: Run Python unit tests with coverage
+        if: matrix.run-full-suite
+        run: make test-python-coverage
+
+      - name: Upload coverage to Codecov
+        if: matrix.run-full-suite
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: ./coverage.xml
+          # Best-effort: keep CI green even before the Codecov app is connected
+          # to the repo. Tokenless upload works for this public repo; add a
+          # CODECOV_TOKEN secret later if rate limits require it.
+          fail_ci_if_error: false
 
       - name: Run Python doctests
         if: matrix.run-full-suite

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,12 @@ __pycache__/
 .venv/
 venv/
 node_modules/
+
+# Coverage artifacts (pytest-cov / coverage.py)
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
 *.dSYM
 callgrind.*
 

--- a/mk/python.mk
+++ b/mk/python.mk
@@ -45,6 +45,7 @@ PYTHON_BUILD_ENV = \
 	dev-python-notebooks-install \
 	test-python \
 	test-python-unit \
+	test-python-coverage \
 	test-python-doctest \
 	test-python-typecheck \
 	test-python-typecheck-core \
@@ -89,6 +90,13 @@ test-python: test-python-unit test-python-doctest test-python-examples
 
 test-python-unit:
 	@$(PYTEST) $(PYTEST_ARGS) $(PYTHON_TEST_DIR)
+
+# Same suite as test-python-unit, with coverage of the hand-written package.
+# Emits term-missing for local reading and coverage.xml for CI upload. Config
+# (source, omit, paths) lives in [tool.coverage.*] in pyproject.toml.
+test-python-coverage:
+	@$(PYTEST) $(PYTEST_ARGS) $(PYTHON_TEST_DIR) \
+		--cov=infomap --cov-report=term-missing --cov-report=xml
 
 test-python-doctest:
 	@$(RUFF) check $(PYTHON_LINT_TARGETS)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ test = [
   # releases routinely add diagnostics. Bump deliberately.
   "pyright==1.1.411",
   "pytest",
+  "pytest-cov",
   "networkx",
   "pyarrow",
   "referencing",
@@ -240,4 +241,25 @@ markers = [
   "slow: Broader or more expensive checks that should stay out of the default fast suite.",
   "crash: Regression checks focused on no-crash behavior for previously brittle code paths.",
   "perf: Performance-oriented checks or benchmarks that should not gate normal correctness runs.",
+]
+
+[tool.coverage.run]
+# Coverage of the hand-written Python package. The C++ core is covered
+# separately by the ctest suite; this measures the wrapper/adapter/IO surface.
+source_pkgs = ["infomap"]
+branch = true
+# _swig.py is generated SWIG binding boilerplate (same boundary ruff excludes):
+# most of it is never-called wrapper stubs, so measuring it is meaningless and
+# only drags the number down.
+omit = ["*/infomap/_swig.py"]
+
+[tool.coverage.paths]
+# Map the editable src tree (local) and the wheel-installed package (CI) to one
+# path so coverage reports them consistently regardless of install mode.
+infomap = ["interfaces/python/src/infomap", "*/site-packages/infomap"]
+
+[tool.coverage.report]
+exclude_also = [
+  "if TYPE_CHECKING:",
+  "raise NotImplementedError",
 ]


### PR DESCRIPTION
The one substantive gap left after the [Scientific Python guide](https://learn.scientific-python.org/development/) reconciliation — coverage measurement — which no `sp-repo-review` check enforces. Adds Python-side coverage; the C++ core stays covered separately by the ctest suite.

## What

- **`pytest-cov`** in the `test` extra; **coverage config** in `[tool.coverage.*]`:
  - `source = infomap`, branch coverage on
  - `_swig.py` omitted (generated SWIG binding boilerplate — same boundary ruff excludes; measuring it is meaningless and drags the number down)
  - a `[tool.coverage.paths]` map so the editable src tree (local) and the wheel-installed package (CI) report as one path
- **`make test-python-coverage`**: the same suite as `test-python-unit`, plus `term-missing` and `coverage.xml`.
- **CI**: the full-suite leg (which installs `[test]+[examples]`, so it exercises the `io/` and `tl/` adapters) now runs coverage and uploads to Codecov. The upload is **best-effort** (`fail_ci_if_error: false`) so CI stays green.
- Coverage artifacts gitignored.

## Result

Current coverage of the hand-written package is **~92%** (branch coverage, `_swig.py` excluded). Most modules are 90–99%; the lower ones are `merge.py` (82%) and `network.py`/`shell.py` (~85%) — useful signal for where wrapper tests are thin.

## Remaining manual step

The Codecov **app must be connected to the repo** for the upload to appear (and a `CODECOV_TOKEN` secret added if tokenless rate limits bite). Until then the upload is a no-op that doesn't fail CI. If you'd rather not use Codecov, the same `coverage.xml` can instead be uploaded as a GitHub Actions artifact — say the word and I'll switch it.

## Verification

- `make test-python-coverage`: `765 passed, 2 skipped`, 92%, `coverage.xml` written.
- Workflow YAML + `pyproject.toml` parse; ruff clean; coverage config loads.