### PR TITLE
docs: restrict commit types and scopes to a frequency-based allowlist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,30 @@ every hook; never reformat them.
 
 ## Commits and Pull Requests
 
+Commit subjects follow Conventional Commits: `type(scope): summary`, written
+in imperative mood, lowercase after the colon, no trailing period.
+release-please derives releases from them: `feat` bumps the minor version,
+`fix` the patch version, and a `BREAKING CHANGE:` footer (or `!` after the
+type) the major version. Only `feat`, `fix`, `perf`, and `revert` commits
+surface in the generated `CHANGELOG.md`; never edit that file by hand.
+
+Types and scopes are a fixed allowlist, restricted to what is frequent in
+this repo's history:
+
+- Allowed types: `feat`, `fix`, `perf`, `docs`, `test`, `refactor`, `build`,
+  `ci`, `chore`.
+- Allowed scopes:
+  - no scope — `src/` (C++ core) and repo-wide changes: `feat: ...`,
+    `fix: ...`, `perf: ...`
+  - `(python)` — the Python interface (`py` is a retired alias; do not use it)
+  - `(R)` — the R interface; `(js)` — the JavaScript interface
+  - `(deps)` / `(deps-dev)` — dependency bumps, dependabot's style
+- Everything else requires explicit confirmation from the user before
+  committing: rare types (`style`, `revert`), scopes that appear only
+  occasionally in history (`notebooks`, `docker`, `skills`, ...), any
+  breaking-change marker, and any type or scope not listed above. Never
+  propose `(core)` — the C++ core is the unscoped default — and never write
+  `chore(master): release ...` commits; those belong to release-please.
 - The user is the author of every commit and pull request. Author and commit
   all work in the user's name; never record yourself as the author.
 - Never add yourself as a co-author. Do not append `Co-Authored-By` trailers,


### PR DESCRIPTION
## What

AGENTS.md's "Commits and Pull Requests" section now spells out the conventional-commit subject format and pins the vocabulary to a strict allowlist:

- **Allowed types:** `feat`, `fix`, `perf`, `docs`, `test`, `refactor`, `build`, `ci`, `chore`
- **Allowed scopes:** none (`src/` and repo-wide), `(python)`, `(R)`, `(js)`, `(deps)`/`(deps-dev)`
- **Everything else needs explicit maintainer confirmation before committing:** rare types (`style`, `revert`), occasional scopes (`notebooks`, `docker`, `skills`, ...), and breaking-change markers

It also documents the release-please coupling (`feat` → minor, `fix` → patch, breaking → major; only `feat`/`fix`/`perf`/`revert` reach the CHANGELOG, which is generated and never hand-edited) and calls out two non-conventions: `(core)` is not a scope, and `chore(master): release ...` commits belong to release-please.

## Why

The lists come from a census of all 1885 commits rather than taste. The cut is clean: every allowed type has ≥17 uses (`style` has 7, `revert` 4); the allowed scopes are the living per-surface conventions (`(python)` 316 uses, `(js)` 60, `(deps-dev)` 28, `(deps)`/`(R)` 18 each), while `(core)` appears exactly once and `(py)` died in April. Pinning the vocabulary keeps subjects greppable and keeps release-please output consistent, and the confirmation rule leaves an escape hatch for the genuinely rare cases instead of banning them.