### PR TITLE
ci: warm release caches, smoke-test arm64 images, attest release assets

### DIFF
--- a/.github/workflows/_r-package.yml
+++ b/.github/workflows/_r-package.yml
@@ -256,10 +256,17 @@ jobs:
       # --build through the same mk/r.mk launcher machinery as make test-r, so
       # the wiring is identical. Windows sccache entries are content-addressed,
       # so this leg reuses the tests job's compiles of the same core for free.
+      # The key-prefix is deliberately the tests job's, not a r-binary-* one:
+      # this job runs on refs/tags/*, and GHA cache entries are only restorable
+      # from the same ref or the default branch -- a namespace only ever saved
+      # from tag runs can never hit. The tests job saves these keys on every
+      # master push (full-matrix covers release and oldrel), so restore-keys
+      # find a warm cache here; the save from this run is unreadable but
+      # harmless.
       - name: Set up ccache
         uses: ./.github/actions/setup-ccache
         with:
-          key-prefix: r-binary-${{ matrix.os }}-${{ matrix.r }}
+          key-prefix: r-${{ matrix.os }}-${{ matrix.r }}
 
       - name: Set up sccache (Windows)
         if: startsWith(matrix.os, 'windows')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,8 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: write
+      id-token: write
+      attestations: write
 
     steps:
       - name: Download native release assets
@@ -204,6 +206,23 @@ jobs:
 
       - name: List packaged assets
         run: find release-assets -maxdepth 3 -type f | sort
+
+      # Provenance for the release assets themselves. PyPI (PEP 740), npm
+      # (--provenance), and the GHCR images are attested downstream, but the
+      # zips/tarballs/wheels as attached to the GitHub release were not.
+      # Same globs as the attach step below so exactly what ships is attested;
+      # verify with `gh attestation verify <file> --repo mapequation/infomap`.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            release-assets/native/*.zip
+            release-assets/python/**/*.tar.gz
+            release-assets/python/**/*.whl
+            release-assets/npm/*.tgz
+            release-assets/r/infomap_*.tar.gz
+            release-assets/r/infomap_*-r*-*.tgz
+            release-assets/r/infomap_*-r*-*.zip
 
       - name: Attach assets to GitHub release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,6 +349,25 @@ jobs:
             org.opencontainers.image.revision=${{ needs.docker-meta.outputs.revision }}
             org.opencontainers.image.licenses=GPL-3.0-or-later
 
+      # Functional smoke test of the pushed artifact on THIS architecture's
+      # native runner, so both arches are executed before any digest can reach
+      # a tag (the old single-arch limitation was a QEMU cost, gone with the
+      # native arm64 runners). docker-publish re-checks amd64 as a final
+      # pre-tag gate.
+      - name: Smoke-test the pushed image
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE: ${{ matrix.image }}
+        run: |
+          set -euo pipefail
+          repo=ghcr.io/mapequation/infomap
+          if [ "$IMAGE" = notebook ]; then
+            docker run --rm "$repo@$DIGEST" \
+              python -c "from infomap import Infomap; print(Infomap(silent=True).num_top_modules)" > /dev/null
+          else
+            docker run --rm "$repo@$DIGEST" --help > /dev/null
+          fi
+
       - name: Export digest
         env:
           DIGEST: ${{ steps.build.outputs.digest }}


### PR DESCRIPTION
## Summary

Release-pipeline polish from the CI-campaign review, three independent commits:

- **R release-binary ccache can now actually hit.** `build-binaries` cached under its own `r-binary-*` namespace, but the job runs on `refs/tags/*` and GHA cache entries are only restorable from the same ref or the default branch — entries saved from tag runs can never be restored by a later release, and no master job ever saved that namespace, so the macOS legs compiled cold every release. It now reuses the tests job's `r-<os>-<r>` prefix, which is saved on every master push (full-matrix covers `release` and `oldrel`; the build-binaries matrix is a subset). Windows is unaffected (`setup-ccache` skips it; sccache already shares by content).
- **arm64 images are executed before they ship.** The pre-tag smoke test only ran the amd64 image; the arm64 digest went straight into the multi-arch manifest. Each `docker-build` leg now runs its just-pushed image by digest on its own native runner before the digest upload; `docker-publish` keeps the amd64 check as the final pre-tag gate.
- **GitHub release assets get provenance.** PyPI (PEP 740), npm (`--provenance`), and GHCR images were attested, but the zips/tarballs/wheels attached to the GitHub release were not. `publish-github-release` now attests with the same globs the attach step uses; verify with `gh attestation verify <file> --repo mapequation/infomap`.

## Verification

- YAML parse of both files; asserted the attest step runs before the attach step, the smoke test before the digest upload, and the `id-token`/`attestations` permissions on the publish job.
- shellcheck clean on the new smoke script.
- Cache-prefix alignment checked against both matrices: every `build-binaries` combination (`macos-15`/`windows-2025-vs2026` × `release`/`oldrel`) exists in the tests job's namespace on master pushes.
- Not run: the release workflow itself — all three changes only execute on a tag push or a `workflow_dispatch` republish. A dry-run republish of v2.15.0 would exercise them (the PyPI/npm legs fail on duplicate versions at the end, expected).

## Notes

- Touches `release.yml` in different hunks than #876 (`verify-master-ci`); no textual conflict whichever merges first.
- The buildx `type=gha` layer caches are left as-is: they only ever help `workflow_dispatch` republishes (which run on the master ref), and removing them saves little.

---
_Generated by [Claude Code](https://claude.ai/code/session_012GAmLaA1ny9yS9juietXCy)_