### PR TITLE
docs(python): state the common-tier defaults in the facade docstrings

### DIFF
--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -578,7 +578,8 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             Deprecated. Accepted for backward compatibility; has no effect. Passing it
             explicitly emits a DeprecationWarning.
         two_level : bool, optional
-            Optimize a two-level partition instead of the default multi-level hierarchy.
+            Optimize a two-level partition instead of the default multi-level hierarchy
+            (default False).
         flow_model : str, optional
             Choose how Infomap derives flow from the input links. Options: undirected,
             directed, undirdir, outdirdir, rawdir, precomputed.
@@ -586,7 +587,8 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             .. versionchanged:: 2.15
                 Pass it via ``Options``; moves off this signature in 3.0.
         directed : bool, optional
-            Treat input links as directed. Shorthand for --flow-model directed.
+            Treat input links as directed. Shorthand for --flow-model directed (default
+            None).
         recorded_teleportation : bool, optional
             When teleportation is used to calculate flow, also record teleportation
             steps in the codelength.
@@ -654,7 +656,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
                 Pass it via ``Options``; moves off this signature in 3.0.
         markov_time : float, optional
             Scale link flow to change the cost of moving between modules. Higher values
-            result in fewer modules.
+            result in fewer modules (default 1.0).
         variable_markov_time : bool, optional
             Vary Markov time locally to reduce overpartitioning in sparse areas while
             keeping higher resolution in dense areas.
@@ -731,9 +733,9 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
             .. versionchanged:: 2.15
                 Pass it via ``Options``; moves off this signature in 3.0.
         seed : int, optional
-            Set the random number generator seed for reproducible results.
+            Set the random number generator seed for reproducible results (default 123).
         num_trials : int, optional
-            Run this many independent trials and keep the best solution.
+            Run this many independent trials and keep the best solution (default 1).
         core_loop_limit : int, optional
             Limit how many core loops try to move each node to the best module.
 

--- a/scripts/generate_binding_options.py
+++ b/scripts/generate_binding_options.py
@@ -1472,7 +1472,14 @@ def _render_facade_docstring_params(names, index):
         if info["doc"] is None:
             continue
         lines.append(f"        {name} : {info['doc_type']}")
-        lines.extend(wrap_doc(info["doc"], "            "))
+        doc = info["doc"]
+        if info.get("tier") == "common":
+            # The signature declares these with the _UNSET sentinel so the merge
+            # can see an explicitly passed default (see _render_facade_signature),
+            # which means it no longer shows the real default. State it here, the
+            # way the hand-written infomap.run() docstring already does.
+            doc = f"{doc.rstrip('.')} (default {info['default']})."
+        lines.extend(wrap_doc(doc, "            "))
         if info.get("inert_without_outdir"):
             lines.append("")
             lines.extend(wrap_doc(_INERT_WITHOUT_OUTDIR_NOTE, "            "))


### PR DESCRIPTION
## Summary

Follow-up to review feedback on #921, which merged before this landed.

#921 declared the five common-tier keywords on `Infomap.__init__` / `Infomap.run` with the `_UNSET` sentinel so the merge can tell an explicitly passed value from silence. The cost is that `help(infomap.Infomap)` and IDE signature help now show `= <unset>` where they used to show `= 123`, `= 1`, `= False`, `= None`, `= 1.0` — and the generated facade docstrings did not repeat the default, so it had no home left on that surface.

State it in the docstring, which is exactly what the hand-written `infomap.run()` docstring already does for the same five parameters:

```
seed : int, optional
    Random-number-generator seed for reproducible results (default 123).
```

After this change the facade matches:

```
seed         Set the random number generator seed for reproducible results (default 123).
num_trials   Run this many independent trials and keep the best solution (default 1).
two_level    Optimize a two-level partition instead of the default multi-level hierarchy (default False).
directed     Treat input links as directed. Shorthand for --flow-model directed (default None).
markov_time  Scale link flow to change the cost of moving between modules. Higher values result in fewer modules (default 1.0).
```

The note is generated from the same catalog default the signature used to render, so it cannot drift from the value `Options` actually uses — and only common-tier parameters get it, since the advanced tier still declares its real default in the signature.

## Verification

- `make test-binding-options-freshness` — exit 0
- `make test-python` — exit 0; `make test-python-typecheck` — 0 errors, 0 warnings
- `inspect.getdoc(infomap.Infomap.__init__)` inspected for all five parameters (output above)

## Notes

Generator-side only (`scripts/generate_binding_options.py` plus the regenerated block in `_facade.py`); no runtime behaviour change.
