### PR TITLE
ci: make the two freshness gates fire on the files they own

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -93,6 +93,33 @@ python-swig:
   - "interfaces/python/generated/**"
   - "interfaces/python/src/infomap/_swig.py"
   - "scripts/generate_python_swig.py"
+  # The wrapper is generated from these headers, so a change to any of them can
+  # stale interfaces/python/generated/infomap_wrap.cpp and _swig.py. Without them
+  # here this filter never fires on a header edit, ci.yml passes
+  # run-swig-freshness: false, and the gate is skipped on every such PR. Listed
+  # explicitly rather than as src/** so an ordinary C++ change does not pay for
+  # a SWIG regeneration; derived from the %include lines in interfaces/swig/*.i
+  # and kept in sync by test/python/test_ci_filters.py.
+  - "src/Infomap.h"
+  - "src/core/FlowData.h"
+  - "src/core/InfoEdge.h"
+  - "src/core/InfoNode.h"
+  - "src/core/InfomapBase.h"
+  - "src/core/InfomapConfig.h"
+  - "src/core/InfomapOptimizer.h"
+  - "src/core/InfomapTypes.h"
+  - "src/core/MapEquation.h"
+  - "src/core/MemMapEquation.h"
+  - "src/core/MetaMapEquation.h"
+  - "src/core/StateNetwork.h"
+  - "src/core/iterators/InfomapIterator.h"
+  - "src/core/iterators/IterWrapper.h"
+  - "src/core/iterators/infomapIterators.h"
+  - "src/core/iterators/treeIterators.h"
+  - "src/io/Config.h"
+  - "src/io/Network.h"
+  - "src/utils/Date.h"
+  - "src/utils/MetaCollection.h"
   - ".github/actions/setup-swig/action.yml"
   - ".github/workflows/_python-package.yml"
   - ".github/filters.yml"
@@ -114,6 +141,13 @@ javascript:
   # output into the tracked interfaces/parameters/policy.md, so it is a generator
   # input like the two above and must trigger the freshness gate.
   - "scripts/render_parameter_policy.py"
+  # Three of the five artifacts that gate owns live outside interfaces/js, so a PR
+  # hand-editing one of them would skip this lane and merge without the check that
+  # exists to catch exactly that. Listed here rather than moving the gate, because
+  # this lane already builds the core binary the gate needs.
+  - "interfaces/python/src/infomap/_options.py"
+  - "interfaces/python/src/infomap/_facade.py"
+  - "interfaces/R/infomap/R/options.R"
   - "scripts/generate_js_metadata.py"
   - "scripts/prepare_npm_package.py"
   - ".github/actions/setup-js-build/action.yml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,12 @@ test = [
   "pytest",
   "networkx",
   "pyarrow",
+  # test_ci_filters.py parses .github/filters.yml, which uses YAML anchors, so it
+  # needs a real YAML parser. It was reaching this environment only transitively
+  # through pre-commit; declared here so a change to that dependency cannot take
+  # the test with it. Unpinned on purpose: unlike ruff and pyright below, a parser
+  # release does not add findings that turn master red on its own.
+  "pyyaml",
   "referencing",
   # Pinned for the same reason as pyright above: `ruff check` gates CI (it is
   # the first step of test-python-doctest), and new ruff releases promote rules

