### PR TITLE
ci: extract SWIG setup into a composite action

### DIFF
--- a/.github/actions/setup-swig/action.yml
+++ b/.github/actions/setup-swig/action.yml
@@ -1,0 +1,40 @@
+name: Set up SWIG
+description: Install a pinned SWIG built from source (cached), and put it on PATH.
+inputs:
+  swig-version:
+    description: SWIG version to install.
+    required: false
+    default: "4.4.1"
+runs:
+  using: composite
+  steps:
+    - name: Cache SWIG ${{ inputs.swig-version }} install
+      id: swig-cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ runner.tool_cache }}/swig/${{ inputs.swig-version }}/${{ runner.arch }}
+        key: swig-${{ inputs.swig-version }}-${{ runner.os }}-${{ runner.arch }}-v2
+
+    - name: Install SWIG ${{ inputs.swig-version }}
+      if: steps.swig-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        swig_prefix="$RUNNER_TOOL_CACHE/swig/${{ inputs.swig-version }}/$RUNNER_ARCH"
+        sudo apt-get update
+        sudo apt-get install -y ca-certificates curl build-essential libpcre2-dev
+        curl -L --retry 3 --output /tmp/swig.tar.gz \
+          https://downloads.sourceforge.net/project/swig/swig/swig-${{ inputs.swig-version }}/swig-${{ inputs.swig-version }}.tar.gz
+        mkdir -p /tmp/swig-src
+        tar -xzf /tmp/swig.tar.gz -C /tmp/swig-src --strip-components=1
+        cd /tmp/swig-src
+        ./configure --prefix="$swig_prefix"
+        make -j"$(nproc)"
+        make install
+
+    - name: Add SWIG to PATH
+      shell: bash
+      run: echo "$RUNNER_TOOL_CACHE/swig/${{ inputs.swig-version }}/$RUNNER_ARCH/bin" >> "$GITHUB_PATH"
+
+    - name: Verify SWIG version
+      shell: bash
+      run: swig -version

--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -67,33 +67,8 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Cache SWIG 4.4.1 install
-        id: swig-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ runner.tool_cache }}/swig/4.4.1/${{ runner.arch }}
-          key: swig-4.4.1-${{ runner.os }}-${{ runner.arch }}-v2
-
-      - name: Install SWIG 4.4.1
-        if: steps.swig-cache.outputs.cache-hit != 'true'
-        run: |
-          swig_prefix="$RUNNER_TOOL_CACHE/swig/4.4.1/$RUNNER_ARCH"
-          sudo apt-get update
-          sudo apt-get install -y ca-certificates curl build-essential libpcre2-dev
-          curl -L --retry 3 --output /tmp/swig.tar.gz \
-            https://downloads.sourceforge.net/project/swig/swig/swig-4.4.1/swig-4.4.1.tar.gz
-          mkdir -p /tmp/swig-src
-          tar -xzf /tmp/swig.tar.gz -C /tmp/swig-src --strip-components=1
-          cd /tmp/swig-src
-          ./configure --prefix="$swig_prefix"
-          make -j"$(nproc)"
-          make install
-
-      - name: Add SWIG to PATH
-        run: echo "$RUNNER_TOOL_CACHE/swig/4.4.1/$RUNNER_ARCH/bin" >> "$GITHUB_PATH"
-
-      - name: Verify SWIG version
-        run: swig -version
+      - name: Set up SWIG
+        uses: ./.github/actions/setup-swig
 
       - name: Verify tracked SWIG outputs
         run: make test-python-swig-freshness

--- a/.github/workflows/_r-package.yml
+++ b/.github/workflows/_r-package.yml
@@ -43,33 +43,8 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Cache SWIG 4.4.1 install
-        id: swig-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ runner.tool_cache }}/swig/4.4.1/${{ runner.arch }}
-          key: swig-4.4.1-${{ runner.os }}-${{ runner.arch }}-v2
-
-      - name: Install SWIG 4.4.1
-        if: steps.swig-cache.outputs.cache-hit != 'true'
-        run: |
-          swig_prefix="$RUNNER_TOOL_CACHE/swig/4.4.1/$RUNNER_ARCH"
-          sudo apt-get update
-          sudo apt-get install -y ca-certificates curl build-essential libpcre2-dev
-          curl -L --retry 3 --output /tmp/swig.tar.gz \
-            https://downloads.sourceforge.net/project/swig/swig/swig-4.4.1/swig-4.4.1.tar.gz
-          mkdir -p /tmp/swig-src
-          tar -xzf /tmp/swig.tar.gz -C /tmp/swig-src --strip-components=1
-          cd /tmp/swig-src
-          ./configure --prefix="$swig_prefix"
-          make -j"$(nproc)"
-          make install
-
-      - name: Add SWIG to PATH
-        run: echo "$RUNNER_TOOL_CACHE/swig/4.4.1/$RUNNER_ARCH/bin" >> "$GITHUB_PATH"
-
-      - name: Verify SWIG version
-        run: swig -version
+      - name: Set up SWIG
+        uses: ./.github/actions/setup-swig
 
       - name: Verify tracked SWIG outputs
         run: make test-r-swig-freshness


### PR DESCRIPTION
Deduplication from the strategy review. The Python and R SWIG-freshness jobs each carried a byte-identical four-step block (cache → build-from-source → PATH-add → verify SWIG 4.4.1). Extracted into a `.github/actions/setup-swig` composite with the version as a defaulted input, so:
- the two jobs share one definition, and
- the SWIG version lives in one place (the composite default).

Each job now reads: Checkout → Set up Python → **Set up SWIG** → Verify tracked SWIG outputs. Behavior-preserving (same steps, same cache key/path, same `$GITHUB_PATH` export which propagates from the composite to the job's later `make test-*-swig-freshness` step).

## Verification
- No `swig-cache` / inline SWIG steps remain in either workflow.
- `actionlint` clean on both reusable workflows.
- Composite mirrors the existing `setup-python-build`/`setup-ccache` local-composite pattern (each `run` step has `shell: bash`).
- Dispatched `ci.yml` on this branch to exercise both swig-freshness jobs through the composite (they're path-gated off for a workflow-only PR). Confirming green.