### PR TITLE
fix(python): name the engine that went stale, and drop a remedy that reproduces the error

### DIFF
--- a/interfaces/python/src/infomap/errors.py
+++ b/interfaces/python/src/infomap/errors.py
@@ -63,6 +63,10 @@ class StaleResultError(InfomapError):
     on a ``Result`` created by an earlier run raises instead of reading the
     rebuilt tree. The eager scalars captured at ``run()`` time (codelength,
     module counts, ...) stay valid on the stale ``Result``.
+
+    The re-run that matters is one of the engine the ``Result`` came from --
+    an :class:`~infomap.Infomap` or a :class:`~infomap.Network` -- so running
+    a different engine leaves this ``Result`` alone.
     """
 
 

--- a/interfaces/python/src/infomap/errors.py
+++ b/interfaces/python/src/infomap/errors.py
@@ -64,9 +64,9 @@ class StaleResultError(InfomapError):
     rebuilt tree. The eager scalars captured at ``run()`` time (codelength,
     module counts, ...) stay valid on the stale ``Result``.
 
-    The re-run that matters is one of the engine the ``Result`` came from --
-    an :class:`~infomap.Infomap` or a :class:`~infomap.Network` -- so running
-    a different engine leaves this ``Result`` alone.
+    Only a re-run of the engine the ``Result`` came from -- an
+    :class:`~infomap.Infomap` or a :class:`~infomap.Network` -- invalidates it.
+    Running a different engine leaves this ``Result`` alone.
     """
 
 

--- a/interfaces/python/src/infomap/result.py
+++ b/interfaces/python/src/infomap/result.py
@@ -19,8 +19,10 @@ reuse, index, or count the result:
 
 Both shapes are guarded by a run-generation token: the C++ result tree is
 destroyed and rebuilt on every ``run()``, so reading node-level data from a
-``Result`` whose ``Infomap`` has re-run since raises :class:`StaleResultError`
-instead of touching freed memory.
+``Result`` whose bound engine has re-run since raises :class:`StaleResultError`
+instead of touching freed memory. That engine is whichever object the run went
+through -- an ``Infomap`` or a ``Network`` -- and only a re-run of *that* one
+invalidates the ``Result``.
 
 Surface conventions: read the run's intrinsic results as **properties** -- the
 scalar metrics (``result.codelength``) and the fixed label / per-trial tables
@@ -623,7 +625,7 @@ class Result(_ResultWritersMixin):
         Measured as the perplexity of the top-module flow distribution.
         Unlike the eager scalar properties, this is computed lazily on first
         access (see :meth:`effective_num_modules`), so it can raise
-        :class:`StaleResultError` if the ``Infomap`` has re-run since.
+        :class:`StaleResultError` if the bound engine has re-run since.
         """
         return self._effective_num_modules_cached(1)
 
@@ -634,7 +636,7 @@ class Result(_ResultWritersMixin):
         Measured as the perplexity of the leaf-module flow distribution.
         Unlike the eager scalar properties, this is computed lazily on first
         access (see :meth:`effective_num_modules`), so it can raise
-        :class:`StaleResultError` if the ``Infomap`` has re-run since.
+        :class:`StaleResultError` if the bound engine has re-run since.
         """
         return self._effective_num_modules_cached(-1)
 

--- a/interfaces/python/src/infomap/result.py
+++ b/interfaces/python/src/infomap/result.py
@@ -476,13 +476,19 @@ class Result(_ResultWritersMixin):
     def _check_generation(self) -> None:
         """Guard live C++ tree access against a re-run of the bound engine."""
         if self._engine._generation != self._generation:
+            # Name the engine that actually went stale: a Result can be bound to a
+            # Network as well as to an Infomap, and naming the wrong one sends the
+            # reader looking for a re-run that never happened. The advice cannot be
+            # "use infomap.run()" either -- run(network) re-runs that same network
+            # in place and bumps this generation, so it reproduces this error.
+            engine = type(self._engine).__name__
             raise StaleResultError(
-                "stale Result: the Infomap instance was re-run, so the C++ "
-                "result tree this Result read is gone. Eager scalars "
-                "(codelength, module counts, summary()) stay valid; to keep "
-                "node-level data across re-runs, materialize it first -- "
-                "dict(result.modules()) / result.to_dataframe() -- or use "
-                "infomap.run(), which never goes stale."
+                f"stale Result: this {engine} was re-run, so the C++ result tree "
+                "this Result read is gone. Eager scalars (codelength, module "
+                "counts, summary()) stay valid; to keep node-level data across a "
+                "re-run, materialize it first -- dict(result.modules()) / "
+                "result.to_dataframe() -- or give each run its own engine, since a "
+                "Result only goes stale when the engine it came from is re-run."
             )
 
     def _guard_iteration(self, iterator):

