### PR TITLE
perf(core): plogp-bound move-loop speedups (bit-exact) — hoisted deltas, Mem fast paths, deferred seeding

### DIFF
--- a/src/core/ColumnarMapEquation.cpp
+++ b/src/core/ColumnarMapEquation.cpp
@@ -288,6 +288,39 @@ namespace {
 
     return delta_enter - delta_enter_log_enter - delta_exit_log_exit + delta_flow_log_flow;
   }
+
+  // Old-module plogp terms of deltaCodelengthMovingNode: constant for every
+  // candidate the move loop probes for the same unit, so the caller computes
+  // them once per unit (6 of the 13 plogp calls per candidate hoist out; the
+  // per-candidate math below keeps the exact expression structure, so results
+  // stay bit-identical to the unhoisted form).
+  struct OldSideTerms {
+    double plogpOldEnter, plogpOldExit, plogpOldEF;
+    double plogpOldEnterAfter, plogpOldExitAfter, plogpOldEFAfter;
+  };
+
+  inline OldSideTerms hoistOldSide(double curEnter, double curExit, double curFlow, double oldEnter, double oldExit, double oldFlow, double deltaOld)
+  {
+    using infomath::plogp;
+    const double oldExitPlusFlow = oldExit + oldFlow;
+    return { plogp(oldEnter), plogp(oldExit), plogp(oldExitPlusFlow), plogp(oldEnter - curEnter + deltaOld), plogp(oldExit - curExit + deltaOld), plogp(oldExitPlusFlow - curExit - curFlow + deltaOld) };
+  }
+
+  inline double deltaCodelengthMovingNodeHoisted(double enterFlow, double enterFlow_log_enterFlow, double curEnter, double curExit, double curFlow, const OldSideTerms& o, double newEnter, double newExit, double newFlow, double deltaOld, double deltaNew)
+  {
+    using infomath::plogp;
+    const double newExitPlusFlow = newExit + newFlow;
+
+    const double delta_enter = plogp(enterFlow + deltaOld - deltaNew) - enterFlow_log_enterFlow;
+    const double delta_enter_log_enter = -o.plogpOldEnter - plogp(newEnter)
+        + o.plogpOldEnterAfter + plogp(newEnter + curEnter - deltaNew);
+    const double delta_exit_log_exit = -o.plogpOldExit - plogp(newExit)
+        + o.plogpOldExitAfter + plogp(newExit + curExit - deltaNew);
+    const double delta_flow_log_flow = -o.plogpOldEF - plogp(newExitPlusFlow)
+        + o.plogpOldEFAfter + plogp(newExitPlusFlow + curExit + curFlow - deltaNew);
+
+    return delta_enter - delta_enter_log_enter - delta_exit_log_exit + delta_flow_log_flow;
+  }
 } // namespace
 
 void ColumnarTwoLevel::buildFromLeaves(const std::vector<InfoNode*>& leafNodes, bool undirected, unsigned long seed)
@@ -489,8 +522,10 @@ void ColumnarTwoLevel::moveUnit(int u, int newMod)
   const double curExit = m_lvl.exit[u];
   const double curFlow = m_lvl.flow[u];
 
-  removeModuleTerms(cMod);
-  removeModuleTerms(newMod);
+  if (!m_deferTerms) {
+    removeModuleTerms(cMod);
+    removeModuleTerms(newMod);
+  }
 
   m_mFlow[cMod] -= curFlow;
   m_mEnter[cMod] -= curEnter;
@@ -512,15 +547,41 @@ void ColumnarTwoLevel::moveUnit(int u, int newMod)
     m_mTeleWeight[newMod] += twu;
   }
 
-  addModuleTerms(cMod);
-  addModuleTerms(newMod);
-  m_enterFlow_log_enterFlow = plogp(m_enterFlow);
-  m_codelength = (m_enterFlow_log_enterFlow - m_enter_log_enter)
-      + (-m_exit_log_exit + m_flow_log_flow - m_nodeFlow_log_nodeFlow);
+  if (!m_deferTerms) {
+    addModuleTerms(cMod);
+    addModuleTerms(newMod);
+    m_enterFlow_log_enterFlow = plogp(m_enterFlow);
+    m_codelength = (m_enterFlow_log_enterFlow - m_enter_log_enter)
+        + (-m_exit_log_exit + m_flow_log_flow - m_nodeFlow_log_nodeFlow);
+  }
 
   m_mMembers[cMod] -= 1;
   m_mMembers[newMod] += 1;
   m_module[u] = newMod;
