### PR TITLE
ci(python): cache Windows MSVC wheel compiles with sccache

### DIFF
--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -419,15 +419,27 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: brew install libomp
 
-      # macOS only for now: cibuildwheel recompiles the whole C++ core once per
-      # Python version (cp311-cp314) with no cross-version or cross-run cache.
-      # sccache + the GitHub Actions cache backend fixes that. sccache runs the
-      # real compiler underneath, so a cache miss or an unavailable backend just
-      # means no speedup -- never a failed build. The action's post step prints
-      # cache stats. Linux (manylinux container) and Windows (MSVC) follow.
-      - name: Set up sccache (macOS + Linux)
-        if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
+      # cibuildwheel recompiles the whole C++ core once per Python version
+      # (cp311-cp314) with no cross-version or cross-run cache. sccache + the
+      # GitHub Actions cache backend fixes that on every platform: unix wraps the
+      # compiler through CXX, Windows through setup.py's MSVC launcher (cl.exe
+      # ignores CXX). sccache runs the real compiler underneath, so a cache miss
+      # or an unavailable backend just means no speedup -- never a failed build.
+      # The action's post step prints cache stats.
+      - name: Set up sccache
+        if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'windows')
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
+      # The nested cl.exe compiles (cibuildwheel -> pip -> setup.py) spawn the
+      # sccache server too late and silently fall back to plain cl if it is not
+      # already running in the GHA-cache env, so start it explicitly at the top
+      # level. sccache-action exports the ACTIONS_* tokens but not the enable
+      # flag, so set that here.
+      - name: Start sccache server (Windows)
+        if: startsWith(matrix.os, 'windows')
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+        run: sccache --start-server
 
       - name: Build wheels
         run: python -m cibuildwheel . --output-dir wheelhouse
@@ -468,6 +480,16 @@ jobs:
             MACOSX_DEPLOYMENT_TARGET=${{ env.MACOS_DEPLOYMENT_TARGET }}
             CPPFLAGS="-I$(brew --prefix libomp)/include"
             LDFLAGS="-L$(brew --prefix libomp)/lib"
+          # cl.exe ignores CXX, so route it through sccache with setup.py's MSVC
+          # launcher instead. Tokens are expanded by cibuildwheel from the host
+          # env (exported by sccache-action); SCCACHE_GHA_ENABLED is set here.
+          CIBW_ENVIRONMENT_WINDOWS: >-
+            INFOMAP_MSVC_COMPILER_LAUNCHER=sccache
+            SCCACHE_GHA_ENABLED=true
+            ACTIONS_CACHE_SERVICE_V2="$ACTIONS_CACHE_SERVICE_V2"
+            ACTIONS_RESULTS_URL="$ACTIONS_RESULTS_URL"
+            ACTIONS_RUNTIME_TOKEN="$ACTIONS_RUNTIME_TOKEN"
+            FEATURES="${{ inputs.features }}"
 
       - name: Patch macOS OpenMP wheel loading
         if: startsWith(matrix.os, 'macos')
@@ -527,12 +549,18 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: brew install libomp
 
-      # See the release build-wheels job: cache the C++ compiles on macOS via
-      # sccache. Mirrored here so the (non-publishing) Python prerelease check
-      # exercises the same sccache wiring before it reaches a real release.
-      - name: Set up sccache (macOS + Linux)
-        if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
+      # See the release build-wheels job: cache the C++ compiles via sccache on
+      # every platform. Mirrored here so the (non-publishing) Python prerelease
+      # check exercises the same sccache wiring before it reaches a real release.
+      - name: Set up sccache
+        if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'windows')
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
+      - name: Start sccache server (Windows)
+        if: startsWith(matrix.os, 'windows')
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+        run: sccache --start-server
 
       - name: Build prerelease wheels
         run: python -m cibuildwheel . --output-dir wheelhouse
@@ -567,6 +595,14 @@ jobs:
             MACOSX_DEPLOYMENT_TARGET=${{ env.MACOS_DEPLOYMENT_TARGET }}
             CPPFLAGS="-I$(brew --prefix libomp)/include"
             LDFLAGS="-L$(brew --prefix libomp)/lib"
