### PR TITLE
ci(R): run R oldrel on push only, release on PRs

### DIFF
--- a/.github/workflows/_r-package.yml
+++ b/.github/workflows/_r-package.yml
@@ -11,6 +11,13 @@ on:
         required: false
         type: boolean
         default: true
+      full-matrix:
+        # When false, the tests job runs only the current R release, not oldrel.
+        # ci.yml sets this false on pull_request to halve the R matrix (oldrel is
+        # still covered on every push to master); everything else gets both.
+        required: false
+        type: boolean
+        default: true
       build-release-artifacts:
         required: false
         type: boolean
@@ -77,7 +84,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, macos-15, windows-2025-vs2026]
-        r: [release, oldrel]
+        # oldrel only when full-matrix is set (push/dispatch/release); PRs run
+        # release alone to keep this at 3 jobs -- the Windows leg is the CI
+        # critical path. oldrel regressions surface on the next push to master.
+        r: ${{ inputs.full-matrix && fromJSON('["release", "oldrel"]') || fromJSON('["release"]') }}
 
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,10 @@ jobs:
     uses: ./.github/workflows/_r-package.yml
     with:
       run-tests: true
+      # Run oldrel on push/dispatch, but only the current release on PRs -- halves
+      # the R matrix (and drops a Windows R leg, the CI critical path) per PR;
+      # oldrel is still exercised on every push to master.
+      full-matrix: ${{ github.event_name != 'pull_request' }}
       build-release-artifacts: false
 
   docs:


### PR DESCRIPTION
The cost lever from the CI-timing thread (after #840 and #841 cut the R critical path).

## What

The R test matrix is **3 OS × 2 R versions = 6 jobs** on every push *and* PR. `oldrel` (the previous R release) rarely breaks independently of `release`, yet it doubles the R matrix — including a **second Windows R leg**, which is the CI critical path.

Gate `oldrel` behind a new `full-matrix` input:
- `ci.yml` sets `full-matrix: ${{ github.event_name != 'pull_request' }}`.
- On **PRs**: current R release on all three OSes → **3 R test jobs** instead of 6.
- On **push / workflow_dispatch / release**: both versions, unchanged.

This mirrors the existing python `mode` input (event-derived control passed from `ci.yml`). Other callers — `release.yml` — omit the input and get the full matrix by default, so releases still test both R versions.

## Trade-off (deliberate)

This is a **cost / queue** lever, not a wall-clock one — the PR critical path is still the release Windows R leg. It saves ~40% of the R runner-minutes per PR and drops one Windows R job from the matrix.

`oldrel` is **still exercised on every push to master**, so a version-specific regression surfaces there — one merge later than a PR gate would catch it, rather than slipping out entirely. Given how stable the R package's oldrel behavior is, that's a reasonable trade. (If it ever bites, the fix is a scheduled full run or reverting this input.)

## Validation

This PR's own CI runs as a `pull_request`, so it should show **only the three `release` R jobs and no `oldrel`** — the direct proof the gate fires. Push behavior (full matrix) is what lands on master after merge.
