### PR TITLE
fix(core): keep the memory codelength scalar in sync with the module map

### DIFF
--- a/src/core/MemMapEquation.cpp
+++ b/src/core/MemMapEquation.cpp
@@ -356,6 +356,15 @@ void MemMapEquation::updateCodelengthOnMovingNode(InfoNode& current,
   nodeFlow_log_nodeFlow += delta_nodeFlow_log_nodeFlow;
   moduleCodelength -= delta_nodeFlow_log_nodeFlow;
   codelength -= delta_nodeFlow_log_nodeFlow;
+
+  // The flag marks that the memory contributions for THIS move were already
+  // accumulated onto the deltas by addMemoryContributions() (the optimize
+  // candidate-evaluation path). It is consumed by this one move; reset it so a
+  // following standalone moveNodeToPredefinedModule() — e.g. the single-node
+  // "drag along" in tryMoveEachNodeIntoBestModule(), which passes fresh
+  // zero-initialised deltas — recomputes its own contributions instead of
+  // updating the physical-node map while leaving nodeFlow_log_nodeFlow stale.
+  m_memoryContributionsAdded = false;
 }
 
 void MemMapEquation::updatePhysicalNodes(InfoNode& current, unsigned int oldModuleIndex, unsigned int bestModuleIndex)

--- a/src/core/RegularizedMultilayerMapEquation.cpp
+++ b/src/core/RegularizedMultilayerMapEquation.cpp
@@ -440,6 +440,13 @@ void RegularizedMultilayerMapEquation::updateCodelengthOnMovingNode(InfoNode& cu
   nodeFlow_log_nodeFlow += delta_nodeFlow_log_nodeFlow;
   moduleCodelength -= delta_nodeFlow_log_nodeFlow;
   codelength -= delta_nodeFlow_log_nodeFlow;
+
+  // The flag marks that this move's memory contributions were already added to
+  // the deltas by addMemoryContributions(). Consumed by this one move; reset so
+  // a following standalone moveNodeToPredefinedModule() (fresh zero deltas)
+  // recomputes them instead of leaving nodeFlow_log_nodeFlow stale. See the
+  // matching note in MemMapEquation::updateCodelengthOnMovingNode.
+  m_memoryContributionsAdded = false;
 }
 
 void RegularizedMultilayerMapEquation::addLayerTeleFlow(unsigned int moduleIndex, const std::vector<LayerTeleFlowData>& layerTeleFlowData)


### PR DESCRIPTION
Fixes #836.

## Problem

On memory / state / multilayer networks the two-level optimizer could report a codelength that did not match the partition it produced. `Infomap air30k.net out -2` printed three different two-level codelengths for one partition: `5.412328513` (progress finish + `Best codelength`), `5.401446` (`Levels` table / `.tree` output), and `5.402782814` (an intermediate restored point).

## Root cause

`getCodelength()` (incremental) and `calcCodelengthOnTree()` (fresh re-evaluation) are algebraically identical given consistent data — and agree exactly on ordinary networks — so this is a drift specific to the memory objective, which keeps two views of per-module physical-node flow:

- `m_physToModuleToMemNodes` — authoritative map; `consolidateModules` copies it into `module.physicalNodes`, feeding eval / output;
- `nodeFlow_log_nodeFlow` — the scalar behind `getCodelength()`.

In `tryMoveEachNodeIntoBestModule` (`src/core/InfomapOptimizer.h`) the optimizer drags a single orphaned node along with a moved node via `moveNodeToPredefinedModule`, which passes fresh zero-initialised memory deltas. Because `m_memoryContributionsAdded` was still `true` from the previous node's `addMemoryContributions`, `updateCodelengthOnMovingNode` took the map-only branch: it updated the map correctly but added a **zero** delta to the scalar. The map stayed correct (eval / output right); the scalar drifted low, so `getCodelength()` over-reported. A following `findTopModulesRepeatedly` normally rebuilds the scalar, which is why it only surfaced when a coarse-tune ended without a rebuild.

Because `getCodelength()` also drives the optimizer's improvement / stopping test, the inflated value made `partition()` stop tuning early at a worse optimum — so this was a search-quality bug, not only a reporting one.

## Fix

`m_memoryContributionsAdded` means "the deltas for *this* move already carry memory contributions" — true for exactly one move. Reset it at the end of `updateCodelengthOnMovingNode` in `MemMapEquation` and `RegularizedMultilayerMapEquation` so a following standalone `moveNodeToPredefinedModule` recomputes its own contributions instead of leaving the scalar stale. 16 lines across two files (mostly explanatory comments).

## Verification

- `air30k -2`: `getCodelength()` now equals the tree codelength — `Best codelength == Levels Total bits` (`5.396864731`). All three reported values collapse to one.
- Codelength improves (the optimizer no longer bails out early):
  - `-2` single-trial `5.412328513 → 5.396864731`; best-of-10 `5.393769623 → 5.392904985`, with much tighter per-trial spread.
  - hierarchical best-of-10 `5.393955343 → 5.392648339`; hierarchical now beats two-level on best-of-10 for `air30k`.
- Cost: ~30% slower per `-2` trial, because the optimizer now runs the tune iterations it previously skipped on the drifted codelength.
- C++ contract tests pass (`make test-native`; the 5 failing tests are the pre-existing `jsonschema`-missing environment gap, not code).
- Ordinary (non-memory) networks are provably unaffected — their objectives have no such flag and never reach the changed path; a small multilayer case is bit-identical to master.

## Not in this PR

The hierarchical recursive/super step can still degrade a good two-level base on some seeds, and the super-index consolidation log reports a wrong value (`flow` vs `enter`-flow). Tracked separately in #837; it no longer causes hierarchical < two-level on best-of-10 once this drift is fixed.


---

Release-notes override (repo convention: the C++ core is unscoped):

BEGIN_COMMIT_OVERRIDE
fix: keep the memory codelength scalar in sync with the module map

Closes #836
END_COMMIT_OVERRIDE
