### PR TITLE
ci: pin remaining mutable action tags, align versions, add missing job timeouts

### DIFF
--- a/.github/actions/setup-ccache/action.yml
+++ b/.github/actions/setup-ccache/action.yml
@@ -31,7 +31,7 @@ runs:
 
     - name: Cache ccache directory
       if: runner.os != 'Windows'
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ github.workspace }}/.ccache
         key: ccache-${{ inputs.key-prefix }}-${{ github.sha }}

--- a/.github/actions/setup-js-build/action.yml
+++ b/.github/actions/setup-js-build/action.yml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Set up Node.js
-      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 24
         cache: npm

--- a/.github/actions/setup-python-build/action.yml
+++ b/.github/actions/setup-python-build/action.yml
@@ -16,7 +16,7 @@ runs:
   using: composite
   steps:
     - name: Set up Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ inputs.python-version }}
         cache: pip

--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Cache SWIG 4.4.1 install
         id: swig-cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ runner.tool_cache }}/swig/4.4.1/${{ runner.arch }}
           key: swig-4.4.1-${{ runner.os }}-${{ runner.arch }}-v2

--- a/.github/workflows/_r-package.yml
+++ b/.github/workflows/_r-package.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Cache SWIG 4.4.1 install
         id: swig-cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ runner.tool_cache }}/swig/4.4.1/${{ runner.arch }}
           key: swig-4.4.1-${{ runner.os }}-${{ runner.arch }}-v2
@@ -100,7 +100,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
 
       - name: Set up R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           r-version: ${{ matrix.r }}
           use-public-rspm: true
@@ -121,7 +121,7 @@ jobs:
           python-version: "3.14"
 
       - name: Install R package dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
+        uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           working-directory: interfaces/R/infomap
           extra-packages: |
@@ -188,7 +188,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
 
       - name: Set up R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           r-version: release
           use-public-rspm: true
@@ -199,7 +199,7 @@ jobs:
           python-version: "3.14"
 
       - name: Install R package dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
+        uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           working-directory: interfaces/R/infomap
           extra-packages: |
@@ -241,7 +241,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
 
       - name: Set up R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           r-version: ${{ matrix.r }}
           use-public-rspm: true
@@ -262,7 +262,7 @@ jobs:
           python-version: "3.14"
 
       - name: Install R package dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
+        uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           working-directory: interfaces/R/infomap
 
@@ -330,7 +330,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
 
       - name: Set up R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           r-version: release
           use-public-rspm: true
@@ -341,7 +341,7 @@ jobs:
           python-version: "3.14"
 
       - name: Install R package dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
+        uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           working-directory: interfaces/R/infomap
           extra-packages: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,6 +323,7 @@ jobs:
     needs: changes
     if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repository
@@ -343,6 +344,7 @@ jobs:
     needs: changes
     if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.docker == 'true'
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy-redirect.yml
+++ b/.github/workflows/deploy-redirect.yml
@@ -79,13 +79,13 @@ jobs:
           HTML
 
       - name: Configure GitHub Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/deploy-redirect.yml
+++ b/.github/workflows/deploy-redirect.yml
@@ -16,6 +16,7 @@ jobs:
   deploy:
     name: Deploy redirect
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
 
     environment:
       name: github-pages


### PR DESCRIPTION
Supply-chain / CI hygiene surfaced by the post-perf-campaign strategy review. Three small, independent commits.

## Pin remaining mutable action tags to commit SHAs
Every third-party and official action in the repo is SHA-pinned except a handful still on moving major tags. Pinned them (with version comments), so the whole workflow surface is now uniformly pinned:

- `actions/cache@v6` → `# v6.1.0` (setup-ccache, _python-package, _r-package)
- `actions/configure-pages@v6`, `upload-pages-artifact@v5`, `deploy-pages@v5` (deploy-redirect)
- `r-lib/actions/setup-r@v2`, `setup-r-dependencies@v2` → `# v2.12.1`

Dependabot bumps SHA pins exactly as it does tag pins, so freshness is unaffected.

## Align duplicated action versions
The two composite actions lagged the versions used elsewhere, so the same action resolved to two different SHAs (an extra pin to audit + a redundant Dependabot PR):

- `setup-python` 6.2.0 → 6.3.0 (matches `_python-package.yml`, `_r-package.yml`)
- `setup-node` 6.3.0 → 7.0.0 (matches `release.yml`/`prerelease.yml` publish-npm)

Both targets are already exercised by green jobs in this repo.

## Add missing `timeout-minutes`
`docs`, `docker` (both in `ci.yml`) and `deploy` (`deploy-redirect.yml`) were the only jobs with real steps and no timeout — a hang would burn the 6-hour default. Bounded with headroom: docs 30m, docker 20m, deploy 10m.

## Verification
- `actionlint` clean on all touched workflows (the only finding is the pre-existing `if: false` on `cxx-format`, unrelated — tracked separately for re-enablement).
- SHAs resolved from the upstream tags and verified (`r-lib/actions` `v2` == `v2.12.1` commit).
- No functional change; CI on this PR exercises the aligned composite actions (js + python + r legs).