### PR TITLE
ci: add actionlint to the pre-commit hooks and CI gate

### DIFF
--- a/.github/workflows/_native-build.yml
+++ b/.github/workflows/_native-build.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Build native binary
         run: |
           make -j build-native OPENMP=${{ matrix.target.openmp }}
-          command -v ccache >/dev/null 2>&1 && ccache -s || true
+          if command -v ccache >/dev/null 2>&1; then ccache -s || true; fi
         shell: bash
         env:
           CXX: ${{ matrix.config.compiler }}

--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Install editable package
         run: |
           make dev-python-install PIP="uv pip"
-          command -v ccache >/dev/null 2>&1 && ccache -s || true
+          if command -v ccache >/dev/null 2>&1; then ccache -s || true; fi
         env:
           FEATURES: ${{ inputs.features }}
           # docs (sphinx/furo) is only needed by build-docs, not the test jobs.
@@ -212,7 +212,7 @@ jobs:
       - name: Build release distributions
         run: |
           make release-python-dist
-          command -v ccache >/dev/null 2>&1 && ccache -s || true
+          if command -v ccache >/dev/null 2>&1; then ccache -s || true; fi
         env:
           FEATURES: ${{ inputs.features }}
 

--- a/.github/workflows/_r-package.yml
+++ b/.github/workflows/_r-package.yml
@@ -146,8 +146,8 @@ jobs:
           else
             make test-r
           fi
-          command -v ccache >/dev/null 2>&1 && ccache -s || true
-          command -v sccache >/dev/null 2>&1 && sccache --show-stats || true
+          if command -v ccache >/dev/null 2>&1; then ccache -s || true; fi
+          if command -v sccache >/dev/null 2>&1; then sccache --show-stats || true; fi
 
   build-source:
     if: inputs.build-release-artifacts
@@ -280,8 +280,8 @@ jobs:
           else
             make build-r-binary-from-tarball
           fi
-          command -v ccache >/dev/null 2>&1 && ccache -s || true
-          command -v sccache >/dev/null 2>&1 && sccache --show-stats || true
+          if command -v ccache >/dev/null 2>&1; then ccache -s || true; fi
+          if command -v sccache >/dev/null 2>&1; then sccache --show-stats || true; fi
 
       - name: Compute platform tag
         id: platform
@@ -403,4 +403,4 @@ jobs:
           fi
           R CMD INSTALL "$tarball"
           Rscript -e 'library(testthat); library(infomap); testthat::test_dir("interfaces/R/infomap/tests/testthat")'
-          command -v ccache >/dev/null 2>&1 && ccache -s || true
+          if command -v ccache >/dev/null 2>&1; then ccache -s || true; fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,18 @@ jobs:
         with:
           version: "0.9.0"
 
+      # actionlint for the `actionlint` pre-commit hook. Downloading the pinned
+      # release binary keeps the gate fast (no Go build). ubuntu runners already
+      # ship shellcheck, which actionlint uses to lint embedded run: scripts.
+      # Bump this pin and the AGENTS.md note together.
+      - name: Set up actionlint
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+        run: |
+          curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin actionlint
+          actionlint -version
+
       # Run the repo's own pre-commit config so local hooks and CI agree. This
       # also restores C++ formatting enforcement (the old cxx-format job was
       # disabled per #479): the clang-format hook is scoped to the same src/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -111,6 +111,18 @@ repos:
         entry: make format-r-check
         pass_filenames: false
         files: \.R$
+      - id: actionlint
+        name: actionlint (workflow YAML)
+        language: system
+        # Lints .github/workflows/*.yml -- syntax, expression typing, and
+        # shellcheck on embedded run: scripts. language: system like biome/air
+        # above: install actionlint locally (`brew install actionlint`) when you
+        # touch workflows. Runs the whole workflow set (pass_filenames: false) so
+        # cross-references between reusable workflows are resolved. The CI
+        # pre-commit job installs the same pinned version -- see AGENTS.md.
+        entry: actionlint
+        pass_filenames: false
+        files: ^\.github/workflows/.*\.ya?ml$
       # pyright runs at PUSH time, not on every commit: it is slower and its
       # results depend on installed deps. Scoped to the core surface (io/, tl/
       # excluded) so it stays deterministic across dev machines -- see the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,8 +148,9 @@ Targeted checks:
 Pre-commit hooks mirror the CI lint gates and give the same feedback locally.
 Install them once with `make hooks` (also run by `make dev-bootstrap`); on
 commit they run `ruff` (Python lint), `clang-format` (C++ `src/`), `biome`
-(JavaScript lint and format), and `air` (R format), plus a C++ stream-policy
-check, and `pyright` on the core Python surface at push time.
+(JavaScript lint and format), `air` (R format), and `actionlint` (GitHub
+workflow YAML), plus a C++ stream-policy check, and `pyright` on the core
+Python surface at push time.
 
 Format on demand without the hooks:
 
@@ -164,7 +165,10 @@ sources — so format changes before committing. Air is pre-1.0 and the repo
 ships no `air.toml`, so its output is version-dependent; the canonical version
 is **0.9.0**, pinned in the `pre-commit` CI job via `posit-dev/setup-air`.
 Install that version locally so `make format-r-check` agrees with CI, and bump
-the CI pin and this note together. Generated and vendored files —
+the CI pin and this note together. The `actionlint` hook is `language: system`
+too: install it locally (`brew install actionlint`) when you touch workflows;
+the canonical version is **1.7.12**, downloaded in the `pre-commit` CI job, and
+the CI pin and this note bump together. Generated and vendored files —
 `interfaces/python/generated/`, `interfaces/R/generated/`,
 `interfaces/python/src/infomap/_swig.py`, and `vendor/` — are excluded from
 every hook; never reformat them.


### PR DESCRIPTION
Fourth and last of the CI/release graph series — the linting gap I kept hitting by hand while doing the other three.

## Change
- Add `actionlint` as a `language: system` pre-commit hook (same shape as the existing `biome` and `air` local hooks), scoped to `.github/workflows/`, `pass_filenames: false` so it lints the whole workflow set and resolves reusable-workflow cross-references.
- Install a pinned `actionlint` **1.7.12** (matching the local Homebrew build) in the `pre-commit` CI job via a fast release-binary download — no Go build per run, no Docker-daemon dependency. ubuntu runners already ship shellcheck, which actionlint uses to lint embedded `run:` scripts.
- Document the pin in `AGENTS.md` next to the Air pin (bump the CI pin and the note together).

## Why system-hook + binary install (not the golang/docker pre-commit hooks)
- `golang` rebuilds actionlint from source on every CI run (the gate has no pre-commit cache) — slow.
- `docker` needs a running Docker daemon locally — bad DX for a quick workflow edit.
- `system` matches how biome and air are already wired here, and the install is a ~2 s pinned download.

## Verification
- `actionlint` is **already clean** on every current workflow (with shellcheck 0.11.0 present), so the gate is green on landing — verified in the worktree.
- Ran the hook through pre-commit (`pre-commit run actionlint --all-files`) → Passed; it also ran on this PR's own commit → Passed.
- Confirmed the pinned release asset exists (`actionlint_1.7.12_linux_amd64.tar.gz`) so the CI download won't 404.

## Note on merge order
Touches `ci.yml` (adds a `Set up actionlint` step to the `pre-commit` job), a different region than #869's `changes`/`ci-summary` edits — they should merge without conflict. If #869 lands first, this may need a trivial rebase.