### PR TITLE
ci(R): cache the r-universe simulation compile with ccache

### DIFF
--- a/.github/workflows/_r-package.yml
+++ b/.github/workflows/_r-package.yml
@@ -341,9 +341,27 @@ jobs:
             any::rmarkdown
             any::tibble
 
+      - name: Set up ccache
+        uses: ./.github/actions/setup-ccache
+        with:
+          key-prefix: r-universe-ubuntu-24.04
+
       - name: Simulate r-universe package build
         run: |
           set -euo pipefail
+          # This job compiles the C++ core twice from clean (the R CMD build
+          # vignette install and R CMD INSTALL), uncached, which made it the R
+          # workflow's critical path. Route both through ccache via the personal
+          # Makevars, the same launcher trick mk/r.mk uses for `make test-r`.
+          # Both compiles happen in fresh temp dirs, so CCACHE_NOHASHDIR=1 is
+          # required for the entries to be reused across runs.
+          mkdir -p ~/.R
+          {
+            printf 'CC = ccache %s\n' "$(R CMD config CC)"
+            printf 'CXX = ccache %s\n' "$(R CMD config CXX)"
+            printf 'CXX17 = ccache %s\n' "$(R CMD config CXX17)"
+          } > ~/.R/Makevars
+          export CCACHE_NOHASHDIR=1
           rm -f interfaces/R/infomap/src/infomap_wrap.cpp
           (
             cd interfaces/R/infomap
@@ -367,3 +385,4 @@ jobs:
           fi
           R CMD INSTALL "$tarball"
           Rscript -e 'library(testthat); library(infomap); testthat::test_dir("interfaces/R/infomap/tests/testthat")'
+          command -v ccache >/dev/null 2>&1 && ccache -s || true


### PR DESCRIPTION
Follow-up to #840. Same theme — cache a from-scratch C++ core compile on the R critical path.

## Why

#840 dropped the Windows R legs (10.7m → 4.3m), which promoted the **r-universe simulation (~7.2m)** to the R workflow's critical path — the gate on the whole `CI` run for a core/R change.

That job faithfully simulates what r-universe/CRAN does: wipe the SWIG wrapper, `bootstrap.R`, `R CMD build` (renders vignettes via a temp install that compiles the core), then `R CMD INSTALL` (compiles the core again), then the testthat suite. So it compiles the ~25-TU core **twice, from clean, uncached** on every run — ~347s in the build step.

## The fix

Route both compiles through **ccache** via the personal `~/.R/Makevars` — the same launcher trick `mk/r.mk` uses for `make test-r`, and the same file the macOS OpenMP step already writes in this workflow. Compilers are derived from `R CMD config` so the flags stay correct. Both compiles happen in fresh temp dirs, so `CCACHE_NOHASHDIR=1` is required for the entries to survive across runs — exactly the r-universe case the existing `mk/r.mk` comment already calls out.

ccache is transparent, so the simulation's fidelity is unchanged: it still regenerates the SWIG wrapper, builds the source tarball, runs the same source-only purity check (no `.o`/`.so` packed), installs, and runs the tests. Dedicated cache key (`r-universe-ubuntu-24.04`), so it warms independently of the tests-job ccache.

## Validation

Dispatched the R jobs on this PR (`_r-package.yml` is in the `r` filter), then re-ran warm:

| run | r-universe sim | ccache |
|---|---|---|
| cold | 7.2m → **5.4m** | 31/62 hits (2nd compile pass hits the 1st within the run) |
| **warm** | **2.2m** | **62/62 = 100%**, 0 misses |

The R workflow's critical path now falls back to the Windows R legs (~4.7m). Full run green.