+}
+
+void ColumnarTwoLevel::rebuildRunningTerms()
+{
+  using infomath::plogp;
+  m_enterFlow = 0.0;
+  m_enter_log_enter = 0.0;
+  m_exit_log_exit = 0.0;
+  m_flow_log_flow = 0.0;
+  const int n = m_lvl.n;
+  for (int m = 0; m < n; ++m) {
+    if (m_mMembers[m] == 0)
+      continue;
+    const double enter = m_mEnter[m] + (m_recordedTeleport ? moduleTeleEnter(m_mTeleFlow[m], m_mTeleWeight[m]) : 0.0);
+    const double exit = m_mExit[m] + (m_recordedTeleport ? moduleTeleExit(m_mTeleFlow[m], m_mTeleWeight[m]) : 0.0);
+    m_enterFlow += enter;
+    m_enter_log_enter += plogp(enter);
+    m_exit_log_exit += plogp(exit);
+    m_flow_log_flow += plogp(exit + m_mFlow[m]);
+  }
+  m_enterFlow += m_exitNetworkFlow;
+  m_enterFlow_log_enterFlow = plogp(m_enterFlow);
+  m_codelength = (m_enterFlow_log_enterFlow - m_enter_log_enter)
+      + (-m_exit_log_exit + m_flow_log_flow - m_nodeFlow_log_nodeFlow);
 }
 
 double ColumnarTwoLevel::deltaCodelengthMovingNodeTele(double curEnter, double curExit, double curFlow, double tfu, double twu, int A, int B, double deltaOld, double deltaNew) const
@@ -554,11 +615,17 @@ double ColumnarTwoLevel::deltaCodelengthMovingNodeTele(double curEnter, double c
 
 void ColumnarTwoLevel::seedAssignment(const std::vector<int>& assign)
 {
-  // Start from singletons, then force each unit into its assigned module so the
-  // module aggregates + running terms end up exact (order-independent sums).
+  // Start from singletons, then force each unit into its assigned module. The
+  // placement is fully deterministic (no move decisions are made), so the
+  // running plogp terms are not maintained per move: only the module
+  // aggregates evolve (m_deferTerms), and the terms are rebuilt once at the
+  // end — one O(K) plogp pass instead of ~12 plogp per placed unit.
+  m_deferTerms = true;
   initPartition();
   for (int u = 0; u < m_lvl.n; ++u)
     moveUnit(u, assign[u]);
+  m_deferTerms = false;
+  rebuildRunningTerms();
   // Rebuild the empty-module list for the subsequent optimizing move loop.
   m_emptyModules.clear();
   for (int m = 0; m < m_lvl.n; ++m)
@@ -673,14 +740,17 @@ unsigned int ColumnarTwoLevel::moveLoop()
         }
       }
 
