### PR TITLE
fix: honor an explicit single-trial cap for --converge

### DIFF
--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -120,25 +120,29 @@ namespace {
       config.numTrials = 1;
     }
 
-    // --converge reinterprets numTrials as a cap, and falls back to a default cap
-    // when the caller did not give one. "Did not give one" is read from
-    // parsedOptions rather than from the value: numTrials == 1 was previously used
-    // as the sentinel, which silently rewrote an explicit `-N 1 --converge` to 50
-    // trials and could change the reported result. A cap of one makes --converge a
-    // no-op, but that is the caller's call to make.
+    // --converge reinterprets numTrials as a cap, and falls back to the default cap
+    // when the caller did not give one. Both signals are needed to decide that:
+    //   * the value, because a library caller mutates the struct and calls
+    //     adaptDefaults(), leaving parsedOptions empty -- provenance alone would
+    //     read a deliberate numTrials = 4 as "not given" and overwrite it;
+    //   * the provenance, because numTrials == 1 was the sole sentinel before, and
+    //     as the option's minimum it is also what an explicit `-N 1 --converge`
+    //     produces, which was silently rewritten to the default cap. A cap of one
+    //     makes --converge a no-op, but that is the caller's call to make.
     //
-    // Reaches the CLI only, for two reasons worth writing down:
-    //   * parsedOptions is empty when a Config is mutated programmatically and
-    //     adaptDefaults() is called by hand (the C++ library path);
+    // So the fix reaches the CLI only, and two paths keep the old behaviour:
+    //   * a library caller who sets numTrials = 1 deliberately still gets the
+    //     default cap, since nothing distinguishes that from leaving it untouched;
     //   * the Python/R bindings do parse an argument string, but their option
     //     renderer omits any value equal to its default, so `num_trials=1` with
-    //     `converge=True` renders no --num-trials at all and still gets the
-    //     default cap (measured: 6 trials on unbalanced_hierarchy either way).
+    //     `converge=True` renders no --num-trials at all (measured: 6 trials on
+    //     unbalanced_hierarchy either way).
     // That elision was assumed behaviour-preserving because the rendered defaults
     // come from this catalog -- this option is the counter-example, since
     // --converge makes "given as 1" mean something different from "not given".
     // Fixing it belongs in the generator (the residue recorded in #914).
-    if (config.convergeTrials && !config.noInfomap && !numTrialsGivenExplicitly(config)) {
+    const bool trialCapWasChosen = numTrialsGivenExplicitly(config) || config.numTrials != 1;
+    if (config.convergeTrials && !config.noInfomap && !trialCapWasChosen) {
       config.numTrials = Config::convergeDefaultMaxTrials;
     }
   }

--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -99,6 +99,17 @@ namespace {
     }
   }
 
