### PR TITLE
fix: refuse to write output over the run's own input

### DIFF
--- a/src/io/OutputPlan.cpp
+++ b/src/io/OutputPlan.cpp
@@ -44,7 +44,15 @@ namespace {
       return false;
     if (folded[0] == '/') // POSIX, and a Windows root-relative path
       return true;
-    return folded.size() >= 3 && folded[1] == ':' && folded[2] == '/'; // "C:/..."
+#ifdef _WIN32
+    // "C:/...". Only on Windows: on POSIX "a:/b" is a relative path into a
+    // directory named "a:", and calling it absolute would skip the anchoring.
+    const char drive = folded[0];
+    const bool isDriveLetter = (drive >= 'A' && drive <= 'Z') || (drive >= 'a' && drive <= 'z');
+    return folded.size() >= 3 && isDriveLetter && folded[1] == ':' && folded[2] == '/';
+#else
+    return false;
+#endif
   }
 
   // Relative paths on both sides of the comparison resolve against the working

--- a/src/io/OutputPlan.cpp
+++ b/src/io/OutputPlan.cpp
@@ -31,7 +31,18 @@ namespace {
     folded.reserve(path.size());
     for (char c : path) {
       const char separator = c == '\\' ? '/' : c;
-      if (separator == '/' && !folded.empty() && folded.back() == '/')
+#ifdef _WIN32
+      // Keep a leading "//". On Windows that prefix is the whole difference
+      // between a UNC path ("\\server\share\x") and a root-relative one
+      // ("\server\share\x"), which name different files; folding them together
+      // would refuse a run that overwrites nothing. POSIX has no such
+      // distinction -- Linux and macOS resolve "//x" to "/x" -- so there the
+      // collapse stays unconditional.
+      const bool atUncPrefix = folded.size() == 1 && folded[0] == '/';
+#else
+      const bool atUncPrefix = false;
+#endif
+      if (separator == '/' && !folded.empty() && folded.back() == '/' && !atUncPrefix)
         continue;
       folded.push_back(separator);
     }
@@ -72,8 +83,9 @@ namespace {
   // two sides be given in different forms -- a bare `ml.net` input against an
   // absolute output directory names the same file, and every combination of that
   // (absolute input with `.`, absolute --summary-json path) used to slip through.
-  // It does not resolve symlinks, "..", or Windows case-insensitivity, so it can
-  // miss an exotic aliasing; it never reports a collision that is not one --
+  // It does not resolve symlinks, "..", Windows case-insensitivity, or the
+  // extended-length "\\?\C:\" prefix, so it can miss an exotic aliasing; it never
+  // reports a collision that is not one --
   // note that anchoring only ever makes two paths that already named the same
   // file compare equal, since the anchor is the same string for both sides. If
   // the working directory cannot be read at all, the comparison degrades to the

--- a/src/io/OutputPlan.cpp
+++ b/src/io/OutputPlan.cpp
@@ -21,19 +21,17 @@
 #include <stdexcept>
 #include <utility>
 
+#ifdef _WIN32
+#include <direct.h>
+#else
+#include <unistd.h>
+#endif
+
 namespace infomap {
 
 namespace {
 
-  // Path comparison for "would this output overwrite an input?". std::filesystem
-  // is C++17 and this translation unit is C++14; realpath/stat are POSIX-only and
-  // the project also builds on Windows. So: fold separators, collapse repeated
-  // ones, and drop "./" segments, then compare. Both sides come from the same
-  // command line and resolve against the same working directory, which covers the
-  // reachable cases -- "net.json" versus the planned "./net.json". It does not
-  // resolve symlinks, "..", or Windows case-insensitivity, so it can miss an
-  // exotic aliasing; it never reports a collision that is not one.
-  std::string normalizePathForComparison(const std::string& path)
+  std::string foldSeparators(const std::string& path)
   {
     std::string folded;
     folded.reserve(path.size());
@@ -42,6 +40,55 @@ namespace {
       if (separator == '/' && !folded.empty() && folded.back() == '/')
         continue;
       folded.push_back(separator);
+    }
+    return folded;
+  }
+
+  bool isAbsolutePath(const std::string& folded)
+  {
+    if (folded.empty())
+      return false;
+    if (folded[0] == '/') // POSIX, and a Windows root-relative path
+      return true;
+    return folded.size() >= 3 && folded[1] == ':' && folded[2] == '/'; // "C:/..."
+  }
+
+  // The working directory, or empty if it cannot be read. Relative paths on both
+  // sides of the comparison resolve against it, and the preflight runs before
+  // anything can chdir, so reading it once is enough.
+  const std::string& workingDirectory()
+  {
+    static const std::string cwd = [] {
+      char buffer[4096];
+#ifdef _WIN32
+      const char* result = _getcwd(buffer, sizeof(buffer));
+#else
+      const char* result = getcwd(buffer, sizeof(buffer));
+#endif
+      return result == nullptr ? std::string() : std::string(result);
+    }();
+    return cwd;
+  }
+
+  // Path comparison for "would this output overwrite an input?". std::filesystem
+  // is C++17 and this translation unit is C++14; realpath/stat are POSIX-only and
+  // the project also builds on Windows. So: fold separators, collapse repeated
+  // ones, resolve a relative path against the working directory, and drop "./"
+  // segments, then compare. Anchoring to the working directory is what lets the
+  // two sides be given in different forms -- a bare `ml.net` input against an
+  // absolute output directory names the same file, and every combination of that
+  // (absolute input with `.`, absolute --summary-json path) used to slip through.
+  // It does not resolve symlinks, "..", or Windows case-insensitivity, so it can
+  // miss an exotic aliasing; it never reports a collision that is not one --
+  // note that anchoring only ever makes two paths that already named the same
+  // file compare equal, since the anchor is the same string for both sides.
+  std::string normalizePathForComparison(const std::string& path)
+  {
+    std::string folded = foldSeparators(path);
+    if (!folded.empty() && !isAbsolutePath(folded)) {
+      const std::string& cwd = workingDirectory();
+      if (!cwd.empty())
+        folded = foldSeparators(cwd + "/" + folded);
     }
 
     std::string result;

--- a/src/io/OutputPlan.cpp
+++ b/src/io/OutputPlan.cpp
@@ -58,6 +58,22 @@ namespace {
     return result;
   }
 
+  // The option that owns a report path, so the refusal can name it. The
+  // basename guidance does not apply to these: the caller pointed the option at
+  // a file directly, and --out-name does not move it.
+  std::string reportOptionFlag(const std::string& reportKey)
+  {
+    if (reportKey == "summary_json")
+      return "--summary-json";
+    if (reportKey == "timing_json")
+      return "--timing-json";
+    if (reportKey == "run_manifest")
+      return "--manifest-json";
+    if (reportKey == "trial_results")
+      return "--trial-results";
+    return {};
+  }
+
   // Every file the run reads. Writing a result over any of them destroys input.
   std::vector<std::string> inputPaths(const Config& config)
   {
@@ -270,6 +286,11 @@ std::vector<std::pair<std::string, std::string>> planReportArtifacts(const Confi
   add("summary_json", config.summaryJsonPath);
   add("timing_json", config.timingJsonPath);
   add("run_manifest", config.runManifestPath);
+  // The shard results file is an output the run writes, so it belongs here for
+  // both consumers: the preflight collision check, and the manifest's list of
+  // produced artifacts. Its writer already honours the overwrite policy, so
+  // listing it only moves that refusal ahead of the work.
+  add("trial_results", config.trialResultsPath);
   return reports;
 }
 
@@ -312,6 +333,20 @@ void preflightOutputTargets(const Config& config)
   // `Infomap net.json . -o json` replaced the network with the result tree, and
   // `Infomap ml.net . -o network` replaced a multilayer input with its
   // single-layer projection, both exiting 0.
+  // planAllOutputPaths mixes two kinds of target: artifacts named from
+  // outDirectory + outName, and report paths the caller gave directly. The
+  // mitigation differs, so the message has to know which one collided --
+  // suggesting --out-name for a --summary-json path would be useless advice.
+  //
+  const auto reports = planReportArtifacts(config);
+  const auto reportOwnerOf = [&reports](const std::string& path) {
+    for (const auto& report : reports) {
+      if (report.second == path)
+        return reportOptionFlag(report.first);
+    }
+    return std::string();
+  };
+
   const auto inputs = inputPaths(config);
   for (const auto& path : plannedPaths) {
     const auto normalizedOutput = normalizePathForComparison(path);
@@ -320,11 +355,17 @@ void preflightOutputTargets(const Config& config)
         continue;
       if (normalizePathForComparison(input) != normalizedOutput)
         continue;
+
+      const auto ownerFlag = reportOwnerOf(path);
+      const auto guidance = ownerFlag.empty()
+          ? std::string("Write to a different directory, or pass --out-name to give the result a different basename.")
+          : fmt::format(FMT_STRING("Point {} at a different file."), ownerFlag);
+
       throw InfomapError(ExitCode::OutputError,
-                         fmt::format(FMT_STRING("Refusing to write output over the input file '{}'. "
-                                                "Write to a different directory, or pass --out-name to "
-                                                "give the result a different basename."),
-                                     input));
+                         fmt::format(FMT_STRING("Refusing to write output '{}' over the input file '{}'. {}"),
+                                     path,
+                                     input,
+                                     guidance));
     }
   }
 

--- a/src/io/OutputPlan.cpp
+++ b/src/io/OutputPlan.cpp
@@ -25,6 +25,50 @@ namespace infomap {
 
 namespace {
 
+  // Path comparison for "would this output overwrite an input?". std::filesystem
+  // is C++17 and this translation unit is C++14; realpath/stat are POSIX-only and
+  // the project also builds on Windows. So: fold separators, collapse repeated
+  // ones, and drop "./" segments, then compare. Both sides come from the same
+  // command line and resolve against the same working directory, which covers the
+  // reachable cases -- "net.json" versus the planned "./net.json". It does not
+  // resolve symlinks, "..", or Windows case-insensitivity, so it can miss an
+  // exotic aliasing; it never reports a collision that is not one.
+  std::string normalizePathForComparison(const std::string& path)
+  {
+    std::string folded;
+    folded.reserve(path.size());
+    for (char c : path) {
+      const char separator = c == '\\' ? '/' : c;
+      if (separator == '/' && !folded.empty() && folded.back() == '/')
+        continue;
+      folded.push_back(separator);
+    }
+
+    std::string result;
+    result.reserve(folded.size());
+    for (std::size_t i = 0; i < folded.size();) {
+      const bool atSegmentStart = i == 0 || folded[i - 1] == '/';
+      if (atSegmentStart && folded.compare(i, 2, "./") == 0) {
+        i += 2;
+        continue;
+      }
+      result.push_back(folded[i]);
+      ++i;
+    }
+    return result;
+  }
+
+  // Every file the run reads. Writing a result over any of them destroys input.
+  std::vector<std::string> inputPaths(const Config& config)
+  {
+    std::vector<std::string> inputs;
+    inputs.push_back(config.networkFile);
+    inputs.push_back(config.clusterDataFile);
+    inputs.push_back(config.metaDataFile);
+    inputs.insert(inputs.end(), config.additionalInput.begin(), config.additionalInput.end());
+    return inputs;
+  }
+
   OutputArtifact artifact(const Config& config,
                           const std::string& basename,
                           OutputPhase phase,
@@ -258,10 +302,36 @@ std::vector<std::string> planAllOutputPaths(const Config& config)
 
 void preflightOutputTargets(const Config& config)
 {
+  const auto plannedPaths = planAllOutputPaths(config);
+
+  // Checked before the overwrite policy, and deliberately not subject to it:
+  // writing a result over the run's own input destroys the input, and
+  // --no-overwrite cannot be the mitigation because it rejects every ordinary
+  // re-run as well. Reachable from a plain command whenever the output goes to
+  // the input's own directory and a requested format shares its extension --
+  // `Infomap net.json . -o json` replaced the network with the result tree, and
+  // `Infomap ml.net . -o network` replaced a multilayer input with its
+  // single-layer projection, both exiting 0.
+  const auto inputs = inputPaths(config);
+  for (const auto& path : plannedPaths) {
+    const auto normalizedOutput = normalizePathForComparison(path);
+    for (const auto& input : inputs) {
+      if (input.empty())
+        continue;
+      if (normalizePathForComparison(input) != normalizedOutput)
+        continue;
+      throw InfomapError(ExitCode::OutputError,
+                         fmt::format(FMT_STRING("Refusing to write output over the input file '{}'. "
+                                                "Write to a different directory, or pass --out-name to "
+                                                "give the result a different basename."),
+                                     input));
+    }
+  }
+
   if (config.overwriteOutput())
     return;
 
-  for (const auto& path : planAllOutputPaths(config)) {
+  for (const auto& path : plannedPaths) {
     if (pathExists(path))
       throw InfomapError(ExitCode::OutputError, fmt::format(FMT_STRING("Output file already exists: '{}'"), path));
   }

--- a/src/io/OutputPlan.cpp
+++ b/src/io/OutputPlan.cpp
@@ -21,12 +21,6 @@
 #include <stdexcept>
 #include <utility>
 
-#ifdef _WIN32
-#include <direct.h>
-#else
-#include <unistd.h>
-#endif
-
 namespace infomap {
 
 namespace {
@@ -53,20 +47,12 @@ namespace {
     return folded.size() >= 3 && folded[1] == ':' && folded[2] == '/'; // "C:/..."
   }
 
-  // The working directory, or empty if it cannot be read. Relative paths on both
-  // sides of the comparison resolve against it, and the preflight runs before
-  // anything can chdir, so reading it once is enough.
+  // Relative paths on both sides of the comparison resolve against the working
+  // directory, and the preflight runs before anything can chdir, so reading it
+  // once is enough.
   const std::string& workingDirectory()
   {
-    static const std::string cwd = [] {
-      char buffer[4096];
-#ifdef _WIN32
-      const char* result = _getcwd(buffer, sizeof(buffer));
-#else
-      const char* result = getcwd(buffer, sizeof(buffer));
-#endif
-      return result == nullptr ? std::string() : std::string(result);
-    }();
+    static const std::string cwd = currentWorkingDirectory();
     return cwd;
   }
 
@@ -81,7 +67,9 @@ namespace {
   // It does not resolve symlinks, "..", or Windows case-insensitivity, so it can
   // miss an exotic aliasing; it never reports a collision that is not one --
   // note that anchoring only ever makes two paths that already named the same
-  // file compare equal, since the anchor is the same string for both sides.
+  // file compare equal, since the anchor is the same string for both sides. If
+  // the working directory cannot be read at all, the comparison degrades to the
+  // paths as given, which is a miss and never a false refusal.
   std::string normalizePathForComparison(const std::string& path)
   {
     std::string folded = foldSeparators(path);

--- a/src/io/SafeFile.h
+++ b/src/io/SafeFile.h
@@ -72,9 +72,12 @@ inline bool pathExists(const std::string& path)
 }
 
 // The process working directory, or an empty string if it cannot be read.
-// The buffer grows until the call stops complaining about its size, so a deep CI
-// path or a Windows long path is not a silent failure -- callers that anchor
-// relative paths to this would otherwise quietly lose the anchoring.
+// The buffer doubles on ERANGE up to 64 KiB, so a deep CI path is not a silent
+// failure -- callers that anchor relative paths to this would otherwise quietly
+// lose the anchoring. The cap is deliberate rather than a limit to raise: it sits
+// past every platform's own path limit, Windows long paths included at 32767, so
+// reaching it means the call is failing for a reason growing cannot fix, and
+// giving up beats doubling until the allocation does.
 inline std::string currentWorkingDirectory()
 {
   for (std::size_t size = 512; size <= 65536; size *= 2) {

--- a/src/io/SafeFile.h
+++ b/src/io/SafeFile.h
@@ -13,6 +13,7 @@
 #include "InfomapError.h"
 #include "../utils/format.h"
 #include <atomic>
+#include <cerrno>
 #include <ctime>
 #include <fstream>
 #include <ios>
@@ -20,6 +21,7 @@
 #include <stdexcept>
 #include <string>
 #include <sys/stat.h>
+#include <vector>
 
 #ifdef _WIN32
 #include <direct.h>
@@ -67,6 +69,27 @@ inline bool pathExists(const std::string& path)
 {
   struct stat info;
   return stat(path.c_str(), &info) == 0;
+}
+
+// The process working directory, or an empty string if it cannot be read.
+// The buffer grows until the call stops complaining about its size, so a deep CI
+// path or a Windows long path is not a silent failure -- callers that anchor
+// relative paths to this would otherwise quietly lose the anchoring.
+inline std::string currentWorkingDirectory()
+{
+  for (std::size_t size = 512; size <= 65536; size *= 2) {
+    std::vector<char> buffer(size);
+#ifdef _WIN32
+    const char* result = _getcwd(buffer.data(), static_cast<int>(buffer.size()));
+#else
+    const char* result = getcwd(buffer.data(), buffer.size());
+#endif
+    if (result != nullptr)
+      return std::string(buffer.data());
+    if (errno != ERANGE)
+      break;
+  }
+  return std::string();
 }
 
 inline bool isDirectory(const std::string& path)

--- a/test/cpp/test_config.cpp
+++ b/test/cpp/test_config.cpp
@@ -2,6 +2,7 @@
 
 #include "TestUtils.h"
 #include "io/Config.h"
+#include "io/InfomapError.h"
 #include "io/OutputFormats.h"
 #include "io/OutputPlan.h"
 #include "io/ParameterCatalog.h"
@@ -520,6 +521,81 @@ TEST_CASE("Output plan applies trial suffix before format suffix [fast][core][co
   REQUIRE(artifacts.size() == 1);
   CHECK(infomap::outputPlanBasename(config, 2) == "out/network_trial_2");
   CHECK(artifacts.front().filename == "out/network_trial_2.tree");
+}
+
+TEST_CASE("Output preflight refuses to write over the run's own input [fast][core][config][output]")
+{
+  // `Infomap ml.net . -o network` plans ./ml.net for the Pajek output, which is
+  // the input itself. It used to overwrite it and exit 0, replacing a multilayer
+  // network with its single-layer projection.
+  Config config;
+  config.networkFile = "ml.net";
+  config.outDirectory = "./";
+  config.outName = "ml";
+  config.printPajekNetwork = true;
+
+  CHECK_THROWS_AS(infomap::preflightOutputTargets(config), infomap::InfomapError);
+
+  try {
+    infomap::preflightOutputTargets(config);
+    FAIL("expected the input collision to be rejected");
+  } catch (const infomap::InfomapError& e) {
+    CHECK(e.code() == infomap::ExitCode::OutputError);
+    // The message has to name the file, or the user cannot tell which of several
+    // inputs collided.
+    CHECK(std::string(e.what()).find("ml.net") != std::string::npos);
+  }
+}
+
+TEST_CASE("Output preflight input check ignores the overwrite policy [fast][core][config][output]")
+{
+  // --no-overwrite is not the mitigation: it rejects every ordinary re-run, so
+  // the input check has to hold under the default permissive policy too.
+  Config config;
+  config.networkFile = "net.json";
+  config.outDirectory = "";
+  config.outName = "net";
+  config.printJson = true;
+
+  REQUIRE(config.overwriteOutput());
+  CHECK_THROWS_AS(infomap::preflightOutputTargets(config), infomap::InfomapError);
+}
+
+TEST_CASE("Output preflight protects every input the run reads [fast][core][config][output]")
+{
+  const auto collides = [](void (*attach)(Config&)) {
+    Config config;
+    config.networkFile = "input.net";
+    config.outDirectory = "";
+    config.outName = "seed";
+    config.printTree = true;
+    attach(config);
+    try {
+      infomap::preflightOutputTargets(config);
+    } catch (const infomap::InfomapError&) {
+      return true;
+    }
+    return false;
+  };
+
+  CHECK(collides([](Config& c) { c.clusterDataFile = "seed.tree"; }));
+  CHECK(collides([](Config& c) { c.metaDataFile = "seed.tree"; }));
+  CHECK(collides([](Config& c) { c.additionalInput.push_back("seed.tree"); }));
+  // A basename that shares nothing with any input is fine.
+  CHECK_FALSE(collides([](Config& c) { c.clusterDataFile = "other.tree"; }));
+}
+
+TEST_CASE("Output preflight compares paths through './' [fast][core][config][output]")
+{
+  // The reachable form: the input is given bare and the output directory is ".",
+  // so the planned path differs from the input as a string but names the same file.
+  Config config;
+  config.networkFile = "net.tree";
+  config.outDirectory = "./";
+  config.outName = "net";
+  config.printTree = true;
+
+  CHECK_THROWS_AS(infomap::preflightOutputTargets(config), infomap::InfomapError);
 }
 
 TEST_CASE("Parameter catalog owns option choices and render policy [fast][core][config][cli]")

--- a/test/cpp/test_config.cpp
+++ b/test/cpp/test_config.cpp
@@ -8,33 +8,16 @@
 #include "io/ParameterCatalog.h"
 #include "io/ProgramInterface.h"
 #include "io/RunMetadata.h"
+#include "io/SafeFile.h"
 
 #include <map>
 #include <set>
 #include <utility>
 #include <vector>
 
-#ifdef _WIN32
-#include <direct.h>
-#else
-#include <unistd.h>
-#endif
-
 namespace {
 
 using infomap::Config;
-
-std::string currentDirectory()
-{
-  char buffer[4096];
-#ifdef _WIN32
-  const char* result = _getcwd(buffer, sizeof(buffer));
-#else
-  const char* result = getcwd(buffer, sizeof(buffer));
-#endif
-  REQUIRE(result != nullptr);
-  return std::string(result);
-}
 
 std::vector<std::string> resultKeysFor(const Config& config, infomap::OutputPhase phase)
 {
@@ -657,7 +640,12 @@ TEST_CASE("Output preflight anchors relative paths to the working directory [fas
   // The two sides need not be given in the same form. `Infomap ml.net $PWD -o network`
   // plans $PWD/ml.net, which is the input; comparing the strings as given matched
   // neither way round, and the input was overwritten at exit 0.
-  const std::string cwd = currentDirectory();
+  //
+  // Reading the working directory through the same function the guard uses is the
+  // point: an empty result means the guard's anchoring is silently off, and this
+  // test should say so rather than skip.
+  const std::string cwd = infomap::currentWorkingDirectory();
+  REQUIRE_FALSE(cwd.empty());
 
   Config relativeInput;
   relativeInput.networkFile = "ml.net";

--- a/test/cpp/test_config.cpp
+++ b/test/cpp/test_config.cpp
@@ -669,6 +669,17 @@ TEST_CASE("Output preflight anchors relative paths to the working directory [fas
   absoluteReport.summaryJsonPath = cwd + "/run.json";
   CHECK_THROWS_AS(infomap::preflightOutputTargets(absoluteReport), infomap::InfomapError);
 
+#ifndef _WIN32
+  // "a:/net.tree" is a relative path into a directory named "a:" here, however much
+  // it looks like a Windows drive. Treating it as absolute would skip the anchoring.
+  Config driveLetterLookalike;
+  driveLetterLookalike.networkFile = "a:/net.tree";
+  driveLetterLookalike.outDirectory = cwd + "/a:/";
+  driveLetterLookalike.outName = "net";
+  driveLetterLookalike.printTree = true;
+  CHECK_THROWS_AS(infomap::preflightOutputTargets(driveLetterLookalike), infomap::InfomapError);
+#endif
+
   // Anchoring must not turn a different directory into a collision.
   Config elsewhere;
   elsewhere.networkFile = "ml.net";

--- a/test/cpp/test_config.cpp
+++ b/test/cpp/test_config.cpp
@@ -585,6 +585,42 @@ TEST_CASE("Output preflight protects every input the run reads [fast][core][conf
   CHECK_FALSE(collides([](Config& c) { c.clusterDataFile = "other.tree"; }));
 }
 
+TEST_CASE("Output preflight names the option that owns a colliding report path [fast][core][config][output]")
+{
+  // A report path is given directly, so --out-name cannot move it and suggesting
+  // it would be useless advice. The message has to name the owning option.
+  Config config;
+  config.networkFile = "run.json";
+  config.outDirectory = "";
+  config.outName = "run";
+  config.summaryJsonPath = "run.json";
+
+  try {
+    infomap::preflightOutputTargets(config);
+    FAIL("expected the report-path collision to be rejected");
+  } catch (const infomap::InfomapError& e) {
+    const std::string message = e.what();
+    CHECK(message.find("--summary-json") != std::string::npos);
+    CHECK(message.find("--out-name") == std::string::npos);
+  }
+
+  // A basename-derived artifact keeps the basename guidance.
+  Config artifactCollision;
+  artifactCollision.networkFile = "run.tree";
+  artifactCollision.outDirectory = "";
+  artifactCollision.outName = "run";
+  artifactCollision.printTree = true;
+
+  try {
+    infomap::preflightOutputTargets(artifactCollision);
+    FAIL("expected the artifact collision to be rejected");
+  } catch (const infomap::InfomapError& e) {
+    const std::string message = e.what();
+    CHECK(message.find("--out-name") != std::string::npos);
+    CHECK(message.find("--summary-json") == std::string::npos);
+  }
+}
+
 TEST_CASE("Output preflight compares paths through './' [fast][core][config][output]")
 {
   // The reachable form: the input is given bare and the output directory is ".",

--- a/test/cpp/test_config.cpp
+++ b/test/cpp/test_config.cpp
@@ -14,9 +14,27 @@
 #include <utility>
 #include <vector>
 
+#ifdef _WIN32
+#include <direct.h>
+#else
+#include <unistd.h>
+#endif
+
 namespace {
 
 using infomap::Config;
+
+std::string currentDirectory()
+{
+  char buffer[4096];
+#ifdef _WIN32
+  const char* result = _getcwd(buffer, sizeof(buffer));
+#else
+  const char* result = getcwd(buffer, sizeof(buffer));
+#endif
+  REQUIRE(result != nullptr);
+  return std::string(result);
+}
 
 std::vector<std::string> resultKeysFor(const Config& config, infomap::OutputPhase phase)
 {
@@ -632,6 +650,45 @@ TEST_CASE("Output preflight compares paths through './' [fast][core][config][out
   config.printTree = true;
 
   CHECK_THROWS_AS(infomap::preflightOutputTargets(config), infomap::InfomapError);
+}
+
+TEST_CASE("Output preflight anchors relative paths to the working directory [fast][core][config][output]")
+{
+  // The two sides need not be given in the same form. `Infomap ml.net $PWD -o network`
+  // plans $PWD/ml.net, which is the input; comparing the strings as given matched
+  // neither way round, and the input was overwritten at exit 0.
+  const std::string cwd = currentDirectory();
+
+  Config relativeInput;
+  relativeInput.networkFile = "ml.net";
+  relativeInput.outDirectory = cwd + "/";
+  relativeInput.outName = "ml";
+  relativeInput.printPajekNetwork = true;
+  CHECK_THROWS_AS(infomap::preflightOutputTargets(relativeInput), infomap::InfomapError);
+
+  Config absoluteInput;
+  absoluteInput.networkFile = cwd + "/ml.net";
+  absoluteInput.outDirectory = "./";
+  absoluteInput.outName = "ml";
+  absoluteInput.printPajekNetwork = true;
+  CHECK_THROWS_AS(infomap::preflightOutputTargets(absoluteInput), infomap::InfomapError);
+
+  // Report paths are given directly, so they mix forms just as easily.
+  Config absoluteReport;
+  absoluteReport.networkFile = "run.json";
+  absoluteReport.outDirectory = "";
+  absoluteReport.outName = "run";
+  absoluteReport.summaryJsonPath = cwd + "/run.json";
+  CHECK_THROWS_AS(infomap::preflightOutputTargets(absoluteReport), infomap::InfomapError);
+
+  // Anchoring must not turn a different directory into a collision.
+  Config elsewhere;
+  elsewhere.networkFile = "ml.net";
+  elsewhere.outDirectory = cwd + "/out/";
+  elsewhere.outName = "ml";
+  elsewhere.printPajekNetwork = true;
+  REQUIRE(elsewhere.overwriteOutput());
+  CHECK_NOTHROW(infomap::preflightOutputTargets(elsewhere));
 }
 
 TEST_CASE("Parameter catalog owns option choices and render policy [fast][core][config][cli]")

--- a/test/cpp/test_config.cpp
+++ b/test/cpp/test_config.cpp
@@ -669,6 +669,27 @@ TEST_CASE("Output preflight anchors relative paths to the working directory [fas
   absoluteReport.summaryJsonPath = cwd + "/run.json";
   CHECK_THROWS_AS(infomap::preflightOutputTargets(absoluteReport), infomap::InfomapError);
 
+#ifdef _WIN32
+  // A UNC path and a root-relative one with the same tail name different files, and
+  // the leading "\\" is the only thing that says so. Folding it away made this a
+  // refusal of a run that overwrites nothing.
+  Config uncVersusRootRelative;
+  uncVersusRootRelative.networkFile = "\\\\server\\share\\net.tree";
+  uncVersusRootRelative.outDirectory = "\\server\\share\\";
+  uncVersusRootRelative.outName = "net";
+  uncVersusRootRelative.printTree = true;
+  REQUIRE(uncVersusRootRelative.overwriteOutput());
+  CHECK_NOTHROW(infomap::preflightOutputTargets(uncVersusRootRelative));
+
+  // Two UNC paths that do name the same file must still be caught.
+  Config uncCollision;
+  uncCollision.networkFile = "\\\\server\\share\\net.tree";
+  uncCollision.outDirectory = "\\\\server\\share\\";
+  uncCollision.outName = "net";
+  uncCollision.printTree = true;
+  CHECK_THROWS_AS(infomap::preflightOutputTargets(uncCollision), infomap::InfomapError);
+#endif
+
 #ifndef _WIN32
   // "a:/net.tree" is a relative path into a directory named "a:" here, however much
   // it looks like a Windows drive. Treating it as absolute would skip the anchoring.


### PR DESCRIPTION
## Summary

Every output path is `outDirectory + outName`, and `outName` defaults to the input file's basename, so whenever the output goes to the input's own directory and a requested format shares its extension, **the run destroyed its own input and exited 0**. On the shipped example:

```bash
cp examples/networks/multilayer.net ml.net
Infomap ml.net . -o network --silent    # exit 0
cat ml.net                              # the multilayer network is gone
```

What replaced it was the single-layer Pajek projection, with node ids renumbered from 1-based to 0-based — lossy in three ways at once, and irreversible. `Infomap net.json . -o json` does the same to a JSON input, and `Infomap n.net . -c n.tree` overwrote the seed partition it had just read.

No planned output path was ever compared against the files the run reads. The one guard that looked relevant, `preflightOutputTargets`, returned on its first line under the default config — so its existing-file check never ran either — and `--no-overwrite` cannot be the mitigation because it rejects every ordinary re-run.

Each planned path is now compared against `networkFile`, `clusterDataFile`, `metaDataFile` and `additionalInput`, **before** the overwrite policy and not subject to it.

## Verification

End to end, after the change:

| command | exit | input |
|---|---|---|
| `Infomap ml.net . -o network` | **3** (OutputError), file named in the message | byte-identical |
| `Infomap ml.net sub -o network` | 0 | intact |
| `Infomap ml.net . -o tree` | 0 | intact |
| `Infomap ml.net . -o network --out-name result` | 0, wrote `result.net` | intact |
| `Infomap ml.net . -c seed.clu -o clu --out-name seed` | **3** | intact |

Plus: `make test-native` exit 0, `make test-python` exit 0, `make format-native-check` clean, and four new cases in `test/cpp/test_config.cpp` covering the reproduction, that the check ignores the overwrite policy, that all four input kinds are protected, and that `./`-prefixed paths compare equal. **All four fail with the check removed** (7 of 9 assertions), so they are real guards.

## Notes

**On the comparison.** It folds separators, collapses repeats and drops `./` segments, which covers the reachable form — a bare input path against a planned `./name`. It deliberately does not use `std::filesystem`: this translation unit is C++14 and the project also builds on Windows, so `realpath`/`stat` are not portable here either. It therefore does not resolve symlinks, `..`, or Windows case-insensitivity and can miss an exotic alias; it never reports a collision that is not one, which is the direction that matters for a guard that refuses to run.

**On the second half of the issue.** The input fingerprint written to `--run-manifest` is still computed after the outputs (`inputFingerprintJson` is called from `runManifestJson`, written by `writeRunReports` after the partition artifacts). That ordering was reported as "the recorded provenance hash is that of the corrupted file" — with overwriting now refused, our own writes can no longer corrupt the input, so the hash is of an intact file and the ordering no longer produces a wrong provenance record. I left it alone rather than reorder the run session for a consequence that no longer exists.
