### PR TITLE
ci: harden the fuzz workflow before its first scheduled run

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -28,12 +28,37 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install clang
+        # libclang-rt-dev ships the libFuzzer/ASAN runtime archives the fuzz
+        # target links. It is only a Recommends of clang: runners install
+        # Recommends today, but that is not a contract, so name it explicitly.
+        # The unversioned metapackage tracks the image's default clang.
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang
+          sudo apt-get install -y clang libclang-rt-dev
+
+      # The evolved corpus compounds across the weekly runs instead of
+      # restarting from the fixture seeds every time. Restore latest, save
+      # under a per-run key.
+      - name: Restore fuzz corpus
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: build/fuzz/corpus
+          key: fuzz-corpus-${{ github.run_id }}
+          restore-keys: |
+            fuzz-corpus-
 
       - name: Build and run the intake fuzzer
         run: make fuzz FUZZ_SECONDS=300
+
+      # always(): a red run means the fuzzer found something -- exactly the
+      # corpus worth keeping. The hashFiles guard skips the save when the job
+      # failed before the corpus existed (e.g. a build failure).
+      - name: Save fuzz corpus
+        if: always() && hashFiles('build/fuzz/corpus/**') != ''
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: build/fuzz/corpus
+          key: fuzz-corpus-${{ github.run_id }}
 
       - name: Upload findings
         if: failure()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,6 +310,12 @@ if(INFOMAP_BUILD_FUZZERS)
     # harness links, so findings surface from library code, not just the harness.
     target_compile_options(infomap_core
         PRIVATE -fsanitize=fuzzer-no-link,address,undefined -fno-omit-frame-pointer)
+    # PUBLIC link options so every consumer of the instrumented core (the CLI,
+    # stray test targets) links the sanitizer runtimes too -- without this,
+    # building anything but fuzz_intake in a fuzz-configured tree fails at
+    # link with undefined ASAN symbols. Mirrors the INFOMAP_ENABLE_SANITIZERS
+    # block above.
+    target_link_options(infomap_core PUBLIC -fsanitize=address,undefined)
 
     add_executable(fuzz_intake test/fuzz/fuzz_intake.cpp)
     target_link_libraries(fuzz_intake PRIVATE infomap_core)

--- a/test/fuzz/fuzz_intake.cpp
+++ b/test/fuzz/fuzz_intake.cpp
@@ -6,9 +6,11 @@
 // exactly as the CLI does. The intake reads from a path, so each input is
 // written to a temporary file.
 //
-// Contract: malformed input is expected to throw (InfomapError /
-// std::runtime_error) and is swallowed. Crashes, sanitizer reports, hangs, and
-// exceptions of any other type are genuine findings.
+// Contract: malformed input is rejected by throwing, and the harness swallows
+// every std::exception -- deliberately matching production, where
+// Network::readInputData catches std::exception and converts it to an
+// InfomapError, so no exception type escapes the CLI either. Findings are
+// therefore crashes, sanitizer reports, and hangs only.
 
 #include <cstddef>
 #include <cstdint>

--- a/test/fuzz/intake.dict
+++ b/test/fuzz/intake.dict
@@ -1,5 +1,7 @@
 # libFuzzer dictionary for the network intake (Pajek-style + JSON).
-# Pajek-style section headings dispatched by parseNetwork.
+# Pajek-style section headings dispatched by parseNetwork -- keep in sync with
+# generalValidHeadings() in src/io/NetworkInputParser.h (matched
+# case-insensitively; spelled here as they appear in the docs/fixtures).
 "*Vertices"
 "*States"
 "*Edges"
@@ -10,17 +12,26 @@
 "*Intra"
 "*Inter"
 "*Bipartite"
-# JSON network keys (see test/schemas/json/infomap-network.schema.json).
+"*Paths"
+"*Contexts"
+# JSON network keys -- keep in sync with the key dispatch in
+# src/io/JsonNetworkInputParser.h (which is what the schema in
+# test/schemas/json/infomap-network.schema.json describes).
+"format"
+"version"
+"type"
+"directed"
+"bipartiteStartId"
+"multilayer"
 "nodes"
-"links"
 "states"
+"edges"
+"node"
 "source"
 "target"
-"weight"
 "id"
-"stateId"
-"physicalId"
+"weight"
 "name"
-"layer"
-"multilayer"
-"metadata"
+"meta"
+"path"
+"layers"


### PR DESCRIPTION
## Summary

The fuzz workflow (#864) has never executed — the first cron fires Tuesday 05:00 UTC. Four small fixes so that first run works and compounds:

- **Explicit libFuzzer runtime**: `libclang-rt-dev` is only a *Recommends* of `clang`; with `--no-install-recommends` the fuzz build fails at link (`cannot find libclang_rt.fuzzer-x86_64.a`). Runners install Recommends today, but that is not a contract — name the package explicitly (unversioned metapackage, tracks the image's default clang).
- **Corpus persistence**: the evolved corpus landed in `build/fuzz/corpus` on an ephemeral runner and was thrown away — every weekly 5-minute run restarted from the fixture seeds, so coverage never compounded (a 20-second local run adds ~500 units). Restore-latest/save-per-run via `actions/cache`, saved `if: always()` so the corpus that found a crash is kept, guarded by `hashFiles` so a build failure skips the save.
- **Dictionary matches the parsers**: five JSON entries (`links`, `stateId`, `physicalId`, `layer`, `metadata`) do not exist in `JsonNetworkInputParser`'s key dispatch, while most real keys (`format`, `version`, `type`, `directed`, `bipartiteStartId`, `edges`, `node`, `meta`, `path`, `layers`) were missing; the Pajek side gains `*Paths` and `*Contexts`. Verified against the string literals in both parsers.
- **Fuzz tree links everywhere**: `INFOMAP_BUILD_FUZZERS` instruments `infomap_core` with ASAN/UBSAN but only `fuzz_intake` linked the runtimes, so building any other target in a fuzz-configured tree failed at link. Added the `PUBLIC` `target_link_options` the `INFOMAP_ENABLE_SANITIZERS` block already uses. Also aligned the harness header comment with what the code (correctly) does — production converts every `std::exception` to `InfomapError`, so only crashes/sanitizer reports/hangs are findings.

## Verification

- `make fuzz FUZZ_SECONDS=10` locally (clang 18, Ubuntu 24.04): builds, loads all 30 dictionary entries, 6 307 execs at ~570/s, 540 new corpus units, clean exit.
- Corpus reuse observed locally: a second run picked up the 420 units from the first.
- `cmake --build build/fuzz --target infomap_cli` now links (failed with undefined ASAN symbols before the CMake fix).
- YAML parse of fuzz.yml; the cache steps use the same pinned `actions/cache` SHA as the rest of the repo.
- Not run: the workflow itself on GitHub. After merge I'd dispatch it once manually to validate the whole chain (build → 300 s run → cache save → artifact/report wiring) before Tuesday's cron.

## Notes

- The `report-cron-failure` wiring is untouched; a crash found by the cron still fails the job and opens the tracking issue.
- Follow-ups not here: a larger memory-network fixture so the invariant tests guard the drag-along codelength class, and release-pipeline polish (separate PRs).

---
_Generated by [Claude Code](https://claude.ai/code/session_012GAmLaA1ny9yS9juietXCy)_