### PR TITLE
fix: read the list form of OMP_NUM_THREADS and give the thread ICV back

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,11 @@ test = [
   # together, deliberately.
   "ruff==0.15.8",
   "scipy",
+  # Reads the loaded OpenMP runtime's thread count, which is how
+  # test_thread_budget.py checks that a run gives the host's limit back. Without
+  # it those tests skip, and the C++ suite cannot cover this: its test targets
+  # compile without OpenMP flags, so `_OPENMP` is undefined there.
+  "threadpoolctl",
 ]
 docs = [
   # Building the docs executes the chapter code cells via myst-nb, so a full

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -156,6 +156,36 @@ namespace {
   private:
     int m_previous;
   };
+
+  // The run's thread budget goes into the OpenMP nthreads-var ICV so every
+  // parallel region inherits it, but that ICV belongs to the process, not to us.
+  // An embedding host that limits OpenMP programmatically -- threadpoolctl, a BLAS
+  // wrapper, torch -- had its limit replaced by one run and never given back, for
+  // the rest of the process. Restore it the same way the neighbouring guard above
+  // restores max-active-levels.
+  class ScopedOpenMpNumThreads {
+  public:
+    explicit ScopedOpenMpNumThreads(int value)
+        : m_previous(omp_get_max_threads())
+    {
+      omp_set_num_threads(value);
+    }
+
+    ~ScopedOpenMpNumThreads()
+    {
+      omp_set_num_threads(m_previous);
+    }
+
+  private:
+    int m_previous;
+  };
+
+  // Clamp before the signed cast: the budget is unsigned, and a value above
+  // INT_MAX would make omp_set_num_threads see a negative thread count.
+  int asOpenMpThreadCount(unsigned int threads)
+  {
+    return static_cast<int>(std::min(threads, static_cast<unsigned int>(std::numeric_limits<int>::max())));
+  }
 #endif
 
 } // namespace
@@ -179,22 +209,20 @@ public:
     {
       // Resolve the thread budget once for the whole run. RunSession is only
       // constructed for the main Infomap (run(Network&) requires isMainInfomap),
-      // so this fires exactly once, before any OpenMP region. Setting the
-      // process-global max thread count lets all parallel regions (recursive
-      // partition, parallel trials, inner parallelization) inherit the budget
-      // via their existing omp_get_max_threads() calls.
+      // so this fires exactly once, before any OpenMP region.
       ThreadSources threadSources = readThreadSourcesFromEnv();
       threadSources.explicitThreads = m_infomap.numThreads; // 0 = auto
       m_threadBudget = resolveThreadBudget(threadSources);
       m_cpusetCount = threadSources.cpusetCount;
-#ifdef _OPENMP
-      // Clamp to INT_MAX before the signed cast: the budget is unsigned, and a value
-      // above INT_MAX would make omp_set_num_threads see a negative thread count.
-      const unsigned int ompThreads = std::min(m_threadBudget.threads,
-                                               static_cast<unsigned int>(std::numeric_limits<int>::max()));
-      omp_set_num_threads(static_cast<int>(ompThreads));
-#endif
     }
