### PR TITLE
fix(core): wire -T and explicit -Tr through the columnar fast path

### DIFF
--- a/src/core/ColumnarMapEquation.cpp
+++ b/src/core/ColumnarMapEquation.cpp
@@ -1907,7 +1907,7 @@ void ColumnarTwoLevel::coarsenModules(double& L, int maxSweeps)
   }
 }
 
-double ColumnarTwoLevel::optimizeFlexible(unsigned int bottomBlockLimit)
+double ColumnarTwoLevel::optimizeFlexible(unsigned int bottomBlockLimit, unsigned int sweepLimit)
 {
   double L = optimizeHierarchical(bottomBlockLimit);
   // A single bottom re-partition within grandparents. refineBottomWithinParents
@@ -1927,7 +1927,7 @@ double ColumnarTwoLevel::optimizeFlexible(unsigned int bottomBlockLimit)
   // fast search that skipped it landed far from the optimum on those (air30k
   // +14%). With it, -F matches converge on those objectives at a fraction of the
   // cost, and stays unchanged on base networks.
-  coarsenModules(L, 1000);
+  coarsenModules(L, sweepLimit > 0 ? static_cast<int>(sweepLimit) : 1000);
   return L;
 }
 

--- a/src/core/ColumnarMapEquation.h
+++ b/src/core/ColumnarMapEquation.h
@@ -246,7 +246,9 @@ public:
 
   // M2: build the hierarchy, then refine to convergence. Returns hierarchical
   // codelength. Uses a fine bottom by default so the interior tune has room.
-  double optimizeFlexible(unsigned int bottomBlockLimit = 1);
+  // sweepLimit caps the module-coarsening sweeps (0 = until convergence),
+  // mirroring the sweep cap of the converge search (--tune-iteration-limit).
+  double optimizeFlexible(unsigned int bottomBlockLimit = 1, unsigned int sweepLimit = 0);
 
   // M3: build the hierarchy, then run the up/down convergence sweep — refine
   // *every* interior layer within its grandparent, iterating across layers

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1768,9 +1768,14 @@ void InfomapBase::columnarPartition()
   // for +0.06% codelength; shallow nets run a single sweep and are unaffected).
   // The shared OO --tune-iteration-relative-threshold default (1e-5) is too fine
   // to trigger it, so honor that flag for the columnar engine only when the user
-  // changed it from the OO default (e.g. 0 to grind fully to convergence).
+  // set it — explicitly on the command line (parsedOptions, so an explicit value
+  // equal to the OO default also counts), or to a non-default value through the
+  // library API (which bypasses the CLI parser).
   static const double kOoRelTuneDefault = Config().minimumRelativeTuneIterationImprovement;
-  if (minimumRelativeTuneIterationImprovement != kOoRelTuneDefault)
+  const bool relTuneSetExplicitly = std::any_of(parsedOptions.begin(), parsedOptions.end(), [](const ParsedOption& o) {
+    return o.longName == "tune-iteration-relative-threshold";
+  });
+  if (relTuneSetExplicitly || minimumRelativeTuneIterationImprovement != kOoRelTuneDefault)
     opt.setMinRelativeTuneImprovement(minimumRelativeTuneIterationImprovement);
   addColumnarCorrections(opt);
 
@@ -1783,7 +1788,7 @@ void InfomapBase::columnarPartition()
   const double columnarL = twoLevel
       ? opt.optimizeTwoLevelStack()
       : fastHierarchicalSolution > 0
-      ? opt.optimizeFlexible(1)
+      ? opt.optimizeFlexible(1, tuneIterationLimit)
       : opt.optimizeColumnar(1, tuneIterationLimit);
 
   // Materialize the result into the InfoNode tree for output. initTree also sets


### PR DESCRIPTION
## Summary

Closes the two knob-wiring edges from #825 (part of the columnar-core gap closure toward replacing the OO engine, #808):

- **Explicit `--tune-iteration-relative-threshold` at the OO default (1e-5) was silently dropped.** `columnarPartition()` compared the value against the OO default instead of checking whether the flag was passed, so `-C --tune-iteration-relative-threshold 1e-5` kept the columnar 5e-3 knee. Now checks `Config::parsedOptions` (an explicitly passed value always counts), keeping the value-differs fallback for library callers that set the field directly without the CLI parser.
- **`-C -F` ignored `--tune-iteration-limit`.** `optimizeFlexible` had no sweep cap; its module-coarsening loop now takes the same limit the converge search passes to `refineHierarchy`.

Not addressed here (still open in #825): the incremental level of `-F` (`-FF`, `-FFF`) is still not differentiated under `-C`.

## Verification

- web-NotreDame `-d --seed 123 -N1 -C --tune-iteration-relative-threshold 1e-5`: **5.569548** (before: 5.572794, the flag was silently ignored); `1e-3` unchanged at 5.569548; default unchanged at 5.572794.
- air30k `--seed 123 -N1 -C -F -T1`: 5.505352 vs uncapped `-F` 5.480216 — the cap now takes effect (fewer coarsening sweeps).
- Defaults are behavior-identical (no flag → same code path as before).
- `ctest -L columnar` and the partition suites pass.