### PR TITLE
perf: hoist the tele-path move delta and cache the Meta correction's move-loop terms

### DIFF
--- a/columnar_wip/benchmark-networks.md
+++ b/columnar_wip/benchmark-networks.md
@@ -21,6 +21,8 @@ Single-thread convention: `MODE=release OPENMP=0`, `--seed 123`, best-of-N via `
 | multilayer (example) | `examples/networks/multilayer.net` | — | undirected | **multilayer** / higher-order (memory) toy | 5 physical nodes |
 | malaria | `networks/multilayer/real-world/malaria/malaria_PLOSCompBiology_2013.net` | — | undirected | **multilayer** / higher-order (memory) real-world | 307 physical nodes · 9 layers |
 | air30k (states) | `networks/states/air2011/air30k.net` | — | undirected | **state / memory** (higher-order) real-world | 183 physical · 13 213 state nodes |
+| air30k (regularized) | `networks/states/air2011/air30k.net` | `-d --regularized` | directed | **state / memory** + **recorded teleportation** | 183 physical · 13 213 state nodes |
+| science2001 (preferred modules) | `networks/db/science2001.net` | `-d --preferred-number-of-modules 25` | directed | first-order + **preferred-number-of-modules** bias | 7 170 nodes |
 
 **Coverage rationale**
 - **Base map equation, undirected**: ninetriangles (hierarchy), jazz, netscicoauthor2010, powergrid.
@@ -28,6 +30,11 @@ Single-thread convention: `MODE=release OPENMP=0`, `--seed 123`, best-of-N via `
   science2001, web-NotreDame (the large stress case).
 - **Composable objectives** (exercise the correction hooks): lazega + metadata; air30k, multilayer,
   malaria for the memory/higher-order objective (physical-node codebook).
+- **Recorded teleportation** (exercises the tele-path move loop): air30k `-d --regularized` — the
+  regularized directed flow model turns on recorded teleportation, so the leaf move loop runs the
+  teleport-inclusive delta (`deltaCodelengthMovingNodeTele*`) rather than the link-only one.
+- **Search-shaping bias**: science2001 `-d --preferred-number-of-modules 25` exercises the columnar
+  `|K − K_pref|` bias (`PreferredModulesCorrection`).
 - **Scale**: from 5-node toys (fast correctness) to 325k-node web-NotreDame (time/memory).
 
 > **Fixed (see `columnar-rethink-notes.md` F15/F16):** `-C` best-of-N on **politicalblogs**

--- a/columnar_wip/columnar-pr-performance-section.md
+++ b/columnar_wip/columnar-pr-performance-section.md
@@ -4,6 +4,8 @@
 
 Single-threaded (`MODE=release OPENMP=0`), `--seed 123 -N10` — **best of 10 trials**, the way Infomap is normally run. Codelength in bits; `time` = total wall for all 10 trials (read + 10× optimize + write); `top`/`lvls` = top modules / levels of the best partition. The network set spans base (undirected + directed), metadata, multilayer and state/memory objectives; see [`columnar_wip/benchmark-networks.md`](columnar_wip/benchmark-networks.md) for paths and full details. Columnar column = the default columnar search (`-C`).
 
+> **Note:** the columnar columns in the tables below predate the #868 move-loop speedups and are stale; they are refreshed to the current engine in **#879**. This branch's tele/meta hoist is **bit-exact** (codelengths unchanged, and no time change on these configs — none use recorded teleportation or metadata beyond tiny lazega), so it does not move these tables. This branch's own measured impact is in the [follow-up subsection](#tele-path-and-metadata-move-loop-hoist-this-branch) at the end.
+
 <table>
 <thead>
 <tr>