+#ifdef _OPENMP
+    // Publishing the budget as the process-global max lets every parallel region
+    // (recursive partition, parallel trials, inner parallelization) inherit it
+    // through its existing omp_get_max_threads() call. Function scope on purpose:
+    // the budget has to hold for the whole run, and the guard has to give the ICV
+    // back on the way out -- including when a run throws.
+    const ScopedOpenMpNumThreads scopedThreadBudget(asOpenMpThreadCount(m_threadBudget.threads));
+#endif
     preflightOutputTargets(m_infomap);
     validateNetwork();
     {

--- a/src/utils/ThreadConfig.cpp
+++ b/src/utils/ThreadConfig.cpp
@@ -68,17 +68,28 @@ const char* threadSourceName(ThreadSource source)
 }
 
 namespace {
-  unsigned int parseEnvCount(const char* name)
+  std::string withoutSurroundingSpace(const std::string& text)
   {
-    const char* raw = std::getenv(name);
-    if (raw == nullptr) {
+    const auto first = text.find_first_not_of(" \t\n\v\f\r");
+    if (first == std::string::npos) {
+      return std::string();
+    }
+    const auto last = text.find_last_not_of(" \t\n\v\f\r");
+    return text.substr(first, last - first + 1);
+  }
+
+  // A single positive count, or 0 when the text is not one. Trailing garbage
+  // ("4x") is rejected rather than parsed loosely; surrounding space is not
+  // garbage, since a value assembled by a shell script easily carries it.
+  unsigned int parseCount(const std::string& raw)
+  {
+    const std::string text = withoutSurroundingSpace(raw);
+    if (text.empty()) {
       return 0;
     }
     try {
-      const std::string text(raw);
       std::size_t consumed = 0;
       const long value = std::stol(text, &consumed);
-      // Reject trailing garbage (e.g. "4x") — treat a non-numeric env value as unset.
       if (consumed == text.size() && value > 0 && value <= static_cast<long>(std::numeric_limits<unsigned int>::max())) {
         return static_cast<unsigned int>(value);
       }
@@ -86,6 +97,48 @@ namespace {
     } catch (...) {
       return 0;
     }
+  }
+
+  unsigned int parseEnvCount(const char* name)
+  {
+    const char* raw = std::getenv(name);
+    return raw == nullptr ? 0 : parseCount(std::string(raw));
+  }
+
+  // OMP_NUM_THREADS is specified as a comma-separated list of positive integers,
+  // one per nesting level, so "2,1" is a valid way to ask for two threads in the
+  // outermost parallel region. Reading it as a single integer rejected the whole
+  // value and left the budget to fall through to the cpuset or the core count --
+  // which then got pushed into the runtime, raising the count above the request
+  // rather than merely ignoring it. Take the first element, which governs the
+  // region we care about. Every element still has to parse, so a malformed list
+  // is treated as unset instead of half-read.
+  unsigned int parseOmpEnvCount(const char* name)
+  {
+    const char* raw = std::getenv(name);
+    if (raw == nullptr) {
+      return 0;
+    }
+
+    const std::string text(raw);
+    unsigned int firstCount = 0;
+    std::size_t start = 0;
+    while (true) {
+      const auto separator = text.find(',', start);
+      const std::string element = text.substr(start, separator == std::string::npos ? std::string::npos : separator - start);
+      const unsigned int count = parseCount(element);
+      if (count == 0) {
+        return 0;
+      }
+      if (firstCount == 0) {
+        firstCount = count;
+      }
+      if (separator == std::string::npos) {
+        break;
+      }
+      start = separator + 1;
+    }
+    return firstCount;
   }
 
   unsigned int readCpusetCount()
@@ -133,7 +186,7 @@ ThreadSources readThreadSourcesFromEnv()
   ThreadSources s;
   s.infomapEnv = parseEnvCount("INFOMAP_NUM_THREADS");
   s.slurmCpusPerTask = parseEnvCount("SLURM_CPUS_PER_TASK");
-  s.ompEnv = parseEnvCount("OMP_NUM_THREADS");
+  s.ompEnv = parseOmpEnvCount("OMP_NUM_THREADS");
   s.cpusetCount = readCpusetCount();
   s.hardwareConcurrency = std::max(1u, std::thread::hardware_concurrency());
   return s;

--- a/test/cpp/test_thread_config.cpp
+++ b/test/cpp/test_thread_config.cpp
@@ -156,4 +156,43 @@ TEST_CASE("readThreadSourcesFromEnv reads env vars and rejects trailing garbage 
     CHECK(s.ompEnv == 0);
   }
 }
+
+TEST_CASE("OMP_NUM_THREADS accepts the spec's list form [fast][core][threads]")
+{
+  ScopedEnv infomapEnv("INFOMAP_NUM_THREADS");
+  ScopedEnv slurmEnv("SLURM_CPUS_PER_TASK");
+  ScopedEnv ompEnv("OMP_NUM_THREADS");
+  infomapEnv.clear();
+  slurmEnv.clear();
+
+  // A comma-separated list is one value per nesting level; the first governs the
+  // outermost parallel region. Rejecting the whole thing made the budget fall
+  // through to the core count, i.e. above what was asked for.
+  ompEnv.set("2,1");
+  CHECK(readThreadSourcesFromEnv().ompEnv == 2);
+
+  ompEnv.set("3,2,1");
+  CHECK(readThreadSourcesFromEnv().ompEnv == 3);
+
+  // Space around a value is not garbage -- a shell script assembling it easily
+  // leaves some -- and neither is space around the list elements.
+  ompEnv.set("4 ");
+  CHECK(readThreadSourcesFromEnv().ompEnv == 4);
+
+  ompEnv.set(" 5 , 1 ");
+  CHECK(readThreadSourcesFromEnv().ompEnv == 5);
+
+  // A malformed list stays unset rather than being read up to the bad element:
+  // guessing half a value is worse than falling through to the next source.
+  for (const char* malformed : { "2,x", "2,", ",2", "2,0", "x,2", "", " ", "," }) {
+    ompEnv.set(malformed);
+    CHECK(readThreadSourcesFromEnv().ompEnv == 0);
+  }
+
+  // The list form only widens OMP_NUM_THREADS. Our own variable keeps its scalar
+  // contract, so a list there is still garbage.
+  ompEnv.clear();
+  infomapEnv.set("2,1");
+  CHECK(readThreadSourcesFromEnv().infomapEnv == 0);
+}
 #endif

--- a/test/cpp/test_thread_config.cpp
+++ b/test/cpp/test_thread_config.cpp
@@ -183,8 +183,11 @@ TEST_CASE("OMP_NUM_THREADS accepts the spec's list form [fast][core][threads]")
   CHECK(readThreadSourcesFromEnv().ompEnv == 5);
 
   // A malformed list stays unset rather than being read up to the bad element:
-  // guessing half a value is worse than falling through to the next source.
-  for (const char* malformed : { "2,x", "2,", ",2", "2,0", "x,2", "", " ", "," }) {
+  // guessing half a value is worse than falling through to the next source. Both
+  // ends of the list matter, and so does each way an element can be invalid --
+  // "0,2" is the one that a parser checking only for non-numeric text would take
+  // as a budget of 2, and "0" is the scalar form of the same mistake.
+  for (const char* malformed : { "2,x", "2,", ",2", "2,0", "x,2", "0,2", "0", "-1,2", "2,-1", "", " ", "," }) {
     ompEnv.set(malformed);
     CHECK(readThreadSourcesFromEnv().ompEnv == 0);
   }

--- a/test/python/test_thread_budget.py
+++ b/test/python/test_thread_budget.py
@@ -1,0 +1,86 @@
+"""The thread budget's effect on the process it runs in.
+
+A run publishes its budget as the OpenMP ``nthreads-var`` ICV so every parallel
+region inherits it. That ICV belongs to the process, not to Infomap, so a run has
+to give it back -- an embedding host that limits OpenMP programmatically
+(threadpoolctl, a BLAS wrapper, torch) must not have its limit rewritten by
+calling us.
+
+These live in Python rather than in the C++ suite on purpose: the C++ test targets
+are compiled without OpenMP flags, so ``_OPENMP`` is undefined there and a guarded
+test case would silently compile to nothing. Here the extension module's own libomp
+is loaded and observable.
+"""
+
+import infomap
+import pytest
+
+threadpoolctl = pytest.importorskip(
+    "threadpoolctl",
+    reason="threadpoolctl reads the loaded OpenMP runtime's thread count",
+)
+
+
+def openmp_threads():
+    """The loaded OpenMP runtime's current thread limit, or None if absent."""
+    for pool in threadpoolctl.threadpool_info():
+        if pool.get("user_api") == "openmp":
+            return pool["num_threads"]
+    return None
+
+
+def run_something(**kwargs):
+    im = infomap.Infomap(silent=True, seed=123, **kwargs)
+    im.add_links([(0, 1), (1, 2), (2, 0), (2, 3), (3, 4), (4, 5), (5, 3)])
+    im.run()
+    return im
+
+
+@pytest.fixture
+def openmp_present():
+    if openmp_threads() is None:
+        pytest.skip("built without OpenMP, so there is no thread ICV to preserve")
+
+
+def test_run_restores_the_hosts_openmp_limit(openmp_present):
+    """A run inside a host's thread limit leaves that limit alone."""
+    with threadpoolctl.threadpool_limits(limits=2):
+        assert openmp_threads() == 2
+        # num_threads above the host's limit, so a run that ignored the restore
+        # leaves an observably different value rather than coincidentally the same.
+        run_something(num_threads=4, num_trials=2)
+        assert openmp_threads() == 2
+
+
+def test_repeated_runs_do_not_drift_the_limit(openmp_present):
+    """Restoring per run means the count cannot creep across runs."""
+    with threadpoolctl.threadpool_limits(limits=1):
+        for _ in range(3):
+            run_something(num_threads=4)
+            assert openmp_threads() == 1
+
+
+def test_limit_survives_a_failing_run(openmp_present):
+    """The guard unwinds, so a run that raises still hands the ICV back."""
+    with threadpoolctl.threadpool_limits(limits=2):
+        im = infomap.Infomap(
+            silent=True, num_threads=4, cluster_data="does-not-exist.clu"
+        )
+        im.add_links([(0, 1), (1, 2)])
+        with pytest.raises(infomap.NetworkParseError):
+            im.run()
+        assert openmp_threads() == 2
+
+
+def test_the_limit_returns_to_the_process_default_with_no_host_limit(openmp_present):
+    """With no host limit set, the ICV still has to come back to what it was.
+
+    Distinct from the tests above: it catches a guard that restores the wrong value
+    -- for instance its own budget -- which a run inside an explicit limit cannot
+    show, since there the budget and the restored value differ either way.
+    """
+    baseline = openmp_threads()
+    assert baseline is not None
+    for requested in (1, 2, 3):
+        run_something(num_threads=requested)
+        assert openmp_threads() == baseline


### PR DESCRIPTION
Two defects from #912 in how a run negotiates threads with the process around it. Same subsystem, so one PR.

## List-form `OMP_NUM_THREADS` was discarded

The variable is specified as a comma-separated list, one value per nesting level, so `2,1` is a valid way to ask for two threads in the outermost parallel region. `parseEnvCount` required a single `std::stol` to consume the whole string, so the list was rejected as garbage and the budget fell through to the core count — which then went into the runtime. Infomap therefore did not merely ignore the smaller request, it **raised** the count above it:

```
before, OMP_NUM_THREADS=2,1 on 12 cores
  - Runtime    OpenMP 202011 with 2 threads          <- the runtime honoured the list
    Parallel trials: 4 workers from 12 OpenMP threads
    Thread budget                 12 (hardware_concurrency)

after
  - Runtime    OpenMP 202011 with 2 threads
    Parallel trials: 2 workers from 2 OpenMP threads
    Thread budget                 2 (OMP_NUM_THREADS)
```

Measured across the forms, with the two binaries checksum-verified as different before trusting the comparison:

| `OMP_NUM_THREADS` | before | after |
|---|---|---|
| `2` | 2 (OMP_NUM_THREADS) | 2 (OMP_NUM_THREADS) |
| `2,1` | 12 (hardware_concurrency) | 2 (OMP_NUM_THREADS) |
| `3,2,1` | 12 (hardware_concurrency) | 3 (OMP_NUM_THREADS) |
| `4 ` | 12 (hardware_concurrency) | 4 (OMP_NUM_THREADS) |
| ` 5 , 1 ` | 12 (hardware_concurrency) | 5 (OMP_NUM_THREADS) |
| `2,x` | 12 (hardware_concurrency) | 12 (hardware_concurrency) |
| `2,` | 12 (hardware_concurrency) | 12 (hardware_concurrency) |
| `0,2` | 12 (hardware_concurrency) | 12 (hardware_concurrency) |
| `4x` | 12 (hardware_concurrency) | 12 (hardware_concurrency) |

Every element still has to parse, so a malformed list counts as unset rather than being read up to the bad element — guessing half a value is worse than falling through to the next source. The list form widens `OMP_NUM_THREADS` only; `INFOMAP_NUM_THREADS` keeps its scalar contract, which the test pins.

## The thread ICV was never given back

The budget goes into the OpenMP `nthreads-var` ICV so every parallel region inherits it through its existing `omp_get_max_threads()` call. That ICV belongs to the process. A host that limits OpenMP programmatically — threadpoolctl, a BLAS wrapper, torch — had its limit replaced by one run and never restored:

```
WITHOUT THE FIX
  inside limits(2) before: 2
  inside limits(2) after : 12     <- destroyed while still inside the context

WITH THE FIX
  inside limits(2) before: 2
  inside limits(2) after : 2
```

A `ScopedOpenMpNumThreads` guard at run scope now restores it, mirroring the `ScopedOpenMpMaxActiveLevels` guard directly above it in the same file, so it unwinds when a run throws too.

## Where the ICV tests live, and why

In Python, not in the C++ suite. While writing a C++ test for this I found that **the C++ test targets are compiled without OpenMP flags** — `infomap_core` gets `-Xpreprocessor -fopenmp`, every `infomap_cpp_*_tests` target gets `-std=gnu++17 -arch arm64 -fno-access-control` and nothing else. So `_OPENMP` is undefined in every test translation unit, my guarded test case compiled to nothing and was absent from the binary while `make test-native` reported success. Rather than land a test that claims coverage it does not have, the assertions went to Python, where the extension's own libomp is loaded and readable through threadpoolctl. `threadpoolctl` is added to the `test` extra so the cases run instead of skipping.

That build gap is worth its own issue: it also silences the 21 existing `#ifdef _OPENMP` blocks in `test_flow.cpp`, `test_partition.cpp` and `test_infomap_wrapper.cpp`, including "Hierarchical partition is invariant to the OpenMP thread count", which never varies the thread count. Filed separately rather than fixed here, since turning those on will likely surface latent failures that do not belong in a two-defect fix.

## Verification

Both fixes fail their tests when reverted, checked one at a time:

- the four Python ICV cases: `4 failed` with `InfomapBase.cpp` stashed, `4 passed` with it;
- the `OMP_NUM_THREADS` list-form case: 4 assertions fail with `ThreadConfig.cpp` stashed.

`make test-native`, `make test-python` (802 passed, 2 skipped), `make test-python-typecheck` (0 errors), `make test-sanitizers` and `make format-native-check` all exit 0.

Closes two boxes of #912.
