### PR TITLE
ci: regenerate the R man pages and gate them against their sources

### DIFF
--- a/.github/workflows/_r-package.yml
+++ b/.github/workflows/_r-package.yml
@@ -110,6 +110,7 @@ jobs:
             any::rmarkdown
             any::tibble
             any::rcmdcheck
+            any::roxygen2
 
       - name: Set up ccache
         uses: ./.github/actions/setup-ccache
@@ -140,6 +141,14 @@ jobs:
         env:
           SCCACHE_GHA_ENABLED: "true"
         run: sccache --start-server
+
+      # One leg only: roxygen output does not vary by platform or R version, and
+      # this needs the package compiled, which the staging step below pays for
+      # anyway. Guards against the drift that had 18 options missing from
+      # infomap_options.Rd.
+      - name: Verify tracked man pages match the roxygen comments
+        if: matrix.os == 'ubuntu-24.04' && matrix.r == 'release'
+        run: make test-r-man-freshness
 
       - name: Stage and check the package
         env:

--- a/.github/workflows/_r-package.yml
+++ b/.github/workflows/_r-package.yml
@@ -99,6 +99,12 @@ jobs:
         with:
           python-version: "3.14"
 
+      # roxygen2 is version-pinned rather than `any::`: its output is
+      # version-dependent (8.0.0 rewrites the whole R6 section), so the tracked man
+      # pages only match one version and make test-r-man-freshness asserts it. Keep
+      # in step with R_ROXYGEN_VERSION in mk/r.mk and the note in AGENTS.md.
+      # Note extra-packages is a list of package refs, not a script: a '#' line
+      # inside the block is parsed as a package name, not a comment.
       - name: Install R package dependencies
         uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
@@ -110,9 +116,6 @@ jobs:
             any::rmarkdown
             any::tibble
             any::rcmdcheck
-            # Pinned: roxygen output is version-dependent (8.0.0 rewrites the whole
-            # R6 section), so the tracked man pages only match one version. Keep in
-            # step with R_ROXYGEN_VERSION in mk/r.mk and the note in AGENTS.md.
             roxygen2@7.3.3
 
       - name: Set up ccache

--- a/.github/workflows/_r-package.yml
+++ b/.github/workflows/_r-package.yml
@@ -110,7 +110,10 @@ jobs:
             any::rmarkdown
             any::tibble
             any::rcmdcheck
-            any::roxygen2
+            # Pinned: roxygen output is version-dependent (8.0.0 rewrites the whole
+            # R6 section), so the tracked man pages only match one version. Keep in
+            # step with R_ROXYGEN_VERSION in mk/r.mk and the note in AGENTS.md.
+            roxygen2@7.3.3
 
       - name: Set up ccache
         uses: ./.github/actions/setup-ccache
@@ -142,22 +145,24 @@ jobs:
           SCCACHE_GHA_ENABLED: "true"
         run: sccache --start-server
 
-      # One leg only: roxygen output does not vary by platform or R version, and
-      # this needs the package compiled, which the staging step below pays for
-      # anyway. Guards against the drift that had 18 options missing from
-      # infomap_options.Rd.
-      - name: Verify tracked man pages match the roxygen comments
-        if: matrix.os == 'ubuntu-24.04' && matrix.r == 'release'
-        run: make test-r-man-freshness
-
       - name: Stage and check the package
         env:
           SCCACHE_GHA_ENABLED: ${{ startsWith(matrix.os, 'windows') && 'true' || '' }}
         run: |
+          # The man-page freshness check shares build-r-stage (and the package
+          # compile roxygen triggers) with test-r, so both go in one make
+          # invocation -- make builds a shared .PHONY prerequisite once per run,
+          # and a separate step would stage and compile twice on the critical path.
+          # One leg only: roxygen output does not vary by platform or R version,
+          # only by roxygen version, which is pinned above.
+          targets=(test-r)
+          if [ "$RUNNER_OS" = "Linux" ] && [ "${{ matrix.r }}" = "release" ]; then
+            targets=(test-r-man-freshness test-r)
+          fi
           if [ "$RUNNER_OS" = "Windows" ]; then
-            make test-r CCACHE_BIN=sccache USE_CCACHE=1
+            make "${targets[@]}" CCACHE_BIN=sccache USE_CCACHE=1
           else
