### PR TITLE
fix: reject a degenerate flow distribution instead of reporting codelength 0

### DIFF
--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -21,6 +21,7 @@
 #include "LossyMapEquation.h"
 #endif
 #include "InfomapOptimizer.h"
+#include "../io/InfomapError.h"
 #include "../io/RunReport.h"
 #include "../io/RunMetadata.h"
 #include "../io/SafeFile.h"
@@ -591,6 +592,48 @@ private:
 
     if (m_infomap.numLeafNodes() == 0)
       throw std::domain_error("No nodes to partition");
+
+    checkFlowPostCondition();
+  }
+
+  // The map equation is defined on a visit-rate distribution, so a non-finite
+  // or empty flow distribution leaves every codelength downstream meaningless.
+  // Such a run used to complete successfully and report "codelength 0" -- a
+  // value lower than any true codelength, so a script comparing flow models
+  // would select the broken run as the best model. Reject it instead.
+  //
+  // Only the run path checks this: initNetwork() is public C++ API that callers
+  // legitimately invoke before any flow has been calculated, so the condition
+  // does not belong inside it.
+  //
+  // A total that merely differs from 1.0 stays a warning. That is what
+  // --skip-adjust-bipartite-flow asks for by design ("Keep flow on bipartite
+  // nodes instead of distributing it to primary nodes"), and other flow models
+  // may have their own reasons; the run is still interpretable. It is warned at
+  // the default verbosity so it is no longer invisible.
+  void checkFlowPostCondition() const
+  {
+    const double sumNodeFlow = m_infomap.root().data.flow;
+
+    // A link-free network has no flow to distribute and no structure to find;
+    // the trivial partition at zero bits is its correct answer, so an empty
+    // total is only degenerate when there were links to carry flow.
+    const bool zeroFlowIsExpected = m_network.numLinks() == 0;
+
+    if (!std::isfinite(sumNodeFlow) || (sumNodeFlow <= 0 && !zeroFlowIsExpected))
+      throw InfomapError(ExitCode::InputError,
+                         fmt::format(FMT_STRING("Degenerate flow: total flow on nodes is {:g} for a network with {} links, so no "
+                                                "codelength is defined. This happens when the flow model cannot distribute flow "
+                                                "over the network -- for example a directed flow model with recorded teleportation "
+                                                "on a bipartite network whose links all point from the primary side to the feature side."),
+                                     sumNodeFlow,
+                                     m_network.numLinks()));
+
+    if (zeroFlowIsExpected)
+      return;
+
+    if (std::abs(sumNodeFlow - 1.0) > 1e-10)
+      Console::warn(0, "Total flow on nodes is {:g}, not 1. The reported codelength is scaled accordingly.", sumNodeFlow);
   }
 
   void releaseInputLinksIfCli()

