### PR TITLE
dx: docs-serve live preview, uv install note, .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,42 @@
+# EditorConfig — https://editorconfig.org
+# Baseline editor settings for drive-by contributors so indentation and
+# encoding match the per-language formatters (clang-format, ruff, biome, Air)
+# without having to install them first.
+#
+# Deliberately scoped to indentation, charset, and line endings. This repo
+# intentionally does NOT enforce trailing-whitespace trimming or final-newline
+# insertion (the corresponding pre-commit hooks were omitted because they
+# rewrite generated SWIG output, notebooks, and data fixtures). So those keys
+# are left unset here too — the language formatters already handle whitespace
+# for the sources they own, and we don't want format-on-save editors churning
+# generated or vendored files.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+
+# C++ core — .clang-format is WebKit-based with IndentWidth 2
+[*.{cpp,cc,h,hpp}]
+indent_size = 2
+
+# Python — ruff format (PEP 8, 4-space)
+[*.py]
+indent_size = 4
+
+# JS/TS + JSON — biome (2-space)
+[*.{js,jsx,mjs,cjs,ts,tsx,json}]
+indent_size = 2
+
+# R — Air (2-space)
+[*.R]
+indent_size = 2
+
+# YAML (workflows, configs)
+[*.{yml,yaml}]
+indent_size = 2
+
+# Makefiles require real tabs
+[{Makefile,*.mk}]
+indent_style = tab

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,12 @@ package with all extras (`.[test,docs,examples,release]`), runs `npm ci`, and
 installs the pre-commit git hooks (`make hooks`). Run it inside the active
 virtual environment.
 
+To speed up the dependency install (the scientific extras are heavy), override
+the installer with [uv](https://docs.astral.sh/uv/): `make dev-bootstrap
+PIP="uv pip"` (and likewise `make dev-python-install PIP="uv pip"`). `uv pip`
+installs into the active virtual environment just like `pip`; only dependency
+resolution is faster. CI already routes its Python installs through uv.
+
 Use an active virtual environment for Python development. Some system-managed
 Python installs, including Homebrew Python on macOS and distro Python on Linux,
 reject direct `pip install` into the system environment.

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -31,6 +31,8 @@ RSCRIPT ?= Rscript
 AIR ?= $(shell command -v air 2>/dev/null || command -v /opt/homebrew/bin/air 2>/dev/null || echo air)
 SPHINX_BUILD_BIN := $(shell command -v sphinx-build 2>/dev/null || true)
 SPHINX_BUILD ?= $(if $(SPHINX_BUILD_BIN),$(SPHINX_BUILD_BIN),$(PYTHON) -m sphinx)
+SPHINX_AUTOBUILD_BIN := $(shell command -v sphinx-autobuild 2>/dev/null || true)
+SPHINX_AUTOBUILD ?= $(if $(SPHINX_AUTOBUILD_BIN),$(SPHINX_AUTOBUILD_BIN),$(PYTHON) -m sphinx_autobuild)
 # Treat Sphinx warnings as errors so broken cross-references, missing labels, and
 # unresolved autodoc targets fail the build instead of shipping silently.
 # --keep-going reports every warning in one pass rather than stopping at the
@@ -197,6 +199,7 @@ help:
 		"" \
 		"Docs / Release" \
 		"  build-docs            Build the Python docs site into docs/ after installing the local package." \
+		"  docs-serve            Live-reloading local docs preview (sphinx-autobuild; builds leniently)." \
 		"  check-docs-links      Verify external documentation links resolve (linkcheck; hits the network)." \
 		"  release-python-dist   Build local sdist and wheel artifacts from the repo root." \
 		"  release-r-dist        Build the R source tarball and platform binary into dist/R/." \

--- a/mk/python.mk
+++ b/mk/python.mk
@@ -53,6 +53,7 @@ PYTHON_BUILD_ENV = \
 	test-python-notebooks-full \
 	build-docs \
 	_build-docs-site \
+	docs-serve \
 	check-docs-links \
 	clean-python \
 	format-python \
@@ -153,6 +154,17 @@ build-docs: build-native dev-python-install
 	@$(call BUILD_DOCS_SITE,$(DOCS_BUILD_DIR))
 	mkdir -p docs; \
 	rsync $(DOCS_SYNC_ARGS) "$(DOCS_BUILD_DIR)/" docs/
+
+# Live-reloading docs preview for local editing: rebuilds and refreshes the
+# browser on save. Builds leniently (SPHINXOPTS, i.e. build-docs's -W, is not
+# passed, so an in-progress warning does not abort the loop); myst-nb's
+# execution cache means unchanged notebooks are not re-run. Shares build-docs's
+# prereqs so the first build works, then autobuild handles reloads. Override
+# host/port etc. via DOCS_SERVE_ARGS (e.g. --port 8001).
+DOCS_SERVE_ARGS ?=
+docs-serve: build-native dev-python-install
+	@$(SPHINX_AUTOBUILD) -b html "$(SPHINX_SOURCE_DIR)" "$(DOCS_BUILD_DIR)/_serve" \
+		--open-browser $(DOCS_SERVE_ARGS)
 
 # Verify external links resolve. Hits the network, so run it on demand or on a
 # schedule rather than as a blocking per-PR gate; DOI hosts that 403 the bot are

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ docs = [
   # scikit-learn, scanpy, ...). Use `pip install -e ".[docs,examples]"`, which is
   # what `make build-docs` installs.
   "sphinx",
+  "sphinx-autobuild",
   "furo",
   "myst-nb",
   "sphinx-copybutton",


### PR DESCRIPTION
Three small developer-experience improvements from the strategy review. Independent commits.

## `make docs-serve` — live docs preview
`sphinx-autobuild` wrapper that rebuilds and refreshes the browser on save, so editing docs prose no longer costs a full `make build-docs` per iteration. Builds leniently (drops build-docs's `-W`, so an in-progress warning doesn't abort the loop); myst-nb's execution cache skips unchanged notebooks. Adds `sphinx-autobuild` to the `docs` extra and a `SPHINX_AUTOBUILD` resolver mirroring the existing `SPHINX_BUILD`. Listed in `make help` under Docs / Release.

## uv install note in AGENTS.md
Documents `make dev-bootstrap PIP="uv pip"` (and `dev-python-install`) as an optional accelerator for the heavy scientific extras. `uv pip` installs into the active venv exactly like `pip`; CI already routes its Python installs through uv (#822).

## `.editorconfig`
Baseline indentation / charset / EOL matching the per-language formatters (clang-format 2-space C++, ruff 4-space Python, biome 2-space JS/TS, Air 2-space R, tab Makefiles) so drive-by contributors get correct indentation without installing the toolchain. **Deliberately omits** `trim_trailing_whitespace` / `insert_final_newline`: this repo does not enforce those (the pre-commit hooks were dropped to avoid churning generated SWIG output, notebooks, and data fixtures), so the editor config shouldn't nudge format-on-save editors to reintroduce that churn.

## Verification
- `make -n docs-serve` expands to the correct `sphinx-autobuild -b html interfaces/python/source build/docs-site/_serve --open-browser` invocation; resolver falls back to `$(PYTHON) -m sphinx_autobuild` when the console script isn't on PATH.
- `make -n dev-bootstrap PIP="uv pip"` / `dev-python-install PIP="uv pip"` confirmed to emit `uv pip install -e ...`; `uv pip install` supports `--editable`.
- `pyproject.toml` re-parsed with `tomllib`; pre-commit hooks green on all three commits.