### PR TITLE
ci(python): build and publish linux-aarch64 wheels

### DIFF
--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -399,7 +399,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-2025-vs2026, macos-15]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025-vs2026, macos-15]
 
     steps:
       - name: Checkout repository
@@ -442,11 +442,14 @@ jobs:
           # the compiler, and pass the GitHub Actions cache tokens (exported on
           # the host by sccache-action) through so the in-container sccache uses
           # the same GHA cache as macOS.
+          # Arch-aware: uname -m is x86_64 on ubuntu-24.04 and aarch64 on the
+          # ubuntu-24.04-arm native runner, matching sccache's musl asset names.
           CIBW_BEFORE_ALL_LINUX: >-
-            curl -fsSL -o /tmp/sccache.tar.gz
-            https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-x86_64-unknown-linux-musl.tar.gz
+            sccache_arch="$(uname -m)"
+            && curl -fsSL -o /tmp/sccache.tar.gz
+            "https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-${sccache_arch}-unknown-linux-musl.tar.gz"
             && tar -xzf /tmp/sccache.tar.gz -C /tmp
-            && install -m 0755 /tmp/sccache-v0.16.0-x86_64-unknown-linux-musl/sccache /usr/local/bin/sccache
+            && install -m 0755 "/tmp/sccache-v0.16.0-${sccache_arch}-unknown-linux-musl/sccache" /usr/local/bin/sccache
           CIBW_ENVIRONMENT_LINUX: >-
             CXX="sccache g++"
             SCCACHE_GHA_ENABLED=true
@@ -470,8 +473,11 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: python scripts/patch_macos_torch_libomp_rpath.py wheelhouse/*.whl
 
+      # Excludes linux-aarch64: PyTorch's aarch64 Linux wheels lag on the newest
+      # CPython, and cibuildwheel's own CIBW_TEST_COMMAND already imports and
+      # smoke-tests every built wheel (including aarch64) inside the container.
       - name: Smoke test wheel with PyTorch
-        if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'windows')
+        if: matrix.os != 'ubuntu-24.04-arm'
         shell: bash
         run: |
           python -m pip install --upgrade pip
@@ -501,7 +507,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-2025-vs2026, macos-15]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025-vs2026, macos-15]
 
     steps:
       - name: Checkout repository
@@ -537,11 +543,14 @@ jobs:
           CIBW_TEST_COMMAND: >-
             python -c "from infomap import Infomap; print(Infomap(silent=True).num_top_modules)"
           # See the release build-wheels job: sccache in the manylinux container.
+          # Arch-aware: uname -m is x86_64 on ubuntu-24.04 and aarch64 on the
+          # ubuntu-24.04-arm native runner, matching sccache's musl asset names.
           CIBW_BEFORE_ALL_LINUX: >-
-            curl -fsSL -o /tmp/sccache.tar.gz
-            https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-x86_64-unknown-linux-musl.tar.gz
+            sccache_arch="$(uname -m)"
+            && curl -fsSL -o /tmp/sccache.tar.gz
+            "https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-${sccache_arch}-unknown-linux-musl.tar.gz"
             && tar -xzf /tmp/sccache.tar.gz -C /tmp
-            && install -m 0755 /tmp/sccache-v0.16.0-x86_64-unknown-linux-musl/sccache /usr/local/bin/sccache
+            && install -m 0755 "/tmp/sccache-v0.16.0-${sccache_arch}-unknown-linux-musl/sccache" /usr/local/bin/sccache
           CIBW_ENVIRONMENT_LINUX: >-
             CXX="sccache g++"
             SCCACHE_GHA_ENABLED=true


### PR DESCRIPTION
Adds linux-aarch64 to the published wheel set. From the strategy review (§3.1). The release currently ships 16 wheels but no aarch64 Linux, so Graviton/CI and Docker-on-Apple-Silicon users compile from sdist — while the repo already builds arm64 Docker images natively (#843).

## Change
`ubuntu-24.04-arm` (native arm64 runner, no QEMU) added to the cibuildwheel matrix in **both** the release `build-wheels` job and the `prerelease-wheels` job, so the release ships manylinux aarch64 wheels for cp311–cp314 alongside x86_64, and the (non-publishing) prerelease check exercises the same aarch64 wiring first.

Reuses the sccache cache wiring from #839, made **arch-aware**: `CIBW_BEFORE_ALL_LINUX` now selects the sccache musl asset by `uname -m` (`x86_64` on `ubuntu-24.04`, `aarch64` on `ubuntu-24.04-arm`) — both assets exist for sccache v0.16.0. Behavior-preserving for x86_64 (same URL as before).

Details:
- `musllinux` stays skipped (matches x86_64 policy).
- PyTorch interop smoke test skipped on aarch64: torch's aarch64 Linux wheels lag the newest CPython, and cibuildwheel's `CIBW_TEST_COMMAND` already imports and smoke-tests every built wheel (including aarch64) inside the container.
- The new `python-wheels-ubuntu-24.04-arm` artifact flows through the existing `python-wheels-*` download globs (`verify-release-artifacts`, `publish-github-release`, `publish-pypi`) with no further change. `verify-release-artifacts` only counts wheels, so aarch64 wheels on an x86 runner are fine.

**Not** adding macOS x86_64 (shrinking Intel base, deployment target 15.0, cross-built wheels can't be CI-tested; sdist covers it).

## Validation
Dispatched `python-prerelease-check.yml` on this branch (`gh workflow run … --ref worktree-aarch64-wheels`) to exercise the aarch64 build (native arm64 runner + arch-aware sccache + manylinux aarch64 container) before merge. Confirming the run is green.

- `actionlint` clean on `_python-package.yml`.
- sccache v0.16.0 `aarch64-unknown-linux-musl` asset confirmed to exist.