### PR TITLE
ci: make UBSan findings fail, and close three path-filter holes

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -110,6 +110,10 @@ javascript:
   - "interfaces/parameters/**"
   - "scripts/generate_binding_options.py"
   - "scripts/parameter_catalog.py"
+  # generate_binding_options.py imports render_parameter_policy and splices its
+  # output into the tracked interfaces/parameters/policy.md, so it is a generator
+  # input like the two above and must trigger the freshness gate.
+  - "scripts/render_parameter_policy.py"
   - "scripts/generate_js_metadata.py"
   - "scripts/prepare_npm_package.py"
   - ".github/actions/setup-js-build/action.yml"
@@ -180,3 +184,9 @@ notebooks:
 meta:
   - ".github/**"
   - ".pre-commit-config.yaml"
+  # The fuzz harness and the native benchmark sources are built only by
+  # schedule-triggered or opt-in targets (make fuzz, bench-native), so they match
+  # no lane filter. Without them here a PR that only edits them runs zero jobs --
+  # not even the pre-commit hygiene gate -- and ci-summary reports green.
+  - "test/fuzz/**"
+  - "test/bench/**"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,11 @@ target_link_options(infomap_core PUBLIC ${INFOMAP_LINK_FLAGS})
 
 if(INFOMAP_ENABLE_SANITIZERS)
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
-        target_compile_options(infomap_core PUBLIC -fsanitize=address,undefined -fno-omit-frame-pointer)
+        # -fno-sanitize-recover=undefined: without it UBSan prints "runtime
+        # error: ..." and carries on, so the doctest binary exits 0, ctest
+        # reports Passed, and --output-on-failure never shows the diagnostic --
+        # the blocking sanitizer job could not fail on any UB finding.
+        target_compile_options(infomap_core PUBLIC -fsanitize=address,undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer)
         target_link_options(infomap_core PUBLIC -fsanitize=address,undefined)
     else()
         message(FATAL_ERROR "INFOMAP_ENABLE_SANITIZERS requires Clang or GCC.")
@@ -309,7 +313,7 @@ if(INFOMAP_BUILD_FUZZERS)
     # Instrument the core for coverage-guided fuzzing plus the sanitizers the
     # harness links, so findings surface from library code, not just the harness.
     target_compile_options(infomap_core
-        PRIVATE -fsanitize=fuzzer-no-link,address,undefined -fno-omit-frame-pointer)
+        PRIVATE -fsanitize=fuzzer-no-link,address,undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer)
     # PUBLIC link options so every consumer of the instrumented core (the CLI,
     # stray test targets) links the sanitizer runtimes too -- without this,
     # building anything but fuzz_intake in a fuzz-configured tree fails at
@@ -320,6 +324,6 @@ if(INFOMAP_BUILD_FUZZERS)
     add_executable(fuzz_intake test/fuzz/fuzz_intake.cpp)
     target_link_libraries(fuzz_intake PRIVATE infomap_core)
     target_compile_options(fuzz_intake
-        PRIVATE -fsanitize=fuzzer,address,undefined -fno-omit-frame-pointer)
+        PRIVATE -fsanitize=fuzzer,address,undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer)
     target_link_options(fuzz_intake PRIVATE -fsanitize=fuzzer,address,undefined)
 endif()

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -116,7 +116,7 @@ test-sanitizers:
 	else \
 		ASAN_OPTS="$$ASAN_OPTS:detect_leaks=1"; \
 	fi; \
-	ASAN_OPTIONS="$$ASAN_OPTS" UBSAN_OPTIONS=print_stacktrace=1 "$(CTEST)" --test-dir $(SANITIZER_BUILD_DIR) --output-on-failure $(CTEST_ARGS)
+	ASAN_OPTIONS="$$ASAN_OPTS" UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 "$(CTEST)" --test-dir $(SANITIZER_BUILD_DIR) --output-on-failure $(CTEST_ARGS)
 
 # Build and briefly run the libFuzzer harness for the network intake (Clang
 # only; opt-in via INFOMAP_BUILD_FUZZERS, kept out of the default build/ctest).
