### PR TITLE
perf: hoist per-node-constant plogp out of the OO move-loop delta

### DIFF
--- a/src/core/BiasedMapEquation.cpp
+++ b/src/core/BiasedMapEquation.cpp
@@ -191,6 +191,27 @@ INFOMAP_HOT double BiasedMapEquation::getDeltaCodelengthOnMovingNode(InfoNode& c
   return deltaL + deltaBiasedCost + deltaEntropyBiasCorrection;
 }
 
+INFOMAP_HOT double BiasedMapEquation::getDeltaCodelengthOnMovingNodeHoisted(InfoNode& current,
+                                                                            DeltaFlow& oldModuleDelta,
+                                                                            const OldSideTerms& oldSide,
+                                                                            DeltaFlow& newModuleDelta,
+                                                                            std::vector<FlowData>& moduleFlowData,
+                                                                            std::vector<unsigned int>& moduleMembers)
+{
+  double deltaL = Base::getDeltaCodelengthOnMovingNodeHoisted(current, oldModuleDelta, oldSide, newModuleDelta, moduleFlowData, moduleMembers);
+
+  if (preferredNumModules == 0)
+    return deltaL;
+
+  int deltaNumModules = getDeltaNumModulesIfMoving(oldModuleDelta.module, newModuleDelta.module, moduleMembers);
+
+  double deltaBiasedCost = calcNumModuleCost(currentNumModules + deltaNumModules) - biasedCost;
+
+  double deltaEntropyBiasCorrection = calcEntropyBiasCorrection(currentNumModules + deltaNumModules) - getEntropyBiasCorrection();
+
+  return deltaL + deltaBiasedCost + deltaEntropyBiasCorrection;
+}
+
 // ===================================================
 // Consolidation
 // ===================================================

--- a/src/core/BiasedMapEquation.h
+++ b/src/core/BiasedMapEquation.h
@@ -82,6 +82,15 @@ public:
                                         std::vector<FlowData>& moduleFlowData,
                                         std::vector<unsigned int>& moduleMembers);
 
+  using Base::hoistOldSide;
+
+  double getDeltaCodelengthOnMovingNodeHoisted(InfoNode& current,
+                                               DeltaFlow& oldModuleDelta,
+                                               const OldSideTerms& oldSide,
+                                               DeltaFlow& newModuleDelta,
+                                               std::vector<FlowData>& moduleFlowData,
+                                               std::vector<unsigned int>& moduleMembers);
+
   // ===================================================
   // Consolidation
   // ===================================================

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -540,16 +540,21 @@ INFOMAP_HOT unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestMod
     DeltaFlowDataType strongestConnectedModule(oldModuleDelta);
     double deltaCodelengthOnStrongestConnectedModule = 0.0;
 