+          # See the release build-wheels job: cl.exe ignores CXX, so route it
+          # through sccache with setup.py's MSVC launcher instead.
+          CIBW_ENVIRONMENT_WINDOWS: >-
+            INFOMAP_MSVC_COMPILER_LAUNCHER=sccache
+            SCCACHE_GHA_ENABLED=true
+            ACTIONS_CACHE_SERVICE_V2="$ACTIONS_CACHE_SERVICE_V2"
+            ACTIONS_RESULTS_URL="$ACTIONS_RESULTS_URL"
+            ACTIONS_RUNTIME_TOKEN="$ACTIONS_RUNTIME_TOKEN"
 
       - name: Upload prerelease wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,25 @@ class BuildExt(build_ext):
 
         compiler._compile = compile_with_source_overrides
 
+        # Optional MSVC compiler launcher (e.g. "sccache"). setuptools' MSVC
+        # compiler ignores CC/CXX, so the launcher-via-CXX trick that routes the
+        # unix builds through sccache never reaches cl.exe. Instead prepend the
+        # launcher to each cl invocation by wrapping the compiler's spawn(). The
+        # link step (link.exe) is left untouched. Opt-in via env so ordinary
+        # builds are byte-for-byte unchanged; a no-op unless an MSVC build asks
+        # for it, and if a future setuptools stops routing compiles through
+        # spawn() the build simply runs uncached rather than breaking.
+        msvc_launcher = os.environ.get("INFOMAP_MSVC_COMPILER_LAUNCHER", "").split()
+        original_spawn = compiler.spawn
+        if msvc_launcher and getattr(compiler, "compiler_type", None) == "msvc":
+
+            def spawn_with_launcher(cmd, **kwargs):
+                if cmd and os.path.basename(str(cmd[0])).lower() in {"cl", "cl.exe"}:
+                    cmd = [*msvc_launcher, *cmd]
+                return original_spawn(cmd, **kwargs)
+
+            compiler.spawn = spawn_with_launcher
+
         # Compile this extension's ~30 translation units concurrently.
         # setuptools' build_ext.parallel only parallelizes *across extensions*,
         # and the package ships a single extension, so we parallelize the
@@ -119,6 +138,7 @@ class BuildExt(build_ext):
             super().build_extensions()
         finally:
             compiler._compile = original_compile
+            compiler.spawn = original_spawn
             if parallelize:
                 compiler.compile = original_compile_method
 


### PR DESCRIPTION
The last uncached wheel compile. #839 cached the C++ core on macOS + Linux (CXX wrapping); Windows was left out because setuptools' MSVC compiler ignores `CC`/`CXX`, so the launcher-via-CXX trick never reaches `cl.exe`. That left the release Windows wheels recompiling the core once per Python version (cp311–cp314), uncached — the single biggest job in the release pipeline (~16 min).

## The fix

It turned out not to be that hard. `setup.py`'s `MSVCCompiler` builds each object with `self.spawn([cl.exe, ...])`, so:

1. **`setup.py`** gains an opt-in MSVC launcher: when `INFOMAP_MSVC_COMPILER_LAUNCHER` is set and the compiler is MSVC, it wraps `spawn()` to prepend the launcher (`sccache`) to each `cl.exe` invocation (link step untouched). No-op unless an MSVC build asks for it, so ordinary builds are byte-for-byte unchanged; if a future setuptools stops routing compiles through `spawn()` the build just runs uncached rather than breaking.
2. **The wheel jobs** wire Windows like the others: extend `sccache-action` to windows, start the sccache server explicitly at the top level (the deeply nested `cl.exe` compiles otherwise spawn it too late and fall back to plain `cl` — the lesson from the Windows R build in #840), and pass `INFOMAP_MSVC_COMPILER_LAUNCHER=sccache` + the GHA cache env through `CIBW_ENVIRONMENT_WINDOWS`. Applied to both the release `build-wheels` job and the non-publishing prerelease check that validates it.

## Validation

Dispatched `python-prerelease-check` on this branch (builds cp315 wheels on every platform, non-publishing), cold then warm:

| run | Windows build step | sccache |
|---|---|---|
| cold | 325s | 64 compiles, 64 misses, **0 non-cacheable**, `Cache location: ghac` |
| **warm** | **169s** | **64/64 = 100% hits** |

So MSVC compiles now route through sccache and cache cleanly (`ghac` backend, all cacheable). cp315 alone (one version) already halves the compile step; the release `build-wheels` job builds **four** versions with the identical wiring, so within a single run cp312–cp314 hit cp311's compiles, and cross-run all four hit — the bulk of the ~16-min job's compile time collapses to a single cold build.

Windows is now the last platform brought onto the shared GHA sccache cache; unix (CXX) and Windows (MSVC launcher) all land in the same backend.
