### PR TITLE
test: map equation objective invariant tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,7 @@ if(BUILD_TESTING)
     add_infomap_cpp_test(infomap_cpp_lossy_tests test/cpp/test_lossy.cpp "fast;core;lossy")
     add_infomap_cpp_test(infomap_cpp_preferred_levels_tests test/cpp/test_preferred_levels.cpp "fast;core;preferred-levels")
     add_infomap_cpp_test(infomap_cpp_random_tests test/cpp/test_random.cpp "fast;core;rng")
+    add_infomap_cpp_test(infomap_cpp_map_equation_invariants_tests test/cpp/test_map_equation_invariants.cpp "fast;core;mapeq")
 
     add_test(
         NAME print_json_parameters
@@ -269,6 +270,9 @@ if(BUILD_TESTING)
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
         target_compile_options(infomap_cpp_lifecycle_tests PRIVATE -fno-access-control)
         target_compile_options(infomap_cpp_partition_tests PRIVATE -fno-access-control)
+        # Reaches InfomapBase::calcCodelengthOnTree (private) to recompute a
+        # partition from scratch and compare against the tracked codelength.
+        target_compile_options(infomap_cpp_map_equation_invariants_tests PRIVATE -fno-access-control)
     endif()
 
     add_custom_target(
@@ -289,6 +293,7 @@ if(BUILD_TESTING)
             infomap_cpp_lossy_tests
             infomap_cpp_preferred_levels_tests
             infomap_cpp_random_tests
+            infomap_cpp_map_equation_invariants_tests
             infomap_cli
     )
 endif()

--- a/test/cpp/test_map_equation_invariants.cpp
+++ b/test/cpp/test_map_equation_invariants.cpp
@@ -1,0 +1,97 @@
+#include "TestUtils.h"
+
+// Invariant tests for the map-equation objective family.
+//
+// After a search, the optimizer's *tracked* codelength (getCodelength(), updated
+// incrementally by updateCodelengthOnMovingNode as nodes move) must equal a
+// *fresh recompute* of the resulting partition (calcCodelengthOnTree, which
+// recomputes every module from its children rather than returning any running
+// value). The search loop relies on this equality; when it drifts, the reported
+// codelength is wrong even if the partition is fine -- the class of OO-engine
+// codelength-consistency bugs (#830/#831/#837).
+//
+// The objective is chosen from the input/flags (see InfomapBase::initOptimizer):
+//   ordinary network      -> BiasedMapEquation (the default)
+//   memory/state network  -> MemMapEquation
+//   --meta-data           -> MetaMapEquation
+//   memory + regularized  -> RegularizedMultilayerMapEquation (feature-gated)
+// so each TEST_CASE picks its objective purely through configuration.
+//
+// getCodelength()/calcCodelengthOnTree are private on InfomapBase; this TU is
+// compiled with -fno-access-control (see CMakeLists.txt) to reach them.
+
+namespace infomap {
+namespace test {
+
+namespace {
+
+// Two-level invariant: the incrementally tracked codelength must match a fresh
+// recompute of the resulting tree.
+void checkTrackedMatchesRecompute(InfomapWrapper& im)
+{
+  const double tracked = im.getCodelength();
+  const double recomputed = im.calcCodelengthOnTree(im.root(), true);
+  INFO("tracked=" << tracked << " recomputed=" << recomputed);
+  checkApproxCodelength(tracked, recomputed);
+}
+
+} // namespace
+
+TEST_CASE("MapEquation invariant: BiasedMapEquation (ordinary), tracked == recompute [fast][core][mapeq][biased]")
+{
+  InfomapWrapper im(defaultFlags("--two-level"));
+  im.readInputData(networkFixturePath("lossy_benchmark.net"));
+  im.run();
+  checkTrackedMatchesRecompute(im);
+}
+
+TEST_CASE("MapEquation invariant: MemMapEquation (memory), tracked == recompute [fast][core][mapeq][mem]")
+{
+  InfomapWrapper im(defaultFlags("--two-level"));
+  im.readInputData(networkFixturePath("states.net"));
+  im.run();
+  checkTrackedMatchesRecompute(im);
+}
+
+TEST_CASE("MapEquation invariant: MetaMapEquation (meta-data), tracked == recompute [fast][core][mapeq][meta]")
+{
+  InfomapWrapper im(defaultFlags("--two-level --meta-data " + repoPath("test/fixtures/meta/states.meta")));
+  im.readInputData(networkFixturePath("states.net"));
+  im.run();
+  checkTrackedMatchesRecompute(im);
+}
+
+#if INFOMAP_FEATURE_REGULARIZED_MULTILAYER
+TEST_CASE("MapEquation invariant: RegularizedMultilayerMapEquation, tracked == recompute [fast][core][mapeq][regularized]")
+{
+  // Regularized multilayer flow requires *Intra/*Inter input (not *Multilayer).
+  InfomapWrapper im(defaultFlags("--two-level --regularized"));
+  im.readInputData(networkFixturePath("intra_inter.net"));
+  im.run();
+  checkTrackedMatchesRecompute(im);
+}
+#endif
+
+// Regression for #830: under --entropy-corrected the tracked codelength drifts
+// from a fresh recompute (observed tracked 2.9815 vs recompute 2.9911). Marked
+// should_fail so it stays green while the bug is present and turns RED the
+// moment #830 is fixed -- at which point drop the decorator so it becomes a
+// normal passing invariant.
+TEST_CASE("MapEquation invariant: entropy-corrected tracked == recompute (repro #830) [core][mapeq][entropy-corrected]"
+          * doctest::should_fail())
+{
+  InfomapWrapper im(defaultFlags("--two-level --entropy-corrected"));
+  im.readInputData(networkFixturePath("lossy_benchmark.net"));
+  im.run();
+  checkTrackedMatchesRecompute(im);
+}
+
+// Follow-ups (not reproduced here): #831 (two-level initPartition/consolidate
+// reentrancy corrupting the recomputed codelength after a prior multi-level
+// trial) and #837 (hierarchical super-step degrading a two-level memory
+// partition via a wrong super-index consolidation value) are the same
+// tracked-vs-recompute drift class but need dedicated multi-trial / hierarchical
+// setups to isolate. Add targeted should_fail cases when those are pinned down.
+
+} // namespace test
+} // namespace infomap


### PR DESCRIPTION
Closes #846.

Adds `test/cpp/test_map_equation_invariants.cpp` asserting the invariant the search loop assumes: each objective's **incrementally tracked** codelength (`getCodelength()`, accumulated by `updateCodelengthOnMovingNode` during search) must equal a **fresh recompute** of the resulting partition (`calcCodelengthOnTree`) within `1e-10`. When that drifts, the reported codelength is wrong even if the partition is fine — the class of bug behind #830/#831/#837.

## Coverage
The objective is chosen purely by configuration (`InfomapBase` selection), so each case just picks flags/input:
- **BiasedMapEquation** — ordinary network (the default objective)
- **MemMapEquation** — memory/state network
- **MetaMapEquation** — `--meta-data`
- **RegularizedMultilayerMapEquation** — `--regularized` + `*Intra`/`*Inter` input, guarded by `#if INFOMAP_FEATURE_REGULARIZED_MULTILAYER` (same pattern as `test_lossy.cpp`)

New TU is compiled with `-fno-access-control` (like `test_partition`/`test_infomap_wrapper`) to reach the private `calcCodelengthOnTree` recompute.

## Regression for the open bugs
- **#830** reproduced as a `doctest::should_fail()` case: under `--entropy-corrected` the tracked codelength drifts from the recompute (observed ~2.9815 vs ~2.9911). It stays green while the bug exists and turns **red the moment #830 is fixed**, prompting removal of the decorator.
- **#831 / #837** are the same drift class but need dedicated multi-trial / hierarchical-memory setups to isolate; documented in-file as follow-ups rather than shipping speculative repros.

## Verification
- Full `make test-native`: **25/25 green** (was 24 — new test registered in the `infomap_cpp_tests` umbrella + `add_infomap_cpp_test`).
- Default build: 3 invariant cases + #830 `should_fail` all green (`Failed as expected → not failed`).
- Feature build (`FEATURES="regularized-multilayer"`): 4 invariant cases + #830, all green.
- Clean under **ASan/UBSan** (`make test-sanitizers`) — no findings, and the `should_fail` case doesn't hard-abort.
- C++14-compatible; tagged `[fast]` so `make test-fast` picks up the invariants.