+  // Whether the caller actually passed --num-trials/-N, as opposed to landing on
+  // its default. parsedOptions records the long name whichever form was typed.
+  bool numTrialsGivenExplicitly(const Config& config)
+  {
+    for (const auto& option : config.parsedOptions) {
+      if (option.longName == "num-trials")
+        return true;
+    }
+    return false;
+  }
+
   void applyOptionInteractions(Config& config)
   {
     if (config.regularized) {
@@ -109,10 +120,25 @@ namespace {
       config.numTrials = 1;
     }
 
-    // --converge reinterprets numTrials as a cap. numTrials has min=1, so a value
-    // of 1 is the unspecified/default sentinel; treat it as "no explicit -N" and
-    // use the default cap (a single-trial cap would make --converge a no-op).
-    if (config.convergeTrials && config.numTrials == 1 && !config.noInfomap) {
+    // --converge reinterprets numTrials as a cap, and falls back to a default cap
+    // when the caller did not give one. "Did not give one" is read from
+    // parsedOptions rather than from the value: numTrials == 1 was previously used
+    // as the sentinel, which silently rewrote an explicit `-N 1 --converge` to 50
+    // trials and could change the reported result. A cap of one makes --converge a
+    // no-op, but that is the caller's call to make.
+    //
+    // Reaches the CLI only, for two reasons worth writing down:
+    //   * parsedOptions is empty when a Config is mutated programmatically and
+    //     adaptDefaults() is called by hand (the C++ library path);
+    //   * the Python/R bindings do parse an argument string, but their option
+    //     renderer omits any value equal to its default, so `num_trials=1` with
+    //     `converge=True` renders no --num-trials at all and still gets the
+    //     default cap (measured: 6 trials on unbalanced_hierarchy either way).
+    // That elision was assumed behaviour-preserving because the rendered defaults
+    // come from this catalog -- this option is the counter-example, since
+    // --converge makes "given as 1" mean something different from "not given".
+    // Fixing it belongs in the generator (the residue recorded in #914).
+    if (config.convergeTrials && !config.noInfomap && !numTrialsGivenExplicitly(config)) {
       config.numTrials = Config::convergeDefaultMaxTrials;
     }
   }

--- a/test/cpp/test_config.cpp
+++ b/test/cpp/test_config.cpp
@@ -209,6 +209,27 @@ TEST_CASE("Config uses a default cap for converge without explicit num-trials [f
   CHECK(config.numTrials == defaultCap);
 }
 
+TEST_CASE("Config honors an explicit single-trial cap for converge [fast][core][config][cli]")
+{
+  // -N 1 --converge used to be rewritten to the default cap, because numTrials
+  // == 1 doubled as the "no explicit -N" sentinel. A cap of one makes --converge
+  // a no-op, which is a legitimate thing to ask for, and silently running 50
+  // trials instead can change the reported result.
+  const unsigned int defaultCap = Config::convergeDefaultMaxTrials;
+
+  const Config explicitOne("input.net --silent --no-file-output --num-trials 1 --converge", true);
+  CHECK(explicitOne.convergeTrials);
+  CHECK(explicitOne.numTrials == 1);
+
+  // The short form is the same option, so it must behave identically.
+  const Config shortForm("input.net --silent --no-file-output -N 1 --converge", true);
+  CHECK(shortForm.numTrials == 1);
+
+  // And the default cap still applies when the count is left unsaid.
+  const Config implicit("input.net --silent --no-file-output --converge", true);
+  CHECK(implicit.numTrials == defaultCap);
+}
+
 TEST_CASE("Config rejects converge combined with parallel trials [fast][core][config][cli]")
 {
   CHECK_THROWS_AS(Config("input.net --silent --no-file-output --converge --parallel-trials --num-trials 10", true), std::runtime_error);

--- a/test/cpp/test_config.cpp
+++ b/test/cpp/test_config.cpp
@@ -213,8 +213,8 @@ TEST_CASE("Config honors an explicit single-trial cap for converge [fast][core][
 {
   // -N 1 --converge used to be rewritten to the default cap, because numTrials
   // == 1 doubled as the "no explicit -N" sentinel. A cap of one makes --converge
-  // a no-op, which is a legitimate thing to ask for, and silently running 50
-  // trials instead can change the reported result.
+  // a no-op, which is a legitimate thing to ask for, and silently running the
+  // default cap's worth of trials instead can change the reported result.
   const unsigned int defaultCap = Config::convergeDefaultMaxTrials;
 
   const Config explicitOne("input.net --silent --no-file-output --num-trials 1 --converge", true);
@@ -228,6 +228,29 @@ TEST_CASE("Config honors an explicit single-trial cap for converge [fast][core][
   // And the default cap still applies when the count is left unsaid.
   const Config implicit("input.net --silent --no-file-output --converge", true);
   CHECK(implicit.numTrials == defaultCap);
+}
+
+TEST_CASE("Converge keeps a library-set trial cap that no option recorded [fast][core][config][library]")
+{
+  // A library caller mutates the struct and calls adaptDefaults(), so parsedOptions
+  // is empty and cannot say whether the count was chosen. Provenance alone would
+  // read that as "not given" and overwrite it; the value has to be consulted too.
+  Config chosenCap;
+  chosenCap.networkFile = "graph.net";
+  chosenCap.numTrials = 4;
+  chosenCap.convergeTrials = true;
+  chosenCap.adaptDefaults();
+  CHECK(chosenCap.parsedOptions.empty());
+  CHECK(chosenCap.numTrials == 4);
+
+  // Left at the default, the library path still gets the default cap -- there is no
+  // provenance to distinguish "untouched" from "deliberately 1" without an option.
+  const unsigned int defaultCap = Config::convergeDefaultMaxTrials;
+  Config untouched;
+  untouched.networkFile = "graph.net";
+  untouched.convergeTrials = true;
+  untouched.adaptDefaults();
+  CHECK(untouched.numTrials == defaultCap);
 }
 
 TEST_CASE("Config rejects converge combined with parallel trials [fast][core][config][cli]")


### PR DESCRIPTION
## Summary

`--converge` reinterprets the trial count as a cap and falls back to a default cap when none was given — but "none was given" was read from the *value*: since the option's minimum is 1, `numTrials == 1` doubled as the sentinel. So an explicit `-N 1 --converge` was silently rewritten to the 50-trial default cap.

That is not just a runtime surprise, it changes the answer. On `unbalanced_hierarchy`:

| command | trials before | trials after |
|---|---|---|
| `-N 1 --converge` | **6** | 1 |
| `--num-trials 1 --converge` | **6** | 1 |
| `--converge` | 6 | 6 |
| `-N 4 --converge` | 4 | 4 |

The documented contract is that the count *is* the cap ("Treat the trial count as a cap ... With no explicit trial count, a default cap is used"), and a cap of one making `--converge` a no-op is the caller's call to make.

Read the provenance from `config.parsedOptions`, which the CLI already populates before `adaptDefaults()` runs, and which records the long name whichever form was typed — so `-N 1` and `--num-trials 1` behave identically.

## Scope, and a finding that came out of testing it

**This reaches the CLI only**, and I measured that rather than assuming it:

- `parsedOptions` is empty on the C++ library path (mutate a `Config`, call `adaptDefaults()` by hand), so the value-based fallback still applies there.
- The **Python/R bindings still get the default cap**: `Options.to_args()` omits any value equal to its default, so `num_trials=1` with `converge=True` renders no `--num-trials` at all. Measured through the engine's own `--summary-json`: 6 trials either way.

That second point matters beyond this option. In #921 I argued the elision was behaviour-preserving, because the rendered defaults are generated from the same parameter catalog the engine defaults come from. **`--converge` is the counter-example**: it makes "given as 1" mean something different from "not given", so an elided default and an explicit one do *not* give the same run. The generator-side residue recorded in #914 — rendering explicitly-set options even at their default — is what would close the binding half, and it is no longer a purely cosmetic item. Both the code comment and #914 now say so.

## Verification

- `make test-native` — exit 0; new `test_config.cpp` case covers the long form, the short form, and that the default cap still applies when the count is unsaid
- `make test-python` — exit 0
- `make format-native-check` — clean
- The end-to-end table above, read from `--summary-json -`

Part of #912; the two thread-configuration items in that issue are a separate PR.
