### PR TITLE
ci: extract path filters, fix composite-action coverage gap, trim the PR graph

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -1,0 +1,161 @@
+# Path filters for the CI change-detection job (ci.yml `changes`).
+#
+# Consumed by dorny/paths-filter, which resolves YAML anchors and flattens the
+# resulting nested lists. The two anchors below are the path clusters that used
+# to be copy-pasted across filters; editing one here now updates every filter
+# that composes it. That duplication was not cosmetic -- it is why the
+# setup-swig / setup-ccache composites silently fell out of coverage: a build
+# step could change without triggering the lane that builds it, yet still get a
+# green "CI Summary" (the only required check). Every composite under
+# .github/actions/ must appear in at least one filter that triggers the
+# workflows using it.
+#
+# Anchors are kept flat (an anchor never references another anchor) so no filter
+# nests deeper than one level, which paths-filter flattens reliably.
+
+# Makefile + build system + C++ sources: the compile inputs shared by every lane
+# that builds the core.
+_build_core: &build_core
+  - "Makefile"
+  - "mk/**"
+  - "src/**"
+
+# The CMake/native-build inputs shared by the native, python-core, and
+# javascript lanes (each of which builds the C++ core through _native-build.yml).
+_cmake_core: &cmake_core
+  - "CMakeLists.txt"
+  - "test/cpp/**"
+  - "test/fixtures/**"
+  - ".github/workflows/_native-build.yml"
+
+policy:
+  - *build_core
+  - "interfaces/swig/**"
+  - "interfaces/R/generated/**"
+  - "scripts/check_cpp_stream_policy.py"
+  - ".github/workflows/ci.yml"
+  - ".github/filters.yml"
+
+native:
+  - *build_core
+  - *cmake_core
+  - ".clang-format"
+  - ".clang-tidy"
+  - "CMakePresets.json"
+  - "test/scripts/**"
+  - "test/schemas/**"
+  - ".github/workflows/ci.yml"
+  - ".github/filters.yml"
+  - ".github/actions/setup-ccache/action.yml"
+
+python-core:
+  - *build_core
+  - *cmake_core
+  - "pyproject.toml"
+  - "setup.py"
+  - "interfaces/swig/**"
+  - "interfaces/python/**"
+  - "examples/python/**"
+  - "examples/notebooks/**"
+  - "examples/networks/**"
+  - "test/python/**"
+  - "test/scripts/**"
+  - "test/schemas/**"
+  - "scripts/build_config.py"
+  - "scripts/generate_python_swig.py"
+  - "scripts/notebook_manifest.py"
+  - ".github/actions/setup-python-build/action.yml"
+  - ".github/actions/setup-ccache/action.yml"
+  - ".github/workflows/ci.yml"
+  - ".github/workflows/_python-package.yml"
+  - ".github/filters.yml"
+
+# Packaging config only -- deliberately NOT *build_core (no src/**): a core
+# source change is covered by python-core, and should not also fire the
+# release-smoke packaging lane.
+python-packaging:
+  - "Makefile"
+  - "mk/**"
+  - "pyproject.toml"
+  - "setup.py"
+  - "scripts/build_config.py"
+  - ".github/actions/setup-python-build/action.yml"
+  - ".github/actions/setup-ccache/action.yml"
+  - ".github/workflows/_python-package.yml"
+  - ".github/filters.yml"
+
+python-swig:
+  - "interfaces/swig/**"
+  - "interfaces/python/generated/**"
+  - "interfaces/python/src/infomap/_swig.py"
+  - "scripts/generate_python_swig.py"
+  - ".github/actions/setup-swig/action.yml"
+  - ".github/workflows/_python-package.yml"
+  - ".github/filters.yml"
+
+javascript:
+  - *build_core
+  - *cmake_core
+  - ".github/workflows/ci.yml"
+  - "package.json"
+  - "package-lock.json"
+  - "interfaces/js/**"
+  # The binding-options freshness gate runs in the JS workflow, so changes to
+  # the generator or its inputs must trigger it.
+  - "interfaces/parameters/**"
+  - "scripts/generate_binding_options.py"
+  - "scripts/parameter_catalog.py"
+  - "scripts/generate_js_metadata.py"
+  - "scripts/prepare_npm_package.py"
+  - ".github/actions/setup-js-build/action.yml"
+  - ".github/workflows/_js-package.yml"
+  - ".github/filters.yml"
+
+r:
+  - *build_core
+  - "interfaces/swig/**"
+  - "interfaces/R/**"
+  - "examples/R/**"
+  - "scripts/generate_r_swig.py"
+  - "scripts/stage_r_package.py"
+  - ".github/actions/setup-swig/action.yml"
+  - ".github/actions/setup-ccache/action.yml"
+  - ".github/workflows/ci.yml"
+  - ".github/workflows/_r-package.yml"
+  - ".github/filters.yml"
+
+docs:
+  - *build_core
+  - "README.rst"
+  - "BUILD.md"
+  - "pyproject.toml"
+  - "setup.py"
+  - "examples/notebooks/**"
+  - "scripts/build_config.py"
+  - "scripts/notebook_manifest.py"
+  - "interfaces/python/**"
+  - ".github/actions/setup-python-build/action.yml"
+  - ".github/filters.yml"
+
+docker:
+  - *build_core
+  - "docker/**"
+  - "docker-compose.yml"
+  - ".dockerignore"
+  - "pyproject.toml"
+  - "setup.py"
+  - "examples/notebooks/**"
+  - "interfaces/python/**"
+  - "scripts/build_config.py"
+  - "README.rst"
+  - ".github/filters.yml"
+
+notebooks:
+  - "interfaces/python/**"
+  - "test/python/**"
+  - "examples/notebooks/**"
+  - "scripts/notebook_manifest.py"
+  - ".github/actions/setup-python-build/action.yml"
+  - ".github/workflows/ci.yml"
+  - ".github/workflows/notebooks.yml"
+  - ".github/filters.yml"

