### PR TITLE
fix(python): keep an adapter's inferred flow model across option rendering

### DIFF
--- a/interfaces/python/src/infomap/_core.py
+++ b/interfaces/python/src/infomap/_core.py
@@ -51,6 +51,29 @@ class Core:
         # conflicts) are thrown while the wrapper parses ``args``.
         with _translate_engine_errors():
             self._im = InfomapWrapper(args)
+        # Flow model an input adapter resolved from the input itself (a
+        # directed graph object, an explicit ``directed=`` on the matrix and
+        # edge-index adapters). Recorded rather than set on the engine: see
+        # note_inferred_flow_model.
+        self.inferred_flow_model: str | None = None
+
+    def note_inferred_flow_model(self, flow_model: str) -> None:
+        """Record a flow model that an input adapter resolved from the input.
+
+        Setting it on the engine directly does not survive a run: options reach
+        the engine as a rendered argument string that it re-parses into a fresh
+        config, so anything configured outside that string is dropped as soon as
+        the string changes -- which any per-run keyword does. The recorded value
+        is instead folded into the options that get rendered
+        (``_with_inferred_flow_model``), so it is authoritative for every run.
+
+        Explicit configuration wins. Nothing is recorded when the engine was
+        constructed with a flow model, and the first inference wins over a later
+        one so a second adapter call cannot silently change the model.
+        """
+        if self.flowModelIsSet or self.inferred_flow_model is not None:
+            return
+        self.inferred_flow_model = flow_model
 
     def get_node_data(self, level=1, states=False):
         """Single-traversal bulk node data over the result tree.
@@ -72,6 +95,25 @@ class Core:
         if name == "_im":
             raise AttributeError(name)
         return getattr(self._im, name)
+
+
+def _with_inferred_flow_model(core: Any, options):
+    """Fold an adapter's inferred flow model into the options to be rendered.
+
+    Shared by ``Infomap.run`` and ``Network.run`` so both entry points agree on
+    the precedence: an inference (recorded by ``Core.note_inferred_flow_model``)
+    applies only when this run's options carry neither ``flow_model`` nor
+    ``directed``, so explicit configuration always wins -- whether it was given
+    at construction, on the options carrier, or as a per-run keyword.
+
+    Returns ``options`` unchanged when there is nothing to fold in.
+    """
+    inferred = getattr(core, "inferred_flow_model", None)
+    if inferred is None:
+        return options
+    if options.flow_model is not None or options.directed is not None:
+        return options
+    return options.replace(flow_model=inferred)
 
 
 def apply_initial_partition(core: Any, module_ids) -> bool:

--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -19,6 +19,7 @@ from ._core import (
     InfomapLeafIteratorPhysical,
     InfomapLeafModuleIterator,
     InfoNode,
+    _with_inferred_flow_model,
     apply_initial_partition,
 )
 from ._core import build_info as _engine_build_info
@@ -2290,6 +2291,9 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             self.initial_partition = old_partition
 
     def _run_from_options(self, args, initial_partition, options):
+        # An input adapter may have resolved the flow model from the input
+        # itself; render it so it survives this run's argument string.
+        options = _with_inferred_flow_model(self._core, options)
         kwargs = options.to_kwargs()
         # engine_emits: whether this instance's engine emits at all. It was
         # baked --silent (or not) at construction and cannot be undone per run,

--- a/interfaces/python/src/infomap/io/edge_index.py
+++ b/interfaces/python/src/infomap/io/edge_index.py
@@ -157,8 +157,8 @@ def add_edge_index(
 
     internal_to_label = {index: label for index, label in enumerate(labels)}
 
-    if not infomap._core.flowModelIsSet and directed:
-        infomap._core.setDirected(True)
+    if directed:
+        infomap._core.note_inferred_flow_model("directed")
 
     for internal_id, label in internal_to_label.items():
         infomap.add_node(internal_id, name=label if isinstance(label, str) else None)

--- a/interfaces/python/src/infomap/io/igraph.py
+++ b/interfaces/python/src/infomap/io/igraph.py
@@ -187,8 +187,8 @@ def add_igraph_graph(
             "`vertex_weights` is not supported by infomap's igraph adapter yet."
         )
 
-    if not infomap._core.flowModelIsSet and g.is_directed():
-        infomap._core.setDirected(True)
+    if g.is_directed():
+        infomap._core.note_inferred_flow_model("directed")
 
     names = _vertex_names(g)
     weights = _edge_weights(g, edge_weights)

--- a/interfaces/python/src/infomap/io/networkx.py
+++ b/interfaces/python/src/infomap/io/networkx.py
@@ -287,8 +287,8 @@ def add_networkx_graph(
     except IndexError:
         return {}
 
-    if not infomap._core.flowModelIsSet and g.is_directed():
-        infomap._core.setDirected(True)
+    if g.is_directed():
+        infomap._core.note_inferred_flow_model("directed")
 
     node_map = _label_to_internal_id(nodes)
     is_string_id = isinstance(first, str)

--- a/interfaces/python/src/infomap/io/scipy.py
+++ b/interfaces/python/src/infomap/io/scipy.py
@@ -101,8 +101,8 @@ def add_scipy_sparse_matrix(
 
     internal_to_label = {index: label for index, label in enumerate(labels)}
 
-    if not infomap._core.flowModelIsSet and directed:
-        infomap._core.setDirected(True)
+    if directed:
+        infomap._core.note_inferred_flow_model("directed")
 
     for internal_id, label in internal_to_label.items():
         infomap.add_node(internal_id, name=label if isinstance(label, str) else None)

--- a/interfaces/python/src/infomap/network.py
+++ b/interfaces/python/src/infomap/network.py
@@ -29,7 +29,7 @@ import os
 import warnings
 from typing import TYPE_CHECKING, Any
 
-from ._core import Core, apply_initial_partition
+from ._core import Core, _with_inferred_flow_model, apply_initial_partition
 from ._logging import engine_log_routing as _engine_log_routing
 from ._logging import is_routed as _is_log_routed
 from ._network_input import add_bulk_links as _add_bulk_links
@@ -444,6 +444,10 @@ class Network(_NetworkWritersMixin):
                     UserWarning,
                     stacklevel=2,
                 )
+
+        # An input adapter may have resolved the flow model from the input
+        # itself; render it so it survives this run's argument string.
+        resolved = _with_inferred_flow_model(self._core, resolved)
 
         # engine_emits stays False: a Network's engine is --silent for its
         # whole lifetime (see the advisory above), so verbosity_level can never

--- a/test/python/test_adapter_flow_model.py
+++ b/test/python/test_adapter_flow_model.py
@@ -1,0 +1,171 @@
+"""The flow model a graph adapter infers must survive option rendering.
+
+The adapters resolve directedness from the input (``g.is_directed()`` for the
+graph libraries, an explicit ``directed=`` for scipy/edge_index). Options reach
+the engine as a rendered argument string that the engine re-parses into a fresh
+config, so an inferred flow model that lives only on the engine is discarded the
+moment any per-run option changes that string. These tests pin the inference to
+the *result*, not to the mechanism: the same input must give the same partition
+whether or not an unrelated keyword such as ``seed`` was passed.
+
+Explicit configuration always wins over the inference, whether it is given at
+construction, on the options carrier, or as a per-run keyword.
+"""
+
+from __future__ import annotations
+
+import infomap
+import networkx as nx
+import pytest
+
+pytestmark = pytest.mark.fast
+
+# A directed graph whose directed and undirected flow models disagree.
+_EDGES = [(1, 2), (2, 3), (3, 1), (3, 4), (4, 5), (5, 6), (6, 4)]
+
+
+def _reference(flow_model: str) -> float:
+    """Codelength of the same links with the flow model stated explicitly."""
+    return infomap.run(
+        list(_EDGES),
+        seed=42,
+        num_trials=1,
+        options=infomap.Options(flow_model=flow_model),
+    ).codelength
+
+
+@pytest.fixture(scope="module")
+def directed_codelength() -> float:
+    return _reference("directed")
+
+
+@pytest.fixture(scope="module")
+def undirected_codelength() -> float:
+    return _reference("undirected")
+
+
+@pytest.fixture
+def digraph() -> nx.DiGraph:
+    return nx.DiGraph(_EDGES)
+
+
+def test_references_disagree(directed_codelength, undirected_codelength):
+    # Guards the fixture itself: if these ever coincide the assertions below
+    # would pass without testing anything.
+    assert directed_codelength != pytest.approx(undirected_codelength)
+
+
+def test_functional_run_infers_directed(digraph, directed_codelength):
+    result = infomap.run(digraph, seed=42, num_trials=1)
+
+    assert result.codelength == pytest.approx(directed_codelength)
+
+
+def test_network_constructor_infers_directed(digraph, directed_codelength):
+    result = infomap.Network.from_networkx(digraph).run(seed=42, num_trials=1)
+
+    assert result.codelength == pytest.approx(directed_codelength)
+
+
+def test_network_constructor_infers_directed_without_keywords(
+    digraph, directed_codelength
+):
+    result = infomap.Network.from_networkx(digraph).run()
+
+    assert result.codelength == pytest.approx(directed_codelength)
+
+
+def test_builder_infers_directed_without_keywords(digraph, directed_codelength):
+    im = infomap.Infomap(num_trials=1)
+    im.add_networkx_graph(digraph)
+
+    assert im.run().codelength == pytest.approx(directed_codelength)
+
+
+def test_builder_inference_survives_an_unrelated_keyword(digraph, directed_codelength):
+    # The regression: passing *any* keyword changed the rendered argument
+    # string, so the engine was reconfigured from that string alone and the
+    # adapter's directedness was lost.
+    im = infomap.Infomap(num_trials=1)
+    im.add_networkx_graph(digraph)
+
+    assert im.run(seed=42).codelength == pytest.approx(directed_codelength)
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        pytest.param({"flow_model": "undirected"}, id="flow_model"),
+        pytest.param({"directed": False}, id="directed"),
+    ],
+)
+def test_explicit_per_run_option_overrides_the_inference(
+    digraph, undirected_codelength, overrides
+):
+    result = infomap.Network.from_networkx(digraph).run(
+        seed=42, num_trials=1, **overrides
+    )
+
+    assert result.codelength == pytest.approx(undirected_codelength)
+
+
+def test_explicit_options_carrier_overrides_the_inference(
+    digraph, undirected_codelength
+):
+    result = infomap.Network.from_networkx(digraph).run(
+        options=infomap.Options(flow_model="undirected", seed=42, num_trials=1)
+    )
+
+    assert result.codelength == pytest.approx(undirected_codelength)
+
+
+def test_construction_time_flow_model_overrides_the_inference(
+    digraph, undirected_codelength
+):
+    # The adapter must not override a flow model the caller chose when the
+    # engine was created.
+    im = infomap.Infomap(flow_model="undirected", num_trials=1)
+    im.add_networkx_graph(digraph)
+
+    assert im.run(seed=42).codelength == pytest.approx(undirected_codelength)
+
+
+def test_undirected_input_is_not_forced_directed(undirected_codelength):
+    graph = nx.Graph(_EDGES)
+
+    result = infomap.Network.from_networkx(graph).run(seed=42, num_trials=1)
+
+    assert result.codelength == pytest.approx(undirected_codelength)
+
+
+def test_scipy_adapter_inference_survives_a_keyword(directed_codelength):
+    sparse = pytest.importorskip("scipy.sparse")
+    matrix = sparse.coo_matrix(
+        (
+            [1.0] * len(_EDGES),
+            (
+                [source - 1 for source, _ in _EDGES],
+                [target - 1 for _, target in _EDGES],
+            ),
+        ),
+        shape=(6, 6),
+    ).tocsr()
+
+    network = infomap.Network.from_scipy_sparse_matrix(matrix, directed=True)
+
+    assert network.run(seed=42, num_trials=1).codelength == pytest.approx(
+        directed_codelength
+    )
+
+
+def test_edge_index_adapter_inference_survives_a_keyword(directed_codelength):
+    np = pytest.importorskip("numpy")
+    edge_index = np.array(
+        [[source - 1 for source, _ in _EDGES], [target - 1 for _, target in _EDGES]]
+    )
+
+    network = infomap.Network.from_edge_index(edge_index, num_nodes=6)
+
+    assert network.run(seed=42, num_trials=1).codelength == pytest.approx(
+        directed_codelength
+    )

--- a/test/python/test_edge_index.py
+++ b/test/python/test_edge_index.py
@@ -35,12 +35,12 @@ class Recorder:
         return self
 
     def __init__(self):
-        self.directed = False
+        self.inferred_flow_model = None
         self.nodes = []
         self.links = []
 
-    def setDirected(self, value):
-        self.directed = value
+    def note_inferred_flow_model(self, flow_model):
+        self.inferred_flow_model = flow_model
 
     def add_node(self, node_id, name=None):
         self.nodes.append((node_id, name))
@@ -122,7 +122,7 @@ def test_add_edge_index_sets_directed_by_default():
 
     add_edge_index(recorder, np.array([[0], [1]], dtype=np.int64))
 
-    assert recorder.directed is True
+    assert recorder.inferred_flow_model == "directed"
 
 
 def test_add_edge_index_undirected_deduplicates_reverse_edges():
@@ -135,7 +135,7 @@ def test_add_edge_index_undirected_deduplicates_reverse_edges():
         directed=False,
     )
 
-    assert recorder.directed is False
+    assert recorder.inferred_flow_model is None
     assert recorder.links == [(0, 1, 2.0), (1, 2, 4.0)]
 
 

--- a/test/python/test_igraph.py
+++ b/test/python/test_igraph.py
@@ -127,7 +127,7 @@ def test_find_igraph_communities_sets_directed_for_directed_graph(monkeypatch):
 
         def __init__(self, **options):
             self.options = options
-            self.directed = False
+            self.inferred_flow_model = None
             self.codelength = 1.0
             instances.append(self)
 
@@ -138,8 +138,8 @@ def test_find_igraph_communities_sets_directed_for_directed_graph(monkeypatch):
                 flow=[0.5, 0.5],
             )
 
-        def setDirected(self, value):
-            self.directed = value
+        def note_inferred_flow_model(self, flow_model):
+            self.inferred_flow_model = flow_model
 
         def add_node(self, node_id, name=None):
             pass
@@ -156,7 +156,7 @@ def test_find_igraph_communities_sets_directed_for_directed_graph(monkeypatch):
     clustering = infomap.find_igraph_communities(graph, trials=3)
 
     assert clustering.membership == [0, 0]
-    assert instances[0].directed is True
+    assert instances[0].inferred_flow_model == "directed"
     # silent and no_file_output are no longer forced: the API is quiet by
     # default and the library surface writes no files without an output
     # directory, so the finder leaves both at the engine default.

--- a/test/python/test_networkx.py
+++ b/test/python/test_networkx.py
@@ -66,7 +66,7 @@ def test_find_communities_sets_directed_for_digraph(monkeypatch):
 
         def __init__(self, **options):
             self.options = options
-            self.directed = False
+            self.inferred_flow_model = None
             instances.append(self)
 
         def get_node_data(self, level=1, states=False):
@@ -76,8 +76,8 @@ def test_find_communities_sets_directed_for_digraph(monkeypatch):
                 flow=[0.5, 0.5],
             )
 
-        def setDirected(self, value):
-            self.directed = value
+        def note_inferred_flow_model(self, flow_model):
+            self.inferred_flow_model = flow_model
 
         def add_node(self, node_id, name=None):
             pass
@@ -93,7 +93,7 @@ def test_find_communities_sets_directed_for_digraph(monkeypatch):
     communities = infomap.find_communities(nx.DiGraph([("source", "target")]))
 
     assert communities == [{"source", "target"}]
-    assert instances[0].directed is True
+    assert instances[0].inferred_flow_model == "directed"
     # silent and no_file_output are no longer forced: the API is quiet by
     # default (Infomap defaults silent=True) and the library surface writes no
     # files without an output directory, so the finder leaves both at the engine


### PR DESCRIPTION
## Summary

The graph adapters resolved directedness from the input and applied it by calling `setDirected` on the engine. `InfomapBase::run` rebuilds its whole config from the concatenated argument string whenever that string changes (`src/core/InfomapBase.cpp:968-972`), so the inference was discarded as soon as any per-run option was passed — including `seed` — and the run silently used the **undirected** flow model. `Network.from_networkx(...)` and its siblings were affected unconditionally, because `Options()` always renders `--silent` and the string therefore always differs.

On a 6-node `DiGraph`, before this change:

```
infomap.run(D, seed=42)                          L=1.773079   (directed, correct)
Network.from_networkx(D).run(seed=42)            L=2.320730   (undirected)
Infomap(); add_networkx_graph(D); run()          L=1.773079   (correct)
Infomap(); add_networkx_graph(D); run(seed=42)   L=2.320730   (undirected)
```

The affected runs matched a run with `flow_model="undirected"` stated explicitly, to the last digit. Adding a seed for reproducibility changed the flow model. Over 40 random `nx.gnp_random_graph(30, 0.08, directed=True)` graphs the directed and undirected groupings differed in 39, so this was not only a wrong codelength.

The fix records the inference on `Core` and folds it into the options that both hosts render, so it survives the round trip. Precedence is now stated once, in one helper called from both `Infomap.run` and `Network.run`, so it cannot drift between the two entry points: nothing is recorded when the engine was constructed with a flow model, and the inference applies only when the run's options carry neither `flow_model` nor `directed`. `Options.flow_model` and `Options.directed` both default to `None`, so "the caller set it" is a reliable test here.

Closes #913.

## Verification

- `make test-python` — exit 0 (unit + doctest + examples)
- Full pytest suite — 778 passed, 2 skipped (`torch` not installed)
- `make test-python-typecheck` — 0 errors, 0 warnings
- `ruff check` + `ruff format --check` — clean; pre-commit hooks passed on commit
- The reproducer above re-run after the change: all four paths give 1.773079, matching the explicit `flow_model="directed"` reference

No C++, SWIG or generated files are touched, so no rebuild or freshness refresh is involved.

## Notes

`setDirected` is no longer called from the adapters rather than being kept alongside the new mechanism, so there is one way to configure the flow model instead of two. `test_builder_infers_directed_without_keywords` covers the path that previously worked *because* of `setDirected`, so its removal is under test.

The new tests assert the resulting codelength against a run with the flow model stated explicitly, rather than asserting that a particular engine setter was called. Three existing adapter tests did the latter — which is why they stayed green while the shipped path returned the wrong partition — and they now pin the recorded inference instead.

Follow-ups, not in this PR:

- The transport seam itself is unchanged: options still reach the engine as a whitespace-joined argument string that it re-parses. That is also the mechanism behind #902 and part of #914.
- The broader gap this exposed is that each entry point is only tested against itself. A cross-path agreement suite — every entry point × every ingress format on the same network, with and without an unrelated keyword — would have caught this and would also cover the byte-order case in #909.
