### PR TITLE
test: drop the duplicated regularized-multilevel flow case

### DIFF
--- a/test/cpp/test_flow.cpp
+++ b/test/cpp/test_flow.cpp
@@ -383,25 +383,6 @@ TEST_CASE("Undirected regularization remains stable on the two-triangles fixture
   infomap::test::checkApproxCodelength(im.codelength(), 2.575767408, 1e-9);
 }
 
-TEST_CASE("Directed regularized codelength matches analytic multi-level tree [fast][core][flow]")
-{
-  InfomapWrapper im(infomap::test::defaultFlags(
-      "--directed --regularized --no-infomap --cluster-data "
-      + infomap::test::clusterFixturePath("regularized_four_pairs_three_level.tree")));
-  im.addLink(1, 2);
-  im.addLink(2, 1);
-  im.addLink(3, 4);
-  im.addLink(4, 3);
-  im.addLink(5, 6);
-  im.addLink(6, 5);
-  im.addLink(7, 8);
-  im.addLink(8, 7);
-  im.run();
-
-  CHECK(im.numLevels() == 3);
-  infomap::test::checkApproxCodelength(im.codelength(), 4.051270346886);
-}
-
 #if INFOMAP_FEATURE_REGULARIZED_MULTILAYER
 TEST_CASE("Regularized multilayer flow supports non-dense matchable state ids [fast][core][flow]")
 {


### PR DESCRIPTION
## Summary

`test/cpp/test_flow.cpp` defined `"Directed regularized codelength matches analytic multi-level tree"` twice, with byte-identical 18-line bodies, so doctest registered and ran two cases under one name. `-tc="Directed regularized codelength matches analytic multi-level tree*"` selected both, and the duplicate cost runtime for nothing.

`git blame` settles which is which: the surviving definition is the original from #461 (`1fae0f7a fix: correct regularized multilevel codelength`), and the removed one is the copy introduced by #462 (`130bce1c feat: regularized multilayer`) when the `#if INFOMAP_FEATURE_REGULARIZED_MULTILAYER` block was added around it. Neither copy ended up inside that block, which is why both compiled unconditionally. The original stays in its historical position.

## Verification

- `make test-native` — exit 0, all targets
- `./build/cmake/infomap_cpp_flow_tests -ltc` — the name now appears once, was twice
- `-tc="Directed regularized codelength matches analytic multi-level tree*"` — selects **1** test case with 2 assertions; it selected 2 cases before
- `make format-native-check` — clean

First of the two items in #911; the degenerate `MetaMapEquation` invariant in the same issue is left for a follow-up, because fixing it needs a meta fixture whose categories do not coincide with the optimal partition, and it touches `test_map_equation_invariants.cpp`, which #922 is currently modifying.
