### PR TITLE
ci: run pre-commit as a CI gate (replaces disabled cxx-format)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,27 +183,46 @@ jobs:
       - name: Check runtime stream policy
         run: make test-cpp-stream-policy PYTHON=python3
 
-  cxx-format:
+  pre-commit:
     needs: changes
-    # Temporarily disabled while compilation warnings are being addressed (see #479).
-    # if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.native == 'true' || needs.changes.outputs.policy == 'true'
-    if: false
-    name: C++ formatting
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || needs.changes.outputs.policy == 'true'
+      || needs.changes.outputs.native == 'true'
+      || needs.changes.outputs.python-core == 'true'
+      || needs.changes.outputs.python-packaging == 'true'
+      || needs.changes.outputs.python-swig == 'true'
+      || needs.changes.outputs.javascript == 'true'
+    name: pre-commit
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Install clang-format
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang-format
-        shell: bash
+      - name: Set up Python
+        uses: ./.github/actions/setup-python-build
+        with:
+          python-version: "3.14"
 
-      - name: Check C++ formatting
-        run: make format-native-check
+      # Run the repo's own pre-commit config so local hooks and CI agree. This
+      # also restores C++ formatting enforcement (the old cxx-format job was
+      # disabled per #479): the clang-format hook is scoped to the same src/
+      # tree as `make format-native-check` and pins clang-format 20.1.7.
+      # Skipped hooks:
+      #   - biome-lint/biome-format: the javascript job already runs them via
+      #     `make test-js`.
+      #   - air-format (R): not gated yet. The committed R tree is not clean
+      #     under a current Air release and Air (pre-1.0) has no repo-wide
+      #     version pin; gating it needs a deliberate reformat + pin decision.
+      # The pre-push-staged pyright-core hook is not triggered by run --all-files.
+      - name: Run pre-commit hooks
+        env:
+          SKIP: biome-lint,biome-format,air-format
+        run: |
+          python -m pip install pre-commit
+          pre-commit run --all-files --show-diff-on-failure
 
   sanitizers:
     needs: changes
@@ -353,7 +372,7 @@ jobs:
 
   ci-summary:
     name: CI Summary
-    needs: [changes, policy, cxx-format, sanitizers, clang-tidy, native, python, notebooks, javascript, r, docs, docker]
+    needs: [changes, policy, pre-commit, sanitizers, clang-tidy, native, python, notebooks, javascript, r, docs, docker]
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 10

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,9 +50,9 @@ repos:
         # owns their formatting).
         exclude: ^examples/notebooks/
 
-  # C++ formatting for the core sources. The equivalent CI job is currently
-  # disabled (see #479), but `src/` is already clean under this clang-format
-  # version, so the hook keeps it that way locally. Scope matches the Makefile's
+  # C++ formatting for the core sources. This hook also runs in CI via the
+  # pre-commit job (which replaced the old, disabled cxx-format job from #479),
+  # so local and CI enforcement agree. Scope matches the Makefile's
   # HEADERS/SOURCES (find src -name '*.h'/'*.cpp').
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v20.1.7

--- a/src/io/JsonNetworkInputParser.h
+++ b/src/io/JsonNetworkInputParser.h
@@ -152,9 +152,21 @@ namespace input {
         return true;
       }
       bool binary(Json::binary_t&) { return true; }
-      bool start_object(std::size_t) { ++objectDepth; return true; }
-      bool key(std::string& val) { currentKey = val; return true; }
-      bool end_object() { --objectDepth; return true; }
+      bool start_object(std::size_t)
+      {
+        ++objectDepth;
+        return true;
+      }
+      bool key(std::string& val)
+      {
+        currentKey = val;
+        return true;
+      }
+      bool end_object()
+      {
+        --objectDepth;
+        return true;
+      }
       bool start_array(std::size_t)
       {
         if (objectDepth == 1 && arrayDepth == 0) {
@@ -166,7 +178,11 @@ namespace input {
         ++arrayDepth;
         return true;
       }
-      bool end_array() { --arrayDepth; return true; }
+      bool end_array()
+      {
+        --arrayDepth;
+        return true;
+      }
       bool parse_error(std::size_t position, const std::string& last_token, const Json::exception& ex)
       {
         throw std::runtime_error(fmt::format(FMT_STRING("JSON parse error at byte {} (near '{}'): {}"), position, last_token, ex.what()));


### PR DESCRIPTION
Closes the gap where a contributor without local hooks could land unformatted code. From the strategy review (§4.1/§4.2). Two commits.

## `style:` clang-format JsonNetworkInputParser.h
The C++ formatting gate has been disabled since #479, and one recently-added file (`src/io/JsonNetworkInputParser.h`) drifted out of clang-format shape as a result. Reformatted with the repo's pinned clang-format 20.1.7 — formatter output only, no behavior change. Prerequisite for the gate below.

## `ci:` pre-commit gate, replacing cxx-format
Adds a `pre-commit` job to `ci.yml` that runs the repo's own `.pre-commit-config.yaml`, so local hooks and CI enforce the same thing. Removes the dead `cxx-format` job (`if: false`) and points `ci-summary` at `pre-commit` instead.

**Restores C++ formatting enforcement** — the clang-format hook covers the same `src/` tree as `make format-native-check` and pins clang-format 20.1.7 (the old cxx-format job used an unpinned `apt install clang-format`, i.e. whatever the runner shipped). Also gates **ruff** (lint + format — ruff-format was previously enforced only locally), the **hygiene** checks (yaml/toml/merge/case/large-files), and the **C++ stream policy**.

Skipped hooks, with reasons in an inline comment:
- `biome-lint`/`biome-format` — the `javascript` job already runs them via `make test-js`.
- `air-format` (R) — **deferred.** The committed R tree is not clean under a current Air release, and Air (pre-1.0) has no repo-wide version pin, so gating it needs a deliberate reformat + version-pin decision rather than riding in this infra PR. R formatting remains enforced locally by the pre-commit hook, exactly as today. (Follow-up worth its own issue.)

Gated on the code-relevant `changes` filters (C++, Python, JS) so docs/R-only PRs keep the fast path.

## Verification
- `pre-commit run --all-files` (with the exact CI SKIP list) is green on this branch: ruff lint/format, clang-format, all hygiene hooks, and cpp-stream-policy Pass; biome + air Skip.
- `actionlint` clean on `ci.yml` (the previous `if: false` finding is gone with the removed job).
- The reformat diff is pure clang-format 20.1.7 output.