--- a/test/python/test_ci_filters.py
+++ b/test/python/test_ci_filters.py
@@ -1,0 +1,154 @@
+"""The CI path filters must cover the files whose gates they trigger.
+
+`.github/filters.yml` decides which lanes run on a pull request, and
+`ci-summary` treats a skipped lane as success. A gate whose inputs match no
+pattern in its own lane's filter therefore does not merely run less often --
+it never runs, and the required check goes green with nothing verified.
+
+Two gates own files outside the lane that hosts them, which is what these tests
+pin:
+
+- the Python SWIG freshness gate (`_python-package.yml`, keyed off the
+  `python-swig` filter) regenerates the wrapper from the headers the SWIG
+  interface `%include`s;
+- the binding-option freshness gate (`make test-binding-options-freshness`,
+  invoked only from `_js-package.yml`, keyed off the `javascript` filter) owns
+  generated artifacts under `interfaces/python` and `interfaces/R`.
+
+Both lists are derived here from their real sources rather than duplicated, so a
+new `%include` or a new generated artifact fails this test instead of silently
+widening the hole.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.fast
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FILTERS = REPO_ROOT / ".github" / "filters.yml"
+SWIG_INTERFACE_DIR = REPO_ROOT / "interfaces" / "swig"
+GENERATOR = REPO_ROOT / "scripts" / "generate_binding_options.py"
+
+
+def _flatten(value):
+    """filters.yml uses YAML anchors, so a filter is a list of str and lists."""
+    for item in value:
+        if isinstance(item, list):
+            yield from _flatten(item)
+        else:
+            yield item
+
+
+def _pattern_to_regex(pattern: str) -> re.Pattern[str]:
+    """Translate the glob subset dorny/paths-filter uses into a regex.
+
+    Handles `**` (crossing separators) and `*` (within one segment), which is
+    everything filters.yml actually uses.
+    """
+    out: list[str] = []
+    index = 0
+    while index < len(pattern):
+        if pattern.startswith("**/", index):
+            out.append("(?:.*/)?")
+            index += 3
+        elif pattern.startswith("**", index):
+            out.append(".*")
+            index += 2
+        elif pattern[index] == "*":
+            out.append("[^/]*")
+            index += 1
+        else:
+            out.append(re.escape(pattern[index]))
+            index += 1
+    return re.compile(f"^{''.join(out)}$")
+
+
+@pytest.fixture(scope="module")
+def filters() -> dict[str, list[str]]:
+    if not FILTERS.is_file():
+        pytest.skip("filters.yml not available in this layout")
+    loaded = yaml.safe_load(FILTERS.read_text())
+    return {
+        name: list(_flatten(value))
+        for name, value in loaded.items()
+        if isinstance(value, list) and not name.startswith("_")
+    }
+
+
+def _uncovered(paths: list[str], patterns: list[str]) -> list[str]:
+    compiled = [_pattern_to_regex(p) for p in patterns]
+    return [path for path in paths if not any(r.match(path) for r in compiled)]
+
+
+def _swig_included_headers() -> list[str]:
+    if not SWIG_INTERFACE_DIR.is_dir():
+        pytest.skip("SWIG interface files not available in this layout")
+    include = re.compile(r'^\s*%include\s+"(src/[^"]+)"', re.MULTILINE)
+    found = {
+        match.group(1)
+        for path in sorted(SWIG_INTERFACE_DIR.glob("*.i"))
+        for match in include.finditer(path.read_text())
+    }
+    assert found, "no %include of a src/ header found; the parser or layout changed"
+    return sorted(found)
+
+
+def _binding_option_artifacts() -> list[str]:
+    """The tracked outputs of scripts/generate_binding_options.py.
+
+    Read from the generator's own module-level path constants so a new output
+    shows up here without anyone remembering to add it.
+    """
+    if not GENERATOR.is_file():
+        pytest.skip("generator not available in this layout")
+    text = GENERATOR.read_text()
+    found = re.findall(r'^[A-Z_]+_OUT\s*=\s*Path\("([^"]+)"\)', text, re.MULTILINE)
+    assert found, "no *_OUT = Path(...) constants found; the generator changed shape"
+    return sorted(set(found))
+
+
+def test_swig_wrapped_headers_trigger_the_swig_freshness_filter(filters):
+    """A header SWIG wraps must fire `python-swig`, or the gate never runs.
+
+    ci.yml derives `run-swig-freshness` from this filter, so a header edit that
+    matches nothing here leaves the generated wrapper unchecked.
+    """
+    headers = _swig_included_headers()
+    uncovered = _uncovered(headers, filters["python-swig"])
+    assert not uncovered, (
+        "these headers are wrapped by SWIG but match no python-swig pattern, so the "
+        f"freshness gate is skipped when they change: {uncovered}"
+    )
+
+
+def test_binding_option_artifacts_trigger_the_lane_that_checks_them(filters):
+    """Every generated binding-option artifact must fire the `javascript` lane.
+
+    That lane is the only place `make test-binding-options-freshness` runs. An
+    artifact that does not match it can be hand-edited and merged with the gate
+    that owns it skipped.
+    """
+    artifacts = _binding_option_artifacts()
+    uncovered = _uncovered(artifacts, filters["javascript"])
+    assert not uncovered, (
+        "these artifacts are checked by make test-binding-options-freshness, which "
+        "only runs in the javascript lane, but match no javascript pattern: "
+        f"{uncovered}"
+    )
+
+
+def test_the_generator_is_itself_covered(filters):
+    """The generator and its inputs must fire the lane that runs its gate."""
+    inputs = [
+        "scripts/generate_binding_options.py",
+        "scripts/render_parameter_policy.py",
+        "scripts/parameter_catalog.py",
+        "interfaces/parameters/overrides.json",
+    ]
+    assert not _uncovered(inputs, filters["javascript"])


### PR DESCRIPTION
The remaining boxes of #910, after #926 closed the UBSan and path-filter ones and #934 the two publication gates.

`ci-summary` treats a skipped lane as success, so a gate whose inputs match no pattern in its own lane's filter does not merely run less often — it **never** runs, and the required check goes green with nothing verified.

## The SWIG freshness gate was skipped on every PR

`python-swig` listed the SWIG interface and the generated wrapper, but not the headers the wrapper is *generated from*. So a PR editing a wrapped header left the filter false, `ci.yml` passed `run-swig-freshness: false`, and the gate never ran.

The 20 headers `%include`d by `interfaces/swig/*.i` are now in the filter — listed explicitly rather than as `src/**`, so an ordinary C++ change does not pay for a SWIG regeneration on every native PR.

The gate is genuinely sensitive to them, checked through the make target CI actually calls:

```
pristine:                          exit 0   "Tracked SWIG outputs are fresh."
+ a public member in Config.h:     exit 2   interfaces/python/generated/infomap_wrap.cpp
                                            "This usually means a C++ header or SWIG
                                             interface changed, but the generated Python
                                             wrapper files were not regenerated."
```

## The binding-option gate did not cover three of its five artifacts

`make test-binding-options-freshness` runs from exactly one place, the `javascript` lane. Three of the five artifacts it owns — `_options.py`, the generated block in `_facade.py`, and `interfaces/R/infomap/R/options.R` — matched no `javascript` pattern. A PR hand-editing one of them skipped the lane and merged without the check whose entire purpose is catching that.

They are listed in that filter rather than moving the gate, because the lane already builds the core binary the gate needs (`./Infomap --print-json-parameters`).

## A test so this cannot drift back

`test/python/test_ci_filters.py` derives both lists from their real sources — the `%include` lines in the interface files, and the generator's own `*_OUT = Path(...)` constants — rather than duplicating them. A new wrapped header or a new generated artifact fails a test instead of silently widening the hole.

Both cases fail against the old filters:

```
FAILED test_swig_wrapped_headers_trigger_the_swig_freshness_filter
FAILED test_binding_option_artifacts_trigger_the_lane_that_checks_them
  these artifacts are checked by make test-binding-options-freshness, which only runs
  in the javascript lane, but match no javascript pattern:
  ['interfaces/R/infomap/R/options.R', '.../_facade.py', '.../_options.py']
```

## Verification

`make test-python` (806 passed, 2 skipped), `actionlint` clean, `filters.yml` parses and `check yaml` passes.

With this, every box of #910 is closed except its closing note, which stands: **which checks are actually required** depends on branch protection and rulesets, and cannot be read from tracked files — worth confirming in the repository settings, since these filters only decide what *runs*, not what *blocks*.
