### PR TITLE
ci: require the release gate to see a success, and feature wheels to be prereleases

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -131,6 +131,36 @@ jobs:
           find dist/python -maxdepth 1 -name '*.whl' -print | sort
           wheel_count="$(find dist/python -maxdepth 1 -name '*.whl' | wc -l | tr -d ' ')"
           [ "$wheel_count" -gt 0 ]
+          # These wheels are compiled with experimental features on, and this job
+          # uploads them to the production `infomap` project. A stable version here
+          # would take that version on PyPI as wheel-only feature builds -- the real
+          # release of the same version then fails on duplicate filenames, and a
+          # plain `pip install infomap` hands out a feature build. RELEASING.md
+          # requires a prerelease version; the only previous gate was that at least
+          # one wheel existed, so assert the rule instead of trusting the dispatcher.
+          python3 - dist/python <<'PY'
+          import pathlib
+          import re
+          import sys
+
+          # PEP 440 pre-releases and dev releases: 1.2.3rc1, 1.2.3a1, 1.2.3b2, 1.2.3.dev4.
+          PRERELEASE = re.compile(r"^\d+(?:\.\d+)*(?:(?:a|b|rc)\d+|\.dev\d+)")
+          # Wheel filenames are {name}-{version}-{python}-{abi}-{platform}.whl.
+          versions = sorted({p.name.split("-")[1] for p in pathlib.Path(sys.argv[1]).glob("*.whl")})
+          if not versions:
+              sys.exit("no wheel versions could be read from the filenames")
+          stable = [v for v in versions if not PRERELEASE.match(v)]
+          for version in versions:
+              print(f"{'stable' if version in stable else 'prerelease'}: {version}")
+          if stable:
+              print(
+                  f"::error::feature wheels carry non-prerelease version(s) {', '.join(stable)}. "
+                  "Feature builds must not occupy a stable version on PyPI; bump the version "
+                  "to a prerelease (e.g. X.Y.ZrcN) before dispatching with publish=true.",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          PY
 
       - name: Publish feature prerelease wheels to PyPI
         uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,12 +135,20 @@ jobs:
             # No real failures is the absence of a negative, not a positive signal.
             # Every lane declares `needs: changes`, so a setup-phase flake on that
             # single job marks all of them 'skipped' -- which the filter above drops,
-            # leaving nothing to report and nothing verified. Require that the run
-            # actually ran something, and that the job every lane keys off finished:
-            # without it, no lane's result means anything.
-            successes="$(jq -c '[ .[] | select(.name != "CI Summary") | select(.conclusion == "success") | .name ]' <<<"$jobs_json")"
+            # leaving nothing to report and nothing verified. Require that a
+            # verification lane actually succeeded, and that the job every lane keys
+            # off finished: without it, no lane's result means anything.
+            #
+            # 'Detect changed paths' is excluded from the success count on purpose. It
+            # is not a verification lane, and it succeeds whenever the filters ran at
+            # all -- so counting it would let a run through in which every real lane
+            # was skipped and only CI Summary flaked. It is required separately below.
+            successes="$(jq -c '[ .[]
+              | select(.name != "CI Summary" and .name != "Detect changed paths")
+              | select(.conclusion == "success")
+              | .name ]' <<<"$jobs_json")"
             if [ "$(jq 'length' <<<"$successes")" -eq 0 ]; then
-              echo "::error::master CI run $run_id concluded '$conclusion' and no job succeeded, so nothing verified this commit; refusing to publish." >&2
+              echo "::error::master CI run $run_id concluded '$conclusion' and no verification lane succeeded, so nothing verified this commit; refusing to publish." >&2
               exit 1
             fi
             changes_conclusion="$(jq -r '[ .[] | select(.name == "Detect changed paths") | .conclusion ] | first // "absent"' <<<"$jobs_json")"
@@ -148,7 +156,7 @@ jobs:
               echo "::error::master CI run $run_id did not complete 'Detect changed paths' (conclusion: $changes_conclusion); every lane keys off it, so no lane result is meaningful; refusing to publish." >&2
               exit 1
             fi
-            echo "::warning::master CI run $run_id concluded '$conclusion', but every failure was a GitHub setup-phase infra flake and $(jq 'length' <<<"$successes") job(s) succeeded. Treating master as acceptable and proceeding."
+            echo "::warning::master CI run $run_id concluded '$conclusion', but every failure was a GitHub setup-phase infra flake and $(jq 'length' <<<"$successes") verification lane(s) succeeded. Treating master as acceptable and proceeding."
             exit 0
           fi
           echo "::error::master CI run $run_id has real (non-setup) job failures; refusing to publish:" >&2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,23 @@ jobs:
                   | not)
               | .name ]' <<<"$jobs_json")"
           if [ "$(jq 'length' <<<"$real_failures")" -eq 0 ]; then
