### PR TITLE
docs(python): correct the parity claim in the facade-docstring comment

### DIFF
--- a/scripts/generate_binding_options.py
+++ b/scripts/generate_binding_options.py
@@ -1476,8 +1476,11 @@ def _render_facade_docstring_params(names, index):
         if info.get("tier") == "common":
             # The signature declares these with the _UNSET sentinel so the merge
             # can see an explicitly passed default (see _render_facade_signature),
-            # which means it no longer shows the real default. State it here, the
-            # way the hand-written infomap.run() docstring already does.
+            # which means it no longer shows the real default. State it here
+            # instead. The hand-written infomap.run() docstring does the same for
+            # seed and num_trials ("...for reproducible results (default 123)");
+            # it leaves two_level, directed and markov_time to prose, and this
+            # covers all five uniformly.
             doc = f"{doc.rstrip('.')} (default {info['default']})."
         lines.extend(wrap_doc(doc, "            "))
         if info.get("inert_without_outdir"):


### PR DESCRIPTION
## Summary

Follow-up to review feedback on #923, which merged before this landed. Comment-only.

The inline comment I added there claimed the hand-written `infomap.run()` docstring "already does" this for the common-tier parameters. It does not, for three of the five — verified by inspecting `getdoc(infomap.run)`:

| parameter | `run()` states a default |
|---|---|
| `seed` | yes — "...for reproducible results (default 123)" |
| `num_trials` | yes — "...the best solution is kept (default 1)" |
| `two_level` | no |
| `directed` | no |
| `markov_time` | no |

So the precedent is real but partial, and the comment overstated it — in a comment whose whole job is to tell a future reader why the note is generated. Reworded to say what `run()` actually does and that the generator covers all five uniformly.

## Verification

- `make build-binding-options` then `make test-binding-options-freshness` — exit 0, so the generated output is byte-identical and only the generator comment changed
- `ruff check` — clean
