### PR TITLE
build(deps-dev): pin ruff so a new release cannot turn master red

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,9 @@ ci:
 repos:
   # Python lint. CI already runs `ruff check` on the package + examples/python
   # (via `make test-python-doctest`); this runs it repo-wide with autofix.
-  # Pinned to the ruff version in the project venv so local and hook agree.
+  # Pinned to the ruff version in the project venv so local and hook agree;
+  # the same version is pinned in pyproject.toml's `test` extra (which is what
+  # CI installs) and all three bump together.
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.8
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,15 @@ test = [
   "networkx",
   "pyarrow",
   "referencing",
-  "ruff",
+  # Pinned for the same reason as pyright above: `ruff check` gates CI (it is
+  # the first step of test-python-doctest), and new ruff releases promote rules
+  # into the default set, so an unpinned ruff turns master red with no code
+  # change. 0.16.0 did exactly that, adding 38 findings across nine rule
+  # families (PLC0414, PLR0402, RUF012, RUF022, RUF023, RUF100, SIM114, SIM117,
+  # TRY004) that no `extend-select` in this project asks for. Keep this in sync
+  # with the ruff-pre-commit `rev` in .pre-commit-config.yaml, and bump both
+  # together, deliberately.
+  "ruff==0.15.8",
   "scipy",
 ]
 docs = [


### PR DESCRIPTION
## Summary

Master is red, and so is every open pull request, at the same step: `python / Python 3.14 / Run Python doctests` on both ubuntu-24.04 and windows-2025. No code change caused it.

`test-python-doctest` starts with `$(RUFF) check $(PYTHON_LINT_TARGETS)` (`mk/python.mk:95`), so a lint finding fails that step. `ruff` was the one linter in pyproject.toml's `test` extra left unpinned, and ruff **0.16.0** promoted nine rule families into its default rule set — `PLC0414`, `PLR0402`, `RUF012`, `RUF022`, `RUF023`, `RUF100`, `SIM114`, `SIM117`, `TRY004` — none of which this project asks for in `extend-select = ["B", "UP", "I"]`. CI installed it and the build broke with no commit behind it.

Reproduced locally with both real binaries on the exact CI lint targets (`interfaces/python/src/infomap` and `examples/python`):

```
ruff 0.15.8   All checks passed!
ruff 0.16.0   Found 38 errors.
```

By family: `PLC0414` 23, `TRY004` 4, `RUF100` 3, `PLR0402` 2, `RUF023` 2, `RUF012` 1, `RUF022` 1, `SIM114` 1, `SIM117` 1.

The fix is a one-line pin to **0.15.8** — the version already pinned as `rev: v0.15.8` in `.pre-commit-config.yaml` and installed in the project venv — so pyproject, the hook and the venv all agree. The comment mirrors the one on `pyright==1.1.411` immediately above it in the same list:

> Pinned: pyright gates CI (test-python-typecheck-core), and new pyright releases routinely add diagnostics. Bump deliberately.

That decision had already been made for the other linter that gates CI. `ruff` was simply missed.

## Verification

- `make test-python-doctest` — exit 0 with the pinned version
- `ruff 0.15.8` on the CI lint targets — `All checks passed!`
- `ruff 0.16.0` on the same targets — 38 errors, i.e. the failure is reproduced and attributed locally rather than inferred from the CI log
- `check toml` and `check yaml` pre-commit hooks passed on commit

Once this is on master, the checks on #916, #917 and #918 need a re-run: the `pull_request` event tests the merge with the base, so they stay red until the pin is in their merge base.

## Notes

**Adopting 0.16.0 deserves its own change.** Two of the new families point at real issues rather than style: `TRY004` (raise `TypeError` rather than `ValueError` for an invalid type — four sites, and this interacts with the error-taxonomy work in #791/#900) and `RUF012` (a mutable default for a class attribute, in `io/writers.py`). The other 32 are import-alias and sorting conventions. Worth doing as a deliberate pass with the pre-commit `rev` bumped in the same commit, not as a side effect of a resolver picking a new release.

**Dependabot will now open bump PRs for ruff**, which is the intended workflow and matches how `pyright`, `air` (0.9.0) and `actionlint` (1.7.12) are handled in this repo — bumped on purpose, with the findings fixed in the same change.