-            make test-r
+            make "${targets[@]}"
           fi
           if command -v ccache >/dev/null 2>&1; then ccache -s || true; fi
           if command -v sccache >/dev/null 2>&1; then sccache --show-stats || true; fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,11 @@ Install that version locally so `make format-r-check` agrees with CI, and bump
 the CI pin and this note together. The `actionlint` hook is `language: system`
 too: install it locally (`brew install actionlint`) when you touch workflows;
 the canonical version is **1.7.12**, downloaded in the `pre-commit` CI job, and
-the CI pin and this note bump together. Generated and vendored files —
+the CI pin and this note bump together. The R man pages are roxygen output and
+its formatting is version-dependent too — 8.0.0 rewrites the whole R6 section —
+so the canonical version is **7.3.3**, pinned as `R_ROXYGEN_VERSION` in `mk/r.mk`
+and as `roxygen2@7.3.3` in the R CI job; `make build-r-man` refuses to run with
+any other version, and the two pins and this note bump together. Generated and vendored files —
 `interfaces/python/generated/`, `interfaces/R/generated/`,
 `interfaces/python/src/infomap/_swig.py`, and `vendor/` — are excluded from
 every hook; never reformat them.

--- a/interfaces/R/infomap/man/Infomap.Rd
+++ b/interfaces/R/infomap/man/Infomap.Rd
@@ -254,7 +254,7 @@ named list/vector mapping \code{node_id} to \code{name} or to
 \subsection{Method \code{add_state_node()}}{
 Add a state node.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{InfomapClass$add_state_node(state_id, node_id)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{InfomapClass$add_state_node(state_id, node_id, name = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -263,6 +263,9 @@ Add a state node.
 \item{\code{state_id}}{Integer state node id.}
 
 \item{\code{node_id}}{Integer physical node id.}
+
+\item{\code{name}}{Optional name of the state node itself, as opposed to the
+physical node.}
 }
 \if{html}{\out{</div>}}
 }
@@ -279,8 +282,9 @@ Add many state nodes at once.
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{state_nodes}}{A list of \code{c(state_id, node_id)} vectors, or a
-named list/vector mapping \code{state_id} to \code{node_id}.}
+\item{\code{state_nodes}}{A list of \code{c(state_id, node_id)} or
+\code{c(state_id, node_id, name)} vectors, or a named list/vector mapping
+\code{state_id} to \code{node_id}.}
 }
 \if{html}{\out{</div>}}
 }
@@ -865,7 +869,7 @@ Get all assigned state node names.
 }
 
 \subsection{Details}{
-Populated for higher-order (state/memory) networks whose \code{*States}
+Populated for higher-order (state/memory) networks whose \verb{*States}
 section names the state nodes; empty otherwise. Physical node names
 are available separately via \code{get_names()}.
 }

--- a/interfaces/R/infomap/man/infomap_options.Rd
+++ b/interfaces/R/infomap/man/infomap_options.Rd
@@ -52,6 +52,15 @@ Output
 \item{\code{output}}{Write selected output formats as a comma-separated list without spaces, e.g. -o clu,tree,ftree. Options: clu, tree, ftree, newick, json, csv, network, states, flow.}
 \item{\code{hide_bipartite_nodes}}{Hide bipartite nodes in output by projecting the solution to primary nodes.}
 \item{\code{print_all_trials}}{Write each trial to separate output files. Has effect only when --num-trials is greater than 1.}
