### PR TITLE
ci: don't cancel in-progress CI runs on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,10 @@ permissions:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel superseded runs on PRs, but never on master: cancelling a master
+  # run marks its CI Summary as failed, leaving a permanent red X on that
+  # commit (ci-auto-rerun only retries setup-phase flakes, not cancellations).
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   changes:


### PR DESCRIPTION
One-line fix for a live problem: intermediate master commits get permanent red ✗ marks.

## Problem
`ci.yml` sets `cancel-in-progress: true` for all events. When a second merge lands on master shortly after the first, the earlier master run is cancelled — and a cancelled run's `CI Summary` concludes as **failed**, leaving a permanent red X on that intermediate commit. `ci-auto-rerun` doesn't help (it only retries setup-phase infra flakes, not cancellations). Seen live when the #853 merge cancelled the previous master run.

## Fix
```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```
PRs still cancel superseded runs (the fast-iteration benefit). Master and `workflow_dispatch` runs now always complete, so every master commit gets a real pass/fail.

## Verification
- `actionlint` clean.
- Behavior-preserving for PRs (still `true`); only master/dispatch change to non-cancelling.