+      const OldSideTerms oldSide = m_recordedTeleport
+          ? OldSideTerms{}
+          : hoistOldSide(curEnter, curExit, curFlow, m_mEnter[cMod], m_mExit[cMod], m_mFlow[cMod], deltaOld);
       for (int m : touched) {
         if (m == cMod)
           continue;
         const double deltaNew = dEnter[m] + dExit[m];
         double dl = m_recordedTeleport
             ? deltaCodelengthMovingNodeTele(curEnter, curExit, curFlow, m_lvl.teleFlow[u], m_lvl.teleWeight[u], cMod, m, deltaOld, deltaNew)
-            : deltaCodelengthMovingNode(
-                  m_enterFlow, m_enterFlow_log_enterFlow, curEnter, curExit, curFlow, m_mEnter[cMod], m_mExit[cMod], m_mFlow[cMod], m_mEnter[m], m_mExit[m], m_mFlow[m], deltaOld, deltaNew);
+            : deltaCodelengthMovingNodeHoisted(
+                  m_enterFlow, m_enterFlow_log_enterFlow, curEnter, curExit, curFlow, oldSide, m_mEnter[m], m_mExit[m], m_mFlow[m], deltaOld, deltaNew);
         for (auto* c : corr)
           dl += c->moveDelta(u, cMod, m);
         if (dl < bestDelta - kMinSingleImprovement) {

--- a/src/core/ColumnarMapEquation.cpp
+++ b/src/core/ColumnarMapEquation.cpp
@@ -1566,10 +1566,22 @@ MemCorrection::MemCorrection(std::vector<int> leafPhysical, std::vector<double> 
   using infomath::plogp;
   for (double f : m_leafFlow)
     m_cState += plogp(f);
+  // Compact the physical ids to [0, P): every downstream structure (module
+  // maps, reverse index) keys on the compact id, and the dense per-module
+  // lookup (see initMoveLoop) indexes with it directly.
+  std::unordered_map<int, int> compact;
+  compact.reserve(m_leafPhysical.size());
+  for (auto& p : m_leafPhysical) {
+    const auto r = compact.emplace(p, static_cast<int>(compact.size()));
+    p = r.first->second;
+  }
+  m_numPhys = static_cast<int>(compact.size());
 }
 
 double MemCorrection::physFlow(int module, int physical) const
 {
+  if (m_dense)
+    return m_densePhysFlow[static_cast<std::size_t>(module) * m_numPhys + physical];
   const auto& pf = m_modulePhysFlow[module];
   const auto it = pf.find(physical);
   return it == pf.end() ? 0.0 : it->second;
@@ -1598,11 +1610,25 @@ double MemCorrection::initMoveLoop(const std::vector<int>& leafModule, int numMo
   using infomath::plogp;
   m_modulePhysFlow.assign(numModules, {});
   m_physModules.clear();
+  m_cacheUnit = -1;
+  // Dense per-module physical-flow lookup when it fits comfortably in memory
+  // (state networks typically have far fewer physical nodes than state nodes):
+  // physFlow becomes an O(1) array read in the move loop's hot path instead of
+  // a hash find. The sparse maps are kept alongside for iteration (merge scan).
+  m_dense = static_cast<double>(numModules) * static_cast<double>(m_numPhys) <= 8e6;
+  if (m_dense)
+    m_densePhysFlow.assign(static_cast<std::size_t>(numModules) * m_numPhys, 0.0);
+  // The physical -> modules reverse index only feeds the co-physical proposals
+  // (coMergeMode); maintaining it is pure overhead when that tuning mode is off.
+  const bool maintainIndex = coMergeMode() != 0;
   const int nLeaves = static_cast<int>(leafModule.size());
   for (int i = 0; i < nLeaves; ++i) {
     const int m = leafModule[i], p = m_leafPhysical[i];
     m_modulePhysFlow[m][p] += m_leafFlow[i];
-    m_physModules[p].insert(m);
+    if (m_dense)
+      m_densePhysFlow[static_cast<std::size_t>(m) * m_numPhys + p] += m_leafFlow[i];
+    if (maintainIndex)
+      m_physModules[p].insert(m);
   }
   double sum = 0.0;
   for (const auto& pf : m_modulePhysFlow)
@@ -1616,17 +1642,31 @@ double MemCorrection::moveDelta(int leaf, int oldMod, int newMod) const
   using infomath::plogp;
   if (oldMod == newMod)
     return 0.0;
+  // term = C_state - sum plogp(physFlow); only phys p in the two modules
+  // changes. The old-module part is identical for every candidate of the same
+  // leaf, so it is computed once and cached (the move loop probes many
+  // candidates per leaf); a candidate without the leaf's physical (the common
+  // case) needs no logs at all: plogp(0) == 0 and plogp(0 + f) == plogp(f),
+  // which is cached alongside.
   const int p = m_leafPhysical[leaf];
   const double f = m_leafFlow[leaf];
-  const double oc = physFlow(oldMod, p), nc = physFlow(newMod, p);
-  // term = C_state - sum plogp(physFlow); only phys p in the two modules changes.
-  return (plogp(oc) - plogp(oc - f)) + (plogp(nc) - plogp(nc + f));
+  if (leaf != m_cacheUnit || oldMod != m_cacheOldMod) {
+    const double oc = physFlow(oldMod, p);
+    m_cacheUnit = leaf;
+    m_cacheOldMod = oldMod;
+    m_cacheOldTerm = plogp(oc) - plogp(oc - f);
+    m_cachePlogpF = plogp(f);
+  }
+  const double nc = physFlow(newMod, p);
+  return m_cacheOldTerm + (nc == 0.0 ? -m_cachePlogpF : (plogp(nc) - plogp(nc + f)));
 }
 
 void MemCorrection::applyMove(int leaf, int oldMod, int newMod)
 {
   if (oldMod == newMod)
     return;
+  m_cacheUnit = -1; // module contents change: drop the per-leaf delta cache
+  const bool maintainIndex = !m_physModules.empty() || coMergeMode() != 0;
   const int p = m_leafPhysical[leaf];
   const double f = m_leafFlow[leaf];
   auto& oldPhys = m_modulePhysFlow[oldMod];
@@ -1635,11 +1675,20 @@ void MemCorrection::applyMove(int leaf, int oldMod, int newMod)
     it->second -= f;
     if (it->second <= 1e-16) {
       oldPhys.erase(it);
-      m_physModules[p].erase(oldMod); // oldMod no longer holds physical p
+      if (maintainIndex)
+        m_physModules[p].erase(oldMod); // oldMod no longer holds physical p
     }
   }
   m_modulePhysFlow[newMod][p] += f;
-  m_physModules[p].insert(newMod);
+  if (m_dense) {
+    auto& ov = m_densePhysFlow[static_cast<std::size_t>(oldMod) * m_numPhys + p];
+    ov -= f;
+    if (ov <= 1e-16)
+      ov = 0.0; // keep the zero fast path exact
+    m_densePhysFlow[static_cast<std::size_t>(newMod) * m_numPhys + p] += f;
+  }
+  if (maintainIndex)
+    m_physModules[p].insert(newMod);
 }
 
 void MemCorrection::proposeMoveTargets(int leaf, std::vector<int>& out) const
@@ -1662,22 +1711,38 @@ double MemCorrection::mergeDelta(int a, int b) const
   // physical in only one keeps its single plogp term). Iterate the (smaller)
   // A side; b-only physicals are handled when B is the A of another pair.
   const auto& pa = m_modulePhysFlow[a];
-  const auto& pb = m_modulePhysFlow[b];
   double dSum = 0.0; // change in sum_p plogp(physFlow)
-  for (const auto& kv : pa) {
-    const auto it = pb.find(kv.first);
-    const double bv = (it == pb.end()) ? 0.0 : it->second;
-    dSum += plogp(kv.second + bv) - plogp(kv.second) - plogp(bv);
+  if (m_dense) {
+    const std::size_t bBase = static_cast<std::size_t>(b) * m_numPhys;
+    for (const auto& kv : pa) {
+      const double bv = m_densePhysFlow[bBase + kv.first];
+      if (bv == 0.0)
+        continue; // physical only in A: plogp(a+0) - plogp(a) - plogp(0) == 0
+      dSum += plogp(kv.second + bv) - plogp(kv.second) - plogp(bv);
+    }
+  } else {
+    const auto& pb = m_modulePhysFlow[b];
+    for (const auto& kv : pa) {
+      const auto it = pb.find(kv.first);
+      if (it == pb.end())
+        continue; // physical only in A: plogp(a+0) - plogp(a) - plogp(0) == 0
+      dSum += plogp(kv.second + it->second) - plogp(kv.second) - plogp(it->second);
+    }
   }
   return -dSum; // correction = C_state - sum_p plogp; delta correction = -dSum
 }
 
 void MemCorrection::applyMerge(int a, int b)
 {
+  m_cacheUnit = -1;
   auto& pa = m_modulePhysFlow[a];
   auto& pb = m_modulePhysFlow[b];
   for (const auto& kv : pa) {
     pb[kv.first] += kv.second;
+    if (m_dense) {
+      m_densePhysFlow[static_cast<std::size_t>(b) * m_numPhys + kv.first] += kv.second;
+      m_densePhysFlow[static_cast<std::size_t>(a) * m_numPhys + kv.first] = 0.0;
+    }
     if (!m_physModules.empty()) { // maintained only when co-physical mode is on
       auto& mods = m_physModules[kv.first];
       mods.erase(a);

--- a/src/core/ColumnarMapEquation.h
+++ b/src/core/ColumnarMapEquation.h
@@ -329,6 +329,9 @@ private:
   // Seed the partition of `m_lvl` at a given unit->module assignment (the shared
   // primitive behind fine/coarse/interior tuning), maintaining exact aggregates.
   void seedAssignment(const std::vector<int>& assign);
+  // Recompute the running plogp terms + codelength from the module aggregates
+  // (one O(K) pass). Pairs with m_deferTerms for deterministic placements.
+  void rebuildRunningTerms();
   // Forced move of one unit to a target module, updating aggregates + terms.
   void moveUnit(int u, int newMod);
   unsigned int moveLoop();
@@ -413,6 +416,7 @@ private:
   unsigned long m_seed = 123;
   double m_exitNetworkFlow = 0.0; // flow leaving this (sub-)network; 0 if closed
   unsigned int m_superAggLimit = 0; // >0: conservative up-build (passes/super-level)
+  bool m_deferTerms = false; // deterministic placement: moveUnit skips running-term (plogp) maintenance; rebuildRunningTerms() restores them
   bool m_leafMoveLoop = false; // true while moveLoop units are leaves (corrections active)
   bool m_seededPhase = false; // true when the move loop starts from an existing partition (fine-tune/refine)
   double m_lastCorrection = 0.0; // correction total of the last leaf move loop (0 if none)

--- a/src/core/ColumnarMapEquation.h
+++ b/src/core/ColumnarMapEquation.h
@@ -567,9 +567,23 @@ public:
 private:
   double physFlow(int module, int physical) const;
 
-  std::vector<int> m_leafPhysical; // per leaf (state node): physical node id
+  std::vector<int> m_leafPhysical; // per leaf (state node): COMPACT physical id in [0, m_numPhys)
   std::vector<double> m_leafFlow; // per leaf: state flow
   double m_cState; // constant sum_leaf plogp(stateFlow)
+
+  // Dense per-module physical-flow lookup (enabled in initMoveLoop when
+  // numModules * numPhys is small): O(1) reads in the move loop's hot path.
+  // The sparse maps stay authoritative for iteration (merge scan).
+  bool m_dense = false;
+  int m_numPhys = 0;
+  std::vector<double> m_densePhysFlow;
+
+  // Per-(leaf, current-module) delta cache: the old-module term and plogp(f)
+  // are identical for every candidate the move loop probes for the same leaf.
+  mutable int m_cacheUnit = -1;
+  mutable int m_cacheOldMod = -1;
+  mutable double m_cacheOldTerm = 0.0;
+  mutable double m_cachePlogpF = 0.0;
 
   std::vector<std::unordered_map<int, double>> m_modulePhysFlow; // physFlow_{m,p}
   // Reverse index physical id -> modules currently holding a state node of that


### PR DESCRIPTION
## Summary

Engine-level speedups found while profiling the air30k state network for #834, split out of PR #835 per review because they are more general than the memory objective — the biggest one (the hoist) speeds up **every** network and objective. All changes are **bit-exact**: identical codelengths verified on all 11 benchmark networks × {`-C`, `-C -F`, `-2 -C`} against this branch's base, and the contract suites pass. Same patterns filed for the OO optimizer as #867.

## Profile that motivated it (air30k `-2 -C`, per-trial phase table, seed 123)

| phase | before | after |
|---|--:|--:|
| pass 1 (leaf move loop from singletons) | 0.35s | 0.23s |
| module passes (3) | 0.10s | 0.06s |
| fine-tune (3–4 iterations) | 0.09s | 0.06s |
| merge scan (coarsening) | 0.05–0.22s | 0.02–0.11s |
| retune / stack / gate evals | 0.04s | 0.03s |
| **trial** | **0.62–0.87s** | **0.34–0.56s** |

Counters: ~35 move-loop sweeps, ~134k unit visits, ~1.3M candidate evaluations per trial — the search was **plogp-bound** (`log2` = 26% of all samples; `MemCorrection::moveDelta` 18%).

## The fixes

**Commit 1 — shared core (all objectives, all networks):**
1. `deltaCodelengthMovingNode` evaluates 13 plogp per candidate; **6 are old-module terms constant across every candidate of the same unit** — hoisted once per unit visit (`hoistOldSide` + `deltaCodelengthMovingNodeHoisted`). The per-candidate expression structure is unchanged, so results are bit-identical. (The OO optimizer has the same pattern — #867.)
2. **Deferred seeding**: `seedAssignment` placed units through `moveUnit`, paying ~12 plogp of running-codelength maintenance per placed unit during a fully deterministic placement. A defer flag skips the term updates and `rebuildRunningTerms()` restores them in one O(K) pass.

**Commit 2 — MemCorrection hot path:**
3. Per-(leaf, module) **delta cache**: the old-module term was recomputed for every candidate.
4. **Zero fast-paths**: candidates without the leaf's physical node need no logs (plogp(0)=0, plogp(0+f)=plogp(f) cached); `mergeDelta` burned 3 plogp per disjoint pair to produce exactly 0 — skipped (−30% on the merge scan).
5. The **co-physical reverse index** (`m_physModules`) only feeds the `COL_COMERGE` proposals (off by default) but was maintained on every init/move — now gated.
6. **Dense per-module physical-flow lookup** (compact physical ids; enabled when numModules × numPhys is small): O(1) reads instead of hash finds. Honest note: measured neutral-to-small after 3+4 removed most logs from this path; kept because it costs nothing and serves the merge scan.

## Benchmark diff (interleaved same-session, user-time, best of 10, seed 123 — codelength column omitted because every value is bit-identical)

| network | `-C` | `-C -F` | `-2 -C` |
|---|--:|--:|--:|
| air30k (states) | 6.02 → **3.96s** (−34%) | 5.73 → 3.76s (−34%) | 8.36 → **5.08s** (−39%) |
| malaria (multilayer) | 5.32 → **3.46s** (−35%) | 5.25 → 3.33s (−37%) | 3.97 → 2.65s (−33%) |
| science2001 `-d` | 4.04 → 3.37s (−17%) | 3.83 → 3.12s (−19%) | 3.05 → 2.49s (−18%) |
| web-NotreDame `-d` | 22.89 → 20.52s (−10%) | 16.09 → 14.75s (−8%) | 21.91 → 20.21s (−8%) |
| powergrid | 0.28 → 0.25s | 0.16 → 0.15s | 0.12 → 0.11s |
| politicalblogs `-d` | 0.08 → 0.07s | 0.08 → 0.07s | 0.06 → 0.05s |
| toys (ninetriangles, jazz, netsci, lazega, multilayer ex.) | ≤0.03s, unchanged | | |

Deep/memory networks gain the most because the correction machinery ran in every leaf loop; plain hierarchy networks gain the hoist share (~8–17%).

## Not in this PR

- The **tele-path variant** of the hoist (`deltaCodelengthMovingNodeTele`, recorded-teleportation runs) — same pattern, straightforward follow-up.
- The **Meta correction** analog of the cache/zero-path treatment.
- PR #835 (module-aware memory correction) will be rebased on top of this once merged; the per-unit aggregate paths there get the same treatment in that rebase.

## Per-commit attribution (interleaved same-session, user-time, best of 10, seed 123)

| run | base | + commit 1 (hoist + deferred seeding) | + commit 2 (Mem fast paths) |
|---|--:|--:|--:|
| air30k `-C` | 6.67s | 5.41s (−19%) | 4.47s (−17% more, −33% total) |
| air30k `-2 -C` | 8.64s | 7.71s (−11%) | 5.48s (−26% more, −37% total) |
| web-NotreDame `-C` | 23.45s | 21.92s (−6.5%) | 21.78s (−0.6% ≈ noise) |
| web-NotreDame `-2 -C` | 23.82s | 21.92s (−8%) | 22.19s (+1% ≈ noise) |

web-NotreDame's entire gain comes from commit 1 (no Mem correction → commit 2 is a no-op there; the ±1% residual is machine noise). air30k splits roughly evenly, with the Mem fast paths weighing more on `-2` (its pipeline runs the correction-heavy merge scan and interleave). Within the commits (instrumented cumulative sequence, indicative): commit 1 is essentially all the hoist (deferred seeding = 7→4ms per trial); commit 2's bulk is the delta cache + zero fast-paths, with index gating small and the dense lookup neutral on totals.