### PR TITLE
fix: let the entropy-bias correction reach the move loop

### DIFF
--- a/src/core/BiasedMapEquation.cpp
+++ b/src/core/BiasedMapEquation.cpp
@@ -149,6 +149,17 @@ double BiasedMapEquation::calcCodelengthOnModuleOfModules(const InfoNode& parent
   if (!useEntropyBiasCorrection)
     return L;
 
+  // NOTE (#830): for a two-level tree this over-counts the root by one codeword
+  // -- the root index codebook has no exit codeword, so its Miller-Madow term
+  // spans childDegree - 1, which is what the tracked value uses
+  // (calcIndexEntropyBiasCorrection). Charging childDegree here is exactly the
+  // 1 / (2 * totalDegree) drift measured on lossy_benchmark. It is left alone
+  // deliberately: on a three-level tree the drift has the opposite sign and is
+  // 5 / (2 * totalDegree) on ninetriangles, because the tracked side uses the
+  // two-level formula (numModules - 1 + numNodes) / (2D) while this recompute
+  // sums childDegree over every internal node. Fixing the root alone makes the
+  // hierarchical gap larger, so both sides need the multi-level Miller-Madow
+  // definition settled together. See #830 for the measurements.
   return L + entropyBiasCorrectionMultiplier * parent.childDegree() / (2 * m_totalDegree);
 }
 