@@ -136,7 +136,7 @@ fuzz:
 		-DCMAKE_C_COMPILER=$(FUZZ_CC)
 	@"$(CMAKE)" --build $(FUZZ_BUILD_DIR) --target fuzz_intake --parallel $(JOBS)
 	@mkdir -p $(FUZZ_BUILD_DIR)/corpus
-	@ASAN_OPTIONS=strict_string_checks=1 UBSAN_OPTIONS=print_stacktrace=1 \
+	@ASAN_OPTIONS=strict_string_checks=1 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 \
 		$(FUZZ_BUILD_DIR)/fuzz_intake \
 			-max_total_time=$(FUZZ_SECONDS) -max_len=1048576 -timeout=10 \
 			-dict=test/fuzz/intake.dict \


### PR DESCRIPTION
## Summary

Two of the gates from #910 that could not fail, both measured rather than argued.

### UBSan findings did not fail the build

The blocking `Linux sanitizers` job builds with `-fsanitize=address,undefined`, but UBSan was left in recover mode: a diagnostic printed `runtime error: ...` and execution continued, so the doctest binary exited 0, ctest reported Passed, and because ctest runs with `--output-on-failure` the diagnostic was not even shown in the log.

Measured in-tree by injecting a deliberate signed overflow into `calculateFlowAndInitNetwork`, which every test reaches:

| | `make test-sanitizers` | `runtime error` lines in the log |
|---|---|---|
| before this change | **exit 0** | **0** |
| after | exit 2 | 13 |

Fixed with `-fno-sanitize-recover=undefined` at all three sanitizer sites — the core plus both fuzz configurations, so `make fuzz` is no longer blind to UB either — and `halt_on_error=1` added to `UBSAN_OPTIONS` in both recipes as a runtime backstop.

**The suite is clean under the stricter setting**, so this does not turn CI red: a full `make test-sanitizers` on the unmodified tree exits 0 with no findings, with `-fno-sanitize-recover=undefined` confirmed present in the generated `flags.make`.

### Three tracked paths matched no filter

`ci-summary` accepts `"skipped"` as success, so a pull request touching only these ran **zero** jobs — not even the `pre-commit` hygiene gate — and reported a green required check:

- **`scripts/render_parameter_policy.py`** — `generate_binding_options.py` imports it and splices its output into the tracked `interfaces/parameters/policy.md`, so it is a generator input. Added next to `generate_binding_options.py` and `parameter_catalog.py` in the `javascript` filter, which is where the binding-options freshness gate runs.
- **`test/fuzz/**`** and **`test/bench/**`** — built only by schedule-triggered or opt-in targets (`make fuzz`, `bench-native`), so no lane filter covered them. Added to the `meta` filter, which exists for exactly this failure mode: its own comment says the anchors were introduced because `release.yml`, `fuzz.yml` and `.pre-commit-config.yaml` previously matched nothing.

Verified by expanding the YAML and matching each path against every pattern: all three now match, and none did before.

## Verification

- `make test-sanitizers` — exit 0 clean; exit 2 with an injected UB; exit 0 with the injected UB *and* the flags removed, i.e. the before/after table above
- `make test-native` — exit 0
- `check yaml` pre-commit hook passed; `actionlint` had no workflow files to check since only `filters.yml` changed

## Notes

The third item in #910 — `verify-master-ci` being unable to distinguish "every lane green except a setup flake" from "no lane ran at all" — is deliberately left out. It needs a decision about what "acceptable master" should mean, and it touches release machinery, so it does not belong in a mechanical PR with two measured fixes.

Also untouched: the Python SWIG freshness gate being skipped on every PR, and the binding-options gate living only in the JS lane whose filter excludes three of the five artifacts it owns. Both are filter-shape decisions rather than holes, and both are still recorded in #910.