--- a/test/python/test_errors.py
+++ b/test/python/test_errors.py
@@ -177,9 +177,7 @@ def test_stale_result_message_names_the_engine_that_was_re_run():
     A Result can be bound to a Network as well as to an Infomap, and naming the
     wrong one sends the reader looking for a re-run that never happened.
     """
-    import infomap
-
-    network = infomap.Network()
+    network = Network()
     network.add_links([(0, 1), (1, 2), (2, 0)])
     stale = run(network, silent=True, seed=1)
     # This is also the call the message used to recommend as staleness-free: it

--- a/test/python/test_errors.py
+++ b/test/python/test_errors.py
@@ -171,6 +171,35 @@ def test_stale_result_raises_stale_result_error(make_infomap):
         stale.modules()
 
 
+def test_stale_result_message_names_the_engine_that_was_re_run():
+    """The message has to name the surface the reader actually re-ran.
+
+    A Result can be bound to a Network as well as to an Infomap, and naming the
+    wrong one sends the reader looking for a re-run that never happened.
+    """
+    import infomap
+
+    network = infomap.Network()
+    network.add_links([(0, 1), (1, 2), (2, 0)])
+    stale = run(network, silent=True, seed=1)
+    # This is also the call the message used to recommend as staleness-free: it
+    # re-runs the same network in place, so it reproduces the error it prescribes.
+    run(network, silent=True, seed=2)
+
+    with pytest.raises(StaleResultError, match="this Network was re-run"):
+        stale.modules()
+    with pytest.raises(StaleResultError) as excinfo:
+        stale.modules()
+    assert "infomap.run()" not in str(excinfo.value)
+
+    im = Infomap(silent=True, seed=1)
+    im.add_links([(0, 1), (1, 2), (2, 0)])
+    stale_engine_result = im.run()
+    im.run()
+    with pytest.raises(StaleResultError, match="this Infomap was re-run"):
+        stale_engine_result.modules()
+
+
 def test_export_before_run_raises_not_run_error(make_infomap):
     networkx = pytest.importorskip("networkx")
     from infomap.io.export import annotate_networkx_graph

--- a/test/python/test_result_agent_fixes.py
+++ b/test/python/test_result_agent_fixes.py
@@ -59,7 +59,13 @@ def test_stale_result_message_carries_a_remedy():
         stale.modules()
     message = str(excinfo.value)
     assert "stale Result" in message  # original prefix preserved
-    assert "infomap.run" in message and "materialize" in message
+    assert "materialize" in message
+    # This used to also require the message to name infomap.run() as the
+    # staleness-free alternative. It is not one: run(network) re-runs that same
+    # network in place and bumps the generation, so following the advice
+    # reproduces this error. The remedy has to be one that actually works.
+    assert "infomap.run()" not in message
+    assert "its own engine" in message
 
 
 def test_write_clu_depth_alias_matches_depth_level(tmp_path):


### PR DESCRIPTION
One box of #912: the `StaleResultError` message was wrong in two ways.

## It named the wrong surface

The text said "the Infomap instance was re-run" unconditionally, but a `Result` can be bound to a `Network` just as well. Naming the wrong surface sends the reader looking for a re-run that never happened. It now names the engine's own type:

```
stale Result: this Network was re-run, so the C++ result tree ...
stale Result: this Infomap was re-run, so the C++ result tree ...
```

## Its remedy reproduced the error

The message offered `infomap.run()` as the staleness-free alternative. It is not one — `run(network)` re-runs that same network in place and bumps the generation, so following the advice reproduces the error it is given for. Demonstrated by the new test, which goes stale using exactly the recommended call:

```python
stale = run(network, silent=True, seed=1)
run(network, silent=True, seed=2)   # the "staleness-free" advice
stale.modules()                     # -> StaleResultError
```

The remedy is now the condition that actually holds: give each run its own engine, since a Result goes stale only when the engine it came from is re-run. Materializing first is still offered and still correct.

## A test that pinned the defect

`test_result_agent_fixes.py::test_stale_result_message_carries_a_remedy` asserted `"infomap.run" in message`. Its intent — the message carries an actionable remedy — is right; the proxy chosen for that intent encoded the bad advice, so the test would have blocked this fix. It now requires the working remedy and asserts `infomap.run()` is *absent*, so the wrong advice cannot come back.

That is worth flagging beyond this PR: a test written to pin a message's helpfulness by matching a substring will hold whatever advice happened to be there, correct or not.

## Verification

Both tests fail against the old message and pass against the new one:

```
FAILED test/python/test_errors.py::test_stale_result_message_names_the_engine_that_was_re_run
FAILED test/python/test_result_agent_fixes.py::test_stale_result_message_carries_a_remedy
2 failed, 24 passed
```

`make test-python` (799 passed, 2 skipped) and `make test-python-typecheck` (0 errors) exit 0. No C++ change, so the native gates are unaffected.