@@ -114,3 +116,20 @@ Parentheses on the columnar columns = change vs OO `-2` (**bold** = columnar bea
 - **Quality** — columnar `-2` ties or beats OO on 9 of 11 networks (beats on netscicoauthor2010, politicalblogs, malaria), and is within +0.11% on web-NotreDame. The exceptions are powergrid (+0.64%) and air30k (+1.22%).
 - **Speed** — faster on every non-trivial network (−38% to −83%) **except air30k (+58%)**.
 - **The one real gap is the state/memory objective (air30k), on both axes.** Profiled cause: the columnar aggregation passes optimize the *base* objective only (corrections act in the leaf move loops, the augmented pass selection, and the gated merges), so the base-driven aggregation stops far too fine for the memory objective (K = 1353 where the optimum wants ~330) and the greedy pairwise merge + leaf re-tune has to carry the whole coarsening. OO's coarse-tune moves modules under the true memory objective. The principled fix is module-level correction state (consolidate per-unit physical-flow aggregates so module moves see the augmented delta); the same machinery is also the likely cure for the residual +1.5% hierarchical air30k gap.
+
+### Tele-path and metadata move-loop hoist (this branch)
+
+Two follow-ups to the #868 move-loop speedups: the recorded-teleportation delta now hoists its six old-module plogp terms once per unit (`hoistOldSideTele`), and the metadata correction caches its per-leaf move-loop terms with the same zero-path fast-track as the memory correction. Both are **bit-exact** — codelengths are unchanged on every benchmark network × {`-C`, `-F`, `-2 -C`}, so the tables above are untouched by this branch (those tables predate #868 and are refreshed to the current engine in #879). The measurable win is on the recorded-teleportation path; the metadata fast paths are correctness/consistency (the benchmark set has no large metadata network).
+
+Two new benchmark configurations exercise these paths (`old` = this branch's base, before the hoist; `new` = with it; best of 2, wall for `-N10`; codelengths bit-identical between old and new):
+
+| config | objective | mode | codelength | old columnar | new columnar |
+|---|---|---|---|--:|--:|
+| air30k `-d --regularized` | state/memory + **recorded teleportation** | `-C` | 5.66883586 | 5.34s | **4.63s (−13%)** |
+| air30k `-d --regularized` | | `-F` | 5.66883586 | 4.69s | **3.98s (−15%)** |
+| air30k `-d --regularized` | | `-2 -C` | 6.01175505 | 6.20s | **5.20s (−16%)** |
+| science2001 `-d --preferred-number-of-modules 25` | base + **`\|K−K_pref\|` bias** | `-C` | 8.46079677 | 3.41s | 3.43s (=) |
+| science2001 `-d --preferred-number-of-modules 25` | | `-F` | 8.65395434 | 3.34s | 3.33s (=) |
+| science2001 `-d --preferred-number-of-modules 25` | | `-2 -C` | 8.23577532 | 3.30s | 3.24s (=) |
+
+The tele hoist gives a consistent ~13–16% on air30k's recorded-teleportation runs; the preferred-modules config (no teleport, no metadata) is unchanged, confirming the hoist touches only the tele path. The `--preferred-number-of-modules 25` bias lands the columnar two-level partition on exactly 25 modules (`-2 -C`, top = 25) and drives the finest level of the hierarchical `-C` to 25 as well — see [#827](https://github.com/mapequation/infomap/issues/827).

--- a/src/core/ColumnarMapEquation.cpp
+++ b/src/core/ColumnarMapEquation.cpp
@@ -321,6 +321,53 @@ namespace {
 
     return delta_enter - delta_enter_log_enter - delta_exit_log_exit + delta_flow_log_flow;
   }
+
+  // Recorded-teleportation (tele-path) analogue of OldSideTerms/hoistOldSide:
+  // the six old-module (A-side) plogp terms plus the A-side shift of enterFlow
+  // are constant across every candidate the move loop probes for the same unit,
+  // so the caller hoists them once per unit visit. moduleTeleEnter/moduleTeleExit
+  // are inlined here as free lambdas (these helpers live in the class); the
+  // per-candidate expression structure below matches deltaCodelengthMovingNodeTele
+  // exactly, so results stay bit-identical to the unhoisted form.
+  struct TeleOldSideTerms {
+    double plogpEA0, plogpXA0, plogpFA0; // before the move
+    double plogpEA1, plogpXA1, plogpFA1; // after
+    double deltaEnterA; // eA1 - eA0, the A-side contribution to enterFlow1
+  };
+
+  inline TeleOldSideTerms hoistOldSideTele(double curEnter, double curExit, double curFlow, double tfu, double twu, double oldEnter, double oldExit, double oldFlow, double oldTeleFlow, double oldTeleWeight, double totalTeleFlow, double deltaOld)
+  {
+    using infomath::plogp;
+    const auto teleEnter = [&](double tf, double tw) { return (totalTeleFlow - tf) * tw; };
+    const auto teleExit = [&](double tf, double tw) { return tf * (1.0 - tw); };
+    const double eA0 = oldEnter + teleEnter(oldTeleFlow, oldTeleWeight);
+    const double xA0 = oldExit + teleExit(oldTeleFlow, oldTeleWeight);
+    const double fA0 = xA0 + oldFlow;
+    const double eA1 = (oldEnter - curEnter + deltaOld) + teleEnter(oldTeleFlow - tfu, oldTeleWeight - twu);
+    const double xA1 = (oldExit - curExit + deltaOld) + teleExit(oldTeleFlow - tfu, oldTeleWeight - twu);
+    const double fA1 = xA1 + (oldFlow - curFlow);
+    return { plogp(eA0), plogp(xA0), plogp(fA0), plogp(eA1), plogp(xA1), plogp(fA1), eA1 - eA0 };
+  }
+
+  inline double deltaCodelengthMovingNodeTeleHoisted(double enterFlow, double enterFlow_log_enterFlow, double curEnter, double curExit, double curFlow, double tfu, double twu, const TeleOldSideTerms& o, double newEnter, double newExit, double newFlow, double newTeleFlow, double newTeleWeight, double totalTeleFlow, double deltaNew)
+  {
+    using infomath::plogp;
+    const auto teleEnter = [&](double tf, double tw) { return (totalTeleFlow - tf) * tw; };
+    const auto teleExit = [&](double tf, double tw) { return tf * (1.0 - tw); };
+    const double eB0 = newEnter + teleEnter(newTeleFlow, newTeleWeight);
+    const double xB0 = newExit + teleExit(newTeleFlow, newTeleWeight);
+    const double fB0 = xB0 + newFlow;
+    const double eB1 = (newEnter + curEnter - deltaNew) + teleEnter(newTeleFlow + tfu, newTeleWeight + twu);
+    const double xB1 = (newExit + curExit - deltaNew) + teleExit(newTeleFlow + tfu, newTeleWeight + twu);
+    const double fB1 = xB1 + (newFlow + curFlow);
+
+    const double enterFlow1 = enterFlow + o.deltaEnterA + (eB1 - eB0);
+    const double d_enter = plogp(enterFlow1) - enterFlow_log_enterFlow;
+    const double d_enter_log = (o.plogpEA1 + plogp(eB1)) - (o.plogpEA0 + plogp(eB0));
+    const double d_exit_log = (o.plogpXA1 + plogp(xB1)) - (o.plogpXA0 + plogp(xB0));
+    const double d_flow_log = (o.plogpFA1 + plogp(fB1)) - (o.plogpFA0 + plogp(fB0));
+    return d_enter - d_enter_log - d_exit_log + d_flow_log;
+  }
 } // namespace
 
 void ColumnarTwoLevel::buildFromLeaves(const std::vector<InfoNode*>& leafNodes, bool undirected, unsigned long seed)
@@ -740,15 +787,24 @@ unsigned int ColumnarTwoLevel::moveLoop()
         }
       }
 