+\item{\code{no_overwrite}}{Fail with an output error if any target output file already exists. By default existing files are replaced.}
+\item{\code{print_config_fingerprint}}{Print the canonical configuration fingerprint and exit.}
+\item{\code{timing_json}}{Write machine-readable run timing JSON to this path. Use - for stdout.}
+\item{\code{summary_json}}{Write machine-readable final run summary JSON to this path. Use - for stdout.}
+\item{\code{manifest_json}}{Write a machine-readable run manifest JSON to this path. Use - for stdout.}
+\item{\code{memory_report}}{Include peak RSS and best-effort bytes per node/link estimates in timing JSON. Requires --timing-json.}
+\item{\code{trial_offset}}{Global index of the first trial this process runs; trial i uses seed = base_seed + (trial_offset + i). Default 0 (single-process behavior).}
+\item{\code{trial_results}}{Write this shard's per-trial results (codelengths, seeds, best-tree reference, fingerprints) as JSON to this path, for deterministic merging of distributed shard runs into a final solution.}
+\item{\code{no_final_output}}{Skip writing this process's aggregate best result. Per-trial outputs and --trial-results are still written.}
 \item{\code{verbosity_level}}{Increase console verbosity. Add more v flags to increase verbosity up to -vvv.}
 \item{\code{silent}}{Suppress console output.}
 }
@@ -65,6 +74,9 @@ Algorithm
 \item{\code{use_node_weights_as_flow}}{Use node weights from the API or Pajek node records as normalized node flow.}
 \item{\code{to_nodes}}{Teleport to nodes instead of links. Uses uniform node weights unless node weights are provided.}
 \item{\code{teleportation_probability}}{Set the probability of teleporting to a random node or link when calculating flow.}
+\item{\code{max_flow_iterations}}{Limit the power iteration used to calculate flow (directed and regularized flow models) to this many iterations.}
+\item{\code{min_flow_iterations}}{Require at least this many power iterations before the flow calculation can converge, even if --flow-tolerance is already met.}
+\item{\code{flow_tolerance}}{Convergence tolerance for the power iteration used to calculate flow. Iteration stops once the per-iteration change in flow drops to or below this value, after --min-flow-iterations have run.}
 \item{\code{regularized}}{Add a fully connected Bayesian prior network to reduce overfitting to missing links. Activates --recorded-teleportation.}
 \item{\code{regularization_strength}}{Scale the relative strength of the Bayesian prior network used by --regularized.}
 \item{\code{entropy_corrected}}{Correct for negative entropy bias in small samples, especially solutions with many modules.}
@@ -74,11 +86,14 @@ Algorithm
 \item{\code{variable_markov_damping}}{With --variable-markov-time, set damping between local effective degree (0) and local entropy (1).}
 \item{\code{variable_markov_min_scale}}{With --variable-markov-time, set the minimum local scale for zero-entropy nodes. Local Markov time is max scale divided by local scale.}
 \item{\code{preferred_number_of_modules}}{Penalize solutions by how far their number of modules differs from this value.}
+\item{\code{preferred_number_of_levels}}{Soft preference for the depth of the hierarchy. Steering to a shallower depth is reliable at a small codelength cost; deeper is best-effort, bounded by what the optimizer proposes. No-op with --two-level or strength 0.}
+\item{\code{preferred_number_of_levels_strength}}{Scale the strength of --preferred-number-of-levels. 0 disables the preference; larger values increase the cost of deviating from the preferred depth.}
 \item{\code{multilayer_relax_rate}}{Set the probability of relaxing from a state node to neighboring layers instead of staying in the current layer.}
 \item{\code{multilayer_relax_limit}}{Limit relaxation to this many neighboring layer ids in each direction. Use a negative value to allow relaxation to any layer.}
 \item{\code{multilayer_relax_limit_up}}{Limit relaxation upward to this many higher neighboring layer ids. Use a negative value to allow relaxation to any higher layer.}
 \item{\code{multilayer_relax_limit_down}}{Limit relaxation downward to this many lower neighboring layer ids. Use a negative value to allow relaxation to any lower layer.}
 \item{\code{multilayer_relax_by_jsd}}{Weight multilayer relaxation by out-link similarity measured with Jensen-Shannon divergence.}
+\item{\code{multilayer_relax_to_self}}{On relaxation, link a state node to its own physical node in the target layer instead of spreading to its out-neighbors. Builds a smaller state network with the same flow as the default.}
 }
 
 Accuracy
@@ -93,6 +108,9 @@ Accuracy
 \item{\code{fast_hierarchical_solution}}{Find top modules quickly. Use -FF to keep all fast levels. Use -FFF to skip recursive refinement.}
 \item{\code{inner_parallelization}}{Experimental: use batched parallel node moves for coarse optimization. Performance gains are workload-dependent, often require a relaxed core-loop-codelength-threshold and low tune-iteration-limit, and may produce a different partition than serial optimization.}
 \item{\code{parallel_trials}}{Run independent trials in parallel with OpenMP. --num-trials remains the total number of trials; the number of parallel workers follows the OpenMP thread count (e.g. OMP_NUM_THREADS), clamped to --num-trials. Peak memory scales with the worker count. Nested OpenMP and --inner-parallelization are disabled inside workers.}
