### PR TITLE
test: make the meta-objective invariant actually exercise the meta term

### DIFF
--- a/test/cpp/test_map_equation_invariants.cpp
+++ b/test/cpp/test_map_equation_invariants.cpp
@@ -55,9 +55,24 @@ TEST_CASE("MapEquation invariant: MemMapEquation (memory), tracked == recompute 
 
 TEST_CASE("MapEquation invariant: MetaMapEquation (meta-data), tracked == recompute [fast][core][mapeq][meta]")
 {
-  InfomapWrapper im(defaultFlags("--two-level --meta-data " + repoPath("test/fixtures/meta/states.meta")));
+  // states_crossing.meta on purpose, not states.meta: the latter's categories
+  // (1,1,1,2,2,2) coincide exactly with the optimal partition of states.net, so
+  // metaCodelength is 0 at every initPartition and every per-move deltaMetaL is
+  // 0. Both sides of the equality then equal the plain memory value and the case
+  // is numerically identical to the MemMapEquation one above -- any bug in the
+  // incremental tracking of the meta term, which is the only thing this case adds,
+  // would pass unnoticed.
+  InfomapWrapper im(defaultFlags("--two-level --meta-data " + repoPath("test/fixtures/meta/states_crossing.meta")));
   im.readInputData(networkFixturePath("states.net"));
   im.run();
+
+  // Guard against silently degenerating again: without a meta term there is
+  // nothing for the meta objective to track incrementally, so the invariant below
+  // would hold for the wrong reason.
+  const double metaCodelength = im.getMetaCodelength();
+  INFO("metaCodelength=" << metaCodelength);
+  CHECK(metaCodelength > 0.0);
+
   checkTrackedMatchesRecompute(im);
 }
 

--- a/test/fixtures/meta/states_crossing.meta
+++ b/test/fixtures/meta/states_crossing.meta
@@ -1,0 +1,12 @@
+# Meta categories that deliberately cut across the optimal partition of
+# states.net ({1,2,3},{4,5,6}), so the meta term is non-zero throughout the
+# search. states.meta assigns 1,1,1,2,2,2, which coincides with that partition
+# exactly and drives metaCodelength to 0 -- making a MetaMapEquation test
+# indistinguishable from the plain memory case.
+# stateId metaData
+1 1
+2 2
+3 1
+4 2
+5 1
+6 2


### PR DESCRIPTION
Closes the remaining box of #911. The other one — the duplicated `TEST_CASE` in `test_flow.cpp` — was already closed by #925, so this PR is only the meta-objective half.

## The case did not test the meta objective

`MapEquation invariant: MetaMapEquation` ran on `states.meta`, whose categories `1,1,1,2,2,2` coincide exactly with the optimal partition of `states.net` (`{1,2,3},{4,5,6}`). The meta term is then 0 at every `initPartition` and every per-move `deltaMetaL` is 0, so both sides of the equality equal the plain memory value and the case is numerically identical to the `MemMapEquation` case above it. Confirmed with the binary alone:

```
with meta   : 2.0114052384459704
without meta: 2.0114052384459704
```

The incremental tracking of the meta term is the only thing this case adds over the memory case, so a bug in it passed unnoticed.

## What changed

A new `states_crossing.meta` assigns `1,2,1,2,1,2`, cutting across the structural partition, which gives `metaCodelength = 0.918296`. The case asserts that term is non-zero before checking the invariant, so it cannot silently degenerate again — `InfomapBase::getMetaCodelength()` is already public, so no access-control tricks were needed.

`states.meta` is kept as is: `test_network`, `test_flow` and `test_infomap_wrapper` use it for parsing and `--meta-data-rate` handling, where its coincidence with the partition does not matter.

## Verification

Pointing the case back at `states.meta` fails the new assertion, which is exactly the check the old case lacked:

```
ERROR: CHECK( metaCodelength > 0.0 ) is NOT correct!
  logged: metaCodelength=0
[doctest] test cases: 5 | 4 passed | 1 failed
```

One thing worth recording, since it nearly became a wrong claim in this description: that run also prints a failing `CHECK` from the `should_fail`-decorated #830 repro case. That is the decorator working as intended, not a second invariant break — only one case fails, and it is this one. Reading the ERROR lines without checking which case owns them would have suggested the tracked codelength diverges under `states.meta`, which it does not.

`make test-native`, `make test-sanitizers` and `make format-native-check` exit 0.
