### PR TITLE
feat: honor search-shaping flags and add the one-level fallback in the columnar engine

### DIFF
--- a/src/core/ColumnarMapEquation.cpp
+++ b/src/core/ColumnarMapEquation.cpp
@@ -1427,6 +1427,79 @@ double BiasedEntropyCorrection::hierarchicalCorrection(const ColumnarTwoLevel& c
   return m_multiplier * static_cast<double>(nonRootNodes) / (2.0 * m_totalDegree);
 }
 
+// ===================================================
+// PreferredModulesCorrection (--preferred-number-of-modules: |K - K_pref| bias)
+// ===================================================
+
+double PreferredModulesCorrection::hierarchicalCorrection(const ColumnarTwoLevel& core) const
+{
+  // Leaf-module level, matching where the move-loop bias acts (and the other
+  // corrections apply). <2 levels means no modules; the base handles that and
+  // the one-level fallback would collapse it anyway.
+  if (core.hierNumLevels() < 2)
+    return 0.0;
+  return cost(core.hierLevelSize(1));
+}
+
+double PreferredModulesCorrection::initMoveLoop(const std::vector<int>& leafModule, int numModules)
+{
+  m_moduleMembers.assign(numModules, 0);
+  for (int m : leafModule)
+    ++m_moduleMembers[m];
+  m_numNonEmpty = 0;
+  for (int c : m_moduleMembers)
+    if (c > 0)
+      ++m_numNonEmpty;
+  return cost(m_numNonEmpty);
+}
+
+double PreferredModulesCorrection::moveDelta(int /*leaf*/, int oldMod, int newMod) const
+{
+  if (oldMod == newMod)
+    return 0.0;
+  // K changes only when the move empties the old module or fills an empty new
+  // one (exactly BiasedMapEquation::getDeltaNumModulesIfMoving).
+  const int deltaK = (m_moduleMembers[oldMod] == 1 ? -1 : 0) + (m_moduleMembers[newMod] == 0 ? 1 : 0);
+  if (deltaK == 0)
+    return 0.0;
+  return cost(m_numNonEmpty + deltaK) - cost(m_numNonEmpty);
+}
+
+void PreferredModulesCorrection::applyMove(int /*leaf*/, int oldMod, int newMod)
+{
+  if (oldMod == newMod)
+    return;
+  if (m_moduleMembers[newMod] == 0)
+    ++m_numNonEmpty;
+  ++m_moduleMembers[newMod];
+  --m_moduleMembers[oldMod];
+  if (m_moduleMembers[oldMod] == 0)
+    --m_numNonEmpty;
+}
+
+double PreferredModulesCorrection::mergeDelta(int a, int b) const
+{
+  // Folding module A into B drops K by one only when both are non-empty.
+  const int deltaK = (m_moduleMembers[a] > 0 && m_moduleMembers[b] > 0) ? -1 : 0;
+  if (deltaK == 0)
+    return 0.0;
+  return cost(m_numNonEmpty + deltaK) - cost(m_numNonEmpty);
+}
+
+void PreferredModulesCorrection::applyMerge(int a, int b)
+{
+  if (m_moduleMembers[a] == 0)
+    return;
+  if (m_moduleMembers[b] == 0) {
+    // Non-empty A into empty B: B gains A's members as A empties — K unchanged.
+    m_moduleMembers[b] = m_moduleMembers[a];
+  } else {
+    m_moduleMembers[b] += m_moduleMembers[a];
+    --m_numNonEmpty;
+  }
+  m_moduleMembers[a] = 0;
+}
+
 double MetaCorrection::hierarchicalCorrection(const ColumnarTwoLevel& core) const
 {
   using infomath::plogp;

--- a/src/core/ColumnarMapEquation.h
+++ b/src/core/ColumnarMapEquation.h
@@ -13,6 +13,7 @@
 #include <functional>
 #include <vector>
 #include <cstddef>
+#include <cstdlib>
 #include <memory>
 #include <unordered_map>
 #include <unordered_set>
@@ -497,6 +498,44 @@ public:
 private:
   double m_multiplier;
   double m_totalDegree;
+};
+
+/**
+ * Preferred-number-of-modules bias (--preferred-number-of-modules): the same
+ * |K - K_pref| penalty (1 bit per module away from the target) that
+ * BiasedMapEquation applies on the OO path, wired into the columnar two-level
+ * move loop and merge so the search — not only the reported codelength — is
+ * steered toward K_pref modules. K is the current non-empty leaf-module count,
+ * tracked from the partition the move loop maintains (initMoveLoop seeds it,
+ * applyMove/applyMerge keep it exact). Objective-agnostic: an additive
+ * structural term that composes with base/meta/mem/lossy, like the entropy
+ * bias. Applies at the top-level partition ONLY — OO does not propagate
+ * preferredNumberOfModules to sub-Infomaps (cloneAsNonMain omits it), so
+ * sliceForLeaves returns nullptr and the bias never recurses into sub-networks.
+ */
+class PreferredModulesCorrection final : public ColumnarCorrection {
+public:
+  explicit PreferredModulesCorrection(unsigned int preferredNumModules)
+      : m_preferredNumModules(static_cast<int>(preferredNumModules)) {}
+  double hierarchicalCorrection(const ColumnarTwoLevel& core) const override;
+
+  bool participatesInMoveLoop() const override { return true; }
+  double initMoveLoop(const std::vector<int>& leafModule, int numModules) override;
+  double moveDelta(int leaf, int oldMod, int newMod) const override;
+  void applyMove(int leaf, int oldMod, int newMod) override;
+  double mergeDelta(int moduleA, int moduleB) const override;
+  void applyMerge(int moduleA, int moduleB) override;
+  // Top-level only (see class note): never slice into sub-networks.
+  std::unique_ptr<ColumnarCorrection> sliceForLeaves(const std::vector<int>&) const override { return nullptr; }
+
+private:
+  // |K - K_pref| with unit weight (1 bit per module), matching
+  // BiasedMapEquation::calcNumModuleCost.
+  double cost(int numModules) const { return std::abs(numModules - m_preferredNumModules); }
+
+  int m_preferredNumModules;
+  std::vector<int> m_moduleMembers; // per module: member count
+  int m_numNonEmpty = 0; // K = number of non-empty modules
 };
 
 /**

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -205,6 +205,7 @@ public:
       auto timer = m_timing.scope("configure_network_s");
       configureNetworkMode();
     }
+    warnColumnarUnsupportedOptions();
     calculateFlowAndInitNetwork();
     {
       auto timer = m_timing.scope("post_flow_output_s");
@@ -567,6 +568,19 @@ private:
       m_infomap.flowModel = FlowModel::directed;
     }
     m_network.setConfig(m_infomap);
+  }
+
+  // Search-shaping flags with no effect on the columnar engine (#827). Wired:
+  // --preferred-number-of-modules (PreferredModulesCorrection) and
+  // --prefer-modular-solution (honored by the one-level fallback). Dead:
+  // --preferred-number-of-levels(-strength), which biases the OO super-search
+  // depth — the columnar enter-flow up-build has no depth-preference dial.
+  void warnColumnarUnsupportedOptions()
+  {
+    if (!m_infomap.columnarSearch)
+      return;
+    if (m_infomap.preferredNumberOfLevels != 0)
+      Console::warn(0, "--preferred-number-of-levels has no effect with --columnar (the columnar up-build has no depth-preference bias); ignoring it.");
   }
 
   void calculateFlowAndInitNetwork()
@@ -1804,8 +1818,42 @@ void InfomapBase::columnarPartition()
   const double materializedL = m_hierarchicalCodelength;
   m_hierarchicalCodelength = columnarL;
   m_numNonTrivialTopModules = calculateNumNonTrivialTopModules();
+
+  // One-level fallback (#827): the columnar search can, like the OO optimizer,
+  // return a modular partition whose codelength is worse than the all-in-one-
+  // module (one-level) codelength — e.g. on near-random networks. The OO path
+  // guards against this (see hierarchicalPartition), collapsing to a single
+  // module; the columnar path had no such guard. Mirror it exactly: same
+  // predicate (skip when the user asked to prefer a modular or a specific-count
+  // solution, and — as OO — for the regularized links-only prior), same
+  // collapse. columnarL and getOneLevelCodelength() are on the same objective
+  // scale (both true map-equation codelengths; the benchmark tables compare
+  // them directly), so the comparison is valid across objectives.
+  const bool regularizedPriorOnly = regularized && network().numLinks() == 0;
+  if (!preferModularSolution && preferredNumberOfModules == 0
+      && (haveNonTrivialModules() || regularizedPriorOnly)
+      && columnarL > getOneLevelCodelength()) {
+    Console::detail(1, "columnar: worse codelength than one-level ({} > {}), putting all nodes in one module",
+                    io::toPrecision(columnarL), io::toPrecision(getOneLevelCodelength()));
+
+    auto& module = root().replaceChildrenWithOneNode();
+    module.data = m_root.data;
+    module.physicalNodes = m_root.physicalNodes;
+#if INFOMAP_FEATURE_LOSSY_MAP_EQUATION
+    module.lossyEntropy = m_root.lossyEntropy;
+    module.lossyFlowLogFlow = m_root.lossyFlowLogFlow;
+#endif
+    module.index = 0;
+    for (auto& node : module)
+      node.index = 0;
+    module.codelength = getOneLevelCodelength();
+    m_hierarchicalCodelength = getOneLevelCodelength();
+    m_root.codelength = 0.0;
+    m_numNonTrivialTopModules = calculateNumNonTrivialTopModules();
+  }
+
   Console::detail(1, "columnar: codelength {}, materialized {}, {} levels",
-                  io::toPrecision(columnarL), io::toPrecision(materializedL), maxTreeDepth());
+                  io::toPrecision(m_hierarchicalCodelength), io::toPrecision(materializedL), maxTreeDepth());
 }
 
 bool InfomapBase::columnarNativeInputEligible() const
@@ -1884,6 +1932,13 @@ void InfomapBase::addColumnarCorrections(ColumnarTwoLevel& opt) const
       totalDegree = m_network.sumDegree();
     opt.addCorrection(std::make_unique<BiasedEntropyCorrection>(entropyBiasCorrectionMultiplier, totalDegree));
   }
+  // Preferred number of modules (#827): |K - K_pref| move-loop bias, the
+  // columnar analogue of BiasedMapEquation. Objective-agnostic (composes with
+  // any of the objectives below). Attached to the top-level optimizer only; its
+  // sliceForLeaves is a no-op, so sub-network refines optimize without it —
+  // matching OO, which does not propagate preferredNumberOfModules downward.
+  if (preferredNumberOfModules != 0)
+    opt.addCorrection(std::make_unique<PreferredModulesCorrection>(preferredNumberOfModules));
   // Metadata: one category per leaf (first dimension), flow-weighted by default
   // (unweighted uses a uniform 1/numNodes, matching MetaMapEquation).
   if (haveMetaData()) {

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -902,6 +902,39 @@ TEST_CASE("numNonTrivialTopModules is zero when all nodes are in one module [fas
   infomap::test::checkCanonicalPartition(im, { { 1, 2, 3, 4, 5 } });
 }
 
+// #827: --preferred-number-of-modules is wired into the columnar engine as the
+// |K - K_pref| move-loop bias (PreferredModulesCorrection), the columnar
+// analogue of BiasedMapEquation. On the OO path this flag was dead under
+// --columnar. Here we verify the columnar two-level search is steered to the
+// requested module count, and that the flag-off run is unaffected.
+TEST_CASE("Columnar --preferred-number-of-modules steers the two-level module count [fast][core][partition][columnar]")
+{
+  // Four 5-cliques in a ring joined by single bridge edges: the unbiased
+  // two-level optimum is the four natural cliques.
+  auto build = [](InfomapWrapper& im) {
+    constexpr int C = 4, S = 5;
+    auto nid = [](int c, int i) { return c * S + i + 1; };
+    for (int c = 0; c < C; ++c)
+      for (int i = 0; i < S; ++i)
+        for (int j = i + 1; j < S; ++j)
+          im.addLink(nid(c, i), nid(c, j));
+    for (int c = 0; c < C; ++c)
+      im.addLink(nid(c, 0), nid((c + 1) % C, 0));
+  };
+  auto topModules = [&](const std::string& extra) {
+    InfomapWrapper im("--seed 123 --num-trials 1 --silent --two-level --columnar " + extra);
+    build(im);
+    im.run();
+    return im.numTopModules();
+  };
+
+  CHECK(topModules("") == 4); // unbiased: the four natural cliques
+  CHECK(topModules("--preferred-number-of-modules 1") == 1); // merge past structure
+  CHECK(topModules("--preferred-number-of-modules 2") == 2);
+  CHECK(topModules("--preferred-number-of-modules 3") == 3);
+  CHECK(topModules("--preferred-number-of-modules 6") == 6); // split the cliques
+}
+
 TEST_CASE("--num-threads bounds parallel-trials workers without changing the result [fast][core][threads]")
 {
   // Parallel trials reseed per trial (seed = base + trialIndex), so the result is


### PR DESCRIPTION
## Summary

Closes the columnar-engine gaps in #827: the missing one-level fallback guard and the search-shaping flags that were dead under `--columnar`.

## Changes

- **One-level fallback** — `columnarPartition()` now mirrors the OO guard (see `hierarchicalPartition`): if the columnar modular partition is worse than the all-in-one-module codelength, collapse to a single module. Same predicate as OO (skipped under `--prefer-modular-solution` / `--preferred-number-of-modules`, and for the regularized links-only prior), same collapse. This also makes **`--prefer-modular-solution`** meaningful on the columnar path (it is what disables the fallback).
- **`--preferred-number-of-modules`** — wired as `PreferredModulesCorrection`, the columnar analogue of `BiasedMapEquation`'s `|K − K_pref|` bias (1 bit per module). It participates in the two-level move loop and the coarsening merge (K tracked from module membership) so the *search* — not only the reported codelength — is steered to the target, and composes additively with base/meta/mem/lossy. Attached to the top-level optimizer only: `sliceForLeaves` is a no-op, matching OO (which does not propagate `preferredNumberOfModules` to sub-Infomaps — `cloneAsNonMain` omits it).
- **`--preferred-number-of-levels(-strength)`** stays dead under `--columnar` (the enter-flow up-build has no depth-preference dial); warn once and ignore.

## Verification

- Flag-off is **bit-identical** to the base branch (science2001 `-d`).
- `-2 --columnar --preferred-number-of-modules K` yields exactly K top modules on a clique-ring (new doctest); on science2001 `-C -d --preferred-number-of-modules 25` the finest-module level lands on exactly 25.
- The existing one-module invariant test passes on the columnar engine; all C++ doctest suites pass on both engines.