+\item{\code{converge}}{Treat the trial count as a cap and stop early once the best codelength has plateaued (no meaningful improvement over several consecutive trials). Runs trials serially; cannot be combined with parallel trials or distributed sharding. With no explicit trial count, a default cap is used.}
+\item{\code{num_threads}}{Effective thread budget: 'auto' (resolve from --num-threads > INFOMAP_NUM_THREADS > SLURM_CPUS_PER_TASK > OMP_NUM_THREADS > cpuset > hardware), or a positive integer. 1 forces fully serial. Governs the recursive partition, parallel trials, and inner parallelization.}
+\item{\code{threads}}{Alias for --num-threads.}
 \item{\code{prefer_modular_solution}}{Prefer a modular solution even when one module gives a lower codelength.}
 \item{\code{num_random_moves}}{Try this many random moves in each core loop to merge weakly connected nodes.}
 \item{\code{max_degree_for_random_moves}}{Try random moves only for nodes with degree at most this value.}

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -164,6 +164,8 @@ help:
 		"  test-r                Run R CMD check --as-cran on the staged infomap R package." \
 		"  test-r-examples       Run the R example smoke tests." \
 		"  test-r-swig-freshness Verify tracked R SWIG outputs are up to date." \
+		"  build-r-man           Regenerate the R man pages from the roxygen comments." \
+		"  test-r-man-freshness  Verify tracked R man pages are up to date." \
 		"  test-binding-options-freshness Verify tracked binding option APIs are current." \
 		"  test-js-metadata      Regenerate JS metadata in a temp dir and verify tracked files are current." \
 		"  test-js               Run JS lint/typecheck/unit/browser/package verification for the built npm package." \

--- a/mk/r.mk
+++ b/mk/r.mk
@@ -140,10 +140,12 @@ test-r-man-freshness: build-r-stage
 	@$(RSCRIPT) -e "roxygen2::roxygenise('$(R_STAGED_DIR)', roclets = 'rd')" >/dev/null
 	@status=0; \
 	diff -ru $(R_SKELETON_DIR)/man $(R_STAGED_DIR)/man || status=$$?; \
-	if [ $$status -ne 0 ]; then \
+	if [ $$status -eq 0 ]; then \
+		echo "Tracked R man pages are fresh."; \
+	elif [ $$status -eq 1 ]; then \
 		echo "Tracked R man pages are stale; regenerate with: make build-r-man" >&2; \
 	else \
-		echo "Tracked R man pages are fresh."; \
+		echo "Could not compare the man pages: diff exited $$status (not 0 or 1, so it failed to run rather than finding differences). The check did not conclude anything about freshness." >&2; \
 	fi; \
 	exit $$status
 

--- a/mk/r.mk
+++ b/mk/r.mk
@@ -84,6 +84,8 @@ endif
 .PHONY: \
 	build-r-swig \
 	test-r-swig-freshness \
+	build-r-man \
+	test-r-man-freshness \
 	build-r-stage \
 	build-r \
 	build-r-binary \
@@ -101,6 +103,32 @@ build-r-swig:
 
 test-r-swig-freshness:
 	@SWIG="$(SWIG)" $(PYTHON) $(R_SWIG_SCRIPT) --check --r-out $(R_GENERATED_R) --cpp-out $(R_GENERATED_CPP)
