### PR TITLE
ci(R): cache Windows R compiles with sccache

### DIFF
--- a/.github/workflows/_r-package.yml
+++ b/.github/workflows/_r-package.yml
@@ -127,10 +127,42 @@ jobs:
         with:
           key-prefix: r-${{ matrix.os }}-${{ matrix.r }}
 
+      # Windows R builds with Rtools gcc, which setup-ccache deliberately skips
+      # (it only persists the Linux/macOS ccache dirs). That left the Windows
+      # R CMD check recompiling the ~25-TU C++ core from scratch every run
+      # (~9 min, vs ~2 min where ccache is warm) -- the CI critical path. sccache
+      # with the GitHub Actions cache backend caches those compiles across runs
+      # the same way; Rtools gcc honors a launcher prefix through the package
+      # Makevars (the same launcher branch mk/r.mk uses for ccache on non-macOS
+      # unix), so pointing CCACHE_BIN at sccache is all the build needs.
+      - name: Set up sccache (Windows)
+        if: startsWith(matrix.os, 'windows')
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
+      # Start the server explicitly, at the top level, in the GHA-cache env. R's
+      # compiles run deeply nested (R CMD check -> INSTALL -> make -> sccache);
+      # if the very first sccache call has to spawn the server from down there it
+      # silently falls back to running g++ directly (no caching). sccache-action
+      # exports the ACTIONS_* tokens but not the enable flag, so set it here (and
+      # again on the build, insurance against an idle-timeout restart) -- without
+      # it sccache uses local disk, which does not persist across runs.
+      - name: Start sccache server (Windows)
+        if: startsWith(matrix.os, 'windows')
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+        run: sccache --start-server
+
       - name: Stage and check the package
+        env:
+          SCCACHE_GHA_ENABLED: ${{ startsWith(matrix.os, 'windows') && 'true' || '' }}
         run: |
-          make test-r
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            make test-r CCACHE_BIN=sccache USE_CCACHE=1
+          else
+            make test-r
+          fi
           command -v ccache >/dev/null 2>&1 && ccache -s || true
+          command -v sccache >/dev/null 2>&1 && sccache --show-stats || true
 
   build-source:
     if: inputs.build-release-artifacts

--- a/mk/r.mk
+++ b/mk/r.mk
@@ -37,6 +37,17 @@ R_PARALLEL := MAKE="$(MAKE) -j$(JOBS)"
 # next assignment cleanly.
 R_CCACHE_ENV := $(if $(CCACHE_LAUNCHER),CCACHE_NOHASHDIR=1 ,)
 R_MAKEVARS_FILE := $(CURDIR)/$(R_BUILD_DIR)/.Makevars.infomap
+# The recipes write the file through the shell, which understands the msys
+# /d/a/... form of $(CURDIR); R reads it, and R is a native Windows program even
+# under the Rtools bash shell, so it needs the Windows-native D:/a/... spelling.
+# Handing R the msys path makes it silently ignore the user Makevars, dropping
+# the compiler-launcher override. cygpath bridges the two; elsewhere the path is
+# already native.
+ifneq ($(filter MINGW% MSYS% CYGWIN%,$(UNAME_S)),)
+R_MAKEVARS_USER_PATH := $(shell cygpath -m '$(R_MAKEVARS_FILE)' 2>/dev/null || echo '$(R_MAKEVARS_FILE)')
+else
+R_MAKEVARS_USER_PATH := $(R_MAKEVARS_FILE)
+endif
 
 # On macOS, Homebrew LLVM clang++ may be first in PATH but Homebrew R uses
 # Apple's libc++ at runtime.  Compilation with LLVM clang++ produces a .so
@@ -52,14 +63,14 @@ R_MAKEVARS_FILE := $(CURDIR)/$(R_BUILD_DIR)/.Makevars.infomap
 ifeq ($(UNAME_S),Darwin)
 _R_CC  := $(if $(CCACHE_LAUNCHER),$(CCACHE_LAUNCHER) ,)/usr/bin/clang
 _R_CXX := $(if $(CCACHE_LAUNCHER),$(CCACHE_LAUNCHER) ,)/usr/bin/clang++