--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -69,12 +69,15 @@ jobs:
       - name: Verify tracked SWIG outputs
         run: make test-python-swig-freshness
 
+  # Runs in parallel with swig-freshness rather than after it: freshness is an
+  # independent invariant that produces no artifact the tests consume, and CI
+  # Summary already requires both to be green, so a stale-SWIG failure surfaces
+  # on its own without gating the (much longer) test matrix.
   tests:
-    if: ${{ always() && inputs.run-tests && (needs.swig-freshness.result == 'success' || needs.swig-freshness.result == 'skipped') }}
+    if: inputs.run-tests
     name: Python ${{ matrix.os }} / ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    needs: swig-freshness
     strategy:
       # quick mode (PRs) fails fast across its two legs; full mode lets every
       # version leg finish so one failure cannot hide another.

--- a/.github/workflows/_r-package.yml
+++ b/.github/workflows/_r-package.yml
@@ -49,12 +49,16 @@ jobs:
       - name: Verify tracked SWIG outputs
         run: make test-r-swig-freshness
 
+  # tests, build-source, and r-universe-simulation no longer gate on
+  # swig-freshness: it produces no artifact they consume (build-source and
+  # r-universe-simulation regenerate SWIG from scratch), and CI Summary already
+  # requires the freshness job to be green. Decoupling lets them all start at
+  # once instead of behind the freshness check.
   tests:
     if: inputs.run-tests
     name: R ${{ matrix.r }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
-    needs: swig-freshness
     strategy:
       fail-fast: false
       matrix:
@@ -154,7 +158,6 @@ jobs:
     name: R source tarball
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    needs: swig-freshness
 
     steps:
       - name: Checkout repository
@@ -325,7 +328,6 @@ jobs:
     name: R r-universe simulation
     runs-on: ubuntu-24.04
     timeout-minutes: 60
-    needs: swig-freshness
 
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,147 +44,7 @@ jobs:
         id: filter
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v3.0.2
         with:
-          filters: |
-            policy:
-              - "Makefile"
-              - "mk/**"
-              - "src/**"
-              - "interfaces/swig/**"
-              - "interfaces/R/generated/**"
-              - "scripts/check_cpp_stream_policy.py"
-              - ".github/workflows/ci.yml"
-            native:
-              - ".clang-format"
-              - ".clang-tidy"
-              - "CMakePresets.json"
-              - "CMakeLists.txt"
-              - "Makefile"
-              - "mk/**"
-              - "src/**"
-              - "test/cpp/**"
-              - "test/scripts/**"
-              - "test/schemas/**"
-              - "test/fixtures/**"
-              - ".github/workflows/ci.yml"
-              - ".github/workflows/_native-build.yml"
-            python-core:
-              - "CMakeLists.txt"
-              - "Makefile"
-              - "mk/**"
-              - "src/**"
-              - "test/cpp/**"
-              - "test/fixtures/**"
-              - ".github/workflows/ci.yml"
-              - ".github/workflows/_native-build.yml"
-              - "pyproject.toml"
-              - "setup.py"
-              - "interfaces/swig/**"
-              - "interfaces/python/**"
-              - "examples/python/**"
-              - "examples/notebooks/**"
-              - "examples/networks/**"
-              - "test/python/**"
-              - "test/scripts/**"
-              - "test/schemas/**"
-              - "scripts/build_config.py"
-              - "scripts/generate_python_swig.py"
-              - "scripts/notebook_manifest.py"
-              - ".github/actions/setup-python-build/action.yml"
-              - ".github/workflows/_python-package.yml"
-            python-packaging:
-              - "Makefile"
-              - "mk/**"
-              - "pyproject.toml"
-              - "setup.py"
-              - "scripts/build_config.py"
-              - ".github/actions/setup-python-build/action.yml"
-              - ".github/workflows/_python-package.yml"
-            python-swig:
-              - "interfaces/swig/**"
-              - "interfaces/python/generated/**"
-              - "interfaces/python/src/infomap/_swig.py"
-              - "scripts/generate_python_swig.py"
-              - ".github/workflows/_python-package.yml"
-            javascript:
-              - "CMakeLists.txt"
-              - "Makefile"
-              - "mk/**"
-              - "src/**"
-              - "test/cpp/**"
-              - "test/fixtures/**"
-              - ".github/workflows/ci.yml"
-              - ".github/workflows/_native-build.yml"
-              - "package.json"
-              - "package-lock.json"
-              - "interfaces/js/**"
-              # The binding-options freshness gate runs in the JS workflow, so
-              # changes to the generator or its inputs must trigger it.
-              - "interfaces/parameters/**"
-              - "scripts/generate_binding_options.py"
-              - "scripts/parameter_catalog.py"
-              - "scripts/generate_js_metadata.py"
-              - "scripts/prepare_npm_package.py"
-              - ".github/actions/setup-js-build/action.yml"
-              - ".github/workflows/_js-package.yml"
-            r:
-              - "Makefile"
-              - "mk/**"
-              - "src/**"
-              - "interfaces/swig/**"
-              - "interfaces/R/**"
-              - "examples/R/**"
-              - "scripts/generate_r_swig.py"
-              - "scripts/stage_r_package.py"
-              - ".github/workflows/ci.yml"
-              - ".github/workflows/_r-package.yml"
-            docs:
-              - "README.rst"
-              - "BUILD.md"
-              - "Makefile"
-              - "mk/**"
-              - "pyproject.toml"
-              - "setup.py"
-              - "examples/notebooks/**"
-              - "scripts/build_config.py"
-              - "scripts/notebook_manifest.py"
-              - "interfaces/python/**"
-              - "src/**"
-              - ".github/actions/setup-python-build/action.yml"
-            docker:
-              - "docker/**"
-              - "docker-compose.yml"
-              - ".dockerignore"
-              - "Makefile"
-              - "mk/**"
-              - "pyproject.toml"
-              - "setup.py"
-              - "examples/notebooks/**"
-              - "src/**"
-              - "interfaces/python/**"
-              - "scripts/build_config.py"
-              - "README.rst"
-            notebooks:
-              - "interfaces/python/**"
-              - "test/python/**"
-              - "examples/notebooks/**"
-              - "scripts/notebook_manifest.py"
-              - ".github/actions/setup-python-build/action.yml"
-              - ".github/workflows/ci.yml"
-              - ".github/workflows/notebooks.yml"
-
-  policy:
-    needs: changes
-    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.policy == 'true'
-    name: C++ stream policy
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Check runtime stream policy
-        run: make test-cpp-stream-policy PYTHON=python3
+          filters: .github/filters.yml
 
   pre-commit:
     needs: changes
@@ -386,7 +246,7 @@ jobs:
 
   ci-summary:
     name: CI Summary
-    needs: [changes, policy, pre-commit, sanitizers, clang-tidy, native, python, notebooks, javascript, r, docs, docker]
+    needs: [changes, pre-commit, sanitizers, clang-tidy, native, python, notebooks, javascript, r, docs, docker]
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 10


### PR DESCRIPTION
First of a small series restructuring the CI/release **graphs** (topology), following on from the step-level perf campaign. This one tightens the per-PR CI graph.

## The bug it fixes
The `changes` job's path filters were seven hand-maintained copies of overlapping path lists. That duplication let two composite actions drift out of coverage — `.github/actions/setup-swig` and `.github/actions/setup-ccache` matched **no** filter. A PR touching only those files ran zero stack jobs yet still got a green **CI Summary** (the only required check), so an untested build-chain change could merge.

## Changes
- **Extract** the filters to `.github/filters.yml` (dorny/paths-filter reads an external file) and factor the repeated `Makefile`/`mk`/`src` and CMake/native clusters into two YAML anchors — one source of truth instead of seven copies. The expanded filters are **byte-for-byte the previous set plus only the two missing composites** (verified offline by resolving the anchors + one-level flatten and diffing against the old inline block; that check also caught one over-trigger — `python-packaging` must *not* gain `src/**`).
- **Fix coverage:** setup-ccache added to native/python-core/python-packaging/r; setup-swig added to python-swig/r. Every filter also re-triggers on `.github/filters.yml` itself.
- **Fold the `policy` job:** the pre-commit job already runs the same `check_cpp_stream_policy.py` via the `cpp-stream-policy` hook on `--all-files`, and its trigger is a superset of policy's — coverage unchanged, one runner slot freed (matters against the free-plan 20-job pool).
- **Decouple test jobs from `swig-freshness`** in the reusable Python and R workflows: freshness produces no artifact the tests consume, and CI Summary still requires it, so the long matrices no longer wait behind the ~10 s gate.

## Verification
- `actionlint` clean on all workflows.
- Offline equivalence check: extracted filters == old filters + intended additions, no drops, no residual nested lists, every composite covered.
- Dispatched `ci.yml` on this branch (workflow_dispatch runs every lane) to confirm the external-file filter parses and the graph runs end-to-end — see the linked run.

No behaviour change to what any lane tests; this is graph structure and coverage only.