### PR TITLE
ci(python): cache wheel compiles with sccache (macOS + Linux)

### DIFF
--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -405,8 +405,8 @@ jobs:
       # real compiler underneath, so a cache miss or an unavailable backend just
       # means no speedup -- never a failed build. The action's post step prints
       # cache stats. Linux (manylinux container) and Windows (MSVC) follow.
-      - name: Set up sccache (macOS)
-        if: startsWith(matrix.os, 'macos')
+      - name: Set up sccache (macOS + Linux)
+        if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - name: Build wheels
@@ -418,6 +418,23 @@ jobs:
             python -c "from infomap import Infomap, build_info; print(Infomap(silent=True).num_top_modules); assert ('regularized-multilayer' not in '${{ inputs.features }}'.replace(',', ' ').split()) or ('regularized-multilayer' in build_info()['enabled_features'])"
           CIBW_ENVIRONMENT: >-
             FEATURES="${{ inputs.features }}"
+          # Linux builds in the manylinux container: install sccache in it, wrap
+          # the compiler, and pass the GitHub Actions cache tokens (exported on
+          # the host by sccache-action) through so the in-container sccache uses
+          # the same GHA cache as macOS.
+          CIBW_BEFORE_ALL_LINUX: >-
+            curl -fsSL -o /tmp/sccache.tar.gz
+            https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-x86_64-unknown-linux-musl.tar.gz
+            && tar -xzf /tmp/sccache.tar.gz -C /tmp
+            && install -m 0755 /tmp/sccache-v0.16.0-x86_64-unknown-linux-musl/sccache /usr/local/bin/sccache
+          CIBW_ENVIRONMENT_LINUX: >-
+            CXX="sccache g++"
+            SCCACHE_GHA_ENABLED=true
+            FEATURES="${{ inputs.features }}"
+          CIBW_ENVIRONMENT_PASS_LINUX: >-
+            ACTIONS_CACHE_SERVICE_V2
+            ACTIONS_RESULTS_URL
+            ACTIONS_RUNTIME_TOKEN
           CIBW_ENVIRONMENT_MACOS: >-
             CXX="sccache /usr/bin/clang++"
             SCCACHE_GHA_ENABLED=true
@@ -487,8 +504,8 @@ jobs:
       # See the release build-wheels job: cache the C++ compiles on macOS via
       # sccache. Mirrored here so the (non-publishing) Python prerelease check
       # exercises the same sccache wiring before it reaches a real release.
-      - name: Set up sccache (macOS)
-        if: startsWith(matrix.os, 'macos')
+      - name: Set up sccache (macOS + Linux)
+        if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - name: Build prerelease wheels
@@ -499,6 +516,19 @@ jobs:
           CIBW_SKIP: "*-musllinux*"
           CIBW_TEST_COMMAND: >-
             python -c "from infomap import Infomap; print(Infomap(silent=True).num_top_modules)"
+          # See the release build-wheels job: sccache in the manylinux container.
+          CIBW_BEFORE_ALL_LINUX: >-
+            curl -fsSL -o /tmp/sccache.tar.gz
+            https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-x86_64-unknown-linux-musl.tar.gz
+            && tar -xzf /tmp/sccache.tar.gz -C /tmp
+            && install -m 0755 /tmp/sccache-v0.16.0-x86_64-unknown-linux-musl/sccache /usr/local/bin/sccache
+          CIBW_ENVIRONMENT_LINUX: >-
+            CXX="sccache g++"
+            SCCACHE_GHA_ENABLED=true
+          CIBW_ENVIRONMENT_PASS_LINUX: >-
+            ACTIONS_CACHE_SERVICE_V2
+            ACTIONS_RESULTS_URL
+            ACTIONS_RUNTIME_TOKEN
           CIBW_ENVIRONMENT_MACOS: >-
             CXX="sccache /usr/bin/clang++"
             SCCACHE_GHA_ENABLED=true

--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -420,6 +420,10 @@ jobs:
             FEATURES="${{ inputs.features }}"
           CIBW_ENVIRONMENT_MACOS: >-
             CXX="sccache /usr/bin/clang++"
+            SCCACHE_GHA_ENABLED=true
+            ACTIONS_CACHE_SERVICE_V2="$ACTIONS_CACHE_SERVICE_V2"
+            ACTIONS_RESULTS_URL="$ACTIONS_RESULTS_URL"
+            ACTIONS_RUNTIME_TOKEN="$ACTIONS_RUNTIME_TOKEN"
             FEATURES="${{ inputs.features }}"
             MACOSX_DEPLOYMENT_TARGET=${{ env.MACOS_DEPLOYMENT_TARGET }}
             CPPFLAGS="-I$(brew --prefix libomp)/include"
@@ -497,6 +501,10 @@ jobs:
             python -c "from infomap import Infomap; print(Infomap(silent=True).num_top_modules)"
           CIBW_ENVIRONMENT_MACOS: >-
             CXX="sccache /usr/bin/clang++"
