### PR TITLE
ci(python): install the built wheel in test jobs instead of recompiling

### DIFF
--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -136,11 +136,12 @@ jobs:
         with:
           key-prefix: python-${{ matrix.os }}-py${{ matrix.python-version }}
 
-      - name: Build Python wheel from repo root
-        run: make build-python
-        env:
-          FEATURES: ${{ inputs.features }}
-
+      # The editable install is the test legs' only compile: it builds the
+      # extension in-place, so the .so lands in the source tree where the
+      # doctests import it from. A separate `make build-python` wheel build used
+      # to run first and recompile the same extension -- redundant in the test
+      # legs (the wheel is unused here; wheel-build health is covered by the
+      # release-smoke and release wheel jobs).
       - name: Install editable package
         run: |
           make dev-python-install
@@ -233,11 +234,12 @@ jobs:
         with:
           key-prefix: python-${{ matrix.os }}-py${{ matrix.python-version }}
 
-      - name: Build Python wheel from repo root
-        run: make build-python
-        env:
-          FEATURES: ${{ inputs.features }}
-
+      # The editable install is the test legs' only compile: it builds the
+      # extension in-place, so the .so lands in the source tree where the
+      # doctests import it from. A separate `make build-python` wheel build used
+      # to run first and recompile the same extension -- redundant in the test
+      # legs (the wheel is unused here; wheel-build health is covered by the
+      # release-smoke and release wheel jobs).
       - name: Install editable package
         run: |
           make dev-python-install


### PR DESCRIPTION
Measured CI optimization: the Python test legs compile the C++ extension **twice**.

## The finding (from a real release run's step timings)

Each Python test leg runs two steps:
1. **Build Python wheel** (`make build-python`) — compiles the extension into a wheel
2. **Install editable package** (`make dev-python-install` = `pip install -e`) — recompiles the *same* extension for the editable install, then installs extras

Measured cost of that second, redundant compile:

| Leg | Build (compile #1) | Install (compile #2 + extras) |
|---|---|---|
| **windows 3.14** | 105s | **165s** |
| ubuntu 3.11–3.14 | 4–7s (ccache warm) | 33–46s |

On Windows there's no warm ccache, so the editable install pays a **full second compile** (~105s) — it roughly doubles the Windows Python job. On ubuntu ccache makes compile #2 cheap, but it's still redundant.

## The fix

Add a `make install-python-built-wheel` target that installs the wheel `build-python` already produced (plus the requested extras: `pip install "dist/python/*.whl[test,examples]"`), and switch the `_python-package.yml` test legs to it.

- `build-python` still runs → the per-Python-version **wheel-build health signal is preserved**; only the wasted second compile is removed.
- Local dev keeps `dev-python-install` (editable) for live source edits.
- `docs` and `notebooks` jobs are unchanged.

## Verification

- The target installs the prebuilt wheel with **no compilation** (confirmed locally: binary install only).
- **The full suite passes against a non-editable wheel install** (`765 passed, 2 skipped`) — so no test relied on the editable src layout. Coverage's `[tool.coverage.paths]` (PR #820) already maps src↔site-packages, so it composes.
- Matrix legs (notably Windows, where the saving is largest) are validated by this PR's own CI run — the `$(wildcard)` path + pip wheel-install were verified on macOS; watch the Windows leg here.

## Scope / follow-ups

This is the "stop double-compiling" lever. The **bigger** Python-CI lever the same measurement exposed is compilation itself: the release `cibuildwheel` jobs spend **16 min (Windows) / 6.8 min (ubuntu)** in `Build wheels`, recompiling the core once per Python version with no cross-version cache — a candidate for sccache inside cibuildwheel, as a separate change. (And `uv` for the extras install is a separate, smaller win.)