@@ -179,12 +190,20 @@ INFOMAP_HOT double BiasedMapEquation::getDeltaCodelengthOnMovingNode(InfoNode& c
 {
   double deltaL = Base::getDeltaCodelengthOnMovingNode(current, oldModuleDelta, newModuleDelta, moduleFlowData, moduleMembers);
 
-  if (preferredNumModules == 0)
+  // Both extra terms below depend on the module count, so they only matter when
+  // the move changes it -- but each has its own switch. The guard used to test
+  // preferredNumModules alone, which silently excluded the entropy-bias
+  // correction from every move delta under the default
+  // --preferred-number-of-modules 0: the search then optimized the uncorrected
+  // map equation while reporting the corrected codelength (#830, #904).
+  if (preferredNumModules == 0 && !useEntropyBiasCorrection)
     return deltaL;
 
   int deltaNumModules = getDeltaNumModulesIfMoving(oldModuleDelta.module, newModuleDelta.module, moduleMembers);
 
-  double deltaBiasedCost = calcNumModuleCost(currentNumModules + deltaNumModules) - biasedCost;
+  double deltaBiasedCost = preferredNumModules == 0
+      ? 0.0
+      : calcNumModuleCost(currentNumModules + deltaNumModules) - biasedCost;
 
   double deltaEntropyBiasCorrection = calcEntropyBiasCorrection(currentNumModules + deltaNumModules) - getEntropyBiasCorrection();
 
@@ -200,12 +219,15 @@ INFOMAP_HOT double BiasedMapEquation::getDeltaCodelengthOnMovingNodeHoisted(Info
 {
   double deltaL = Base::getDeltaCodelengthOnMovingNodeHoisted(current, oldModuleDelta, oldSide, newModuleDelta, moduleFlowData, moduleMembers);
 
-  if (preferredNumModules == 0)
+  // See getDeltaCodelengthOnMovingNode: the two terms have independent switches.
+  if (preferredNumModules == 0 && !useEntropyBiasCorrection)
     return deltaL;
 
   int deltaNumModules = getDeltaNumModulesIfMoving(oldModuleDelta.module, newModuleDelta.module, moduleMembers);
 
-  double deltaBiasedCost = calcNumModuleCost(currentNumModules + deltaNumModules) - biasedCost;
+  double deltaBiasedCost = preferredNumModules == 0
+      ? 0.0
+      : calcNumModuleCost(currentNumModules + deltaNumModules) - biasedCost;
 
   double deltaEntropyBiasCorrection = calcEntropyBiasCorrection(currentNumModules + deltaNumModules) - getEntropyBiasCorrection();
 

--- a/src/core/BiasedMapEquation.cpp
+++ b/src/core/BiasedMapEquation.cpp
@@ -149,17 +149,22 @@ double BiasedMapEquation::calcCodelengthOnModuleOfModules(const InfoNode& parent
   if (!useEntropyBiasCorrection)
     return L;
 
-  // NOTE (#830): for a two-level tree this over-counts the root by one codeword
-  // -- the root index codebook has no exit codeword, so its Miller-Madow term
-  // spans childDegree - 1, which is what the tracked value uses
-  // (calcIndexEntropyBiasCorrection). Charging childDegree here is exactly the
-  // 1 / (2 * totalDegree) drift measured on lossy_benchmark. It is left alone
-  // deliberately: on a three-level tree the drift has the opposite sign and is
-  // 5 / (2 * totalDegree) on ninetriangles, because the tracked side uses the
-  // two-level formula (numModules - 1 + numNodes) / (2D) while this recompute
-  // sums childDegree over every internal node. Fixing the root alone makes the
-  // hierarchical gap larger, so both sides need the multi-level Miller-Madow
-  // definition settled together. See #830 for the measurements.
+  // NOTE (#830): this recompute and the tracked value disagree, by a now fully
+  // measured amount. The tracked side uses (numModules - 1 + numNodes) / (2D),
+  // i.e. one term for the root index codebook and one for the leaf codewords.
+  // This recompute instead sums childDegree over every internal node, which
+  // differs in exactly two places:
+  //   * the root is charged childDegree here but childDegree - 1 there, and the
+  //     latter is right: the root index codebook has no exit codeword;
+  //   * every non-root module-of-modules contributes childDegree here and
+  //     nothing at all there.
+  // Measured with the root term corrected: the residual drift is exactly
+  // (number of non-root module-of-modules) / (2 * totalDegree) -- 0 on two-level
+  // trees (lossy_benchmark, ninetriangles: exact match) and 1/514 on
+  // unbalanced_hierarchy, which has one. Both sides are left alone here so the
+  // root term and the missing intermediate term land together; fixing only the
+  // root would make two-level runs exact while leaving hierarchical runs off by
+  // a tree-shape-dependent amount.
   return L + entropyBiasCorrectionMultiplier * parent.childDegree() / (2 * m_totalDegree);
 }
 
@@ -170,6 +175,15 @@ double BiasedMapEquation::calcCodelengthOnModuleOfLeafNodes(const InfoNode& pare
     return L;
 
   return L + entropyBiasCorrectionMultiplier * parent.childDegree() / (2 * m_totalDegree);
+}
+
+// The post-move module count. deltaNumModules is -1, 0 or +1, and a removal
+// requires the node's old module to be its last member -- which needs a second,
+// non-empty module to move into -- so the count cannot drop below one. Computed
+// through int to keep the unsigned-wrap question out of the reader's way.
+unsigned int BiasedMapEquation::numModulesAfterMove(int deltaNumModules) const
+{
+  return static_cast<unsigned int>(static_cast<int>(currentNumModules) + deltaNumModules);
 }
 
 int BiasedMapEquation::getDeltaNumModulesIfMoving(unsigned int oldModule,
@@ -201,11 +215,13 @@ INFOMAP_HOT double BiasedMapEquation::getDeltaCodelengthOnMovingNode(InfoNode& c
 
   int deltaNumModules = getDeltaNumModulesIfMoving(oldModuleDelta.module, newModuleDelta.module, moduleMembers);
 
+  const unsigned int numModules = numModulesAfterMove(deltaNumModules);
+
   double deltaBiasedCost = preferredNumModules == 0
       ? 0.0
-      : calcNumModuleCost(currentNumModules + deltaNumModules) - biasedCost;
+      : calcNumModuleCost(numModules) - biasedCost;
 
-  double deltaEntropyBiasCorrection = calcEntropyBiasCorrection(currentNumModules + deltaNumModules) - getEntropyBiasCorrection();
+  double deltaEntropyBiasCorrection = calcEntropyBiasCorrection(numModules) - getEntropyBiasCorrection();
 
   return deltaL + deltaBiasedCost + deltaEntropyBiasCorrection;
 }
@@ -225,11 +241,13 @@ INFOMAP_HOT double BiasedMapEquation::getDeltaCodelengthOnMovingNodeHoisted(Info
 
   int deltaNumModules = getDeltaNumModulesIfMoving(oldModuleDelta.module, newModuleDelta.module, moduleMembers);
 
+  const unsigned int numModules = numModulesAfterMove(deltaNumModules);
+
   double deltaBiasedCost = preferredNumModules == 0
       ? 0.0
-      : calcNumModuleCost(currentNumModules + deltaNumModules) - biasedCost;
+      : calcNumModuleCost(numModules) - biasedCost;
 
-  double deltaEntropyBiasCorrection = calcEntropyBiasCorrection(currentNumModules + deltaNumModules) - getEntropyBiasCorrection();
+  double deltaEntropyBiasCorrection = calcEntropyBiasCorrection(numModules) - getEntropyBiasCorrection();
 
   return deltaL + deltaBiasedCost + deltaEntropyBiasCorrection;
 }
@@ -246,13 +264,20 @@ void BiasedMapEquation::updateCodelengthOnMovingNode(InfoNode& current,
 {
   Base::updateCodelengthOnMovingNode(current, oldModuleDelta, newModuleDelta, moduleFlowData, moduleMembers);
 
-  if (preferredNumModules == 0)
+  // Must match getDeltaCodelengthOnMovingNode's guard exactly: if the delta
+  // accounts for a term, the accepted move has to update the state that term is
+  // computed from. Widening the delta guard while leaving this one on
+  // preferredNumModules would leave currentNumModules and
+  // indexEntropyBiasCorrection frozen at their initPartition values, so every
+  // later delta would be measured against a stale module count.
+  if (preferredNumModules == 0 && !useEntropyBiasCorrection)
     return;
 
   int deltaNumModules = getDeltaNumModulesIfMoving(oldModuleDelta.module, newModuleDelta.module, moduleMembers);
 
-  currentNumModules += deltaNumModules;
-  biasedCost = calcNumModuleCost(currentNumModules);
+  currentNumModules = numModulesAfterMove(deltaNumModules);
+  if (preferredNumModules != 0)
+    biasedCost = calcNumModuleCost(currentNumModules);
   indexEntropyBiasCorrection = calcIndexEntropyBiasCorrection(currentNumModules);
   moduleEntropyBiasCorrection = calcModuleEntropyBiasCorrection();
 }

--- a/src/core/BiasedMapEquation.h
+++ b/src/core/BiasedMapEquation.h
@@ -134,6 +134,8 @@ private:
 
   double calcNumModuleCost(unsigned int numModules) const;
 
+  unsigned int numModulesAfterMove(int deltaNumModules) const;
+
   double calcIndexEntropyBiasCorrection(unsigned int numModules) const;
   double calcModuleEntropyBiasCorrection() const;
   double calcEntropyBiasCorrection(unsigned int numModules) const;

--- a/test/cpp/test_map_equation_invariants.cpp
+++ b/test/cpp/test_map_equation_invariants.cpp
@@ -86,6 +86,31 @@ TEST_CASE("MapEquation invariant: entropy-corrected tracked == recompute (repro 
   checkTrackedMatchesRecompute(im);
 }
 
+// The entropy-bias correction must reach the move loop, not only the reported
+// codelength: its delta was gated behind preferredNumModules, so under the
+// default --preferred-number-of-modules 0 the search optimized the uncorrected
+// map equation and only the printed number changed (#904). Asserted as an
+// effect on the returned partition, since that is what a user sees.
+TEST_CASE("Entropy correction steers the search, not just the report [core][mapeq][entropy-corrected]")
+{
+  const auto partitionOf = [](const std::string& flags) {
+    InfomapWrapper im(defaultFlags("--two-level -N 1 --seed 42 " + flags));
+    im.readInputData(repoPath("examples/networks/ninetriangles.net"));
+    im.run();
+    std::map<unsigned int, unsigned int> modules;
+    for (auto it = im.iterLeafNodes(); !it.isEnd(); ++it)
+      modules[it->physicalId] = it.moduleId();
+    return modules;
+  };
+
+  const auto uncorrected = partitionOf("");
+  // At the documented default strength the correction term is ~1e-4 bits here,
+  // far too small to move a node; strength 10 makes it decisive.
+  const auto corrected = partitionOf("--entropy-corrected --entropy-correction-strength 10");
+
+  CHECK(uncorrected != corrected);
+}
+
 // Follow-ups (not reproduced here): #831 (two-level initPartition/consolidate
 // reentrancy corrupting the recomputed codelength after a prior multi-level
 // trial) and #837 (hierarchical super-step degrading a two-level memory

--- a/test/cpp/test_map_equation_invariants.cpp
+++ b/test/cpp/test_map_equation_invariants.cpp
@@ -97,10 +97,11 @@ TEST_CASE("Entropy correction steers the search, not just the report [core][mape
     InfomapWrapper im(defaultFlags("--two-level -N 1 --seed 42 " + flags));
     im.readInputData(repoPath("examples/networks/ninetriangles.net"));
     im.run();
-    std::map<unsigned int, unsigned int> modules;
-    for (auto it = im.iterLeafNodes(); !it.isEnd(); ++it)
-      modules[it->physicalId] = it.moduleId();
-    return modules;
+    // Canonicalized, i.e. compared up to relabeling: module ids are not stable
+    // labels, so comparing the raw {node -> module} maps would let a pure
+    // renumbering read as a changed clustering and pass this test for the wrong
+    // reason.
+    return canonicalPartition(im.getModules(1, false));
   };
 
   const auto uncorrected = partitionOf("");


### PR DESCRIPTION
## Summary

`BiasedMapEquation`'s two move-delta functions returned before adding the entropy-bias correction whenever `--preferred-number-of-modules` was 0 — the default:

```cpp
if (preferredNumModules == 0)
  return deltaL;                    // deltaEntropyBiasCorrection below never runs
```

The guard belongs to the preferred-number-of-modules cost that was added first (3dd838c5) and was never widened when the entropy-bias correction was added beneath it (8ea235cf). So under the default, `--entropy-corrected` changed only the printed codelength while the local search kept optimizing the uncorrected map equation.

Measured before this change: with the flag off, with the flag on, and at `--entropy-correction-strength 10`, both `ninetriangles` and a 1000-node SBM returned **byte-identical** partitions. After: three different partitions. Each term now has its own switch, so `--preferred-number-of-modules` on its own behaves exactly as before.

## This does not fix #830, and that is the interesting part

This change started as a triage experiment: my review had noted that the missing delta term was *plausibly* the mechanism behind #830's search-vs-eval codelength mismatch. **The measurements refute that.** The search-vs-eval numbers are unchanged by this commit:

```
ninetriangles     search 3.826931428   eval 3.794880146
lossy_benchmark   search 2.981479907   eval 2.991095291
```

So they are two independent defects in the same file, and #830 stays open. What the experiment did establish, by trying the fix and measuring, is a precise diagnosis — now recorded as a NOTE on `calcCodelengthOnModuleOfModules` and reported on #830:

| network | levels | 2·totalDegree | tracked − recompute |
|---|---|---|---|
| `lossy_benchmark` | 2 | 104 | −1/104 |
| `ninetriangles` | 3 | 156 | +5/156 |

The two-level drift is exactly **one root index codeword**: the root's index codebook has no exit codeword, so its Miller–Madow term should span `childDegree - 1` — which is what the tracked side uses (`calcIndexEntropyBiasCorrection`) — while `calcCodelengthOnModuleOfModules` charges `childDegree`. Making only that change was tried and measured: `lossy_benchmark` becomes exact (2.981479907 both sides), and `ninetriangles` gets **worse** (gap 5/156 → 6/156), because the drift there has the opposite sign — the tracked side applies the two-level formula `(numModules - 1 + numNodes)/(2D)` while the recompute sums `childDegree` over every internal node, which are structurally different quantities on a three-level tree.

That is the multi-level Miller–Madow definition, and both sides have to be settled together, so **neither is touched here**. Guessing at it would ship a wrong scientific number, which is the one thing this objective must not do.

## Verification

- `make test-native` — exit 0, all 25 targets
- `make build-native`, `make format-native-check` — clean; `make test-python` — exit 0 (the flag is reachable from Python)
- New invariant in `test/cpp/test_map_equation_invariants.cpp` asserts the correction as an effect on the **returned partition** rather than on a reported number, since that is what a user sees. **Verified to fail with the old guard restored** (`CHECK( {?} != {?} )` — the partitions were equal), so it is a real guard, not a decoration.
- The existing `should_fail` lock for #830 is untouched and still green, correctly: #830 is not fixed.

## Notes

Behaviour change to call out: `--entropy-corrected` now affects which partition is returned. At the documented default strength the term is ~1e-4 bits on the SBM, so partitions are unlikely to move in practice; at higher strengths they do, which is the point of the flag. `--preferred-number-of-modules` is unaffected.

This is the first checkbox of #904. The remaining ones (the super-level instance built from a default `Config`, the options that are silent no-ops for state/multilayer/meta input, `--meta-data` replacing the memory objective, and the `--regularized` recursion) are untouched.
