### PR TITLE
ci(python): route test-job installs through uv

### DIFF
--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -136,20 +136,30 @@ jobs:
         with:
           key-prefix: python-${{ matrix.os }}-py${{ matrix.python-version }}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: true
+          cache-dependency-glob: pyproject.toml
+
       # The editable install is the test legs' only compile: it builds the
       # extension in-place, so the .so lands in the source tree where the
       # doctests import it from. A separate `make build-python` wheel build used
       # to run first and recompile the same extension -- redundant in the test
       # legs (the wheel is unused here; wheel-build health is covered by the
       # release-smoke and release wheel jobs).
+      # Route pip through uv (UV_SYSTEM_PYTHON installs into the setup-python
+      # environment): far faster resolution and a hardlinked cache for the heavy
+      # test/examples extras. The in-place compile of the extension is unchanged.
       - name: Install editable package
         run: |
-          make dev-python-install
+          make dev-python-install PIP="uv pip"
           command -v ccache >/dev/null 2>&1 && ccache -s || true
         env:
           FEATURES: ${{ inputs.features }}
           # docs (sphinx/furo) is only needed by build-docs, not the test jobs.
           PYTHON_DEV_EXTRAS: test,examples
+          UV_SYSTEM_PYTHON: "1"
 
       - name: Run Python smoke test
         if: matrix.smoke-only
@@ -234,20 +244,30 @@ jobs:
         with:
           key-prefix: python-${{ matrix.os }}-py${{ matrix.python-version }}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: true
+          cache-dependency-glob: pyproject.toml
+
       # The editable install is the test legs' only compile: it builds the
       # extension in-place, so the .so lands in the source tree where the
       # doctests import it from. A separate `make build-python` wheel build used
       # to run first and recompile the same extension -- redundant in the test
       # legs (the wheel is unused here; wheel-build health is covered by the
       # release-smoke and release wheel jobs).
+      # Route pip through uv (UV_SYSTEM_PYTHON installs into the setup-python
+      # environment): far faster resolution and a hardlinked cache for the heavy
+      # test/examples extras. The in-place compile of the extension is unchanged.
       - name: Install editable package
         run: |
-          make dev-python-install
+          make dev-python-install PIP="uv pip"
           command -v ccache >/dev/null 2>&1 && ccache -s || true
         env:
           FEATURES: ${{ inputs.features }}
           # docs (sphinx/furo) is only needed by build-docs, not the test jobs.
           PYTHON_DEV_EXTRAS: test,examples
+          UV_SYSTEM_PYTHON: "1"
 
       - name: Run Python smoke test
         if: matrix.smoke-only


### PR DESCRIPTION
Speeds up the **measured dominant cost** of the Python test legs — the dependency install (33–46s on ubuntu, ~165s on Windows) — by routing it through uv. **Stacked on #821** (base = `chore/ci-no-double-compile`); review/merge #821 first.

## What

- Add an `astral-sh/setup-uv` step (SHA-pinned v8.3.2) with its hardlinking cache enabled (keyed on `pyproject.toml`).
- Set `PIP="uv pip"` + `UV_SYSTEM_PYTHON=1` on the install step, so `make install-python-built-wheel` resolves and installs the heavy `test`/`examples` extras via uv into the setup-python environment.

Only the **PIP mechanism** is overridden — the install *target* is unchanged — so this composes with #821's wheel-install (and would compose with `dev-python-install` too). Local dev keeps plain pip + editable. Only the test legs (`tests-quick`, `tests-full`) are routed through uv; docs and notebook jobs keep pip.

## Why it helps

The install step downloads + installs the sci stack (scipy, scanpy, scikit-learn, pandas, matplotlib, igraph, anndata, …) on every non-smoke leg. uv's parallel resolver plus a warm hardlinked cache turns a cold tens-of-seconds install into near-instant on a cache hit — pip re-installs every run even with its wheel cache.

## Verification

- Locally: `uv pip install "<wheel>[test]"` installs the prebuilt wheel with **no compilation** (~9s cold vs ~22s for pip), and the **full suite passes against the uv-installed environment** (`765 passed, 2 skipped`) — so uv produces an equivalent env.
- The CI-specific wiring (setup-uv action, `UV_SYSTEM_PYTHON` targeting the setup-python env, cache hits) is validated by this PR's own run — watch the "Install built wheel with test extras" step timing vs the base.

## Context

This is the smaller of the two remaining Python-CI levers. The larger one — compiler caching (sccache) inside the release `cibuildwheel` jobs (16 min Windows / 6.8 min ubuntu of uncached compilation) — is a separate, bigger change not included here.