### PR TITLE
ci(R): cache Windows R binary compiles with sccache

### DIFF
--- a/.github/workflows/_r-package.yml
+++ b/.github/workflows/_r-package.yml
@@ -272,8 +272,41 @@ jobs:
           name: r-source
           path: dist/R
 
+      # Cache the platform-binary compile the same way the tests job does: ccache
+      # on macOS, sccache (GitHub Actions backend) on Windows Rtools gcc, which
+      # setup-ccache skips. build-r-binary-from-tarball drives R CMD INSTALL
+      # --build through the same mk/r.mk launcher machinery as make test-r, so
+      # the wiring is identical. Windows sccache entries are content-addressed,
+      # so this leg reuses the tests job's compiles of the same core for free.
+      - name: Set up ccache
+        uses: ./.github/actions/setup-ccache
+        with:
+          key-prefix: r-binary-${{ matrix.os }}-${{ matrix.r }}
+
+      - name: Set up sccache (Windows)
+        if: startsWith(matrix.os, 'windows')
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
+      # Start the server explicitly, in the GHA-cache env, before the build: R's
+      # nested compiles otherwise spawn it too late and fall back to plain g++.
+      # sccache-action exports the ACTIONS_* tokens but not the enable flag.
+      - name: Start sccache server (Windows)
+        if: startsWith(matrix.os, 'windows')
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+        run: sccache --start-server
+
       - name: Build platform binary
-        run: make build-r-binary-from-tarball
+        env:
+          SCCACHE_GHA_ENABLED: ${{ startsWith(matrix.os, 'windows') && 'true' || '' }}
+        run: |
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            make build-r-binary-from-tarball CCACHE_BIN=sccache USE_CCACHE=1
+          else
+            make build-r-binary-from-tarball
+          fi
+          command -v ccache >/dev/null 2>&1 && ccache -s || true
+          command -v sccache >/dev/null 2>&1 && sccache --show-stats || true
 
       - name: Compute platform tag
         id: platform


### PR DESCRIPTION
The last uncached Windows compile in the whole pipeline. After #840 cached the R tests job and #855 cached the Windows wheels, the release `build-binaries` job was still compiling the C++ core from scratch on Windows — ~200s per leg (release + oldrel).

## The fix

`build-r-binary-from-tarball` drives `R CMD INSTALL --build` through the **same `mk/r.mk` launcher machinery** as `make test-r`, so this is a direct copy of the #840 wiring onto the `build-binaries` Windows legs: `setup-ccache` (macOS), `sccache-action` + explicit server start (Windows Rtools gcc), and `CCACHE_BIN=sccache` on the build step. The cygpath native-path fix from #840 already lives in `mk/r.mk`, so nothing else was needed.

## Validation

`build-binaries` only runs on a real release, so I validated `build-r-binary` on Windows via a throwaway branch-triggered job (removed before merge):

```
Compile requests   33
Cache hits         31 / 31   (100%)
Cache misses        0
Non-cacheable       0
Cache location      ghac
```

**31/31 hits, zero misses on the first run** — because Windows sccache entries are content-addressed, this leg reused the tests job's compiles of the same core straight from the shared GHA cache. `R CMD INSTALL --build` caches cleanly.

## Scope

Release-only, and the smallest of the campaign (~200s/leg, two legs that run in parallel, not on the release critical path). It's here for completeness: **every compile in both PR and release CI is now cached.** macOS `build-binaries` legs also pick up ccache in passing.
