### PR TITLE
ci: fix Windows wheel tooling, fail the release gate closed, close filter gaps

### DIFF
--- a/.github/actions/setup-ccache/action.yml
+++ b/.github/actions/setup-ccache/action.yml
@@ -41,4 +41,4 @@ runs:
     - name: Reset ccache stats
       if: runner.os != 'Windows'
       shell: bash
-      run: command -v ccache >/dev/null 2>&1 && ccache -z || true
+      run: if command -v ccache >/dev/null 2>&1; then ccache -z || true; fi

--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -14,11 +14,14 @@
 # nests deeper than one level, which paths-filter flattens reliably.
 
 # Makefile + build system + C++ sources: the compile inputs shared by every lane
-# that builds the core.
+# that builds the core. vendor/ headers (fmt, nlohmann_json) are compiled into
+# every one of those builds (-Ivendor/... in mk/common.mk, CMakeLists.txt, and
+# setup.py), so a vendored bump must fire the same lanes as a src/ change.
 _build_core: &build_core
   - "Makefile"
   - "mk/**"
   - "src/**"
+  - "vendor/**"
 
 # The CMake/native-build inputs shared by the native, python-core, and
 # javascript lanes (each of which builds the C++ core through _native-build.yml).
@@ -76,6 +79,7 @@ python-core:
 python-packaging:
   - "Makefile"
   - "mk/**"
+  - "MANIFEST.in"
   - "pyproject.toml"
   - "setup.py"
   - "scripts/build_config.py"
@@ -97,6 +101,7 @@ javascript:
   - *build_core
   - *cmake_core
   - ".github/workflows/ci.yml"
+  - "biome.json"
   - "package.json"
   - "package-lock.json"
   - "interfaces/js/**"
@@ -118,14 +123,19 @@ r:
   - "examples/R/**"
   - "scripts/generate_r_swig.py"
   - "scripts/stage_r_package.py"
+  # The R CMD check driver mk/r.mk's test-r target executes: weakening it must
+  # run the R lane it gates.
+  - "scripts/r_check.R"
   - ".github/actions/setup-swig/action.yml"
   - ".github/actions/setup-ccache/action.yml"
+  - ".github/actions/setup-python-build/action.yml"
   - ".github/workflows/ci.yml"
   - ".github/workflows/_r-package.yml"
   - ".github/filters.yml"
 
 docs:
   - *build_core
+  - ".github/workflows/ci.yml"
   - "README.rst"
   - "BUILD.md"
   - "pyproject.toml"
@@ -139,6 +149,7 @@ docs:
 
 docker:
   - *build_core
+  - ".github/workflows/ci.yml"
   - "docker/**"
   - "docker-compose.yml"
   - ".dockerignore"
@@ -159,3 +170,13 @@ notebooks:
   - ".github/workflows/ci.yml"
   - ".github/workflows/notebooks.yml"
   - ".github/filters.yml"
+
+# The CI surface with no build lane of its own: workflow definitions, composite
+# actions, and the hook config. Gates the pre-commit job (and with it
+# actionlint plus the YAML/hygiene hooks), so none of these can change with
+# zero checks running -- release.yml, fuzz.yml, report-cron-failure, and
+# .pre-commit-config.yaml itself previously matched no filter at all, and
+# ci-summary treats an all-skipped run as green.
+meta:
+  - ".github/**"
+  - ".pre-commit-config.yaml"

--- a/.github/workflows/_python-package.yml
+++ b/.github/workflows/_python-package.yml
@@ -300,6 +300,9 @@ jobs:
           python-version: "3.14"
 
       - name: Install Python release tooling
+        # bash explicitly: this job has no shell default and the assignment
+        # below is not valid pwsh, which Windows runners default to.
+        shell: bash
         run: |
           # cibuildwheel is single-sourced from the pyproject release extra
           # (bumped by dependabot); read it here instead of a duplicate pin.
@@ -434,6 +437,8 @@ jobs:
           python-version: "3.14"
 
       - name: Install cibuildwheel
+        # bash explicitly: see the release build-wheels tooling step.
+        shell: bash
         run: |
           # Single-sourced from the pyproject release extra (see build-wheels).
           cibw="$(python -c 'import tomllib; print(next(r for r in tomllib.load(open("pyproject.toml","rb"))["project"]["optional-dependencies"]["release"] if r.startswith("cibuildwheel==")))')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,14 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
   # Cancel superseded runs on PRs, but never on master: cancelling a master
   # run marks its CI Summary as failed, leaving a permanent red X on that
   # commit (ci-auto-rerun only retries setup-phase flakes, not cancellations).