+    // Old-module plogp terms are constant across every candidate of this node:
+    // hoist them out of the per-candidate delta (see MapEquation::hoistOldSide).
+    const OldSideTerms oldSide = m_objective.hoistOldSide(current, oldModuleDelta, m_moduleFlowData);
+
     // Find the move that minimizes the description length
     for (unsigned int k = 0; k < numModuleLinks; ++k) {
       auto j = moduleEnumeration[k];
       unsigned int otherModule = moduleDeltaEnterExit[j].module;
       if (otherModule != current.index) {
-        double deltaCodelength = m_objective.getDeltaCodelengthOnMovingNode(current,
-                                                                            oldModuleDelta,
-                                                                            moduleDeltaEnterExit[j],
-                                                                            m_moduleFlowData,
-                                                                            m_moduleMembers);
+        double deltaCodelength = m_objective.getDeltaCodelengthOnMovingNodeHoisted(current,
+                                                                                   oldModuleDelta,
+                                                                                   oldSide,
+                                                                                   moduleDeltaEnterExit[j],
+                                                                                   m_moduleFlowData,
+                                                                                   m_moduleMembers);
 
         if (deltaCodelength < bestDeltaCodelength - m_infomap->minimumSingleNodeCodelengthImprovement) {
           bestDeltaModule = moduleDeltaEnterExit[j];
@@ -779,16 +784,22 @@ INFOMAP_HOT unsigned int InfomapOptimizer<Objective>::tryMoveEachNodeIntoBestMod
       DeltaFlowDataType strongestConnectedModule(oldModuleDelta);
       double deltaCodelengthOnStrongestConnectedModule = 0.0;
 
+      // Old-module plogp terms are constant across every candidate of this node
+      // (per-thread stack local; reads m_moduleFlowData read-only). See
+      // MapEquation::hoistOldSide.
+      const OldSideTerms oldSide = m_objective.hoistOldSide(current, oldModuleDelta, m_moduleFlowData);
+
       // Find the move that minimizes the description length
       for (unsigned int k = 0; k < numModuleLinks; ++k) {
         auto j = moduleEnumeration[k];
         unsigned int otherModule = moduleDeltaEnterExit[j].module;
         if (otherModule != current.index) {
-          double deltaCodelength = m_objective.getDeltaCodelengthOnMovingNode(current,
-                                                                              oldModuleDelta,
-                                                                              moduleDeltaEnterExit[j],
-                                                                              m_moduleFlowData,
-                                                                              m_moduleMembers);
+          double deltaCodelength = m_objective.getDeltaCodelengthOnMovingNodeHoisted(current,
+                                                                                     oldModuleDelta,
+                                                                                     oldSide,
+                                                                                     moduleDeltaEnterExit[j],
+                                                                                     m_moduleFlowData,
+                                                                                     m_moduleMembers);
 
           if (deltaCodelength < bestDeltaCodelength - m_infomap->minimumSingleNodeCodelengthImprovement) {
             bestDeltaModule = moduleDeltaEnterExit[j];

--- a/src/core/LossyMapEquation.cpp
+++ b/src/core/LossyMapEquation.cpp
@@ -190,6 +190,33 @@ INFOMAP_HOT double LossyMapEquation::getDeltaCodelengthOnMovingNode(InfoNode& cu
   return deltaL - (corrAfter - corrBefore);
 }
 
+INFOMAP_HOT double LossyMapEquation::getDeltaCodelengthOnMovingNodeHoisted(InfoNode& current,
+                                                                           DeltaFlow& oldModuleDelta,
+                                                                           const OldSideTerms& oldSide,
+                                                                           DeltaFlow& newModuleDelta,
+                                                                           std::vector<FlowData>& moduleFlowData,
+                                                                           std::vector<unsigned int>& moduleMembers)
+{
+  double deltaL = Base::getDeltaCodelengthOnMovingNodeHoisted(current, oldModuleDelta, oldSide, newModuleDelta, moduleFlowData, moduleMembers);
+
+  unsigned int oldM = oldModuleDelta.module;
+  unsigned int newM = newModuleDelta.module;
+  if (oldM == newM)
+    return deltaL;
+
+  double curFlow = current.data.flow;
+  double curFlf = current.lossyFlowLogFlow;
+  double curEnt = current.lossyEntropy;
+
+  double corrBefore = calcCorrection(moduleFlowData[oldM].flow, m_moduleFlowLogFlow[oldM], m_moduleEntropy[oldM])
+      + calcCorrection(moduleFlowData[newM].flow, m_moduleFlowLogFlow[newM], m_moduleEntropy[newM]);
+  double corrAfter = calcCorrection(moduleFlowData[oldM].flow - curFlow, m_moduleFlowLogFlow[oldM] - curFlf, m_moduleEntropy[oldM] - curEnt)
+      + calcCorrection(moduleFlowData[newM].flow + curFlow, m_moduleFlowLogFlow[newM] + curFlf, m_moduleEntropy[newM] + curEnt);
+
+  // J = L_full - sum of corrections, so a correction increase lowers the objective.
+  return deltaL - (corrAfter - corrBefore);
+}
+
 // ===================================================
 // Consolidation
 // ===================================================

--- a/src/core/LossyMapEquation.h
+++ b/src/core/LossyMapEquation.h
@@ -92,6 +92,15 @@ public:
                                         std::vector<FlowData>& moduleFlowData,
                                         std::vector<unsigned int>& moduleMembers);
 
+  using Base::hoistOldSide;
+
+  double getDeltaCodelengthOnMovingNodeHoisted(InfoNode& current,
+                                               DeltaFlow& oldModuleDelta,
+                                               const OldSideTerms& oldSide,
+                                               DeltaFlow& newModuleDelta,
+                                               std::vector<FlowData>& moduleFlowData,
+                                               std::vector<unsigned int>& moduleMembers);
+
   // ===================================================
   // Consolidation
   // ===================================================

--- a/src/core/MapEquation.h
+++ b/src/core/MapEquation.h
@@ -37,6 +37,24 @@ struct ModuleMemNodes {
   double sumFlow;
 };
 
+// Old-module plogp terms of getDeltaCodelengthOnMovingNode. For a fixed node
+// visit the old module and the node's own flow are constant, so 6 of the 13
+// plogp values the delta needs are identical for every candidate module the
+// move loop probes for that node. hoistOldSide() computes them once per node;
+// getDeltaCodelengthOnMovingNodeHoisted() consumes them per candidate, keeping
+// the exact same expression structure as the unhoisted form. Plain doubles and
+// namespace scope so the (privately-inheriting) objectives can pass it around
+// by `auto` without accessibility juggling. Not bit-identical to the unhoisted
+// path at the last ulp: splitting the single 13-wide plogp_batch into a 6-wide
+// (once/node) and 7-wide (per candidate) batch regroups the SIMD lanes.
+struct OldSideTerms {
+  double deltaEnterExitOld; // oldModuleDelta.deltaEnter + deltaExit (with teleportation folded in)
+  double curEnter, curExit, curFlow; // current.data, cached to keep the hoisted delta self-contained
+  double plogpOldEnter, plogpOldEnterAfter;
+  double plogpOldExit, plogpOldExitAfter;
+  double plogpOldExitFlow, plogpOldExitFlowAfter;
+};
+
 /**
  * Base implementation of the map equation, shared by the concrete objectives
  * (BiasedMapEquation, MemMapEquation, MetaMapEquation, RegularizedMultilayerMapEquation).
@@ -152,6 +170,20 @@ public:
                                         DeltaFlowDataType& newModuleDelta,
                                         std::vector<FlowDataType>& moduleFlowData,
                                         std::vector<unsigned int>& /*moduleMembers*/);
+
+  // Precompute the old-module (per-node-constant) plogp terms of the move delta.
+  // Called once per node visit by the optimize move loop; the result feeds every
+  // candidate through getDeltaCodelengthOnMovingNodeHoisted().
+  OldSideTerms hoistOldSide(InfoNode& current,
+                            DeltaFlowDataType& oldModuleDelta,
+                            std::vector<FlowDataType>& moduleFlowData);
+
+  double getDeltaCodelengthOnMovingNodeHoisted(InfoNode& current,
+                                               DeltaFlowDataType& oldModuleDelta,
+                                               const OldSideTerms& oldSide,
+                                               DeltaFlowDataType& newModuleDelta,
+                                               std::vector<FlowDataType>& moduleFlowData,
+                                               std::vector<unsigned int>& /*moduleMembers*/);
 
   // ===================================================
   // Consolidation
@@ -319,6 +351,76 @@ INFOMAP_HOT double MapEquation<FlowDataType, DeltaFlowDataType>::getDeltaCodelen
   double delta_enter_log_enter = -pl[1] - pl[2] + pl[3] + pl[4];
   double delta_exit_log_exit = -pl[5] - pl[6] + pl[7] + pl[8];
   double delta_flow_log_flow = -pl[9] - pl[10] + pl[11] + pl[12];
+
+  double deltaL = delta_enter - delta_enter_log_enter - delta_exit_log_exit + delta_flow_log_flow;
+  return deltaL;
+}
+
+template <typename FlowDataType, typename DeltaFlowDataType>
+INFOMAP_HOT OldSideTerms MapEquation<FlowDataType, DeltaFlowDataType>::hoistOldSide(InfoNode& current, DeltaFlowDataType& oldModuleDelta, std::vector<FlowDataType>& moduleFlowData)
+{
+  using infomath::plogp_batch;
+  unsigned int oldModule = oldModuleDelta.module;
+  double deltaEnterExitOldModule = oldModuleDelta.deltaEnter + oldModuleDelta.deltaExit;
+
+  FlowDataType& oldMfd = moduleFlowData[oldModule];
+  double oldEnter = oldMfd.enterFlow;
+  double oldExit = oldMfd.exitFlow;
+  double oldExitPlusFlow = oldMfd.exitFlow + oldMfd.flow;
+  double curEnter = current.data.enterFlow;
+  double curExit = current.data.exitFlow;
+  double curFlow = current.data.flow;
+
+  // The 6 args are exactly the 6 old-module entries of the 13-wide batch in
+  // getDeltaCodelengthOnMovingNode (indices 1,3,5,7,9,11 there).
+  double args[6] = {
+    oldEnter,
+    oldEnter - curEnter + deltaEnterExitOldModule,
+    oldExit,
+    oldExit - curExit + deltaEnterExitOldModule,
+    oldExitPlusFlow,
+    oldExitPlusFlow - curExit - curFlow + deltaEnterExitOldModule,
+  };
+  double pl[6];
+  plogp_batch(args, pl, 6);
+
+  return OldSideTerms { deltaEnterExitOldModule, curEnter, curExit, curFlow, pl[0], pl[1], pl[2], pl[3], pl[4], pl[5] };
+}
+
+template <typename FlowDataType, typename DeltaFlowDataType>
+INFOMAP_HOT double MapEquation<FlowDataType, DeltaFlowDataType>::getDeltaCodelengthOnMovingNodeHoisted(InfoNode& /*current*/, DeltaFlowDataType& /*oldModuleDelta*/, const OldSideTerms& oldSide, DeltaFlowDataType& newModuleDelta, std::vector<FlowDataType>& moduleFlowData, std::vector<unsigned int>&)
+{
+  using infomath::plogp_batch;
+  unsigned int newModule = newModuleDelta.module;
+  double deltaEnterExitNewModule = newModuleDelta.deltaEnter + newModuleDelta.deltaExit;
+  double deltaEnterExitOldModule = oldSide.deltaEnterExitOld;
+
+  FlowDataType& newMfd = moduleFlowData[newModule];
+  double newEnter = newMfd.enterFlow;
+  double newExit = newMfd.exitFlow;
+  double newExitPlusFlow = newMfd.exitFlow + newMfd.flow;
+  double curEnter = oldSide.curEnter;
+  double curExit = oldSide.curExit;
+  double curFlow = oldSide.curFlow;
+
+  // The 7 candidate-dependent entries of the 13-wide batch (indices 0,2,4,6,8,10,12).
+  constexpr int kPlogpBatchN = 7;
+  double args[kPlogpBatchN] = {
+    enterFlow + deltaEnterExitOldModule - deltaEnterExitNewModule,
+    newEnter,
+    newEnter + curEnter - deltaEnterExitNewModule,
+    newExit,
+    newExit + curExit - deltaEnterExitNewModule,
+    newExitPlusFlow,
+    newExitPlusFlow + curExit + curFlow - deltaEnterExitNewModule,
+  };
+  double pl[kPlogpBatchN];
+  plogp_batch(args, pl, kPlogpBatchN);
+
+  double delta_enter = pl[0] - enterFlow_log_enterFlow;
+  double delta_enter_log_enter = -oldSide.plogpOldEnter - pl[1] + oldSide.plogpOldEnterAfter + pl[2];
+  double delta_exit_log_exit = -oldSide.plogpOldExit - pl[3] + oldSide.plogpOldExitAfter + pl[4];
+  double delta_flow_log_flow = -oldSide.plogpOldExitFlow - pl[5] + oldSide.plogpOldExitFlowAfter + pl[6];
 
   double deltaL = delta_enter - delta_enter_log_enter - delta_exit_log_exit + delta_flow_log_flow;
   return deltaL;

--- a/src/core/MemMapEquation.cpp
+++ b/src/core/MemMapEquation.cpp
@@ -299,23 +299,28 @@ void MemMapEquation::addMemoryContributions(InfoNode& current,
   unsigned int numPhysicalNodes = physicalNodes.size();
   for (unsigned int i = 0; i < numPhysicalNodes; ++i) {
     PhysData& physData = physicalNodes[i];
+    // plogp(sumFlowFromM2Node) is constant across every module holding this
+    // physical node, so compute it once per physical node instead of per
+    // (physical node, module). Bit-exact; the per-module plogp of the changed
+    // flows (old/new) still varies and stays in the loop.
+    const double physFlow = physData.sumFlowFromM2Node;
+    const double plogpPhysFlow = infomath::plogp(physFlow);
     ModuleToMemNodes& moduleToMemNodes = m_physToModuleToMemNodes[physData.physNodeIndex];
     for (const auto& memNodes : moduleToMemNodes) {
       unsigned int moduleIndex = memNodes.module;
       if (moduleIndex == current.index) // From where the multiple assigned node is moved
       {
         double oldPhysFlow = memNodes.sumFlow;
-        double newPhysFlow = memNodes.sumFlow - physData.sumFlowFromM2Node;
+        double newPhysFlow = memNodes.sumFlow - physFlow;
         oldModuleDelta.sumDeltaPlogpPhysFlow += infomath::plogp(newPhysFlow) - infomath::plogp(oldPhysFlow);
-        oldModuleDelta.sumPlogpPhysFlow += infomath::plogp(physData.sumFlowFromM2Node);
+        oldModuleDelta.sumPlogpPhysFlow += plogpPhysFlow;
       } else // To where the multiple assigned node is moved
       {
         double oldPhysFlow = memNodes.sumFlow;
-        double newPhysFlow = memNodes.sumFlow + physData.sumFlowFromM2Node;
+        double newPhysFlow = memNodes.sumFlow + physFlow;
 
         double sumDeltaPlogpPhysFlow = infomath::plogp(newPhysFlow) - infomath::plogp(oldPhysFlow);
-        double sumPlogpPhysFlow = infomath::plogp(physData.sumFlowFromM2Node);
-        moduleDeltaFlow.add(moduleIndex, DeltaFlowDataType(moduleIndex, 0.0, 0.0, sumDeltaPlogpPhysFlow, sumPlogpPhysFlow));
+        moduleDeltaFlow.add(moduleIndex, DeltaFlowDataType(moduleIndex, 0.0, 0.0, sumDeltaPlogpPhysFlow, plogpPhysFlow));
       }
     }
   }
@@ -330,6 +335,22 @@ INFOMAP_HOT double MemMapEquation::getDeltaCodelengthOnMovingNode(InfoNode& curr
 {
   double deltaL = Base::getDeltaCodelengthOnMovingNode(current, oldModuleDelta, newModuleDelta, moduleFlowData, moduleMembers);
 
+  double delta_nodeFlow_log_nodeFlow = oldModuleDelta.sumDeltaPlogpPhysFlow + newModuleDelta.sumDeltaPlogpPhysFlow + oldModuleDelta.sumPlogpPhysFlow - newModuleDelta.sumPlogpPhysFlow;
+
+  return deltaL - delta_nodeFlow_log_nodeFlow;
+}
+
+INFOMAP_HOT double MemMapEquation::getDeltaCodelengthOnMovingNodeHoisted(InfoNode& current,
+                                                                         DeltaFlowDataType& oldModuleDelta,
+                                                                         const OldSideTerms& oldSide,
+                                                                         DeltaFlowDataType& newModuleDelta,
+                                                                         std::vector<FlowDataType>& moduleFlowData,
+                                                                         std::vector<unsigned int>& moduleMembers)
+{
+  double deltaL = Base::getDeltaCodelengthOnMovingNodeHoisted(current, oldModuleDelta, oldSide, newModuleDelta, moduleFlowData, moduleMembers);
+
+  // The physical-codebook old-side terms are already per-node constants:
+  // addMemoryContributions() computed them once into oldModuleDelta.
   double delta_nodeFlow_log_nodeFlow = oldModuleDelta.sumDeltaPlogpPhysFlow + newModuleDelta.sumDeltaPlogpPhysFlow + oldModuleDelta.sumPlogpPhysFlow - newModuleDelta.sumPlogpPhysFlow;
 
   return deltaL - delta_nodeFlow_log_nodeFlow;

--- a/src/core/MemMapEquation.h
+++ b/src/core/MemMapEquation.h
@@ -78,6 +78,15 @@ public:
                                         std::vector<FlowDataType>& moduleFlowData,
                                         std::vector<unsigned int>& moduleMembers);
 
+  using Base::hoistOldSide;
+
+  double getDeltaCodelengthOnMovingNodeHoisted(InfoNode& current,
+                                               DeltaFlowDataType& oldModuleDelta,
+                                               const OldSideTerms& oldSide,
+                                               DeltaFlowDataType& newModuleDelta,
+                                               std::vector<FlowDataType>& moduleFlowData,
+                                               std::vector<unsigned int>& moduleMembers);
+
   // ===================================================
   // Consolidation
   // ===================================================

--- a/src/core/MetaMapEquation.cpp
+++ b/src/core/MetaMapEquation.cpp
@@ -186,6 +186,31 @@ INFOMAP_HOT double MetaMapEquation::getDeltaCodelengthOnMovingNode(InfoNode& cur
   return deltaL + deltaMetaL * metaDataRate;
 }
 
+INFOMAP_HOT double MetaMapEquation::getDeltaCodelengthOnMovingNodeHoisted(InfoNode& current,
+                                                                          DeltaFlow& oldModuleDelta,
+                                                                          const OldSideTerms& oldSide,
+                                                                          DeltaFlow& newModuleDelta,
+                                                                          std::vector<FlowData>& moduleFlowData,
+                                                                          std::vector<unsigned int>& moduleMembers)
+{
+  double deltaL = Base::getDeltaCodelengthOnMovingNodeHoisted(current, oldModuleDelta, oldSide, newModuleDelta, moduleFlowData, moduleMembers);
+
+  double deltaMetaL = 0.0;
+
+  unsigned int oldModuleIndex = oldModuleDelta.module;
+  unsigned int newModuleIndex = newModuleDelta.module;
+
+  // Remove codelength of old and new module before changes
+  deltaMetaL -= getCurrentModuleMetaCodelength(oldModuleIndex, current, 0);
+  deltaMetaL -= getCurrentModuleMetaCodelength(newModuleIndex, current, 0);
+  // Add codelength of old module with current node removed
+  deltaMetaL += getCurrentModuleMetaCodelength(oldModuleIndex, current, -1);
+  // Add codelength of old module with current node added
+  deltaMetaL += getCurrentModuleMetaCodelength(newModuleIndex, current, 1);
+
+  return deltaL + deltaMetaL * metaDataRate;
+}
+
 double MetaMapEquation::getCurrentModuleMetaCodelength(unsigned int module, InfoNode& current, int addRemoveOrNothing)
 {
   auto& currentMetaCollection = m_moduleToMetaCollection[module];

--- a/src/core/MetaMapEquation.h
+++ b/src/core/MetaMapEquation.h
@@ -84,6 +84,15 @@ public:
                                         std::vector<FlowData>& moduleFlowData,
                                         std::vector<unsigned int>& moduleMembers);
 
+  using Base::hoistOldSide;
+
+  double getDeltaCodelengthOnMovingNodeHoisted(InfoNode& current,
+                                               DeltaFlow& oldModuleDelta,
+                                               const OldSideTerms& oldSide,
+                                               DeltaFlow& newModuleDelta,
+                                               std::vector<FlowData>& moduleFlowData,
+                                               std::vector<unsigned int>& moduleMembers);
+
   // ===================================================
   // Consolidation
   // ===================================================

--- a/src/core/RegularizedMultilayerMapEquation.cpp
+++ b/src/core/RegularizedMultilayerMapEquation.cpp
@@ -416,6 +416,20 @@ double RegularizedMultilayerMapEquation::getDeltaCodelengthOnMovingNode(InfoNode
   return deltaL - delta_nodeFlow_log_nodeFlow;
 }
 
+double RegularizedMultilayerMapEquation::getDeltaCodelengthOnMovingNodeHoisted(InfoNode& current,
+                                                                               DeltaFlowDataType& oldModuleDelta,
+                                                                               const OldSideTerms& oldSide,
+                                                                               DeltaFlowDataType& newModuleDelta,
+                                                                               std::vector<FlowDataType>& moduleFlowData,
+                                                                               std::vector<unsigned int>& moduleMembers)
+{
+  double deltaL = Base::getDeltaCodelengthOnMovingNodeHoisted(current, oldModuleDelta, oldSide, newModuleDelta, moduleFlowData, moduleMembers);
+
+  double delta_nodeFlow_log_nodeFlow = oldModuleDelta.sumDeltaPlogpPhysFlow + newModuleDelta.sumDeltaPlogpPhysFlow + oldModuleDelta.sumPlogpPhysFlow - newModuleDelta.sumPlogpPhysFlow;
+
+  return deltaL - delta_nodeFlow_log_nodeFlow;
+}
+
 // ===================================================
 // Consolidation
 // ===================================================

--- a/src/core/RegularizedMultilayerMapEquation.h
+++ b/src/core/RegularizedMultilayerMapEquation.h
@@ -79,6 +79,15 @@ public:
                                         std::vector<FlowDataType>& moduleFlowData,
                                         std::vector<unsigned int>& moduleMembers);
 
+  using Base::hoistOldSide;
+
+  double getDeltaCodelengthOnMovingNodeHoisted(InfoNode& current,
+                                               DeltaFlowDataType& oldModuleDelta,
+                                               const OldSideTerms& oldSide,
+                                               DeltaFlowDataType& newModuleDelta,
+                                               std::vector<FlowDataType>& moduleFlowData,
+                                               std::vector<unsigned int>& moduleMembers);
+
   // ===================================================
   // Consolidation
   // ===================================================


### PR DESCRIPTION
## Summary

Translates the plogp move-loop speedups from PR #868 (columnar engine) to the **OO core**, closing #867. Two bit-exact changes to the per-candidate delta hot path:

1. **Old-side plogp hoist** — `getDeltaCodelengthOnMovingNode` evaluates 13 `plogp` per candidate module; **6 are old-module terms that are constant for every candidate of the same node**. `hoistOldSide()` computes them once per node visit; `getDeltaCodelengthOnMovingNodeHoisted()` consumes them per candidate, keeping the exact expression structure. Applied across all six objectives (base + Mem/Meta/Biased/Lossy/RegularizedMultilayer) so every objective's base term benefits, and both move-loop paths (serial + parallel).
2. **Mem `plogp(f)` hoist** — in `MemMapEquation::addMemoryContributions`, `plogp(sumFlowFromM2Node)` was recomputed for every co-physical module though it is a per-physical-node constant; hoisted out of the inner loop.

Same finding as #868's fixes 1–2. Fixes 3 (deferred seeding, ~1.2% ceiling, invasive per-objective rebuild) and 4 (dense lookup — OO already uses sorted vectors) don't clear the bar and are left as notes on #867.

## Correctness

**Bit-identical codelengths** to `master` on all 11 benchmark networks × {main, `-2`} across every objective — the default build uses the scalar `plogp_batch`, which splits identically. The single 13-wide batch is now a 6-wide (once/node) + 7-wide (per candidate); the only numerical difference is a ≤1 ulp SIMD-lane regrouping in the **opt-in** `INFOMAP_USE_SIMD_LOG` build (observed identical to 10 digits, no partition change). Contract/unit suite (`make test-native`) passes; OpenMP parallel move loop verified (fix vs baseline match under threads).

## Benchmark (single-thread `MODE=release OPENMP=0`, `--seed 123 -N10`, best-of-10, user-time, interleaved same-session, baseline = master)

| network | objective | main base→fix | `-2` base→fix |
|---|---|--:|--:|
| powergrid | base | 1.89→1.78s (−6%) | 0.56→0.53s (−5%) |
| science2001 `-d` | base | 9.04→8.23s (**−9%**) | 4.41→4.05s (−8%) |
| web-NotreDame `-d` | base | 169.0→160.1s (−5%) | 47.8→46.0s (−4%) |
| malaria | multilayer | 10.55→9.25s (**−12%**) | 7.49→6.61s (−12%) |
| air30k | state | 15.46→13.05s (**−16%**) | 5.78→4.99s (−14%) |
| politicalblogs `-d` | base | 0.15→0.14s | 0.08→0.08s |
| toys (ninetriangles, jazz, netsci, lazega, multilayer) | — | ≤0.1s, = | ≤0.1s, = |

Codelength column omitted: every value is bit-identical to master.

## Cumulative per-fix (air30k, interleaved same-session)

| stage | main | `-2` |
|---|--:|--:|
| baseline | 16.02s | 5.83s |
| + fix1 (hoist) | 14.17s (−12%) | 5.14s (−12%) |
| + fix2 (Mem plogp) | 13.28s (−17% cum.) | 5.08s (−13% cum.) |

fix1 carries the bulk everywhere; fix2 adds a further ~6% on air30k main (many co-physical modules per physical node). On base networks fix2 is a no-op (`addMemoryContributions` never runs), so there the whole gain is fix1. The win scales with candidates-per-node → largest on the dense memory/multilayer nets.

---

Release-notes override (repo convention: the C++ core is unscoped):

BEGIN_COMMIT_OVERRIDE
perf: hoist per-node-constant plogp out of the OO move-loop delta

Closes #867
END_COMMIT_OVERRIDE