+            SCCACHE_GHA_ENABLED=true
+            ACTIONS_CACHE_SERVICE_V2="$ACTIONS_CACHE_SERVICE_V2"
+            ACTIONS_RESULTS_URL="$ACTIONS_RESULTS_URL"
+            ACTIONS_RUNTIME_TOKEN="$ACTIONS_RUNTIME_TOKEN"
             MACOSX_DEPLOYMENT_TARGET=${{ env.MACOS_DEPLOYMENT_TARGET }}
             CPPFLAGS="-I$(brew --prefix libomp)/include"
             LDFLAGS="-L$(brew --prefix libomp)/lib"

--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -399,6 +399,16 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: brew install libomp
 
+      # macOS only for now: cibuildwheel recompiles the whole C++ core once per
+      # Python version (cp311-cp314) with no cross-version or cross-run cache.
+      # sccache + the GitHub Actions cache backend fixes that. sccache runs the
+      # real compiler underneath, so a cache miss or an unavailable backend just
+      # means no speedup -- never a failed build. The action's post step prints
+      # cache stats. Linux (manylinux container) and Windows (MSVC) follow.
+      - name: Set up sccache (macOS)
+        if: startsWith(matrix.os, 'macos')
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
       - name: Build wheels
         run: python -m cibuildwheel . --output-dir wheelhouse
         env:
@@ -409,7 +419,7 @@ jobs:
           CIBW_ENVIRONMENT: >-
             FEATURES="${{ inputs.features }}"
           CIBW_ENVIRONMENT_MACOS: >-
-            CXX=/usr/bin/clang++
+            CXX="sccache /usr/bin/clang++"
             FEATURES="${{ inputs.features }}"
             MACOSX_DEPLOYMENT_TARGET=${{ env.MACOS_DEPLOYMENT_TARGET }}
             CPPFLAGS="-I$(brew --prefix libomp)/include"
@@ -470,6 +480,13 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: brew install libomp
 
+      # See the release build-wheels job: cache the C++ compiles on macOS via
+      # sccache. Mirrored here so the (non-publishing) Python prerelease check
+      # exercises the same sccache wiring before it reaches a real release.
+      - name: Set up sccache (macOS)
+        if: startsWith(matrix.os, 'macos')
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
       - name: Build prerelease wheels
         run: python -m cibuildwheel . --output-dir wheelhouse
         env:
@@ -479,7 +496,7 @@ jobs:
           CIBW_TEST_COMMAND: >-
             python -c "from infomap import Infomap; print(Infomap(silent=True).num_top_modules)"
           CIBW_ENVIRONMENT_MACOS: >-
-            CXX=/usr/bin/clang++
+            CXX="sccache /usr/bin/clang++"
             MACOSX_DEPLOYMENT_TARGET=${{ env.MACOS_DEPLOYMENT_TARGET }}
             CPPFLAGS="-I$(brew --prefix libomp)/include"
             LDFLAGS="-L$(brew --prefix libomp)/lib"


### PR DESCRIPTION
The biggest remaining Python-CI lever: the `cibuildwheel` jobs recompile the whole C++ core **once per Python version**, with no cross-version or cross-run cache. Measured on a release run, `Build wheels` = **16 min (Windows) / 6.8 min (ubuntu) / 2.8 min (macOS)**.

This adds sccache with the GitHub Actions cache backend to the **macOS and Linux** wheel builds, in both the release (`cp311–cp314`) and prerelease (`cp315`) jobs.

## What

- **macOS** (native runner): `mozilla-actions/sccache-action` (SHA-pinned v0.0.10) + `CXX="sccache /usr/bin/clang++"`, with `SCCACHE_GHA_ENABLED` and the `ACTIONS_*` cache tokens passed through `CIBW_ENVIRONMENT_MACOS`.
- **Linux** (manylinux container): `CIBW_BEFORE_ALL_LINUX` installs sccache *inside the container*, `CIBW_ENVIRONMENT_LINUX` sets `CXX="sccache g++"` + `SCCACHE_GHA_ENABLED`, and `CIBW_ENVIRONMENT_PASS_LINUX` forwards the `ACTIONS_*` tokens into the container. `setup.py` reads `CXX` as the build compiler on every platform, so wrapping it works on both.
- **Non-fatal**: sccache runs the real compiler underneath — a cache miss or an unreachable backend only forgoes the speedup, it never breaks the build.

## Validated

Wheel jobs don't run on PR CI (they're gated on `build-release-artifacts`), so this was verified by dispatching `python-prerelease-check` (non-publishing) on this branch and comparing cold vs warm builds:

| Platform | Cold build | Warm build (100% cache hit) | Speedup |
|---|---|---|---|
| macOS | 100s | **37s** | ~63% |
| Linux (manylinux) | 142s | **46s** | ~68% |

Every C++ unit compiles through sccache (`sccache g++ -c …` / `sccache clang++ -c …`), `Cache location: ghac`, `Cache errors: 0`. The real release `build-wheels` job (four Python versions) gains even more, since the versions also reuse each other's cached objects within a run.

## Not included

- **Windows / MSVC** — the 16-min prize, and the hardest: MSVC / setuptools doesn't honor `CXX`, so it needs a different sccache wiring. Left as a separate follow-up.

## Notes for review

- Tokens are GHA-masked in logs.
- Linux builds are x86_64-only (musllinux skipped; no i686 in the published matrix), so the x86_64 musl sccache binary is safe.
- sccache 0.16 uses the GHA cache **v2** API (`ACTIONS_RESULTS_URL`), which is what the pinned action exports.