-      const OldSideTerms oldSide = m_recordedTeleport
+      // Hoist the old-module (A-side) terms once per unit visit — 6 of the 13
+      // plogp per candidate on the base path, 6 of 12 on the recorded-teleport
+      // path. Per-candidate math below is unchanged, so results stay bit-exact.
+      const bool tele = m_recordedTeleport;
+      const double tfu = tele ? m_lvl.teleFlow[u] : 0.0;
+      const double twu = tele ? m_lvl.teleWeight[u] : 0.0;
+      const OldSideTerms oldSide = tele
           ? OldSideTerms{}
           : hoistOldSide(curEnter, curExit, curFlow, m_mEnter[cMod], m_mExit[cMod], m_mFlow[cMod], deltaOld);
+      const TeleOldSideTerms teleOldSide = tele
+          ? hoistOldSideTele(curEnter, curExit, curFlow, tfu, twu, m_mEnter[cMod], m_mExit[cMod], m_mFlow[cMod], m_mTeleFlow[cMod], m_mTeleWeight[cMod], m_totalTeleFlow, deltaOld)
+          : TeleOldSideTerms{};
       for (int m : touched) {
         if (m == cMod)
           continue;
         const double deltaNew = dEnter[m] + dExit[m];
-        double dl = m_recordedTeleport
-            ? deltaCodelengthMovingNodeTele(curEnter, curExit, curFlow, m_lvl.teleFlow[u], m_lvl.teleWeight[u], cMod, m, deltaOld, deltaNew)
+        double dl = tele
+            ? deltaCodelengthMovingNodeTeleHoisted(m_enterFlow, m_enterFlow_log_enterFlow, curEnter, curExit, curFlow, tfu, twu, teleOldSide, m_mEnter[m], m_mExit[m], m_mFlow[m], m_mTeleFlow[m], m_mTeleWeight[m], m_totalTeleFlow, deltaNew)
             : deltaCodelengthMovingNodeHoisted(
                   m_enterFlow, m_enterFlow_log_enterFlow, curEnter, curExit, curFlow, oldSide, m_mEnter[m], m_mExit[m], m_mFlow[m], deltaOld, deltaNew);
         for (auto* c : corr)
@@ -795,7 +851,7 @@ unsigned int ColumnarTwoLevel::moveLoop()
         m_mExit[bestMod] -= deltaNew;
 
         if (m_recordedTeleport) {
-          const double tfu = m_lvl.teleFlow[u], twu = m_lvl.teleWeight[u];
+          // tfu/twu were hoisted at the top of this unit visit.
           m_mTeleFlow[cMod] -= tfu;
           m_mTeleWeight[cMod] -= twu;
           m_mTeleFlow[bestMod] += tfu;
@@ -1563,18 +1619,31 @@ double MetaCorrection::moveDelta(int leaf, int oldMod, int newMod) const
     return 0.0;
   const int q = m_leafCategory[leaf];
   const double w = m_leafWeight[leaf];
-  const double Fo = m_moduleFlow[oldMod], Fn = m_moduleFlow[newMod];
-  const double fo = moduleCategoryFlow(oldMod, q), fn = moduleCategoryFlow(newMod, q);
-  // term(m) = plogp(F_m) - sum_c plogp(f_c). Only F and category q change.
-  const double dOld = (plogp(Fo - w) - plogp(Fo)) - (plogp(fo - w) - plogp(fo));
-  const double dNew = (plogp(Fn + w) - plogp(Fn)) - (plogp(fn + w) - plogp(fn));
-  return m_metaDataRate * (dOld + dNew);
+  // term(m) = plogp(F_m) - sum_c plogp(f_c); only F_m and category q change.
+  // The old-module delta is identical for every candidate the move loop probes
+  // for the same leaf, so it (and plogp(w)) is computed once and cached; a
+  // candidate module lacking category q (the common case) needs no category
+  // logs — plogp(0) == 0 and plogp(0 + w) == plogp(w), cached alongside.
+  if (leaf != m_cacheUnit || oldMod != m_cacheOldMod) {
+    const double Fo = m_moduleFlow[oldMod];
+    const double fo = moduleCategoryFlow(oldMod, q);
+    m_cacheUnit = leaf;
+    m_cacheOldMod = oldMod;
+    m_cacheDOld = (plogp(Fo - w) - plogp(Fo)) - (plogp(fo - w) - plogp(fo));
+    m_cachePlogpW = plogp(w);
+  }
+  const double Fn = m_moduleFlow[newMod];
+  const double fn = moduleCategoryFlow(newMod, q);
+  const double dNew = (plogp(Fn + w) - plogp(Fn))
+      - (fn == 0.0 ? m_cachePlogpW : (plogp(fn + w) - plogp(fn)));
+  return m_metaDataRate * (m_cacheDOld + dNew);
 }
 
 void MetaCorrection::applyMove(int leaf, int oldMod, int newMod)
 {
   if (oldMod == newMod)
     return;
+  m_cacheUnit = -1; // module contents change: drop the per-leaf delta cache
   const int q = m_leafCategory[leaf];
   const double w = m_leafWeight[leaf];
   m_moduleFlow[oldMod] -= w;
@@ -1599,7 +1668,9 @@ double MetaCorrection::mergeDelta(int a, int b) const
   const auto& cb = m_moduleCatFlow[b];
   for (const auto& kv : ca) {
     const auto it = cb.find(kv.first);
-    const double bv = (it == cb.end()) ? 0.0 : it->second;
+    if (it == cb.end())
+      continue; // category only in A: plogp(a+0) - plogp(a) - plogp(0) == 0
+    const double bv = it->second;
     d -= plogp(kv.second + bv) - plogp(kv.second) - plogp(bv); // -sum_c plogp(f_c)
   }
   return m_metaDataRate * d;
@@ -1607,6 +1678,7 @@ double MetaCorrection::mergeDelta(int a, int b) const
 
 void MetaCorrection::applyMerge(int a, int b)
 {
+  m_cacheUnit = -1;
   m_moduleFlow[b] += m_moduleFlow[a];
   m_moduleFlow[a] = 0.0;
   auto& ca = m_moduleCatFlow[a];

--- a/src/core/ColumnarMapEquation.h
+++ b/src/core/ColumnarMapEquation.h
@@ -347,8 +347,10 @@ private:
 
   // Recorded-teleport-aware move delta: change in the augmented base codelength
   // from moving unit u (link enter/exit/flow cur*, teleport tfu/twu) out of module
-  // A into module B, with deltaOld/deltaNew the link flow between u and A/B. Used
-  // instead of deltaCodelengthMovingNode when m_recordedTeleport is on.
+  // A into module B, with deltaOld/deltaNew the link flow between u and A/B. This
+  // is the unhoisted reference form (the readable counterpart of the free
+  // hoistOldSideTele + deltaCodelengthMovingNodeTeleHoisted the move loop uses
+  // when m_recordedTeleport is on); kept for clarity like deltaCodelengthMovingNode.
   double deltaCodelengthMovingNodeTele(double curEnter, double curExit, double curFlow, double tfu, double twu, int A, int B, double deltaOld, double deltaNew) const;
 
   // Aggregate a base level under a unit->group assignment (K groups): group
@@ -574,6 +576,14 @@ private:
   // Move-loop state (per module): total weight F_m and category->weight map.
   std::vector<double> m_moduleFlow; // F_m
   std::vector<std::unordered_map<int, double>> m_moduleCatFlow; // f_{m,c}
+
+  // Per-(leaf, current-module) delta cache: the old-module delta and plogp(w)
+  // are identical for every candidate the move loop probes for the same leaf
+  // (mirrors MemCorrection).
+  mutable int m_cacheUnit = -1;
+  mutable int m_cacheOldMod = -1;
+  mutable double m_cacheDOld = 0.0;
+  mutable double m_cachePlogpW = 0.0;
 };
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #868, closing the two items it flagged as deferred: the **tele-path** variant of the move-loop hoist and the **Meta** correction analogue of the cache / zero-path treatment. Both are **bit-exact**.

> Stacked on #874 (#827). Review/merge that first; this PR targets its branch so the diff shows only the follow-up.

## Changes

**Tele hoist.** The recorded-teleportation move delta (`deltaCodelengthMovingNodeTele`) recomputed the six old-module (A-side) plogp terms for every candidate module of the same unit — the exact pattern #868 hoisted on the base path. Added free `hoistOldSideTele` + `deltaCodelengthMovingNodeTeleHoisted` (mirroring `OldSideTerms` / `hoistOldSide`); the A-side terms are hoisted once per unit visit. The unhoisted `deltaCodelengthMovingNodeTele` stays as the readable reference.

**Meta fast paths.** `MetaCorrection::moveDelta` recomputed the per-leaf-constant old-module delta for every candidate and paid category logs on candidates lacking the leaf's category (the common case, where `plogp(0) == 0` and `plogp(0 + w) == plogp(w)`); `mergeDelta` burned three plogp per category present in only one module. Now caches the old-module delta and `plogp(w)` per `(leaf, module)`, drops the logs on the empty-category path, and skips disjoint categories in the merge — the Meta analogue of the `MemCorrection` treatment in #868.

**Benchmark set** gains **air30k `-d --regularized`** (recorded teleportation — exercises the tele hoist) and **science2001 `-d --preferred-number-of-modules 25`** (the #827 bias).

## Verification

- **Bit-exact**: identical codelengths on all 12 benchmark networks × {`-C`, `-C -F`, `-2 -C`} against this branch's base, including the tele path (air30k `-d --regularized`) and the meta path (lazega). Per-candidate expression structure is preserved, so results are bit-identical by construction.
- C++ doctest suites pass on both engines.

## Tele timing (best of 3, user-time, `-N10`)

| config | before | after |
|---|--:|--:|
| air30k `-d --regularized` `-C` | 5.06s | **4.23s (−16%)** |
| air30k `-d --regularized` `-2 -C` | 5.67s | **4.82s (−15%)** |

Mem / base / flag networks are within ±3% machine noise — expected, since the tele hoist touches only recorded-teleport runs and the Meta fast paths only metadata runs (the benchmark set has no large metadata network, so the Meta change is correctness/consistency, not a measurable speedup here).
