### PR TITLE
ci(docker): build multi-arch GHCR images on native arm64 runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,15 +167,20 @@ jobs:
         with:
           packages-dir: dist/python
 
-  publish-ghcr:
-    name: Publish GHCR Docker images
+  # Multi-arch GHCR publish, split into three stages so each architecture builds
+  # on a NATIVE runner (arm64 on ubuntu-24.04-arm) instead of under QEMU
+  # emulation, which made the old single job ~34 min. docker-build fans out over
+  # image x platform (4 parallel jobs) and pushes each by digest; docker-publish
+  # stitches the digests into the multi-arch tags. Layer caching (type=gha) is
+  # scoped per image+platform so the four builds don't clobber each other.
+  docker-meta:
+    name: Resolve Docker release metadata
     needs: [publish-github-release]
     runs-on: ubuntu-24.04
-    timeout-minutes: 90
-    permissions:
-      contents: read
-      packages: write
-
+    timeout-minutes: 5
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+      revision: ${{ steps.release.outputs.revision }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -194,22 +199,29 @@ jobs:
             exit 1
           fi
 
-          version="${RELEASE_TAG#v}"
-          revision="$(git rev-parse HEAD)"
-
           {
-            echo "tag=$RELEASE_TAG"
-            echo "version=$version"
-            echo "revision=$revision"
+            echo "version=${RELEASE_TAG#v}"
+            echo "revision=$(git rev-parse HEAD)"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Build and smoke-test supported Docker images
-        run: make test-docker-supported
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+  docker-build:
+    name: Build ${{ matrix.image }} image (${{ matrix.platform }})
+    needs: [docker-meta]
+    runs-on: ${{ matrix.platform == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [infomap, notebook]
+        platform: [amd64, arm64]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          platforms: amd64,arm64
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -221,52 +233,108 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and publish CLI image
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
-          file: docker/infomap.Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/mapequation/infomap:${{ steps.release.outputs.version }}
-            ghcr.io/mapequation/infomap:latest
+          file: docker/${{ matrix.image }}.Dockerfile
+          platforms: linux/${{ matrix.platform }}
+          # push-by-digest: no tag yet; docker-publish assembles the tagged
+          # multi-arch manifest once every arch has pushed. provenance:false keeps
+          # the pushed digest a plain image manifest so imagetools can merge it.
+          outputs: type=image,name=ghcr.io/mapequation/infomap,push-by-digest=true,name-canonical=true,push=true
+          provenance: false
+          cache-from: type=gha,scope=docker-${{ matrix.image }}-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=docker-${{ matrix.image }}-${{ matrix.platform }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
-            org.opencontainers.image.version=${{ steps.release.outputs.version }}
-            org.opencontainers.image.revision=${{ steps.release.outputs.revision }}
+            org.opencontainers.image.version=${{ needs.docker-meta.outputs.version }}
+            org.opencontainers.image.revision=${{ needs.docker-meta.outputs.revision }}
             org.opencontainers.image.licenses=GPL-3.0-or-later
 
-      - name: Build and publish notebook image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          file: docker/notebook.Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/mapequation/infomap:notebook-${{ steps.release.outputs.version }}
-            ghcr.io/mapequation/infomap:notebook
-          labels: |
-            org.opencontainers.image.source=https://github.com/${{ github.repository }}
-            org.opencontainers.image.version=${{ steps.release.outputs.version }}
-            org.opencontainers.image.revision=${{ steps.release.outputs.revision }}
-            org.opencontainers.image.licenses=GPL-3.0-or-later
-
-      - name: Verify published multi-arch manifests
+      - name: Export digest
         env:
-          VERSION: ${{ steps.release.outputs.version }}
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           set -euo pipefail
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
 
-          for image in \
-            "ghcr.io/mapequation/infomap:$VERSION" \
-            "ghcr.io/mapequation/infomap:latest" \
-            "ghcr.io/mapequation/infomap:notebook-$VERSION" \
-            "ghcr.io/mapequation/infomap:notebook"
-          do
-            echo "Inspecting $image"
-            docker buildx imagetools inspect "$image" | tee manifest.txt
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digests-${{ matrix.image }}-${{ matrix.platform }}
+          path: /tmp/digests/*
+          retention-days: 1
+          if-no-files-found: error
+
+  docker-publish:
+    name: Publish ${{ matrix.image }} multi-arch image
+    needs: [docker-meta, docker-build]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [infomap, notebook]
+    steps:
+      - name: Download amd64 digest
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: digests-${{ matrix.image }}-amd64
+          path: /tmp/digests/amd64
+
+      - name: Download arm64 digest
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: digests-${{ matrix.image }}-arm64
+          path: /tmp/digests/arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Smoke-test, assemble, and verify the multi-arch image
+        env:
+          VERSION: ${{ needs.docker-meta.outputs.version }}
+          IMAGE: ${{ matrix.image }}
+        run: |
+          set -euo pipefail
+          repo=ghcr.io/mapequation/infomap
+          amd64_digest="$(basename "$(ls /tmp/digests/amd64/)")"
+          arm64_digest="$(basename "$(ls /tmp/digests/arm64/)")"
+
+          # Functional smoke test of the real pushed artifact (amd64) BEFORE any
+          # tag points at it -- if it fails, no tag is created and the release
+          # does not ship a broken image.
+          if [ "$IMAGE" = notebook ]; then
+            docker run --rm "$repo@sha256:$amd64_digest" \
+              python -c "from infomap import Infomap; print(Infomap(silent=True).num_top_modules)" > /dev/null
+            tags=("$repo:notebook-$VERSION" "$repo:notebook")
+          else
+            docker run --rm "$repo@sha256:$amd64_digest" --help > /dev/null
+            tags=("$repo:$VERSION" "$repo:latest")
+          fi
+
+          tag_args=()
+          for t in "${tags[@]}"; do tag_args+=(-t "$t"); done
+          docker buildx imagetools create "${tag_args[@]}" \
+            "$repo@sha256:$amd64_digest" \
+            "$repo@sha256:$arm64_digest"
+
+          for t in "${tags[@]}"; do
+            echo "Inspecting $t"
+            docker buildx imagetools inspect "$t" | tee manifest.txt
             grep -q "linux/amd64" manifest.txt
             grep -q "linux/arm64" manifest.txt
           done


### PR DESCRIPTION
The release-pipeline lever. The GHCR publish was the release's biggest and most fragile job.

## The problem

`publish-ghcr` built both images (CLI + notebook) for `linux/amd64,linux/arm64` in a single job, with the arm64 half under **QEMU emulation**. Emulated compilation of the C++ core and the scipy/scanpy stack made it the release pipeline's biggest job — **~34 min** on the 2.15.0 release — and, per @antoneri, the one that hurts most when it breaks.

## The fix (all three levers)

Split into three stages so each architecture builds on a **native runner**:

- **`docker-meta`** — resolve version/revision once.
- **`docker-build`** — fan out over image × platform (**4 parallel jobs**), arm64 on `ubuntu-24.04-arm` (no QEMU), push each arch **by digest**, with **gha layer cache** scoped per image+platform.
- **`docker-publish`** — stitch the per-arch digests into the multi-arch tags with `buildx imagetools`, **smoke-testing the real pushed amd64 artifact before any tag points at it**, then verify both arches are present.

This is **#1 native arm64 runners + #2 gha layer cache + #3 parallelism** together. Same four tags (`:VERSION`, `:latest`, `:notebook-VERSION`, `:notebook`) to the same repo; the rest of `release.yml` is untouched.

## Validation

`publish-ghcr` only runs on a real release, so I validated the risky part — native arm64 building the scipy-notebook-based image — on a throwaway native-runner dry-run (both images × both arches, `push: false`, same cache scopes, native smoke). All green:

| image / arch | native build (cold) |
|---|---|
| CLI amd64 / arm64 | 1.2m / 1.1m |
| notebook amd64 / arm64 | 6.2m / **6.5m** |

**arm64 builds at native speed — no emulation penalty** (6.5m vs amd64's 6.2m). The four builds run in parallel, so `docker-build` finishes in **~6.5m**; with `docker-publish` (~2–3m) the whole GHCR stage lands around **~9m vs the old ~34m**. The arm64 notebook install (scanpy/leidenalg/umap-learn) and `import infomap` were exercised on a native arm64 runner — coverage the old QEMU path never had.

## Robustness notes

- **No broken image ships**: tags are only created in `docker-publish`, after the amd64 smoke test of the actual pushed digest passes. A failed build or smoke means no tag moves.
- **Cache caveat**: `type=gha` helps the base-image + apt layers; the notebook's heavy `pip install` sits after `COPY .`, so it re-runs when source changes (i.e. every release). The native-runner win is what carries the bulk — layer caching is upside, not the load-bearing piece.
- Can only be fully exercised by a real release (or a `workflow_dispatch` republish of an existing tag); the dry-run above covered the build matrix.
