### PR TITLE
fix(R): validate node, state and layer ids instead of coercing them

### DIFF
--- a/interfaces/R/infomap/R/Infomap.R
+++ b/interfaces/R/infomap/R/Infomap.R
@@ -37,6 +37,75 @@ Infomap <- function(args = NULL, opts = NULL, ...) {
   InfomapClass$new(args = args, opts = opts, ...)
 }
 
+# Node, state, layer and category ids cross into C++ as R integers, and the SWIG
+# wrapper coerces to integer range: a value above .Machine$integer.max becomes
+# NA, and every such id then lands on the same node. That silently partitions a
+# different network than the caller described -- a 6-node graph with ids around
+# 3e9 came back as one node with codelength 0. Validate at the boundary and name
+# the offending value instead.
+#
+# The engine itself accepts the full 32-bit unsigned range; reaching it from R
+# would need a change to the generated SWIG typemap, so the representable limit
+# is the R integer maximum for now.
+.ID_MAX <- 2147483647L
+
+.as_ids <- function(x, what) {
+  if (length(x) == 0L) {
+    return(integer(0L))
+  }
+  if (is.factor(x)) {
+    x <- as.character(x)
+  }
+  values <- suppressWarnings(as.numeric(x))
+
+  if (anyNA(values)) {
+    stop(
+      sprintf("%s cannot be missing or non-numeric.", what),
+      call. = FALSE
+    )
+  }
+  if (!all(is.finite(values))) {
+    stop(sprintf("%s must be finite.", what), call. = FALSE)
+  }
+  if (any(values != trunc(values))) {
+    stop(
+      sprintf(
+        "%s must be a whole number, got %s.",
+        what,
+        format(values[values != trunc(values)][1L], scientific = FALSE)
+      ),
+      call. = FALSE
+    )
+  }
+  if (any(values < 0)) {
+    stop(
+      sprintf(
+        "%s cannot be negative, got %s.",
+        what,
+        format(values[values < 0][1L], scientific = FALSE)
+      ),
+      call. = FALSE
+    )
+  }
+  if (any(values > .ID_MAX)) {
+    stop(
+      sprintf(
+        paste0(
+          "%s %s is larger than %d, the largest id the R interface can ",
+          "represent. Renumber the nodes to a compact range (for example ",
+          "with match(ids, unique(ids))) and keep the original ids as names."
+        ),
+        what,
+        format(values[values > .ID_MAX][1L], scientific = FALSE),
+        .ID_MAX
+      ),
+      call. = FALSE
+    )
+  }
+
+  as.integer(values)
+}
+
 .network_input_columns <- function(input, columns) {
   if (is.matrix(input)) {
     lapply(columns, function(index) input[, index])
@@ -252,7 +321,7 @@ InfomapClass <- R6::R6Class(
     #' @param name Optional node name.
     #' @param teleportation_weight Optional teleportation weight.
     add_node = function(node_id, name = NULL, teleportation_weight = NULL) {
-      id <- as.integer(node_id)
+      id <- .as_ids(node_id, "node id")
       if (!is.null(name) && !is.null(teleportation_weight)) {
         private$.swig$addNode(
           id,
@@ -287,7 +356,7 @@ InfomapClass <- R6::R6Class(
       } else {
         for (id_str in names(nodes)) {
           attr <- nodes[[id_str]]
-          id <- as.integer(id_str)
+          id <- .as_ids(id_str, "node id")
           if (is.character(attr) && length(attr) == 1L) {
             self$add_node(id, name = attr)
           } else if (is.list(attr) || length(attr) > 1L) {
@@ -310,8 +379,8 @@ InfomapClass <- R6::R6Class(
     #' @param name Optional name of the state node itself, as opposed to the
     #'   physical node.
     add_state_node = function(state_id, node_id, name = NULL) {
-      id <- as.integer(state_id)
-      phys_id <- as.integer(node_id)
+      id <- .as_ids(state_id, "state id")
+      phys_id <- .as_ids(node_id, "node id")
       if (!is.null(name)) {
         private$.swig$addStateNode(id, phys_id, as.character(name))
       } else {
@@ -331,7 +400,10 @@ InfomapClass <- R6::R6Class(
         }
       } else {
         for (state_str in names(state_nodes)) {
-          self$add_state_node(as.integer(state_str), state_nodes[[state_str]])
+          self$add_state_node(
+            .as_ids(state_str, "state id"),
+            state_nodes[[state_str]]
+          )
         }
       }
       invisible(self)
@@ -344,7 +416,7 @@ InfomapClass <- R6::R6Class(
       if (is.null(name)) {
         name <- ""
       }
-      private$.swig$addName(as.integer(node_id), as.character(name))
+      private$.swig$addName(.as_ids(node_id, "node id"), as.character(name))
       invisible(self)
     },
 
@@ -358,7 +430,7 @@ InfomapClass <- R6::R6Class(
         }
       } else {
         for (id_str in names(mapping)) {
-          self$set_name(as.integer(id_str), mapping[[id_str]])
+          self$set_name(.as_ids(id_str, "node id"), mapping[[id_str]])
         }
       }
       invisible(self)
@@ -370,8 +442,8 @@ InfomapClass <- R6::R6Class(
     #' @param weight Link weight.
     add_link = function(source_id, target_id, weight = 1.0) {
       private$.swig$addLink(
-        as.integer(source_id),
-        as.integer(target_id),
+        .as_ids(source_id, "node id"),
+        .as_ids(target_id, "node id"),
         as.numeric(weight)
       )
       invisible(self)
@@ -451,8 +523,8 @@ InfomapClass <- R6::R6Class(
       }
 
       private$.swig$addLinks(
-        as.integer(sources),
-        as.integer(targets),
+        .as_ids(sources, "node id"),
+        .as_ids(targets, "node id"),
         as.numeric(weights)
       )
       invisible(self)
@@ -463,8 +535,8 @@ InfomapClass <- R6::R6Class(
     #' @param target_id Target node id.
     remove_link = function(source_id, target_id) {
       private$.swig$network()$removeLink(
-        as.integer(source_id),
-        as.integer(target_id)
+        .as_ids(source_id, "node id"),
+        .as_ids(target_id, "node id")
       )
       invisible(self)
     },
@@ -489,8 +561,8 @@ InfomapClass <- R6::R6Class(
       target_multilayer_node,
       weight = 1.0
     ) {
-      src <- as.integer(source_multilayer_node)
-      tgt <- as.integer(target_multilayer_node)
+      src <- .as_ids(source_multilayer_node, "multilayer node")
+      tgt <- .as_ids(target_multilayer_node, "multilayer node")
       private$.swig$addMultilayerLink(
         src[[1L]],
         src[[2L]],
@@ -513,9 +585,9 @@ InfomapClass <- R6::R6Class(
       weight = 1.0
     ) {
       private$.swig$addMultilayerIntraLink(
-        as.integer(layer_id),
-        as.integer(source_node_id),
-        as.integer(target_node_id),
+        .as_ids(layer_id, "layer id"),
+        .as_ids(source_node_id, "node id"),
+        .as_ids(target_node_id, "node id"),
         as.numeric(weight)
       )
       invisible(self)
@@ -558,9 +630,9 @@ InfomapClass <- R6::R6Class(
       }
 
       private$.swig$addMultilayerIntraLinks(
-        as.integer(layers),
-        as.integer(sources),
-        as.integer(targets),
+        .as_ids(layers, "layer id"),
+        .as_ids(sources, "node id"),
+        .as_ids(targets, "node id"),
         as.numeric(weights)
       )
       invisible(self)
@@ -578,9 +650,9 @@ InfomapClass <- R6::R6Class(
       weight = 1.0
     ) {
       private$.swig$addMultilayerInterLink(
-        as.integer(source_layer_id),
-        as.integer(node_id),
-        as.integer(target_layer_id),
+        .as_ids(source_layer_id, "layer id"),
+        .as_ids(node_id, "node id"),
+        .as_ids(target_layer_id, "layer id"),
         as.numeric(weight)
       )
       invisible(self)
@@ -623,9 +695,9 @@ InfomapClass <- R6::R6Class(
       }
 
       private$.swig$addMultilayerInterLinks(
-        as.integer(source_layers),
-        as.integer(nodes),
-        as.integer(target_layers),
+        .as_ids(source_layers, "layer id"),
+        .as_ids(nodes, "node id"),
+        .as_ids(target_layers, "layer id"),
         as.numeric(weights)
       )
       invisible(self)
@@ -712,10 +784,10 @@ InfomapClass <- R6::R6Class(
       }
 
       private$.swig$addMultilayerLinks(
-        as.integer(source_layers),
-        as.integer(source_nodes),
-        as.integer(target_layers),
-        as.integer(target_nodes),
+        .as_ids(source_layers, "layer id"),
+        .as_ids(source_nodes, "node id"),
+        .as_ids(target_layers, "layer id"),
+        .as_ids(target_nodes, "node id"),
         as.numeric(weights)
       )
       invisible(self)
@@ -726,8 +798,8 @@ InfomapClass <- R6::R6Class(
     #' @param meta_category Integer meta category.
     set_meta_data = function(node_id, meta_category) {
       private$.swig$network()$addMetaData(
-        as.integer(node_id),
-        as.integer(meta_category)
+        .as_ids(node_id, "node id"),
+        .as_ids(meta_category, "meta category")
       )
       invisible(self)
     },
@@ -774,7 +846,7 @@ InfomapClass <- R6::R6Class(
     #' @description Set the bipartite start id.
     #' @param start_id Integer node id where the second node type starts.
     set_bipartite_start_id = function(start_id) {
-      private$.swig$setBipartiteStartId(as.integer(start_id))
+      private$.swig$setBipartiteStartId(.as_ids(start_id, "bipartite start id"))
       invisible(self)
     },
 
@@ -887,7 +959,7 @@ InfomapClass <- R6::R6Class(
 
       if (has_phys && has_layer) {
         # Multilayer state network.
-        layers <- as.integer(igraph::vertex_attr(g, layer_id))
+        layers <- .as_ids(igraph::vertex_attr(g, layer_id), "layer id")
         for (i in seq_len(igraph::vcount(g))) {
           if (is.character(raw_vertex_names)) {
             self$add_state_node(
@@ -1495,14 +1567,13 @@ InfomapClass <- R6::R6Class(
   }
 
   if (is.numeric(values)) {
-    ids <- as.integer(values)
-    if (any(!is.finite(values)) || any(values != ids)) {
-      stop(
-        "`phys_id` vertex attribute must contain integer-like numeric values or non-missing labels.",
-        call. = FALSE
-      )
-    }
-    return(list(ids = ids, mapping = NULL))
+    # Shares the id validator, so an out-of-range or fractional attribute is
+    # named instead of failing as "missing value where TRUE/FALSE needed" (the
+    # NA that `values != ids` produced once as.integer() overflowed).
+    return(list(
+      ids = .as_ids(values, "`phys_id` vertex attribute"),
+      mapping = NULL
+    ))
   }
 
   labels <- as.character(values)

--- a/interfaces/R/infomap/R/Infomap.R
+++ b/interfaces/R/infomap/R/Infomap.R
@@ -47,7 +47,7 @@ Infomap <- function(args = NULL, opts = NULL, ...) {
 # The engine itself accepts the full 32-bit unsigned range; reaching it from R
 # would need a change to the generated SWIG typemap, so the representable limit
 # is the R integer maximum for now.
-.ID_MAX <- 2147483647L
+.ID_MAX <- .Machine$integer.max
 
 .as_ids <- function(x, what) {
   if (length(x) == 0L) {

--- a/interfaces/R/infomap/tests/testthat/test-node-ids.R
+++ b/interfaces/R/infomap/tests/testthat/test-node-ids.R
@@ -1,0 +1,81 @@
+# Node, state and layer ids cross into C++ as R integers: the SWIG layer coerces
+# to integer range, so a value above .Machine$integer.max becomes NA and every
+# such id collapses onto the same node -- silently partitioning a different
+# network than the caller described. These tests pin the boundary to an error.
+
+test_that("add_links rejects node ids above the representable range", {
+  im <- Infomap(silent = TRUE, num_trials = 1L)
+  edges <- data.frame(source = c(1, 2) + 3e9, target = c(2, 3) + 3e9)
+
+  expect_error(im$add_links(edges), "2147483647", fixed = TRUE)
+})
+
+test_that("add_link rejects a single out-of-range node id", {
+  im <- Infomap(silent = TRUE, num_trials = 1L)
+
+  expect_error(im$add_link(3e9, 1), "2147483647", fixed = TRUE)
+  expect_error(im$add_link(1, 3e9), "2147483647", fixed = TRUE)
+})
+
+test_that("add_node rejects an out-of-range node id", {
+  im <- Infomap(silent = TRUE, num_trials = 1L)
+
+  expect_error(im$add_node(2^31), "2147483647", fixed = TRUE)
+})
+
+test_that("node ids at the representable limit are accepted", {
+  im <- Infomap(silent = TRUE, num_trials = 1L)
+
+  expect_silent(im$add_link(2147483647, 1))
+  expect_equal(im$num_nodes, 2L)
+})
+
+test_that("node ids are rejected rather than silently truncated or wrapped", {
+  im <- Infomap(silent = TRUE, num_trials = 1L)
+
+  expect_error(im$add_link(-1, 2), "negative", fixed = TRUE)
+  expect_error(im$add_link(1.5, 2), "whole number", fixed = TRUE)
+  expect_error(im$add_link(NA, 2), "missing", fixed = TRUE)
+  expect_error(im$add_link(NaN, 2), "missing", fixed = TRUE)
+  expect_error(im$add_link(Inf, 2), "finite", fixed = TRUE)
+})
+
+test_that("an out-of-range id no longer collapses a network into one node", {
+  # The regression: the same topology with large ids partitioned as a single
+  # node with codelength 0 instead of two modules.
+  edges <- data.frame(
+    source = c(1, 2, 3, 4, 5, 6, 3),
+    target = c(2, 3, 1, 5, 6, 4, 4)
+  )
+
+  small <- Infomap(silent = TRUE, num_trials = 1L, seed = 1L)
+  small$add_links(edges)
+  reference <- small$run()
+
+  expect_equal(reference$num_nodes, 6L)
+  expect_gt(reference$codelength, 0)
+
+  large <- Infomap(silent = TRUE, num_trials = 1L, seed = 1L)
+  expect_error(large$add_links(edges + 3e9), "2147483647", fixed = TRUE)
+})
+
+test_that("multilayer ids are validated too", {
+  im <- Infomap(silent = TRUE, num_trials = 1L)
+
+  expect_error(
+    im$add_multilayer_intra_link(1, 3e9, 2),
+    "2147483647",
+    fixed = TRUE
+  )
+  expect_error(
+    im$add_multilayer_intra_link(3e9, 1, 2),
+    "2147483647",
+    fixed = TRUE
+  )
+})
+
+test_that("state ids are validated too", {
+  im <- Infomap(silent = TRUE, num_trials = 1L)
+
+  expect_error(im$add_state_node(3e9, 1), "2147483647", fixed = TRUE)
+})


### PR DESCRIPTION
## Summary

Every id-carrying method in the R package coerced with `as.integer()`, and so does the generated SWIG layer, so any value above `.Machine$integer.max` became `NA_integer_` and every such id landed on the same node. The result was silently the wrong network:

```r
library(infomap)
e <- data.frame(source = c(1,2,3,4,5,6,3), target = c(2,3,1,5,6,4,4))
f <- function(x) { im <- Infomap(silent = TRUE, num_trials = 1L, seed = 1L)
                   im$add_links(x); r <- im$run()
                   cat(r$num_nodes, r$num_links, r$codelength, "\n") }
f(e)         # 6 7 2.32073
f(e + 3e9)   # before: 1 1 0        <- same topology, one node, codelength 0
```

The only tells were a generic `NAs introduced by coercion to integer range` warning (one per column, regardless of how many ids were affected) and `NA` in the `node_id` column. Python accepts the same input and returns 6 nodes at 2.320730, so identical scripts produced different science in the two bindings. Ids above 2^31 are ordinary in real data — OpenStreetMap ids, database keys, hashed identifiers.

After, the same call names the value, the limit and a remedy:

```
Error: node id 3000000001 is larger than 2147483647, the largest id the R
interface can represent. Renumber the nodes to a compact range (for example
with match(ids, unique(ids))) and keep the original ids as names.
```

One helper validates all 35 id entry points — `add_node`, `add_state_node`, `set_name`, `add_link`/`add_links`, `remove_link`, the multilayer intra/inter methods and their bulk forms, `add_meta_data`, `set_bipartite_start_id`, the igraph layer attribute and the `phys_id` mapping. Ids read back *out* of the engine and loop indices are untouched.

The same helper turns three other silent coercions into errors that say which value is wrong:

| input | before | after |
|---|---|---|
| `add_link(-1, 2)` | engine saw `2^32 - 1` | `node id cannot be negative, got -1.` |
| `add_link(1.5, 2)` | truncated to 1 | `node id must be a whole number, got 1.5.` |
| `add_link(NA, 2)` | `NA_integer_` → node 2147483648 | `node id cannot be missing or non-numeric.` |
| `add_link(Inf, 2)` | `NA_integer_` → same | `node id must be finite.` |
| `add_link(2147483647, 1)` | accepted | accepted (unchanged) |

Closes #901.

## Verification

- `make test-r` — exit 0 (R CMD check, `--as-cran`), `make test-r-examples` — exit 0
- `make format-r-check` — clean (air 0.9.0, the pinned version)
- New `tests/testthat/test-node-ids.R`: 13 assertions covering the collapse regression, the accepted limit, each rejected shape, and the multilayer and state-id paths. All 13 failed before the change.
- The reproducer above, run against the installed working tree

One note on the check: the first `make test-r` run reported a WARNING from the CRAN incoming-feasibility step (`unable to access index for repository .../src/contrib: download ... failed`, which then reports R6/igraph/testthat as "not in mainstream repositories"). That is a transient network failure, not this change — a clean master run and a second run with the change both exit 0.

## Notes

**The ceiling is the R integer maximum, not the engine's unsigned range.** The generated SWIG typemap coerces to integer range as well, so `3e9` is unreachable even when passed straight to the wrapper, bypassing the R methods:

```r
sw$addLink(3e9, 7)   # WARNING: NAs introduced by coercion to integer range
```

So this PR validates against what the binding can actually represent. Lifting the ceiling to `2^32-1` means changing the typemap in the generator, which is a separate piece of work — worth deciding before #662 (CRAN), since the limit becomes a documented contract there.

**Not fixed here, same symptom class:** `infomap_options(seed = 2^31)` still fails with `missing value where TRUE/FALSE needed`, from `format_value()` in the generated `options.R`. That is the option renderer, tracked in #902, and it lives in generated code, so the fix belongs in `scripts/generate_binding_options.py`.

**Follow-up worth considering:** the roxygen `@param node_id Integer node id.` blocks do not mention the limit. The error message teaches at the point of failure, which is where it matters most, but documenting the ceiling on the user-facing methods would need a roxygen pass and Rd regeneration — deliberately left out of this diff.
