### PR TITLE
ci: attest build provenance for GHCR images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,6 +281,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -309,6 +311,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Smoke-test, assemble, and verify the multi-arch image
+        id: assemble
         env:
           VERSION: ${{ needs.docker-meta.outputs.version }}
           IMAGE: ${{ matrix.image }}
@@ -342,6 +345,17 @@ jobs:
             grep -q "linux/amd64" manifest.txt
             grep -q "linux/arm64" manifest.txt
           done
+
+          # Manifest-list digest (both tags point at it) for the attestation below.
+          digest="$(docker buildx imagetools inspect "${tags[0]}" --format '{{.Manifest.Digest}}')"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ghcr.io/mapequation/infomap
+          subject-digest: ${{ steps.assemble.outputs.digest }}
+          push-to-registry: true
 
   publish-npm:
     name: Publish to npm


### PR DESCRIPTION
Closes the last publish target without attestation. PyPI (PEP 740) and npm (`--provenance`) already emit signed attestations; the GHCR Docker images did not.

## Change
In the `docker-publish` job, after `imagetools create` assembles and the smoke test passes, capture the multi-arch **manifest-list digest** and attest it with `actions/attest-build-provenance` (`push-to-registry: true`). Grants the job `id-token: write` + `attestations: write`.

Attesting the **manifest-list** digest (rather than per-arch) means `gh attestation verify oci://ghcr.io/mapequation/infomap:<tag>` resolves the tag → attested list digest and finds the attestation. The per-arch `provenance: false` on the `build-push` stage stays as-is — it's required for the push-by-digest + `imagetools` merge pattern (#843); flipping it would break the manifest assembly.

## Verification
- `actionlint` clean on `release.yml`.
- Digest capture uses the documented `docker buildx imagetools inspect --format '{{.Manifest.Digest}}'`.
- Attestation runs **after** the smoke test + manifest assembly, so images are validated before attesting; a failed attest fails the release loudly without shipping an unattested-but-broken image.
- ⚠️ **Cannot be CI-validated pre-merge**: `docker-publish` only runs on a real release (or a `workflow_dispatch` republish of an existing tag). The change follows the standard `attest-build-provenance` pattern; confirm on the next release with `gh attestation verify oci://ghcr.io/mapequation/infomap:<version>`.