### PR TITLE
chore: stop the issue templates declaring labels that do not exist

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,7 +1,10 @@
 name: Bug report
 description: Report a reproducible Infomap bug.
 title: "[Bug]: "
-labels: ["bug"]
+# No labels: here on purpose. This repository labels by component (python, R,
+# build, docs, test, performance, ...), not by issue type, so the type label a
+# template could declare does not exist -- declaring one silently drops it and
+# the issue arrives unlabelled. The component is not knowable from the template.
 body:
   - type: input
     id: version

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,7 +1,10 @@
 name: Feature request
 description: Propose a new or changed Infomap capability.
 title: "[Feature]: "
-labels: ["enhancement"]
+# No labels: here on purpose. This repository labels by component (python, R,
+# build, docs, test, performance, ...), not by issue type, so the type label a
+# template could declare does not exist -- declaring one silently drops it and
+# the issue arrives unlabelled. The component is not knowable from the template.
 body:
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -1,7 +1,10 @@
 name: Maintenance chore
 description: Track repository, CI, docs, or packaging maintenance.
 title: "[Maintenance]: "
-labels: ["maintenance"]
+# No labels: here on purpose. This repository labels by component (python, R,
+# build, docs, test, performance, ...), not by issue type, so the type label a
+# template could declare does not exist -- declaring one silently drops it and
+# the issue arrives unlabelled. The component is not knowable from the template.
 body:
   - type: textarea
     id: task


### PR DESCRIPTION
One box of #912. The three issue templates declared labels that do not exist in this repository:

```
declared:  bug (bug.yml), enhancement (feature.yml), maintenance (maintenance.yml)
exists:    R, algorithm, build, dependencies, docs, js, linux, macos,
           performance, python, test, windows, autorelease: pending/tagged
```

GitHub drops an unknown label silently, so every issue filed through a template arrived unlabelled while the template looked like it was labelling it.

Removed rather than created: the label set is deliberately component-based, with no type dimension, and the component a report belongs to is not knowable from which template was used. Each template now carries a short note saying why the line is absent, so the next editor does not add it back and re-create the same silent drop.

Verified all four template files still parse as YAML and no longer carry a `labels` key. `check yaml` passes in pre-commit.