+  # Pushes (master only, see `on:`) also get a per-sha group: a shared group
+  # holds at most one *queued* run, so a merge burst still cancelled the middle
+  # commits' runs while they waited (runs 1514-1516) -- the same red X, and a
+  # run verify-master-ci (release.yml) refuses to publish from.
+  group: ci-${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
       docker: ${{ steps.filter.outputs.docker }}
       notebooks: ${{ steps.filter.outputs.notebooks }}
+      meta: ${{ steps.filter.outputs.meta }}
 
     steps:
       - name: Checkout repository
@@ -52,8 +53,14 @@ jobs:
 
   pre-commit:
     needs: changes
+    # Gated on every filter output: pre-commit is the base hygiene/lint gate
+    # (actionlint, YAML checks, formatting), so any recognized change runs it.
+    # `meta` covers the CI surface with no build lane of its own -- release.yml,
+    # fuzz.yml, the composite actions, .pre-commit-config.yaml itself -- which
+    # previously matched no filter and merged with zero checks.
     if: >-
       github.event_name == 'workflow_dispatch'
+      || needs.changes.outputs.meta == 'true'
       || needs.changes.outputs.policy == 'true'
       || needs.changes.outputs.native == 'true'
       || needs.changes.outputs.python-core == 'true'
@@ -61,6 +68,9 @@ jobs:
       || needs.changes.outputs.python-swig == 'true'
       || needs.changes.outputs.javascript == 'true'
       || needs.changes.outputs.r == 'true'
+      || needs.changes.outputs.docs == 'true'
+      || needs.changes.outputs.docker == 'true'
+      || needs.changes.outputs.notebooks == 'true'
     name: pre-commit
     runs-on: ubuntu-24.04
     timeout-minutes: 15

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,12 @@ jobs:
   # purely from GitHub setup-phase infra flakes (action-resolution "Internal
   # Server Error" in "Set up job"), which ci-auto-rerun.yml already treats as
   # non-defects -- the v2.15.0 release commit was red for exactly this reason.
-  # So we apply the same test ci-auto-rerun uses: block only on a real
-  # (non-setup) job failure, tolerate setup-phase flakes.
+  # So a 'failure' run passes iff every failed job is positively such a flake
+  # ("Set up job" failed and no other step did). Every other non-success
+  # conclusion (cancelled, timed_out, startup_failure, ...) fails closed: those
+  # jobs never ran to completion, so nothing vouches for this commit. In
+  # particular a run cancelled while *queued* reports zero jobs -- treating
+  # that as "no real failures" would publish a commit no test ever saw.
   verify-master-ci:
     name: Verify master CI passed
     needs: [validate-stable-tag]
@@ -98,15 +102,34 @@ jobs:
             exit 0
           fi
 
-          # Red run: accept it only if every failure is a setup-phase infra
-          # flake -- same definition as ci-auto-rerun.yml's "real failure" test.
+          # Anything that is not a plain failure never ran its jobs to
+          # completion on this commit. The common case is a queued master run
+          # evicted by a newer push (concurrency groups hold one pending run),
+          # which completes as 'cancelled' with an empty job list. Fail closed.
+          if [ "$conclusion" != "failure" ]; then
+            echo "::error::master CI run $run_id concluded '$conclusion', so its jobs never ran to completion on $sha. Re-run it (gh run rerun $run_id) and re-run this workflow once it is green." >&2
+            exit 1
+          fi
+
+          # Red run: accept it only if every failed job is positively a
+          # setup-phase infra flake. Deliberately stricter than
+          # ci-auto-rerun.yml's re-run trigger: a failed job with no failed
+          # step at all (e.g. killed by timeout-minutes, which records the
+          # running step as 'cancelled') is a real failure here, not a flake.
           jobs_json="$(gh api --paginate "repos/$GH_REPO/actions/runs/$run_id/jobs" \
             --jq '.jobs[]' | jq -s '.')"
+          if [ "$(jq 'length' <<<"$jobs_json")" -eq 0 ]; then
+            echo "::error::master CI run $run_id concluded '$conclusion' but reports no jobs; refusing to publish." >&2
+            exit 1
+          fi
           real_failures="$(jq -c '
             [ .[]
               | select(.name != "CI Summary")
               | select(.conclusion == "failure")
-              | select(any(.steps[]?; .conclusion == "failure" and .name != "Set up job"))
+              | select(
+                  (any(.steps[]?; .name == "Set up job" and .conclusion == "failure")
+                    and all(.steps[]?; .name == "Set up job" or .conclusion != "failure"))
+                  | not)
               | .name ]' <<<"$jobs_json")"
           if [ "$(jq 'length' <<<"$real_failures")" -eq 0 ]; then
             echo "::warning::master CI run $run_id concluded '$conclusion', but every failure was a GitHub setup-phase infra flake. Treating master as acceptable and proceeding."


### PR DESCRIPTION
## Summary

Follow-ups from a correctness review of the CI campaign (#821–#872), four commits:

- **`ci(python)`: run the cibuildwheel install steps under bash on Windows.** The pin-extraction steps from the pyproject single-sourcing change use bash command substitution, but `build-wheels` and `prerelease-wheels` have no shell default, so the `windows-2025-vs2026` legs ran them under pwsh, which cannot parse the assignment. Every release tag and the weekly prerelease check would have failed on Windows at the install step.
- **`ci`: fail the release gate on any non-failure master CI conclusion.** `verify-master-ci` only blocked on jobs with conclusion `failure`; a master run cancelled while queued completes as `cancelled` with zero jobs, so the setup-flake analysis found nothing to object to and the gate published — on a commit no test ever saw. The gate now requires an explicit conclusion: success passes, failure gets the flake analysis, everything else fails closed with re-run instructions. The flake analysis also now requires a failed job to positively look like a setup flake ("Set up job" failed, nothing else did), so a job killed by `timeout-minutes` (running step recorded as `cancelled`) no longer passes as an "infra flake".
- **`ci`: give master pushes per-sha concurrency groups.** A shared group holds at most one queued run, so a merge burst still cancelled the middle commits' runs while they waited (runs 1514–1516, all after #856 landed) — the same permanent red X #856 was meant to remove, and exactly the run the hardened gate refuses to publish from.
- **`ci`: gate pre-commit on a meta filter and close path-filter coverage gaps.** A PR touching only `release.yml`, `fuzz.yml`, `prerelease.yml`, the composite actions, or `.pre-commit-config.yaml` matched no filter, ran zero jobs, and merged green (CI Summary treats all-skipped as success) — the actionlint gate was blind to most of the CI surface itself. A new `meta` filter (`.github/**` + `.pre-commit-config.yaml`) gates the pre-commit job, which is now gated on every filter output. Also: `vendor/**` joins `_build_core` (the fmt/nlohmann_json headers are compiled into every lane but a bump fired nothing), `scripts/r_check.R` and `setup-python-build/action.yml` join the `r` filter, `MANIFEST.in` joins `python-packaging`, `biome.json` joins `javascript`, `ci.yml` joins `docs`/`docker`, and the last `A && B || C` in `setup-ccache/action.yml` is rewritten the way #872 rewrote the workflow copies (actionlint only scans `.github/workflows/`, so composites never got the lint).

## Verification

- YAML parse of all five changed files at HEAD.
- The new gate jq run against synthetic job lists: pure setup flake passes; real step failure, timeout-killed job (cancelled step), failed job with no steps, and flake-plus-real-failure in one job all block; CI Summary is ignored.
- shellcheck clean on the `verify-master-ci` script and both tooling steps; `shell: bash` asserted present on both via YAML.
- `filters.yml` anchor expansion checked (`vendor/**` reaches every `*build_core` consumer; the `meta` output is wired through the `changes` job into the pre-commit `if:`).
- Not run: actionlint locally (release-binary download blocked in this environment; the pre-commit CI job runs it on this PR). The concurrency and gate behavior is only observable on GitHub — the gate needs a release tag, the per-sha groups a merge burst.

## Notes

- The Windows fix only helps the scheduled python-prerelease-check if it reaches master before Monday ~09:20 UTC; otherwise expect one red Windows leg and a `ci-cron` tracking issue.
- Branch protection cannot be verified from tracked files: worth confirming "CI Summary" is still the only required check now that job names changed during the campaign — a stale required job name would leave PRs pending forever.
- Per-sha groups mean a merge burst runs full CI per commit in parallel instead of serializing behind one run; nothing is queued, so nothing gets evicted.
- Remaining review follow-ups not in this PR: fuzz workflow first dispatch + explicit `libclang-rt` dependency + corpus caching + dictionary key fixes, release-job cache `restore-keys`, and an arm64 image smoke test in `docker-build`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012GAmLaA1ny9yS9juietXCy)_