### PR TITLE
fix: keep a rejected argument off stdout when the caller asked for silence

### DIFF
--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -327,13 +327,23 @@ namespace {
   // lines of English on the process's stdout, flushed at exit after everything the
   // Python program had written, against its documented quiet-by-default contract.
   //
-  // Tokenized the same way the parser tokenizes, so "--silent" inside a value does
-  // not count and "--silentish" does not match; there is no short form. The parser
-  // also accepts the --no-<option> negation and lets the last occurrence win
-  // (verified: "--silent --no-silent" parses to silent = false and the reverse to
-  // true), so this reads the last of either rather than the first --silent, and
-  // agrees with the Config the parse is about to produce. Defaults to
-  // Config::silent's own default when neither appears.
+  // Split on whitespace, the way tokenizeArgs does, and compared whole, so
+  // "--silentish" does not match; there is no short form. The parser accepts the
+  // --no-<option> negation and lets the last occurrence win (verified:
+  // "--silent --no-silent" parses to silent = false and the reverse to true), so
+  // this reads the last of either rather than the first --silent and agrees with
+  // the Config the parse is about to produce. Defaults to Config::silent's own
+  // default when neither appears.
+  //
+  // Not option-aware, and that is a deliberate limit rather than an oversight.
+  // The parser decides option-versus-value by position -- parseLongOption consumes
+  // the following token as an argument even when it starts with "--" -- so
+  // `--out-name --silent` sets out_name to the literal "--silent" with silent
+  // false, while this scan counts the token and silences the window. Telling the
+  // two apart needs the per-option requireArgument knowledge that lives in
+  // ProgramInterface, and mirroring it here would put the parser's rules in a
+  // second place that can drift. The whole cost of being wrong is that a rejected
+  // argument prints no banner in a run whose out-name is literally "--silent".
   bool flagsRequestSilence(const std::string& flags)
   {
     bool silent = false;

--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -317,7 +317,7 @@ namespace {
     Log::init(config.verbosity, config.silent, config.verboseNumberPrecision);
   }
 
-  // Whether the flags ask for silence, read before anything is parsed.
+  // What the flags say about silence, read before anything is parsed.
   //
   // Log visibility comes from the parsed Config, which does not exist yet while
   // the flags are being read -- so a rejected argument emitted the version banner
@@ -328,42 +328,51 @@ namespace {
   // Python program had written, against its documented quiet-by-default contract.
   //
   // Tokenized the same way the parser tokenizes, so "--silent" inside a value does
-  // not count and "--silentish" does not match. There is no short form.
+  // not count and "--silentish" does not match; there is no short form. The parser
+  // also accepts the --no-<option> negation and lets the last occurrence win
+  // (verified: "--silent --no-silent" parses to silent = false and the reverse to
+  // true), so this reads the last of either rather than the first --silent, and
+  // agrees with the Config the parse is about to produce. Defaults to
+  // Config::silent's own default when neither appears.
   bool flagsRequestSilence(const std::string& flags)
   {
+    bool silent = false;
     std::istringstream stream(flags);
     std::string token;
     while (stream >> token) {
       if (token == "--silent")
-        return true;
+        silent = true;
+      else if (token == "--no-silent")
+        silent = false;
     }
-    return false;
+    return silent;
   }
 
-  // Silences Log for the window between the first token and initializeLogging,
-  // and only when the flags asked for it. A non-silent CLI run still gets the
-  // banner and usage on a bad argument, which is what a person at a terminal
-  // wants. Restores on the way out so a library caller that catches the error is
-  // not left with a muted engine.
+  // Sets Log's silence for the window between the first token and
+  // initializeLogging, from the current flags alone, and restores the previous
+  // value on the way out.
+  //
+  // Unconditional on purpose. Engaging only for a silent request would leave a
+  // non-silent parse reading whatever the last run in this process happened to
+  // set -- a successful silent run leaves Log silent, so a later non-silent
+  // rejection printed nothing. Parse-time output has to follow the flags in front
+  // of it, not process history. Restoring also means a library caller that catches
+  // the error is not left with a muted engine.
   class ScopedParseSilence {
   public:
     explicit ScopedParseSilence(bool silent)
-        : m_previous(Log::isSilent()),
-          m_engaged(silent)
+        : m_previous(Log::isSilent())
     {
-      if (m_engaged)
-        Log::setSilent(true);
+      Log::setSilent(silent);
     }
 
     ~ScopedParseSilence()
     {
-      if (m_engaged)
-        Log::setSilent(m_previous);
+      Log::setSilent(m_previous);
     }
 
   private:
     bool m_previous;
-    bool m_engaged;
   };
 
   void buildConfigFromFlags(Config& config, const std::string& flags, bool isCLI)

--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -21,6 +21,7 @@
 #include <cstddef>
 #include <iterator>
 #include <limits>
+#include <sstream>
 #include <vector>
 #include <stdexcept>
 #include <utility>
@@ -316,6 +317,55 @@ namespace {
     Log::init(config.verbosity, config.silent, config.verboseNumberPrecision);
   }
 
+  // Whether the flags ask for silence, read before anything is parsed.
+  //
+  // Log visibility comes from the parsed Config, which does not exist yet while
+  // the flags are being read -- so a rejected argument emitted the version banner
+  // and the usage line through Log() at default verbosity
+  // (ProgramInterface::exitWithError) even for a caller that asked for silence.
+  // The Python API passes --silent on every call, so any rejected keyword put two
+  // lines of English on the process's stdout, flushed at exit after everything the
+  // Python program had written, against its documented quiet-by-default contract.
+  //
+  // Tokenized the same way the parser tokenizes, so "--silent" inside a value does
+  // not count and "--silentish" does not match. There is no short form.
+  bool flagsRequestSilence(const std::string& flags)
+  {
+    std::istringstream stream(flags);
+    std::string token;
+    while (stream >> token) {
+      if (token == "--silent")
+        return true;
+    }
+    return false;
+  }
+
+  // Silences Log for the window between the first token and initializeLogging,
+  // and only when the flags asked for it. A non-silent CLI run still gets the
+  // banner and usage on a bad argument, which is what a person at a terminal
+  // wants. Restores on the way out so a library caller that catches the error is
+  // not left with a muted engine.
+  class ScopedParseSilence {
+  public:
+    explicit ScopedParseSilence(bool silent)
+        : m_previous(Log::isSilent()),
+          m_engaged(silent)
+    {
+      if (m_engaged)
+        Log::setSilent(true);
+    }
+
+    ~ScopedParseSilence()
+    {
+      if (m_engaged)
+        Log::setSilent(m_previous);
+    }
+
+  private:
+    bool m_previous;
+    bool m_engaged;
+  };
+
   void buildConfigFromFlags(Config& config, const std::string& flags, bool isCLI)
   {
     config.parsedString = flags;
@@ -330,16 +380,23 @@ namespace {
     ParsedParameterSet staging;
     registerCatalogWithProgramInterface(api, { config, staging }, isCLI);
 
-    api.parseArgs(flags);
-    config.parsedOptions = api.getUsedOptionArguments();
+    // Scoped to end before initializeLogging: the guard restores the previous
+    // silence on destruction, so leaving it open would undo the real setting.
+    {
+      const ScopedParseSilence parseSilence(flagsRequestSilence(flags));
 
-    rejectDeprecatedAliases(staging);
-    applyOutputDirectory(config, staging);
-    applyFlowModelSelection(config, staging);
+      api.parseArgs(flags);
+      config.parsedOptions = api.getUsedOptionArguments();
 
-    config.adaptDefaults();
+      rejectDeprecatedAliases(staging);
+      applyOutputDirectory(config, staging);
+      applyFlowModelSelection(config, staging);
 
-    validateOutputDirectory(config);
+      config.adaptDefaults();
+
+      validateOutputDirectory(config);
+    }
+
     initializeLogging(config);
   }
 

--- a/test/python/test_logging.py
+++ b/test/python/test_logging.py
@@ -343,7 +343,10 @@ class TestRejectedArgumentStaysQuiet:
         """
         infomap_logger = logging.getLogger("infomap")
         saved = list(infomap_logger.handlers)
-        disable_log()
+        # Removed directly rather than through disable_log(): that clears
+        # _logging's _helper_handler reference, and re-attaching a saved helper
+        # handler afterwards would leave the two out of step -- a later
+        # disable_log() would not remove it and enable_log() could add a second.
         for handler in list(infomap_logger.handlers):
             infomap_logger.removeHandler(handler)
         assert not infomap_logger.handlers, "engine output would be routed, not printed"
@@ -383,6 +386,30 @@ class TestRejectedArgumentStaysQuiet:
         printed = _engine_stdout(capfd)
         assert "Infomap version" in printed
         assert "Usage:" in printed
+
+    def test_the_negation_form_agrees_with_the_parser(self, capfd):
+        # The parser accepts --no-silent and lets the last occurrence win, so the
+        # pre-parse read has to do the same or the two disagree.
+        with pytest.raises(Exception, match="Unrecognized option"):
+            Infomap(args="--silent --no-silent --bogus-flag", silent=False)
+        assert "Infomap version" in _engine_stdout(capfd)
+
+        with pytest.raises(Exception, match="Unrecognized option"):
+            Infomap(args="--no-silent --silent --bogus-flag", silent=False)
+        assert _engine_stdout(capfd) == ""
+
+    def test_a_previous_silent_run_does_not_mute_a_later_rejection(self, capfd):
+        # Log's silence is process-global and a successful silent run leaves it set,
+        # so the parse window has to take its value from the flags in front of it
+        # rather than from whatever ran last.
+        im = Infomap(silent=True, num_trials=1, seed=1)
+        im.add_links([(0, 1), (1, 2), (2, 0)])
+        im.run()
+        _engine_stdout(capfd)  # drain
+
+        with pytest.raises(Exception, match="Unrecognized option"):
+            Infomap(args="--bogus-flag", silent=False)
+        assert "Infomap version" in _engine_stdout(capfd)
 
     def test_silence_is_not_left_behind_after_a_caught_rejection(self, capfd):
         # The parse-time silence is scoped, so a caller that catches the error and

--- a/test/python/test_logging.py
+++ b/test/python/test_logging.py
@@ -398,6 +398,16 @@ class TestRejectedArgumentStaysQuiet:
             Infomap(args="--no-silent --silent --bogus-flag", silent=False)
         assert _engine_stdout(capfd) == ""
 
+    def test_a_value_that_looks_like_the_flag_is_a_known_limitation(self, capfd):
+        # The scan is not option-aware: the parser decides option-versus-value by
+        # position, so `--out-name --silent` sets out_name to the literal "--silent"
+        # with silent false, while the scan counts the token and silences. Pinned as
+        # the documented behaviour rather than left to be discovered -- the whole
+        # cost is a missing banner in a run whose out-name is literally "--silent".
+        with pytest.raises(Exception, match="Unrecognized option"):
+            Infomap(args="--out-name --silent --bogus-flag", silent=False)
+        assert _engine_stdout(capfd) == ""
+
     def test_a_previous_silent_run_does_not_mute_a_later_rejection(self, capfd):
         # Log's silence is process-global and a successful silent run leaves it set,
         # so the parse window has to take its value from the flags in front of it

--- a/test/python/test_logging.py
+++ b/test/python/test_logging.py
@@ -20,6 +20,7 @@ import warnings
 
 import pytest
 from infomap import Infomap, Options, disable_log, enable_log, run
+from infomap._logging import _sync_engine_routing
 
 # These tests drive the engine log -> Python logging routing, deliberately
 # using silent=False to produce engine output; the pending deprecation on the
@@ -320,3 +321,77 @@ def test_raising_log_handler_does_not_kill_the_run(infomap_log_handler):
         assert result.num_top_modules >= 1
     finally:
         logger.removeHandler(raising)
+
+
+# A rejected argument used to put the version banner and the usage line on the
+# process's stdout before the error was raised: Log visibility is configured from
+# the parsed Config, which does not exist yet while the flags are being read, so
+# ProgramInterface::exitWithError wrote at default verbosity. The Python API passes
+# --silent on every call, so this contradicted its quiet-by-default contract, and
+# the two lines arrived at exit after everything the program had written.
+class TestRejectedArgumentStaysQuiet:
+    @pytest.fixture(autouse=True)
+    def _engine_writes_to_stdout(self):
+        """Guarantee stdout is the engine's sink, whatever ran before.
+
+        Routing keys on handlers attached directly to the ``infomap`` logger
+        (``_logging.should_route``), and a leftover handler from another test sends
+        the banner to the logger instead of fd 1. That would make the silence
+        assertions below pass *vacuously* -- stdout is empty either way -- so the
+        precondition is asserted rather than assumed. `disable_log()` alone is not
+        enough: it removes only the handler `enable_log()` installed.
+        """
+        infomap_logger = logging.getLogger("infomap")
+        saved = list(infomap_logger.handlers)
+        disable_log()
+        for handler in list(infomap_logger.handlers):
+            infomap_logger.removeHandler(handler)
+        assert not infomap_logger.handlers, "engine output would be routed, not printed"
+        # Removing the handlers is not enough: the C++ callback stays installed
+        # until _sync_engine_routing runs, and only engine_log_routing() calls it --
+        # which construction does not go through. Sync explicitly so the sink
+        # matches the handler configuration this test just established.
+        _sync_engine_routing()
+        try:
+            yield
+        finally:
+            for handler in list(infomap_logger.handlers):
+                infomap_logger.removeHandler(handler)
+            for handler in saved:
+                infomap_logger.addHandler(handler)
+            _sync_engine_routing()
+
+    def test_the_args_escape_hatch_does_not_print(self, capfd):
+        with pytest.raises(Exception, match="Unrecognized option"):
+            Infomap(args="--bogus-flag", silent=True)
+        assert _engine_stdout(capfd) == ""
+
+    def test_a_documented_keyword_does_not_print(self, capfd):
+        # Reachable without the raw escape hatch: markov_time reaches the engine's
+        # own parser, which rejects a non-finite value by name.
+        with pytest.raises(Exception, match="Cannot parse"):
+            run(
+                [(0, 1), (1, 2)], options=Options(markov_time=float("inf")), silent=True
+            )
+        assert _engine_stdout(capfd) == ""
+
+    def test_a_non_silent_caller_still_gets_the_banner_and_usage(self, capfd):
+        # The fix is silence-aware, not a blanket mute: someone who did not ask for
+        # silence still wants to know how to invoke the thing.
+        with pytest.raises(Exception, match="Unrecognized option"):
+            Infomap(args="--bogus-flag", silent=False)
+        printed = _engine_stdout(capfd)
+        assert "Infomap version" in printed
+        assert "Usage:" in printed
+
+    def test_silence_is_not_left_behind_after_a_caught_rejection(self, capfd):
+        # The parse-time silence is scoped, so a caller that catches the error and
+        # carries on gets a working log again rather than a permanently muted engine.
+        with pytest.raises(Exception, match="Unrecognized option"):
+            Infomap(args="--bogus-flag", silent=True)
+        _engine_stdout(capfd)  # drain
+
+        im = Infomap(silent=False, num_trials=1, seed=1)
+        im.add_links([(0, 1), (1, 2), (2, 0)])
+        im.run()
+        assert _engine_stdout(capfd) != ""


### PR DESCRIPTION
Closes #912 — the last of its seven boxes.

Alternative 2 of the two I put up: check whether `--silent` is active before parsing, rather than moving the banner out of `ProgramInterface`.

## The leak

`Log` visibility comes from the parsed `Config`, which does not exist yet while the flags are being read, so `ProgramInterface::exitWithError` wrote the version banner and usage line at default verbosity. The Python API passes `--silent` on every call, so *any* rejected argument put two lines of English on the process's stdout — flushed at exit, after everything the Python program had written.

Captured at the file-descriptor level, since `std::cout` is fully buffered there:

```
run([(0, 1)], args="--bogus-flag", silent=True)
  raised:  InfomapError: Unrecognized option: '--bogus-flag'
  on fd 1: 'Infomap version 2.15.0 compiled with OpenMP\nUsage: Infomap out_directory ...'
```

Reachable without the `args=` escape hatch too: `Options(markov_time=float("inf"))` reaches the engine's own parser, which rejects it by name — and leaked the same two lines.

## The fix

The flags are read for a `--silent` token before the parse, and `Log` is silenced for exactly the window between the first token and `initializeLogging`. Tokenized the way the parser tokenizes, so `--silent` inside a *value* does not count and `--silentish` does not match; there is no short form.

Two details worth flagging:

- The guard is **scoped to end before `initializeLogging`**. It restores the previous state on destruction, so leaving it open would undo the real setting on the success path.
- It restores on the way out, so a library caller that catches the error is not left with a permanently muted engine — one of the four tests pins that.

## Silence-aware, not a blanket mute

| invocation | stdout | stderr |
|---|---|---|
| `Infomap net.edges out --bogus-flag` | banner + usage | `Error: Unrecognized option` |
| `Infomap net.edges out --silent --bogus-flag` | *empty* | `Error: Unrecognized option` |

Someone at a terminal who did not ask for silence still wants to know how to invoke the thing, and the error stays on stderr either way so a script still learns what went wrong.

## Verification

Four tests. Two fail without the change; the other two are guards — that a non-silent caller still gets the banner, and that silence is not left behind after a caught rejection.

```
FAILED ...::test_the_args_escape_hatch_does_not_print
FAILED ...::test_a_documented_keyword_does_not_print
2 failed, 2 passed
```

`make test-native`, `make test-python` (810 passed), `make test-sanitizers` and `make format-native-check` all exit 0.

## A test-isolation trap worth recording

The fixture has to clear the handlers on the `infomap` logger **and** re-sync the sink, not just call `disable_log()`. Three things compound:

1. routing keys on handlers attached *directly* to that logger, so `disable_log()` — which removes only the handler `enable_log()` installed — is not enough;
2. the C++ callback stays installed until `_sync_engine_routing()` runs;
3. construction does not go through `engine_log_routing()`, so nothing re-syncs it.

The consequence is that a leftover handler from an earlier test sends the banner to the logger, leaving stdout empty — and these assertions would have passed **vacuously**. My first two attempts at the fixture did exactly that, and only the non-silent guard test failing revealed it.

That third point is a small latent library issue rather than a test one: after a handler is removed with no engine call in between, output goes to the logging path until the next call re-syncs. It self-heals, so I have not filed it — say the word if you want it tracked.
