### PR TITLE
ci: gate R (Air) formatting in the pre-commit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,7 @@ jobs:
       || needs.changes.outputs.python-packaging == 'true'
       || needs.changes.outputs.python-swig == 'true'
       || needs.changes.outputs.javascript == 'true'
+      || needs.changes.outputs.r == 'true'
     name: pre-commit
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -206,20 +207,28 @@ jobs:
         with:
           python-version: "3.14"
 
+      # Air (R formatter) for the air-format hook. Pinned to the canonical
+      # version documented in AGENTS.md so local and CI formatting agree: Air is
+      # pre-1.0 and, with no air.toml in the repo, its output is version-
+      # dependent. Bump this pin and the AGENTS.md note together.
+      - name: Set up Air
+        uses: posit-dev/setup-air@cf390573ff4fe0f198f35df3a642b1409328d859 # v1.0.1
+        with:
+          version: "0.9.0"
+
       # Run the repo's own pre-commit config so local hooks and CI agree. This
       # also restores C++ formatting enforcement (the old cxx-format job was
       # disabled per #479): the clang-format hook is scoped to the same src/
-      # tree as `make format-native-check` and pins clang-format 20.1.7.
+      # tree as `make format-native-check` and pins clang-format 20.1.7. The
+      # air-format hook runs `make format-r-check` against the Air installed by
+      # the setup-air step above.
       # Skipped hooks:
       #   - biome-lint/biome-format: the javascript job already runs them via
       #     `make test-js`.
-      #   - air-format (R): not gated yet. The committed R tree is not clean
-      #     under a current Air release and Air (pre-1.0) has no repo-wide
-      #     version pin; gating it needs a deliberate reformat + pin decision.
       # The pre-push-staged pyright-core hook is not triggered by run --all-files.
       - name: Run pre-commit hooks
         env:
-          SKIP: biome-lint,biome-format,air-format
+          SKIP: biome-lint,biome-format
         run: |
           python -m pip install pre-commit
           pre-commit run --all-files --show-diff-on-failure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,11 +158,16 @@ Format on demand without the hooks:
 - R: `make format-r` (check only: `make format-r-check`)
 - JavaScript: `make format-js`
 
-CI enforces C++ formatting through the required `cxx-format` job
-(`make format-native-check`), so format `src/` changes before committing.
-Generated and vendored files — `interfaces/python/generated/`,
-`interfaces/R/generated/`, `interfaces/python/src/infomap/_swig.py`, and
-`vendor/` — are excluded from every hook; never reformat them.
+CI enforces formatting through the `pre-commit` job, which runs the same
+hooks locally and in CI — `clang-format` for C++ `src/` and `air` for the R
+sources — so format changes before committing. Air is pre-1.0 and the repo
+ships no `air.toml`, so its output is version-dependent; the canonical version
+is **0.9.0**, pinned in the `pre-commit` CI job via `posit-dev/setup-air`.
+Install that version locally so `make format-r-check` agrees with CI, and bump
+the CI pin and this note together. Generated and vendored files —
+`interfaces/python/generated/`, `interfaces/R/generated/`,
+`interfaces/python/src/infomap/_swig.py`, and `vendor/` — are excluded from
+every hook; never reformat them.
 
 ## Environment
 

--- a/interfaces/R/infomap/R/Infomap.R
+++ b/interfaces/R/infomap/R/Infomap.R
@@ -890,7 +890,11 @@ InfomapClass <- R6::R6Class(
         layers <- as.integer(igraph::vertex_attr(g, layer_id))
         for (i in seq_len(igraph::vcount(g))) {
           if (is.character(raw_vertex_names)) {
-            self$add_state_node(vertex_ids[i], phys[i], name = raw_vertex_names[i])
+            self$add_state_node(
+              vertex_ids[i],
+              phys[i],
+              name = raw_vertex_names[i]
+            )
           } else {
             self$add_state_node(vertex_ids[i], phys[i])
           }
@@ -949,7 +953,11 @@ InfomapClass <- R6::R6Class(
         # State network without explicit layer info.
         for (i in seq_len(igraph::vcount(g))) {
           if (is.character(raw_vertex_names)) {
-            self$add_state_node(vertex_ids[i], phys[i], name = raw_vertex_names[i])
+            self$add_state_node(
+              vertex_ids[i],
+              phys[i],
+              name = raw_vertex_names[i]
+            )
           } else {
             self$add_state_node(vertex_ids[i], phys[i])
           }


### PR DESCRIPTION
## What

Enforce R formatting (Air) in the CI `pre-commit` job. R was the one lint gate not enforced in CI: `air-format` sat in the job's `SKIP` list because the committed tree wasn't Air-clean and Air (pre-1.0) had no pinned version.

## Changes

- **`style:` reformat** — `make format-r` with Air 0.9.0. Only `interfaces/R/infomap/R/Infomap.R` changes: one over-long `add_state_node()` call wrapped in the two igraph state-node paths. Formatting only, no behavior change.
- **`ci:` wiring**
  - Install Air via the SHA-pinned `posit-dev/setup-air` (v1.0.1) with `version: "0.9.0"`.
  - Drop `air-format` from the `pre-commit` job's `SKIP` (now `biome-lint,biome-format`).
  - Re-add `needs.changes.outputs.r == 'true'` to the job's `if:` gate so R-only changes run it.
  - Document the canonical Air version (0.9.0) in `AGENTS.md`, and correct its stale "required `cxx-format` job" reference (replaced by this pre-commit job in #852).

## Version pin

0.9.0 matches the current local Air; the repo ships no `air.toml`, so the pinned version fully determines formatting output. Bump the CI `version:` and the `AGENTS.md` note together. (Latest Air is 0.10.0, which adds an `assignment-style` option plus parser changes — deliberately deferred to a separate bump.)

## Verification

`SKIP=biome-lint,biome-format pre-commit run --all-files` is green locally, with `air (R format)` now Passed (biome the only skipped hook). YAML of the edited workflow validated via the `check-yaml` hook.