--- a/src/utils/FlowCalculator.cpp
+++ b/src/utils/FlowCalculator.cpp
@@ -40,8 +40,9 @@ inline void normalize(std::vector<T>& v, const T sum) noexcept
 {
   // A zero or non-finite total has no meaningful normalization. Leaving the
   // vector untouched keeps the degenerate state recognizable (an all-zero
-  // distribution) instead of turning every entry into NaN, and the flow
-  // post-condition in InfomapBase::initNetwork reports it with context.
+  // distribution) instead of turning every entry into NaN, and
+  // InfomapBase::RunSession::checkFlowPostCondition -- run after initNetwork on
+  // the run path -- reports it with context.
   if (sum == T {} || !std::isfinite(sum))
     return;
   for (auto& numerator : v) {

--- a/src/utils/FlowCalculator.cpp
+++ b/src/utils/FlowCalculator.cpp
@@ -38,6 +38,12 @@ namespace {
 template <typename T>
 inline void normalize(std::vector<T>& v, const T sum) noexcept
 {
+  // A zero or non-finite total has no meaningful normalization. Leaving the
+  // vector untouched keeps the degenerate state recognizable (an all-zero
+  // distribution) instead of turning every entry into NaN, and the flow
+  // post-condition in InfomapBase::initNetwork reports it with context.
+  if (sum == T {} || !std::isfinite(sum))
+    return;
   for (auto& numerator : v) {
     numerator /= sum;
   }

--- a/test/cpp/test_flow.cpp
+++ b/test/cpp/test_flow.cpp
@@ -1,6 +1,7 @@
 #include "vendor/doctest.h"
 
 #include "Infomap.h"
+#include "io/InfomapError.h"
 
 #include "TestUtils.h"
 
@@ -752,6 +753,91 @@ TEST_CASE("multilayer-relax-to-self matches spread on a single-node overlap [fas
   CHECK(spread.first == 2); // the two triangles
   CHECK(toself.first == spread.first);
   infomap::test::checkApproxCodelength(toself.second, spread.second, 1e-9);
+}
+
+// The canonical bipartite shape: every link runs primary -> feature, as in
+// examples/networks/bipartite.net. Several directed flow models degenerate on
+// it (all-zero or non-finite node flow); the map equation is undefined there, so
+// the run must fail rather than report a codelength.
+void addCanonicalBipartiteLinks(InfomapWrapper& im)
+{
+  im.network().setBipartiteStartId(4);
+  im.addLink(1, 4);
+  im.addLink(2, 4);
+  im.addLink(2, 5, 0.25);
+  im.addLink(3, 5);
+}
+
+TEST_CASE("Degenerate flow is rejected instead of reported as a zero codelength [fast][core][flow]")
+{
+  // Each of these left node flow all-zero or NaN and still reported
+  // "Best codelength 0" with a successful exit.
+  for (const std::string& flags : { std::string("--directed --recorded-teleportation"),
+                                    std::string("--directed --bipartite-teleportation"),
+                                    std::string("--directed --recorded-teleportation --bipartite-teleportation") }) {
+    InfomapWrapper im(infomap::test::defaultFlags("-N 1 --seed 7 " + flags));
+    addCanonicalBipartiteLinks(im);
+
+    CHECK_THROWS_AS(im.run(), infomap::InfomapError);
+  }
+}
+
+TEST_CASE("Degenerate flow reports an input error [fast][core][flow]")
+{
+  InfomapWrapper im(infomap::test::defaultFlags("-N 1 --seed 7 --directed --recorded-teleportation"));
+  addCanonicalBipartiteLinks(im);
+
+  try {
+    im.run();
+    FAIL("expected the degenerate flow to be rejected");
+  } catch (const infomap::InfomapError& e) {
+    CHECK(e.code() == infomap::ExitCode::InputError);
+    // The message must name the quantity, so a user can tell this from a
+    // parse failure or an empty network.
+    CHECK(std::string(e.what()).find("flow") != std::string::npos);
+  }
+}
+
+TEST_CASE("skip-adjust-bipartite-flow keeps its documented unnormalized flow [fast][core][flow]")
+{
+  // The flag is documented as "Keep flow on bipartite nodes instead of
+  // distributing it to primary nodes", so flow deliberately sums to less than
+  // one here. That is an opt-out, not a defect: the run must still complete.
+  InfomapWrapper im(infomap::test::defaultFlags("-N 1 --seed 7 --two-level --directed --skip-adjust-bipartite-flow"));
+  addCanonicalBipartiteLinks(im);
+
+  im.run();
+
+  infomap::test::checkApproxCodelength(im.codelength(), 0.04164969778);
+}
+
+TEST_CASE("A link-free network keeps its trivial zero-flow result [fast][core][flow]")
+{
+  // No links means no flow to distribute and no structure to find: the trivial
+  // partition is the correct answer, so the post-condition must not fire.
+  InfomapWrapper isolatedNodes(infomap::test::defaultFlags("-N 1 --seed 7"));
+  isolatedNodes.addNode(1);
+  isolatedNodes.addNode(2);
+  isolatedNodes.run();
+  CHECK(isolatedNodes.numLeafNodes() == 2);
+
+  InfomapWrapper singleNode(infomap::test::defaultFlags("-N 1 --seed 7"));
+  singleNode.addNode(1);
+  singleNode.run();
+  CHECK(singleNode.numLeafNodes() == 1);
+}
+
+TEST_CASE("Ordinary bipartite runs are unaffected by the flow post-condition [fast][core][flow]")
+{
+  InfomapWrapper undirected(infomap::test::defaultFlags("-N 1 --seed 7"));
+  addCanonicalBipartiteLinks(undirected);
+  undirected.run();
+  infomap::test::checkApproxCodelength(undirected.codelength(), 1.478406227);
+
+  InfomapWrapper directed(infomap::test::defaultFlags("-N 1 --seed 7 --directed"));
+  addCanonicalBipartiteLinks(directed);
+  directed.run();
+  infomap::test::checkApproxCodelength(directed.codelength(), 0.4729743142);
 }
 
 } // namespace

--- a/test/python/test_flow.py
+++ b/test/python/test_flow.py
@@ -1,8 +1,36 @@
 import re
 
+import infomap
 import pytest
 
 pytestmark = pytest.mark.fast
+
+
+def test_degenerate_flow_raises_instead_of_reporting_zero(example_network_path):
+    # The canonical bipartite shape (every link primary -> feature) leaves this
+    # flow model with no flow to distribute. It used to return codelength 0.0 --
+    # lower than any true codelength, so a script comparing flow models would
+    # pick the broken run as the best model.
+    net = infomap.Network.from_file(str(example_network_path("bipartite.net")))
+
+    with pytest.raises(infomap.InfomapError, match="Degenerate flow"):
+        net.run(directed=True, recorded_teleportation=True, seed=7, num_trials=1)
+
+
+def test_skip_adjust_bipartite_flow_still_runs(example_network_path):
+    # The documented opt-out from distributing flow to the primary nodes: flow
+    # deliberately sums to less than one, so the run must complete.
+    net = infomap.Network.from_file(str(example_network_path("bipartite.net")))
+
+    result = net.run(
+        directed=True,
+        skip_adjust_bipartite_flow=True,
+        two_level=True,
+        seed=7,
+        num_trials=1,
+    )
+
+    assert result.codelength == pytest.approx(0.04164969778)
 
 
 def test_precomputed_requirements(make_infomap, example_network_path):


### PR DESCRIPTION
## Summary

The map equation is defined on a visit-rate distribution, but a run whose flow came out non-finite or empty completed successfully, reported `codelength 0` and exited 0. Because 0 is finite and lower than any true codelength, a script comparing flow models recorded the broken run as the *best* model. Three directed flow models reach that state on the canonical bipartite shape — every link running from the primary side to the feature side — which is the shape of the shipped `examples/networks/bipartite.net`.

Before, on that file:

```
-d -e                                     exit=0   Best codelength 0
-d --bipartite-teleportation              exit=0   Best codelength 0
-d -e --bipartite-teleportation           exit=0   Best codelength 0
-d --skip-adjust-bipartite-flow           exit=0   Best codelength 0.04164969778
-d                                        exit=0   Best codelength 0.4729743142
(undirected)                              exit=0   Best codelength 1.478406227
```

After:

```
-d -e                                     exit=2   Error: Degenerate flow: total flow on nodes is 0 for a network with 4 links, ...
-d --bipartite-teleportation              exit=2   Error: Degenerate flow: ...
-d -e --bipartite-teleportation           exit=2   Error: Degenerate flow: ...
-d --skip-adjust-bipartite-flow           exit=0   Best codelength 0.04164969778   + a visible warning
-d                                        exit=0   Best codelength 0.4729743142
(undirected)                              exit=0   Best codelength 1.478406227
```

Two changes: a flow post-condition on the run path after the flow calculation, and a guard in `normalize()` so a zero or non-finite total leaves an all-zero distribution instead of turning every entry into NaN. Through the Python API the same inputs now raise `InfomapError` rather than returning `0.0`.

Deliberately narrow, and each boundary is under test:

- **A total that merely differs from 1 stays a warning.** That is what `--skip-adjust-bipartite-flow` asks for by design ("Keep flow on bipartite nodes instead of distributing it to primary nodes"), and other flow models may have their own reasons — the run is still interpretable. The warning moves from verbosity 1 to the default, so it is no longer invisible: `Warning: Total flow on nodes is 0.15, not 1. The reported codelength is scaled accordingly.`
- **A link-free network keeps its trivial zero-flow result.** With no links there is no flow to distribute and no structure to find, so zero bits is the correct answer, not a degenerate one. Two existing scipy tests caught this when the first version of the check was too broad.
- **The post-condition lives on the run path, not in `initNetwork()`.** `initNetwork` is public C++ API that callers legitimately invoke before any flow has been calculated — eight cluster-data tests in `test_partition.cpp` do exactly that — so the condition does not belong inside it.

This makes the failures loud; it does **not** fix why the flow degenerates. The underlying bipartite flow defects stay open in #899, so this refs rather than closes it.

## Verification

- `make test-native` — exit 0 (all 25 targets, including the eight `test_partition.cpp` cluster-data cases that an earlier placement of the check broke)
- `make test-python` — exit 0
- `make build-native`, `make dev-python-install`, `make build-python` — exit 0
- `make test-python-typecheck` — 0 errors, 0 warnings
- `make format-native-check` and ruff — clean; pre-commit hooks passed on commit
- The six-flag table above, re-run against the rebuilt CLI, plus a link-free network by CLI (`exit=0`) and through Python (`nodes=2 codelength=0.0`)

New tests: four cases in `test/cpp/test_flow.cpp` (the three rejected combinations, the `InputError` code and message, the `--skip-adjust-bipartite-flow` opt-out at its documented codelength, the link-free network, and the two ordinary bipartite runs at their unchanged codelengths) and two in `test/python/test_flow.py`. `test_flow.cpp` had no bipartite coverage at all before this.

## Notes

Behaviour change to call out in release notes: three flag combinations that used to return a number now fail with exit code 2. Every one of them returned `codelength 0` with NaN or all-zero node flows, so no correct result is lost — but a pipeline that swallowed the zero will now stop.

`C++14`-compatible throughout, per the open question on the C++17 bump.

Follow-ups in #899, unchanged by this PR: bipartite input skips the dangling-node reordering, so directed flow is wrong in the default configuration (`FlowCalculator.cpp:403`); `--bipartite-teleportation` assumes feature→primary links that canonical bipartite files do not contain (`:1157`); and power-iteration non-convergence is still invisible to every machine-readable channel (the summary/timing/manifest reports carry no field for it).