+
+# The man pages are roxygen output, like the SWIG files above, but nothing checked
+# them: 18 options were missing from infomap_options.Rd and add_state_node()'s name
+# argument from Infomap.Rd, so `?infomap_options` documented a smaller API than the
+# package had.
+#
+# Both targets go through the staged package rather than the tracked skeleton,
+# because roxygen has to *load* the package to document its R6 class and the
+# skeleton has no wrapper sources -- src/ holds only Makevars.in. The staged copy
+# is a build directory, so generating there leaves the tracked tree alone.
+build-r-man: build-r-stage
+	@$(RSCRIPT) -e "roxygen2::roxygenise('$(R_STAGED_DIR)', roclets = 'rd')" >/dev/null
+	@rm -f $(R_SKELETON_DIR)/man/*.Rd
+	@cp $(R_STAGED_DIR)/man/*.Rd $(R_SKELETON_DIR)/man/
+	@echo "Regenerated $(R_SKELETON_DIR)/man from the roxygen comments."
+
+test-r-man-freshness: build-r-stage
+	@$(RSCRIPT) -e "roxygen2::roxygenise('$(R_STAGED_DIR)', roclets = 'rd')" >/dev/null
+	@status=0; \
+	diff -ru $(R_SKELETON_DIR)/man $(R_STAGED_DIR)/man || status=$$?; \
+	if [ $$status -ne 0 ]; then \
+		echo "Tracked R man pages are stale; regenerate with: make build-r-man" >&2; \
+	else \
+		echo "Tracked R man pages are fresh."; \
+	fi; \
+	exit $$status
 
 build-r-stage:
 	@$(PYTHON) $(R_STAGE_SCRIPT) --out-dir $(R_STAGED_DIR)

--- a/mk/r.mk
+++ b/mk/r.mk
@@ -113,13 +113,30 @@ test-r-swig-freshness:
 # because roxygen has to *load* the package to document its R6 class and the
 # skeleton has no wrapper sources -- src/ holds only Makevars.in. The staged copy
 # is a build directory, so generating there leaves the tracked tree alone.
+#
+# roxygen's output is version-dependent -- 8.0.0 rewrites the whole R6 section,
+# +731/-685 lines on Infomap.Rd against 7.3.3 -- so the version is pinned the way
+# air's is, and asserted here rather than left to produce a diff CI rejects for a
+# reason the local run does not explain. Keep R_ROXYGEN_VERSION, the pin in
+# .github/workflows/_r-package.yml, and the note in AGENTS.md in step.
+R_ROXYGEN_VERSION := 7.3.3
+
+define require_roxygen_version
+	@$(RSCRIPT) -e "v <- as.character(packageVersion('roxygen2')); \
+	if (v != '$(R_ROXYGEN_VERSION)') stop(sprintf( \
+	  'roxygen2 %s is installed, but the tracked man pages are generated with %s. Its output is version-dependent; install the pinned version or bump R_ROXYGEN_VERSION, the CI pin and the AGENTS.md note together.', \
+	  v, '$(R_ROXYGEN_VERSION)'), call. = FALSE)"
+endef
+
 build-r-man: build-r-stage
+	$(require_roxygen_version)
 	@$(RSCRIPT) -e "roxygen2::roxygenise('$(R_STAGED_DIR)', roclets = 'rd')" >/dev/null
 	@rm -f $(R_SKELETON_DIR)/man/*.Rd
 	@cp $(R_STAGED_DIR)/man/*.Rd $(R_SKELETON_DIR)/man/
 	@echo "Regenerated $(R_SKELETON_DIR)/man from the roxygen comments."
 
 test-r-man-freshness: build-r-stage
+	$(require_roxygen_version)
 	@$(RSCRIPT) -e "roxygen2::roxygenise('$(R_STAGED_DIR)', roclets = 'rd')" >/dev/null
 	@status=0; \
 	diff -ru $(R_SKELETON_DIR)/man $(R_STAGED_DIR)/man || status=$$?; \

--- a/test/python/test_ci_filters.py
+++ b/test/python/test_ci_filters.py
@@ -143,6 +143,29 @@ def test_binding_option_artifacts_trigger_the_lane_that_checks_them(filters):
     )
 
 
+def test_roxygen_sources_trigger_the_lane_that_checks_the_man_pages(filters):
+    """A roxygen comment change must fire the `r` filter.
+
+    `make test-r-man-freshness` runs only in that lane, and the man pages had
+    drifted from their sources with nothing to catch it. A roxygen comment lives in
+    an ordinary R source file, so the coverage that matters is that those files and
+    the generated man pages both match the filter -- otherwise a PR editing one
+    skips the lane and the gate never runs.
+    """
+    r_files = sorted(
+        str(path.relative_to(REPO_ROOT))
+        for path in (REPO_ROOT / "interfaces" / "R" / "infomap").rglob("*")
+        if path.suffix in {".R", ".Rd"} and path.is_file()
+    )
+    if not r_files:
+        pytest.skip("R package not available in this layout")
+    uncovered = _uncovered(r_files, filters["r"])
+    assert not uncovered, (
+        "these R sources or man pages match no `r` pattern, so a change to them "
+        f"would skip the lane that runs make test-r-man-freshness: {uncovered}"
+    )
+
+
 def test_the_generator_is_itself_covered(filters):
     """The generator and its inputs must fire the lane that runs its gate."""
     inputs = [

--- a/test/python/test_ci_filters.py
+++ b/test/python/test_ci_filters.py
@@ -152,8 +152,11 @@ def test_roxygen_sources_trigger_the_lane_that_checks_the_man_pages(filters):
     the generated man pages both match the filter -- otherwise a PR editing one
     skips the lane and the gate never runs.
     """
+    # as_posix(), not str(): the filter patterns and _pattern_to_regex are
+    # "/"-separated, and str() on Windows yields backslashes, so this would report
+    # every R file as uncovered on a platform where the filter is perfectly fine.
     r_files = sorted(
-        str(path.relative_to(REPO_ROOT))
+        path.relative_to(REPO_ROOT).as_posix()
         for path in (REPO_ROOT / "interfaces" / "R" / "infomap").rglob("*")
         if path.suffix in {".R", ".Rd"} and path.is_file()
     )

--- a/test/python/test_ci_workflows.py
+++ b/test/python/test_ci_workflows.py
@@ -92,8 +92,21 @@ def test_the_roxygen_pin_matches_the_makefile():
         if "roxygen2" in item
     ]
     assert refs, "no roxygen2 ref found in any workflow"
+    # Compare the version, not the whole ref: setup-r-dependencies also accepts a
+    # source qualifier ("any::roxygen2@7.3.3"), and adding one should not fail a
+    # check about the pinned version.
+    ref_pattern = re.compile(
+        r"^(?:[A-Za-z0-9._-]+::)?roxygen2(?:@(?P<version>[A-Za-z0-9._-]+))?$"
+    )
     for ref in refs:
-        assert ref == f"roxygen2@{pinned}", (
-            f"workflow installs {ref!r} but mk/r.mk pins {pinned}; the tracked man "
-            "pages only match one version"
+        match = ref_pattern.match(ref)
+        assert match, f"cannot read a version from the roxygen2 ref {ref!r}"
+        version = match.group("version")
+        assert version is not None, (
+            f"workflow installs {ref!r} with no version, but the tracked man pages "
+            f"only match roxygen2 {pinned}"
+        )
+        assert version == pinned, (
+            f"workflow installs roxygen2 {version} but mk/r.mk pins {pinned}; the "
+            "tracked man pages only match one version"
         )

--- a/test/python/test_ci_workflows.py
+++ b/test/python/test_ci_workflows.py
@@ -1,0 +1,99 @@
+"""Shape checks on the workflow YAML that actionlint cannot make.
+
+actionlint validates workflow syntax, expressions and shell, but it does not know
+what a third-party action's inputs mean. So an input that carries a *list* rather
+than a script accepts a comment line as data: `extra-packages` on
+``r-lib/actions/setup-r-dependencies`` is newline-separated package refs, and a
+literal block scalar keeps ``#`` verbatim, so
+
+    extra-packages: |
+      any::testthat
+      # Pinned because ...
+      roxygen2@7.3.3
+
+fails the whole install with ``Cannot parse packages: #, Pinned,`` and takes every
+R leg with it. Caught in CI once; pinned here so the next one is caught locally.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.fast
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+
+# A pak/remotes package ref: "pkg", "any::pkg", "pkg@1.2.3", "user/repo", with an
+# optional trailing comment-free version or source qualifier.
+PACKAGE_REF = re.compile(r"^[A-Za-z0-9._/-]+(::[A-Za-z0-9._/-]+)?(@[A-Za-z0-9._-]+)?$")
+
+# Inputs whose value is a newline-separated list of items rather than a script.
+LIST_VALUED_INPUTS = ("extra-packages", "packages")
+
+
+def _steps(workflow: dict):
+    for job in (workflow.get("jobs") or {}).values():
+        yield from job.get("steps") or []
+
+
+def _workflows():
+    if not WORKFLOW_DIR.is_dir():
+        pytest.skip("workflows not available in this layout")
+    for path in sorted(WORKFLOW_DIR.glob("*.yml")):
+        yield path, yaml.safe_load(path.read_text())
+
+
+def test_list_valued_action_inputs_carry_only_list_items():
+    """No comment lines or prose inside an input that is parsed as a list."""
+    offenders: list[str] = []
+    for path, workflow in _workflows():
+        for step in _steps(workflow):
+            with_block = step.get("with") or {}
+            for input_name in LIST_VALUED_INPUTS:
+                value = with_block.get(input_name)
+                if not isinstance(value, str):
+                    continue
+                for line in value.splitlines():
+                    item = line.strip()
+                    if not item:
+                        continue
+                    if not PACKAGE_REF.match(item):
+                        offenders.append(
+                            f"{path.name}: {input_name} entry {item!r} is not a package ref"
+                        )
+    assert not offenders, (
+        "these entries sit inside an input that is parsed as a list, so they are "
+        "read as items rather than comments:\n" + "\n".join(offenders)
+    )
+
+
+def test_the_roxygen_pin_matches_the_makefile():
+    """The two roxygen2 pins have to agree, or CI regenerates different output.
+
+    roxygen's formatting is version-dependent, so the tracked man pages match one
+    version only. `make test-r-man-freshness` asserts the installed version against
+    R_ROXYGEN_VERSION; this asserts CI installs that same one.
+    """
+    makefile = (REPO_ROOT / "mk" / "r.mk").read_text()
+    match = re.search(r"^R_ROXYGEN_VERSION\s*:=\s*([0-9.]+)", makefile, re.MULTILINE)
+    assert match, "R_ROXYGEN_VERSION not found in mk/r.mk"
+    pinned = match.group(1)
+
+    refs = [
+        item.strip()
+        for _, workflow in _workflows()
+        for step in _steps(workflow)
+        for item in str((step.get("with") or {}).get("extra-packages", "")).splitlines()
+        if "roxygen2" in item
+    ]
+    assert refs, "no roxygen2 ref found in any workflow"
+    for ref in refs:
+        assert ref == f"roxygen2@{pinned}", (
+            f"workflow installs {ref!r} but mk/r.mk pins {pinned}; the tracked man "
+            "pages only match one version"
+        )


### PR DESCRIPTION
Closes #938.

## What had drifted

The roxygen output in `interfaces/R/infomap/man` was the one generated artifact with no freshness check. Regenerating on pristine master rewrote two files:

**`infomap_options.Rd` — 18 options absent:**

```
no_overwrite, print_config_fingerprint, timing_json, summary_json, manifest_json,
memory_report, trial_offset, trial_results, no_final_output, max_flow_iterations,
min_flow_iterations, flow_tolerance, preferred_number_of_levels,
preferred_number_of_levels_strength, multilayer_relax_to_self, converge,
num_threads, threads
```

**`Infomap.Rd`** documented `add_state_node()` as `(state_id, node_id)` while the method takes `(state_id, node_id, name = NULL)`, and `add_state_nodes()`'s accepted shapes were out of date.

`infomap_options()` accepted every one of those options — only the help was behind. So `?infomap_options` has been showing R users a smaller API than they had.

## The gate

`make test-r-man-freshness`, alongside `test-r-swig-freshness` and `test-binding-options-freshness`, plus `make build-r-man` to regenerate.

Both go through the **staged** package rather than the tracked skeleton, because roxygen has to *load* the package to document its R6 class and the skeleton has no wrapper sources — `src/` holds only `Makevars.in`. The staged copy is a build directory, so generating there leaves the tracked tree alone; `build-r-man` copies the result back, clearing `man/*.Rd` first so a removed topic cannot linger.

I tried the cheaper load strategies first, and neither works here:

- `load_source` — fails, the package's R6/S4 loading needs a real load;
- `load_installed` — needs the package installed with `--with-keep.source`, or roxygen aborts with *"R6 class <Infomap> lacks source references"*.

So the gate compiles, which is why it runs on **one leg** of the R matrix: roxygen output does not vary by platform or R version, and that leg already pays for the compile. 30s locally on a warm ccache.

## Verification

Broken on purpose — a roxygen `@section` added without regenerating:

```
$ make test-r-man-freshness
+\section{Drift probe}{
Tracked R man pages are stale; regenerate with: make build-r-man
exit 2
```

And deleting a tracked `.Rd` then running `make build-r-man` restores it. `make test-python` (807 passed), `make format-r-check`, `check yaml` and `actionlint` all pass.

`test_ci_filters` gains a case pinning that the R sources and man pages match the `r` filter, since the gate runs only in that lane — the same silent-skip hole #935 closed for the other two freshness gates.

## Note on #937

That PR adds a roxygen `@section` to `construct_args` and regenerates `construct_args.Rd`. This PR does not touch that file (verified: regenerating on master leaves it unchanged), so they do not conflict. Whichever merges second is still covered — if a stale page slips through, this gate now fails.