-            echo "::warning::master CI run $run_id concluded '$conclusion', but every failure was a GitHub setup-phase infra flake. Treating master as acceptable and proceeding."
+            # No real failures is the absence of a negative, not a positive signal.
+            # Every lane declares `needs: changes`, so a setup-phase flake on that
+            # single job marks all of them 'skipped' -- which the filter above drops,
+            # leaving nothing to report and nothing verified. Require that the run
+            # actually ran something, and that the job every lane keys off finished:
+            # without it, no lane's result means anything.
+            successes="$(jq -c '[ .[] | select(.name != "CI Summary") | select(.conclusion == "success") | .name ]' <<<"$jobs_json")"
+            if [ "$(jq 'length' <<<"$successes")" -eq 0 ]; then
+              echo "::error::master CI run $run_id concluded '$conclusion' and no job succeeded, so nothing verified this commit; refusing to publish." >&2
+              exit 1
+            fi
+            changes_conclusion="$(jq -r '[ .[] | select(.name == "Detect changed paths") | .conclusion ] | first // "absent"' <<<"$jobs_json")"
+            if [ "$changes_conclusion" != "success" ]; then
+              echo "::error::master CI run $run_id did not complete 'Detect changed paths' (conclusion: $changes_conclusion); every lane keys off it, so no lane result is meaningful; refusing to publish." >&2
+              exit 1
+            fi
+            echo "::warning::master CI run $run_id concluded '$conclusion', but every failure was a GitHub setup-phase infra flake and $(jq 'length' <<<"$successes") job(s) succeeded. Treating master as acceptable and proceeding."
             exit 0
           fi
           echo "::error::master CI run $run_id has real (non-setup) job failures; refusing to publish:" >&2


### PR DESCRIPTION
Two of #910's boxes: the gates that guard *publication* and could not fail. Boxes 2–4 (UBSan recover, two path-filter holes) were already closed by #926, so this PR is the release-side remainder.

## The release gate never required a success

`verify-master-ci` deliberately tolerates a red master run when every failure is a setup-phase flake — v2.15.0's `CI Summary` failed exactly that way, which is why the tolerance exists. But its only sanity guard was that the job list is non-empty, and jobs that never ran report `skipped` and are filtered out. So the step could pass with **zero** successes.

Every lane declares `needs: changes`, so one setup flake on that single job marks all ten lanes `skipped`, leaves no failures to report, and publishes a commit no test ever saw — the invariant the file's own comment states.

It now requires at least one successful job, and that `Detect changed paths` itself concluded successfully, since without it no lane's result means anything.

I replayed the gate's own shell (extracted verbatim from `release.yml`, 36 lines) against constructed job payloads:

| scenario | before | after |
|---|---|---|
| healthy run, `CI Summary` setup flake | PROCEED | PROCEED |
| a real test failure | REFUSE | REFUSE |
| `changes` dies in setup, lanes skipped | **PROCEED** | REFUSE |
| every job dies in setup | **PROCEED** | REFUSE |
| skipped dependents absent (2 jobs) | **PROCEED** | REFUSE |
| `changes` skipped, one lane green | **PROCEED** | REFUSE |

The two rows that must not change are unchanged; the four holes close.

## Feature wheels could take a stable version on PyPI

`publish-feature-pypi` uploads feature-compiled wheels to the production `infomap` project, gated only on `wheel_count -gt 0`. A stable version there takes that version on PyPI as wheel-only feature builds: the real release of the same version then fails on duplicate filenames, and a plain `pip install infomap` hands out a feature build. `RELEASING.md` states the rule; nothing enforced it.

The job now reads the versions from the wheel filenames and requires a PEP 440 pre-release or dev release. Checked by extracting the block and running it against filename sets:

```
ACCEPT  2.16.0rc1        ACCEPT  2.16.0b2        ACCEPT  2.16.0a1      ACCEPT  2.16.0.dev3
REJECT  2.15.0           REJECT  2.15.0.post1    REJECT  mixed 2.15.0 + 2.16.0rc1
```

`2.15.0.post1` is rejected on purpose: a post-release still occupies a stable slot.

## Verification

Both files parse as YAML and `actionlint` is clean (it also runs as a pre-commit hook, which passed). The gate logic is verified by replay rather than by inspection, since neither path can be exercised without tagging a release.

## Still open in #910

Boxes 5 and 6 — the binding-option freshness gate runs only in the JS lane whose filter excludes three of the five artifacts it owns, and the Python SWIG freshness gate is skipped on every PR. Those are filter/lane wiring rather than publication safety, so they belong in their own change.

The issue's closing note also stands: which checks are actually *required* depends on branch protection and rulesets, which cannot be read from tracked files and are worth confirming in the repository settings.
