### PR TITLE
ci: open a tracking issue when a scheduled workflow fails

### DIFF
--- a/.github/actions/report-cron-failure/action.yml
+++ b/.github/actions/report-cron-failure/action.yml
@@ -1,0 +1,58 @@
+name: Report cron failure
+description: >-
+  Open, or comment on, a deduplicated tracking issue when a scheduled workflow
+  fails. Scheduled workflows (notebooks, prerelease checks, fuzzing) are
+  deliberately non-blocking, so a red weekly run is otherwise only visible to
+  whoever happens to look at the Actions tab. Intended to be called from a
+  failure()-gated job on a schedule event; a no-op otherwise.
+inputs:
+  workflow-name:
+    description: Human-readable name of the failing scheduled workflow (github.workflow).
+    required: true
+  run-url:
+    description: URL of the failing workflow run.
+    required: true
+  token:
+    description: Token with issues:write on this repository (e.g. github.token).
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Open or update the tracking issue
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        GH_REPO: ${{ github.repository }}
+        WORKFLOW_NAME: ${{ inputs.workflow-name }}
+        RUN_URL: ${{ inputs.run-url }}
+      run: |
+        set -euo pipefail
+
+        label="ci-cron"
+        title="CI: scheduled \"$WORKFLOW_NAME\" is failing"
+
+        # Create the label on first use; ignore "already exists".
+        gh label create "$label" \
+          --color b60205 \
+          --description "A scheduled (cron) workflow is failing" 2>/dev/null || true
+
+        # One open issue per workflow: dedup on an exact title match among the
+        # open ci-cron issues. The title is passed to jq via --arg (not
+        # interpolated into the program) because it contains double quotes.
+        number="$(gh issue list --state open --label "$label" --json number,title \
+          | jq -r --arg t "$title" '[.[] | select(.title == $t)] | first | .number // empty')"
+
+        if [ -n "$number" ]; then
+          echo "Existing tracking issue #$number; adding a comment."
+          gh issue comment "$number" --body "Still failing: $RUN_URL"
+        else
+          echo "No open tracking issue; creating one."
+          body="$(printf '%s\n' \
+            "The scheduled workflow **$WORKFLOW_NAME** failed." \
+            "" \
+            "Latest failing run: $RUN_URL" \
+            "" \
+            "This issue was opened automatically and is deduplicated by title." \
+            "Close it once the failure is resolved; a new one opens if it recurs.")"
+          gh issue create --title "$title" --label "$label" --body "$body"
+        fi

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -47,3 +47,27 @@ jobs:
             build/fuzz/oom-*
           if-no-files-found: ignore
           retention-days: 14
+
+  # Non-blocking workflow: surface a scheduled failure (a reproducer was found)
+  # as a tracking issue so it is not lost in the Actions tab. Only fires for
+  # cron runs -- a manual dispatch failure is seen by whoever triggered it.
+  report-failure:
+    name: Report scheduled failure
+    needs: [fuzz-intake]
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Open or update the tracking issue
+        uses: ./.github/actions/report-cron-failure
+        with:
+          workflow-name: ${{ github.workflow }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          token: ${{ github.token }}

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -39,3 +39,27 @@ jobs:
 
       - name: Run full notebook suite
         run: make test-python-notebooks-full
+
+  # Non-blocking workflow: surface a scheduled failure as a tracking issue so it
+  # is not lost in the Actions tab. Only fires for cron runs -- a manual
+  # dispatch failure is seen by whoever triggered it.
+  report-failure:
+    name: Report scheduled failure
+    needs: [full]
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Open or update the tracking issue
+        uses: ./.github/actions/report-cron-failure
+        with:
+          workflow-name: ${{ github.workflow }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          token: ${{ github.token }}

--- a/.github/workflows/python-prerelease-check.yml
+++ b/.github/workflows/python-prerelease-check.yml
@@ -20,3 +20,27 @@ jobs:
       run-tests: false
       build-release-artifacts: false
       prerelease-python-check: true
+
+  # Non-blocking workflow: surface a scheduled failure as a tracking issue so it
+  # is not lost in the Actions tab. Only fires for cron runs -- a manual
+  # dispatch failure is seen by whoever triggered it.
+  report-failure:
+    name: Report scheduled failure
+    needs: [prerelease-wheels]
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Open or update the tracking issue
+        uses: ./.github/actions/report-cron-failure
+        with:
+          workflow-name: ${{ github.workflow }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          token: ${{ github.token }}


### PR DESCRIPTION
Third of the CI/release graph series — a small reliability fix rather than a topology change.

## Problem
`notebooks.yml`, `python-prerelease-check.yml`, and `fuzz.yml` are deliberately **non-blocking** (nothing depends on them, so they never gate PRs). The flip side: when one of these weekly cron runs goes red, it's only visible to whoever happens to open the Actions tab. A fuzz reproducer or a prerelease-CPython build break can sit unnoticed for weeks.

## Change
- New composite action `.github/actions/report-cron-failure` that opens a deduplicated tracking issue (label `ci-cron`) — or comments on the existing open one — for the failing workflow.
- A `report-failure` job added to each of the three workflows, gated `if: failure() && github.event_name == 'schedule'` (manual dispatch failures are left alone — the person who triggered them sees the result). Each carries `issues: write` and nothing more.

## Details that bit during review
- The issue title embeds the workflow name in quotes, so the dedup match passes the title to `jq --arg` rather than interpolating it into the jq program — a dry-run caught that the interpolated form produced invalid jq.
- The `ci-cron` label is created idempotently on first use (`|| true`), so no manual repo setup is needed.

## Verification
- `actionlint` clean on all three workflows.
- `shellcheck -S warning` clean on the composite's script.
- Read-only dry-run of the dedup query against the live repo (returns empty → would create; confirms the quoted-title jq parses).
- The failure path itself can only be exercised by an actual scheduled failure; it's isolated to a `failure()`-gated job, so it cannot affect the normal (green) runs.