### PR TITLE
ci: dependabot composite-action coverage + single-source cibuildwheel pin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,12 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: /
+    # Glob so composite actions under .github/actions/*/action.yml are scanned
+    # too, not just workflows and the root. A bare "directory: /" misses them,
+    # which let the setup-python/setup-node pins in the composites drift.
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: weekly
     labels:

--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -40,10 +40,6 @@ permissions:
   contents: read
 
 env:
-  # Single source of truth for the cibuildwheel pin used by the wheel jobs
-  # in this workflow. Keep in sync with the `release` extra in pyproject.toml
-  # (bumped there by dependabot).
-  CIBW_VERSION: "4.1.0"
   # Single source of truth for the macOS deployment target used by the
   # cibuildwheel jobs below. Keep in sync with mk/ci.mk (ci-export-github-env),
   # which sets the same value for the make-based macOS builds.
@@ -413,7 +409,11 @@ jobs:
           python-version: "3.14"
 
       - name: Install Python release tooling
-        run: python -m pip install build "cibuildwheel==${{ env.CIBW_VERSION }}" twine wheel
+        run: |
+          # cibuildwheel is single-sourced from the pyproject release extra
+          # (bumped by dependabot); read it here instead of a duplicate pin.
+          cibw="$(python -c 'import tomllib; print(next(r for r in tomllib.load(open("pyproject.toml","rb"))["project"]["optional-dependencies"]["release"] if r.startswith("cibuildwheel==")))')"
+          python -m pip install build "$cibw" twine wheel
 
       - name: Install macOS OpenMP runtime
         if: startsWith(matrix.os, 'macos')
@@ -543,7 +543,10 @@ jobs:
           python-version: "3.14"
 
       - name: Install cibuildwheel
-        run: python -m pip install "cibuildwheel==${{ env.CIBW_VERSION }}"
+        run: |
+          # Single-sourced from the pyproject release extra (see build-wheels).
+          cibw="$(python -c 'import tomllib; print(next(r for r in tomllib.load(open("pyproject.toml","rb"))["project"]["optional-dependencies"]["release"] if r.startswith("cibuildwheel==")))')"
+          python -m pip install "$cibw"
 
       - name: Install macOS OpenMP runtime
         if: startsWith(matrix.os, 'macos')


### PR DESCRIPTION
Two dependency-pin hygiene fixes, both verified against actual repo state during the strategy review. Independent commits.

## Let dependabot scan composite actions
`github-actions` used `directory: /`, which scans `.github/workflows/*` and the root `action.yml` but **not** composite actions under `.github/actions/*/action.yml`. That's the confirmed root cause of the setup-python (6.2.0 vs 6.3.0) / setup-node (6.3.0 vs 7.0.0) drift that #849 fixed symptomatically. Switch to a `directories` glob (`/` + `/.github/actions/*`) so dependabot keeps the composites current too.

## Single-source the cibuildwheel pin
cibuildwheel was pinned in **two** places — the `pyproject.toml` `release` extra (bumped by dependabot) and a `CIBW_VERSION` workflow env — so a bare dependabot bump silently drifted them until someone hand-synced the env (documented papercut). The two wheel jobs now read the version from the pyproject release extra and `CIBW_VERSION` is removed, leaving pyproject as the sole dependabot-maintained source.

## Verification
- Derivation confirmed locally: `python -c '...'` against `pyproject.toml` prints `cibuildwheel==4.1.0`.
- No `CIBW_VERSION` references remain anywhere in `.github/`.
- `actionlint` clean on `_python-package.yml`.
- No behavior change to the builds — same cibuildwheel version installed, just sourced once.