-R_CMD_ENV := R_MAKEVARS_USER=$(R_MAKEVARS_FILE) $(R_PARALLEL) $(R_CCACHE_ENV)INFOMAP_R_CXX_LAUNCHER=$(CCACHE_LAUNCHER)
+R_CMD_ENV := R_MAKEVARS_USER=$(R_MAKEVARS_USER_PATH) $(R_PARALLEL) $(R_CCACHE_ENV)INFOMAP_R_CXX_LAUNCHER=$(CCACHE_LAUNCHER)
 _write_r_makevars = @mkdir -p $(R_BUILD_DIR) && \
 	printf 'CC = %s\nCXX = %s\nCXX17 = %s\n' '$(_R_CC)' '$(_R_CXX)' '$(_R_CXX)' \
 	> $(R_MAKEVARS_FILE)
 else ifneq ($(CCACHE_LAUNCHER),)
-# Other unix: no configure override, so route R's configured compiler through
-# ccache via a user Makevars.
-R_CMD_ENV := R_MAKEVARS_USER=$(R_MAKEVARS_FILE) $(R_PARALLEL) $(R_CCACHE_ENV)
+# Other unix and Windows/Rtools: no configure override, so route R's configured
+# compiler through the launcher via a user Makevars.
+R_CMD_ENV := R_MAKEVARS_USER=$(R_MAKEVARS_USER_PATH) $(R_PARALLEL) $(R_CCACHE_ENV)
 _write_r_makevars = @mkdir -p $(R_BUILD_DIR) && \
 	cc="$$($(R) CMD config CC)"; cxx="$$($(R) CMD config CXX)"; cxx17="$$($(R) CMD config CXX17)"; \
 	printf 'CC = %s %s\nCXX = %s %s\nCXX17 = %s %s\n' \


### PR DESCRIPTION
Follow-up to #839 (sccache for wheel builds). Same tool, the last uncached spot on the CI critical path.

## The problem

On a core/R change, the whole `CI` run was gated by the **Windows R legs** (~10.6 min each). The tax is compilation: `setup-ccache` deliberately no-ops on Windows, so `R CMD check` recompiled the ~25-TU C++ core from scratch every run.

| R leg | before | `Stage and check` |
|---|---|---|
| release / windows | **10.7m** | **533s** |
| oldrel / windows | 10.2m | ~same |
| release / ubuntu | 2.9m | 106s (ccache warm) |

Windows R check was ~5× the ubuntu one, entirely because it was uncached.

## The fix

Windows R builds with **Rtools gcc — not MSVC** — and `mk/r.mk` already has a platform-generic launcher branch that prefixes R's configured `CC`/`CXX`/`CXX17` via the package Makevars (that's how ccache works on Linux R today). So the mechanism already existed; the only reason Windows missed out is that `setup-ccache` skips it. This wires **sccache with the GitHub Actions cache backend** into the Windows R legs.

Two Windows-specific details this needed, both found by validating on real runs:

1. **R reads `R_MAKEVARS_USER` as a native Windows program** even under the Rtools bash shell, so it must get the `D:/a/...` path — not the msys `/d/a/...` form `$(CURDIR)` yields there. With the msys path R silently ignored the user Makevars and compiled with plain g++ (0 sccache calls). `cygpath -m` bridges it; the recipes still *write* the file through the shell's msys path.
2. **The sccache server must be started explicitly, at the top level, in the GHA-cache env, before the build.** R's compiles run deeply nested (`R CMD check` → `INSTALL` → `make` → `sccache`); if the first sccache call has to spawn the server from down there it falls back to running g++ directly. `sccache-action` also exports the `ACTIONS_*` tokens but not `SCCACHE_GHA_ENABLED`, so that's set too — otherwise sccache uses local disk (no cross-run persistence).

## Validation

Dispatched the R jobs on this PR (the `_r-package.yml` path is in the `r` filter). Warm run, ghac populated:

| R leg | before | after |
|---|---|---|
| **release / windows** | 10.7m | **4.3m** |
| **oldrel / windows** | 10.2m | **4.7m** |

`Stage and check` on Windows: **533s → 170s**; sccache **64/64 = 100% hit rate**, `Cache location: ghac`. The same run shows Linux R at 64/64 ccache hits, confirming the launcher mechanism itself was already sound — this just extends it to Windows.

The R workflow's critical path is now the **r-universe simulation (~7.2m)**, an ubuntu job that deliberately rebuilds from clean and isn't cached — so overall CI on a core change drops from ~10.7m to ~7.2m. Caching r-universe is a possible separate follow-up.

## Not included

- **Release `build-binaries` Windows leg** (`make build-r-binary-from-tarball`) also compiles the core uncached on Windows, but it's release-only and needs a release dispatch to validate. Straightforward follow-up once this pattern is confirmed in `master`.
- **Linux/macOS R** stay on ccache via `actions/cache` (already warm); untouched.
