### PR TITLE
fix: reject intake values that were silently reinterpreted as another network

### DIFF
--- a/interfaces/python/src/infomap/_network_input.py
+++ b/interfaces/python/src/infomap/_network_input.py
@@ -9,11 +9,16 @@ def as_native_contiguous(np, array):
     itemsize, and ``readUnaligned`` memcpys into a native-endian value -- so a
     big-endian array on a little-endian host was reinterpreted byte-swapped, with
     no exception and no warning. A 6-node, 7-link network read as 1 node and 1
-    link with codelength 0. Converting rather than rejecting keeps the values and
-    costs one copy of an array that was going to be copied anyway.
+    link with codelength 0. Converting rather than rejecting keeps the values, and
+    the array was going to be made contiguous anyway.
+
+    The dtype and the layout are converted in one call on purpose. Swapping first
+    with ``astype`` copies twice for an F-ordered input: ``astype`` keeps the
+    layout, so the result is still not C-contiguous and ``ascontiguousarray`` then
+    copies it again.
     """
     if not array.dtype.isnative:
-        array = array.astype(array.dtype.newbyteorder("="), copy=False)
+        return np.ascontiguousarray(array, dtype=array.dtype.newbyteorder("="))
     return np.ascontiguousarray(array)
 
 

--- a/interfaces/python/src/infomap/_network_input.py
+++ b/interfaces/python/src/infomap/_network_input.py
@@ -2,6 +2,21 @@ def is_numpy_input(value):
     return value.__class__.__module__.startswith("numpy")
 
 
+def as_native_contiguous(np, array):
+    """Contiguous and in the host's byte order, which the C++ side assumes.
+
+    ``add_bulk_links`` hands the raw buffer across with only the dtype's kind and
+    itemsize, and ``readUnaligned`` memcpys into a native-endian value -- so a
+    big-endian array on a little-endian host was reinterpreted byte-swapped, with
+    no exception and no warning. A 6-node, 7-link network read as 1 node and 1
+    link with codelength 0. Converting rather than rejecting keeps the values and
+    costs one copy of an array that was going to be copied anyway.
+    """
+    if not array.dtype.isnative:
+        array = array.astype(array.dtype.newbyteorder("="), copy=False)
+    return np.ascontiguousarray(array)
+
+
 def as_contiguous_numeric_array(np, array, name):
     if array.dtype.kind not in "uif":
         raise ValueError(f"Numpy {name} arrays must have a numeric dtype.")
@@ -11,7 +26,7 @@ def as_contiguous_numeric_array(np, array, name):
     elif array.dtype.kind in "ui" and array.dtype.itemsize not in (1, 2, 4, 8):
         array = array.astype(np.float64, copy=False)
 
-    return np.ascontiguousarray(array)
+    return as_native_contiguous(np, array)
 
 
 def normalize_numpy_links(
@@ -40,7 +55,7 @@ def normalize_numpy_links(
             raise ValueError(
                 f"Numpy {name} arrays must use 32-bit or 64-bit numeric values."
             )
-        return np.ascontiguousarray(links_array)
+        return as_native_contiguous(np, links_array)
 
     return as_contiguous_numeric_array(np, links_array, name)
 

--- a/src/core/StateNetwork.cpp
+++ b/src/core/StateNetwork.cpp
@@ -437,7 +437,8 @@ std::pair<StateNetwork::NodeMap::iterator, bool> StateNetwork::addStateNodeWithD
   // Config::adaptDefaults rejects a largest-layer-id this big, but a caller that
   // builds a Network directly never goes through it.
   if (shift >= 32) {
-    throw std::runtime_error(fmt::format(FMT_STRING("Matchable multilayer ids need to shift the physical id left by {} bits, which does not fit a 32-bit id. The largest layer id is too large: reduce it so ceil(log2(largest layer id)) + 1 is below 32."), shift));
+    const unsigned int maxLargestLayerId = Config::maxMatchableMultilayerIds;
+    throw std::runtime_error(fmt::format(FMT_STRING("Matchable multilayer ids need to shift the physical id left by {} bits, which does not fit a 32-bit id. Reduce the largest layer id to at most {}."), shift, maxLargestLayerId));
   }
 
   const unsigned int maxPhysId = 1u << (32 - shift);

--- a/src/core/StateNetwork.cpp
+++ b/src/core/StateNetwork.cpp
@@ -424,7 +424,20 @@ std::pair<StateNetwork::NodeMap::iterator, bool> StateNetwork::addStateNodeWithA
 
 std::pair<StateNetwork::NodeMap::iterator, bool> StateNetwork::addStateNodeWithDeterministicId(unsigned int physId, unsigned int layerId, unsigned int numLayersLog2)
 {
-  unsigned int stateId = physId << (numLayersLog2 + 1) | layerId;
+  // The shift has to fit in 32 bits. Only layerId was checked (Network.cpp), so a
+  // physical id at or above this bound wrapped and produced a state id already
+  // taken by a smaller id in the same layer -- 2147483748 << 2 is 400, and so is
+  // 100 << 2. Network::addMultilayerNode then aliased the second physical node
+  // onto the first, so a node disappeared from the partition and every flow moved,
+  // at exit 0 with no warning. With --matchable-multilayer-ids 2 the safe range is
+  // only [0, 2^30), which ordinary ids can exceed.
+  const unsigned int shift = numLayersLog2 + 1;
+  const unsigned int maxPhysId = shift >= 32 ? 0 : (1u << (32 - shift));
+  if (physId >= maxPhysId) {
+    throw std::runtime_error(fmt::format(FMT_STRING("Physical node id {} is too large for matchable multilayer ids: the id is shifted left by {} bits to make room for the layer, so ids must be below {}. Use smaller physical ids, or drop --matchable-multilayer-ids."), physId, shift, maxPhysId));
+  }
+
+  unsigned int stateId = physId << shift | layerId;
   return addStateNode(stateId, physId);
 }
 

--- a/src/core/StateNetwork.cpp
+++ b/src/core/StateNetwork.cpp
@@ -432,7 +432,15 @@ std::pair<StateNetwork::NodeMap::iterator, bool> StateNetwork::addStateNodeWithD
   // at exit 0 with no warning. With --matchable-multilayer-ids 2 the safe range is
   // only [0, 2^30), which ordinary ids can exceed.
   const unsigned int shift = numLayersLog2 + 1;
-  const unsigned int maxPhysId = shift >= 32 ? 0 : (1u << (32 - shift));
+  // Its own error: with shift >= 32 the bound below is 0, so every id would be
+  // reported as "must be below 0", which describes neither the cause nor a fix.
+  // Config::adaptDefaults rejects a largest-layer-id this big, but a caller that
+  // builds a Network directly never goes through it.
+  if (shift >= 32) {
+    throw std::runtime_error(fmt::format(FMT_STRING("Matchable multilayer ids need to shift the physical id left by {} bits, which does not fit a 32-bit id. The largest layer id is too large: reduce it so ceil(log2(largest layer id)) + 1 is below 32."), shift));
+  }
+
+  const unsigned int maxPhysId = 1u << (32 - shift);
   if (physId >= maxPhysId) {
     throw std::runtime_error(fmt::format(FMT_STRING("Physical node id {} is too large for matchable multilayer ids: the id is shifted left by {} bits to make room for the layer, so ids must be below {}. Use smaller physical ids, or drop --matchable-multilayer-ids."), physId, shift, maxPhysId));
   }

--- a/src/io/ClusterMap.cpp
+++ b/src/io/ClusterMap.cpp
@@ -14,6 +14,7 @@
 #include "../utils/FileURI.h"
 #include "../utils/format.h"
 #include <sstream>
+#include "../utils/convert.h"
 
 namespace infomap {
 
@@ -182,8 +183,14 @@ void ClusterMap::readClu(const std::string& filename, bool includeFlow, const st
     unsigned int moduleId;
     unsigned int layerId;
 
-    if (!(lineStream >> stateId >> moduleId))
+    // Validated rather than read straight into the unsigneds: `>> unsigned`
+    // accepts a leading '-' and stores the value modulo 2^32.
+    std::string stateIdToken;
+    std::string moduleIdToken;
+    if (!(lineStream >> stateIdToken >> moduleIdToken))
       throw std::runtime_error(fmt::format(FMT_STRING("Couldn't parse node key and cluster id from line '{}'"), line));
+    if (!io::parseNonNegativeInteger(stateIdToken, stateId) || !io::parseNonNegativeInteger(moduleIdToken, moduleId))
+      throw std::runtime_error(fmt::format(FMT_STRING("Couldn't parse node key and cluster id from line '{}': expected two non-negative integers, got '{}' and '{}'"), line, stateIdToken, moduleIdToken));
 
     auto flow = 0.0;
     if (lineStream >> flow) {

--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -148,6 +148,19 @@ namespace {
     }
   }
 
+  // The matchable state id is `physId << (ceil(log2(N)) + 1) | layerId`, so an N
+  // this large makes the shift count 32 or more: undefined behaviour, which in
+  // practice changed the flows even for single-digit node ids at exit 0. Bounding N
+  // keeps the shift inside 32 bits; the companion check on the physical id lives in
+  // StateNetwork::addStateNodeWithDeterministicId.
+  void validateMatchableMultilayerIds(const Config& config)
+  {
+    const unsigned int maxLargestLayerId = 1u << 30;
+    if (config.matchableMultilayerIds > maxLargestLayerId) {
+      throw std::runtime_error(fmt::format(FMT_STRING("--matchable-multilayer-ids {} is too large: the largest layer id must be at most {}, so the state id shift stays within 32 bits"), config.matchableMultilayerIds, maxLargestLayerId));
+    }
+  }
+
   void validateConvergeTrials(const Config& config)
   {
     if (!config.convergeTrials) {
@@ -482,6 +495,7 @@ void Config::adaptDefaults()
   validateRequiredCliOutput(*this);
   applyOptionInteractions(*this);
   validateConvergeTrials(*this);
+  validateMatchableMultilayerIds(*this);
 #if INFOMAP_FEATURE_LOSSY_MAP_EQUATION
   applyAndValidateLossyInteraction(*this);
 #endif

--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -155,7 +155,8 @@ namespace {
   // StateNetwork::addStateNodeWithDeterministicId.
   void validateMatchableMultilayerIds(const Config& config)
   {
-    const unsigned int maxLargestLayerId = 1u << 30;
+    // Local copy avoids odr-use of the constexpr member (no out-of-line definition).
+    const unsigned int maxLargestLayerId = Config::maxMatchableMultilayerIds;
     if (config.matchableMultilayerIds > maxLargestLayerId) {
       throw std::runtime_error(fmt::format(FMT_STRING("--matchable-multilayer-ids {} is too large: the largest layer id must be at most {}, so the state id shift stays within 32 bits"), config.matchableMultilayerIds, maxLargestLayerId));
     }

--- a/src/io/Config.h
+++ b/src/io/Config.h
@@ -134,6 +134,11 @@ struct Config {
   static constexpr unsigned int convergePatience = 5; // consecutive non-improving trials before stopping
   static constexpr unsigned int convergeMinTrials = 5; // floor before the plateau rule can fire
   static constexpr unsigned int convergeDefaultMaxTrials = 50; // cap used when --converge is set without an explicit -N (~3.5x headroom over worst observed)
+  // Largest --matchable-multilayer-ids value whose state id still fits 32 bits: the
+  // id is `physId << (ceil(log2(N)) + 1) | layerId`, so N above 2^30 makes the shift
+  // count 32 or more, which is undefined behaviour. Shared with StateNetwork, which
+  // reports the same bound when it rejects the shift.
+  static constexpr unsigned int maxMatchableMultilayerIds = 1u << 30;
 #endif
   double minimumCodelengthImprovement = 1e-10;
   double minimumSingleNodeCodelengthImprovement = 1e-16;

--- a/src/io/JsonNetworkInputParser.h
+++ b/src/io/JsonNetworkInputParser.h
@@ -294,8 +294,12 @@ namespace input {
             node.hasWeight = true;
           } else if (currentKey == "meta") {
             unsigned int meta = 0;
-            if (!coerceUnsigned(number.value, meta) || !number.integral)
-              throw std::runtime_error(fmt::format(FMT_STRING("Invalid node meta '{:g}' (must be a non-negative integer)"), number.value));
+            // Bounded by int, not unsigned: the value is stored in a vector<int>, so
+            // anything above INT_MAX came back out negative -- the same wrap the text
+            // path had, and fixing one without the other would just move the
+            // disagreement between the two parsers.
+            if (!coerceUnsigned(number.value, meta) || !number.integral || meta > static_cast<unsigned int>(std::numeric_limits<int>::max()))
+              throw std::runtime_error(fmt::format(FMT_STRING("Invalid node meta '{:g}' (must be a non-negative integer no greater than {})"), number.value, std::numeric_limits<int>::max()));
             node.meta = static_cast<int>(meta);
             node.hasMeta = true;
           } else if (currentKey == "path" && inFieldArray()) {

--- a/src/io/JsonNetworkInputParser.h
+++ b/src/io/JsonNetworkInputParser.h
@@ -282,6 +282,14 @@ namespace input {
               throw std::runtime_error(fmt::format(FMT_STRING("Invalid node id '{:g}' (must be a non-negative integer <= {})"), number.value, std::numeric_limits<unsigned int>::max()));
             node.hasId = true;
           } else if (currentKey == "weight") {
+            // Same rule the text parser applies to a *Vertices weight, and the
+            // one the normative schema states (weight.minimum: 0). Without it a
+            // negative weight reached addPhysicalNode verbatim -- unlike addLink,
+            // which is the documented funnel that rejects these -- and the run
+            // only failed later, in the flow guard, with a message about
+            // bipartite teleportation that has nothing to do with the cause.
+            if (!(number.value >= 0) || !std::isfinite(number.value))
+              throw std::runtime_error(fmt::format(FMT_STRING("Invalid node weight '{:g}' (must be a finite non-negative number)"), number.value));
             node.weight = number.value;
             node.hasWeight = true;
           } else if (currentKey == "meta") {
@@ -306,6 +314,8 @@ namespace input {
               throw std::runtime_error(fmt::format(FMT_STRING("Invalid state physical node '{:g}' (must be a non-negative integer)"), number.value));
             state.hasNode = true;
           } else if (currentKey == "weight") {
+            if (!(number.value >= 0) || !std::isfinite(number.value))
+              throw std::runtime_error(fmt::format(FMT_STRING("Invalid state weight '{:g}' (must be a finite non-negative number)"), number.value));
             state.weight = number.value;
             state.hasWeight = true;
           } else if (currentKey == "path" && inFieldArray()) {

--- a/src/io/NetworkInputParser.h
+++ b/src/io/NetworkInputParser.h
@@ -242,8 +242,13 @@ namespace input {
 
         std::istringstream extractor(line);
         ParsedVertex vertex;
-        if (!(extractor >> vertex.id))
+        std::string idToken;
+        if (!(extractor >> idToken))
           throw std::runtime_error(fmt::format(FMT_STRING("Can't parse node id from line '{}'"), line));
+        // Validated rather than read straight into the unsigned: `>> unsigned`
+        // accepts "-2" and stores 4294967294.
+        if (!io::parseNonNegativeInteger(idToken, vertex.id))
+          throw std::runtime_error(fmt::format(FMT_STRING("Can't parse node id '{}' from line '{}': expected a non-negative integer no greater than {}"), idToken, line, std::numeric_limits<unsigned int>::max()));
 
         auto nameStart = line.find_first_of('\"');
         auto nameEnd = line.find_last_of('\"');
@@ -511,8 +516,11 @@ namespace input {
 
       std::istringstream extractor(line);
       unsigned int nodeId = 0;
-      if (!(extractor >> nodeId))
+      std::string metaIdToken;
+      if (!(extractor >> metaIdToken))
         throw std::runtime_error(fmt::format(FMT_STRING("Can't parse node id from line '{}'"), line));
+      if (!io::parseNonNegativeInteger(metaIdToken, nodeId))
+        throw std::runtime_error(fmt::format(FMT_STRING("Can't parse node id '{}' from line '{}': expected a non-negative integer no greater than {}"), metaIdToken, line, std::numeric_limits<unsigned int>::max()));
 
       std::vector<int> metaData;
       unsigned int metaId = 0;

--- a/src/io/NetworkInputParser.h
+++ b/src/io/NetworkInputParser.h
@@ -529,10 +529,25 @@ namespace input {
       std::vector<int> metaData;
       std::string metaToken;
       while (extractor >> metaToken) {
-        unsigned int metaId = 0;
-        if (!io::parseNonNegativeInteger(metaToken, metaId) || metaId > static_cast<unsigned int>(std::numeric_limits<int>::max()))
-          throw std::runtime_error(fmt::format(FMT_STRING("Can't parse meta category '{}' from line '{}': expected a non-negative integer no greater than {}"), metaToken, line, std::numeric_limits<int>::max()));
-        metaData.push_back(static_cast<int>(metaId));
+        // An inline '#' ends the line, the same convention the link rows use
+        // (parseLink stops at '#'). Reading the categories as unsigned used to give
+        // this for free -- the stream failed on '#' and quietly ended the loop -- so
+        // validating the tokens has to keep it explicitly or "1 2 # note" stops
+        // parsing, which it did.
+        const auto commentStart = metaToken.find('#');
+        const bool commentFollows = commentStart != std::string::npos;
+        if (commentFollows)
+          metaToken.erase(commentStart);
+
+        if (!metaToken.empty()) {
+          unsigned int metaId = 0;
+          if (!io::parseNonNegativeInteger(metaToken, metaId) || metaId > static_cast<unsigned int>(std::numeric_limits<int>::max()))
+            throw std::runtime_error(fmt::format(FMT_STRING("Can't parse meta category '{}' from line '{}': expected a non-negative integer no greater than {}"), metaToken, line, std::numeric_limits<int>::max()));
+          metaData.push_back(static_cast<int>(metaId));
+        }
+
+        if (commentFollows)
+          break;
       }
       if (metaData.empty())
         throw std::runtime_error(fmt::format(FMT_STRING("Can't parse any meta data from line '{}'"), line));

--- a/src/io/NetworkInputParser.h
+++ b/src/io/NetworkInputParser.h
@@ -516,11 +516,11 @@ namespace input {
 
       std::istringstream extractor(line);
       unsigned int nodeId = 0;
-      std::string metaIdToken;
-      if (!(extractor >> metaIdToken))
+      std::string nodeIdToken;
+      if (!(extractor >> nodeIdToken))
         throw std::runtime_error(fmt::format(FMT_STRING("Can't parse node id from line '{}'"), line));
-      if (!io::parseNonNegativeInteger(metaIdToken, nodeId))
-        throw std::runtime_error(fmt::format(FMT_STRING("Can't parse node id '{}' from line '{}': expected a non-negative integer no greater than {}"), metaIdToken, line, std::numeric_limits<unsigned int>::max()));
+      if (!io::parseNonNegativeInteger(nodeIdToken, nodeId))
+        throw std::runtime_error(fmt::format(FMT_STRING("Can't parse node id '{}' from line '{}': expected a non-negative integer no greater than {}"), nodeIdToken, line, std::numeric_limits<unsigned int>::max()));
 
       // Same treatment as the id above, and for the same reason: `>> unsigned`
       // takes "-1" as 4294967295, which then becomes -1 again in this vector<int>,

--- a/src/io/NetworkInputParser.h
+++ b/src/io/NetworkInputParser.h
@@ -522,10 +522,17 @@ namespace input {
       if (!io::parseNonNegativeInteger(metaIdToken, nodeId))
         throw std::runtime_error(fmt::format(FMT_STRING("Can't parse node id '{}' from line '{}': expected a non-negative integer no greater than {}"), metaIdToken, line, std::numeric_limits<unsigned int>::max()));
 
+      // Same treatment as the id above, and for the same reason: `>> unsigned`
+      // takes "-1" as 4294967295, which then becomes -1 again in this vector<int>,
+      // so two different files produced the same category with no complaint. The
+      // upper bound is int, not unsigned, because that is what the vector holds.
       std::vector<int> metaData;
-      unsigned int metaId = 0;
-      while (extractor >> metaId) {
-        metaData.push_back(metaId);
+      std::string metaToken;
+      while (extractor >> metaToken) {
+        unsigned int metaId = 0;
+        if (!io::parseNonNegativeInteger(metaToken, metaId) || metaId > static_cast<unsigned int>(std::numeric_limits<int>::max()))
+          throw std::runtime_error(fmt::format(FMT_STRING("Can't parse meta category '{}' from line '{}': expected a non-negative integer no greater than {}"), metaToken, line, std::numeric_limits<int>::max()));
+        metaData.push_back(static_cast<int>(metaId));
       }
       if (metaData.empty())
         throw std::runtime_error(fmt::format(FMT_STRING("Can't parse any meta data from line '{}'"), line));

--- a/src/utils/convert.h
+++ b/src/utils/convert.h
@@ -192,8 +192,12 @@ namespace io {
   // its name. The link and *States rows never had that problem because they parse
   // ids by hand; this is the same rule, in a place every id reader can reach.
   //
-  // Deliberately strict: no sign, no whitespace inside, no trailing characters,
-  // no overflow. A caller that wants a signed value should read a signed type.
+  // An optional leading '+' is accepted because detail::parseUnsigned, which the link
+  // rows use, accepts it -- the point of this function is to give every id reader the
+  // same rule, so it has to match the reader that was already right. A '-' is refused,
+  // and so is anything after the digits: the link rows refuse "1x" and "1.5" too, so
+  // the *Vertices and .clu readers refusing them is the same convention rather than a
+  // new one.
   //
   // The bound is checked after every digit, not once at the end, so `result` is at
   // most 4294967295 entering an iteration and the next step reaches at most
@@ -202,11 +206,15 @@ namespace io {
   // the check out of the loop and that stops being true.
   inline bool parseNonNegativeInteger(const std::string& token, unsigned int& value)
   {
-    if (token.empty())
+    std::size_t index = 0;
+    if (index < token.size() && token[index] == '+')
+      ++index;
+    if (index >= token.size())
       return false;
 
     unsigned long long result = 0;
-    for (const char c : token) {
+    for (; index < token.size(); ++index) {
+      const char c = token[index];
       if (c < '0' || c > '9')
         return false;
       result = result * 10 + static_cast<unsigned long long>(c - '0');

--- a/src/utils/convert.h
+++ b/src/utils/convert.h
@@ -194,6 +194,12 @@ namespace io {
   //
   // Deliberately strict: no sign, no whitespace inside, no trailing characters,
   // no overflow. A caller that wants a signed value should read a signed type.
+  //
+  // The bound is checked after every digit, not once at the end, so `result` is at
+  // most 4294967295 entering an iteration and the next step reaches at most
+  // 42949672959 -- nowhere near the 64-bit ceiling. That is what keeps an arbitrarily
+  // long digit string safe: it is rejected by the eleventh digit at the latest. Move
+  // the check out of the loop and that stops being true.
   inline bool parseNonNegativeInteger(const std::string& token, unsigned int& value)
   {
     if (token.empty())

--- a/src/utils/convert.h
+++ b/src/utils/convert.h
@@ -183,6 +183,35 @@ namespace io {
     return std::string(size - valStr.size(), paddingChar).append(valStr);
   }
 
+  // Whether `token` is exactly a non-negative decimal integer that fits an
+  // unsigned int, storing it in `value` when it is.
+  //
+  // `std::istream >> unsigned` accepts a leading '-' and stores the value modulo
+  // 2^32, so reading an id that way turned "-2" into 4294967294 instead of
+  // failing: a phantom node in its own module, and the real node silently losing
+  // its name. The link and *States rows never had that problem because they parse
+  // ids by hand; this is the same rule, in a place every id reader can reach.
+  //
+  // Deliberately strict: no sign, no whitespace inside, no trailing characters,
+  // no overflow. A caller that wants a signed value should read a signed type.
+  inline bool parseNonNegativeInteger(const std::string& token, unsigned int& value)
+  {
+    if (token.empty())
+      return false;
+
+    unsigned long long result = 0;
+    for (const char c : token) {
+      if (c < '0' || c > '9')
+        return false;
+      result = result * 10 + static_cast<unsigned long long>(c - '0');
+      if (result > std::numeric_limits<unsigned int>::max())
+        return false;
+    }
+
+    value = static_cast<unsigned int>(result);
+    return true;
+  }
+
   // Defined in convert.cpp with fmt, to keep the heavy fmt header out of this
   // widely-included file. {:.{}g} reproduces std::setprecision(precision) with
   // the default floatfield, {:.{}f} reproduces std::fixed << setprecision(...);

--- a/test/cpp/test_network.cpp
+++ b/test/cpp/test_network.cpp
@@ -1009,11 +1009,19 @@ TEST_CASE("Node id tokens must be exactly a non-negative integer [fast][core][pa
     return ok;
   };
 
+  // The reference is what the link rows accept: detail::parseUnsigned is the reader
+  // that was already right, so the *Vertices reader has to agree with it token for
+  // token. Verified against the link rows for every case here -- "+1" is accepted
+  // because they accept it, and "1x"/"1.5" are refused because they refuse those.
   CHECK(parses("1"));
   CHECK(parses("0"));
+  CHECK(parses("+1")); // a leading plus, which the link rows allow
+  CHECK(parses("+4294967295"));
   CHECK(parses("4294967295")); // the largest id that fits
   CHECK(parses("0000000000000000000000000000000000000042")); // leading zeros are fine
   CHECK_FALSE(parses("-2"));
+  CHECK_FALSE(parses("+")); // a sign with no digits
+  CHECK_FALSE(parses("++1"));
   CHECK_FALSE(parses("4294967296")); // one past the top, previously wrapped to 0
   CHECK_FALSE(parses("2x"));
   CHECK_FALSE(parses("1.5"));

--- a/test/cpp/test_network.cpp
+++ b/test/cpp/test_network.cpp
@@ -1083,6 +1083,63 @@ TEST_CASE("Matchable multilayer ids reject a physical id that would wrap [fast][
   CHECK_THROWS_AS(safeNetwork.addMultilayerLink(1, 1u << 30, 1, 7, 1.0), std::runtime_error);
 }
 
+TEST_CASE("Meta categories must be non-negative and fit an int [fast][core][parser]")
+{
+  // The categories land in a vector<int>, and `>> unsigned` took "-1" as 4294967295
+  // which became -1 again on the way in -- so two different files produced the same
+  // category with no complaint. The bound is int, not unsigned, for the same reason.
+  const auto parses = [](const std::string& metaLine) {
+    const std::string net = "meta_category_test.net";
+    const std::string meta = "meta_category_test.meta";
+    {
+      std::ofstream out(net.c_str());
+      out << "*Vertices 2\n1 \"a\"\n2 \"b\"\n*Edges\n1 2 1\n";
+    }
+    {
+      std::ofstream out(meta.c_str());
+      out << metaLine << "\n2 1\n";
+    }
+    FakeInputSink sink;
+    bool ok = true;
+    try {
+      infomap::input::parseMetaDataInput(meta, sink);
+    } catch (const std::runtime_error&) {
+      ok = false;
+    }
+    std::remove(net.c_str());
+    std::remove(meta.c_str());
+    return ok;
+  };
+
+  CHECK(parses("1 0"));
+  CHECK(parses("1 2147483647")); // the largest category that fits an int
+  CHECK_FALSE(parses("1 -1"));
+  CHECK_FALSE(parses("1 2147483648")); // fits an unsigned, not an int
+  CHECK_FALSE(parses("1 4294967295")); // previously arrived as -1
+  CHECK_FALSE(parses("1 x"));
+}
+
+TEST_CASE("A shift past 32 bits reports the shift, not an id bound of zero [fast][core][crash]")
+{
+  // Config::adaptDefaults refuses a largest-layer-id this big, but a caller that
+  // builds a Network directly never goes through it -- and there the id bound
+  // computes to 0, so every id was reported as "must be below 0", which describes
+  // neither the cause nor a fix.
+  Config config;
+  config.silent = true;
+  config.matchableMultilayerIds = 1u << 31;
+  Network network(config);
+
+  try {
+    network.addMultilayerLink(1, 1, 1, 2, 1.0);
+    FAIL("expected the out-of-range shift to be rejected");
+  } catch (const std::runtime_error& e) {
+    const std::string message = e.what();
+    CHECK(message.find("32-bit") != std::string::npos);
+    CHECK(message.find("must be below 0") == std::string::npos);
+  }
+}
+
 TEST_CASE("A largest-layer-id that would shift past 32 bits is rejected [fast][core][config]")
 {
   // ceil(log2(N)) + 1 >= 32 is undefined behaviour, and in practice changed the

--- a/test/cpp/test_network.cpp
+++ b/test/cpp/test_network.cpp
@@ -1089,12 +1089,8 @@ TEST_CASE("Meta categories must be non-negative and fit an int [fast][core][pars
   // which became -1 again on the way in -- so two different files produced the same
   // category with no complaint. The bound is int, not unsigned, for the same reason.
   const auto parses = [](const std::string& metaLine) {
-    const std::string net = "meta_category_test.net";
+    // Only the .meta file: parseMetaDataInput never reads the network.
     const std::string meta = "meta_category_test.meta";
-    {
-      std::ofstream out(net.c_str());
-      out << "*Vertices 2\n1 \"a\"\n2 \"b\"\n*Edges\n1 2 1\n";
-    }
     {
       std::ofstream out(meta.c_str());
       out << metaLine << "\n2 1\n";
@@ -1106,7 +1102,6 @@ TEST_CASE("Meta categories must be non-negative and fit an int [fast][core][pars
     } catch (const std::runtime_error&) {
       ok = false;
     }
-    std::remove(net.c_str());
     std::remove(meta.c_str());
     return ok;
   };

--- a/test/cpp/test_network.cpp
+++ b/test/cpp/test_network.cpp
@@ -1012,10 +1012,18 @@ TEST_CASE("Node id tokens must be exactly a non-negative integer [fast][core][pa
   CHECK(parses("1"));
   CHECK(parses("0"));
   CHECK(parses("4294967295")); // the largest id that fits
+  CHECK(parses("0000000000000000000000000000000000000042")); // leading zeros are fine
   CHECK_FALSE(parses("-2"));
   CHECK_FALSE(parses("4294967296")); // one past the top, previously wrapped to 0
   CHECK_FALSE(parses("2x"));
   CHECK_FALSE(parses("1.5"));
+  // Long digit strings, including values that would wrap a 64-bit accumulator. The
+  // parser bounds the result after every digit rather than once at the end, so it
+  // gives up by the eleventh digit; moving that check out of the loop would make
+  // these accept a wrapped value instead.
+  CHECK_FALSE(parses("18446744073709551616")); // 2^64
+  CHECK_FALSE(parses("18446744073709551620")); // 2^64 + 4
+  CHECK_FALSE(parses("42949672960000000000000000000000000000"));
 }
 
 TEST_CASE("JSON node and state weights must be finite and non-negative [fast][core][parser][json]")

--- a/test/cpp/test_network.cpp
+++ b/test/cpp/test_network.cpp
@@ -1108,6 +1108,11 @@ TEST_CASE("Meta categories must be non-negative and fit an int [fast][core][pars
 
   CHECK(parses("1 0"));
   CHECK(parses("1 2147483647")); // the largest category that fits an int
+  // An inline '#' ends the line, as it does for the link rows. Reading the
+  // categories as unsigned used to give this for free (the stream failed on '#'
+  // and quietly ended the loop), so validating the tokens has to keep it.
+  CHECK(parses("1 0 # a trailing comment"));
+  CHECK(parses("1 0#tight"));
   CHECK_FALSE(parses("1 -1"));
   CHECK_FALSE(parses("1 2147483648")); // fits an unsigned, not an int
   CHECK_FALSE(parses("1 4294967295")); // previously arrived as -1

--- a/test/cpp/test_network.cpp
+++ b/test/cpp/test_network.cpp
@@ -958,3 +958,136 @@ TEST_CASE("External --meta-data composes with a JSON network [fast][core][parser
 }
 
 } // namespace
+
+// Four intake paths accepted values they should reject, and each accepted value was
+// then reinterpreted as a *different* network -- a phantom node, two physical nodes
+// merged into one, a NaN codelength (#909). In every case a sibling path in the same
+// codebase already validated correctly.
+
+TEST_CASE("Negative node ids are rejected rather than wrapped [fast][core][parser]")
+{
+  // `istream >> unsigned` accepts a leading '-' and stores the value modulo 2^32, so
+  // "-2" became 4294967294: a phantom zero-flow node in its own module, while the
+  // real node 2 silently lost its name. The link rows never had this problem, since
+  // they parse ids by hand.
+  const std::string path = "vertices_negative_id_test.net";
+  {
+    std::ofstream out(path.c_str());
+    out << "*Vertices 3\n1 \"a\"\n-2 \"b\"\n3 \"c\"\n*Edges\n1 2 1\n2 3 1\n";
+  }
+
+  FakeInputSink sink;
+  CHECK_THROWS_AS(infomap::input::parseNetworkInput(path, sink, defaultInputOptions), std::runtime_error);
+  try {
+    FakeInputSink retry;
+    infomap::input::parseNetworkInput(path, retry, defaultInputOptions);
+  } catch (const std::runtime_error& e) {
+    const std::string message = e.what();
+    // The message has to name the token, or the reader cannot find the bad line.
+    CHECK(message.find("-2") != std::string::npos);
+  }
+
+  std::remove(path.c_str());
+}
+
+TEST_CASE("Node id tokens must be exactly a non-negative integer [fast][core][parser]")
+{
+  const auto parses = [](const std::string& idToken) {
+    const std::string path = "vertices_id_token_test.net";
+    {
+      std::ofstream out(path.c_str());
+      out << "*Vertices 2\n" << idToken << " \"a\"\n2 \"b\"\n*Edges\n1 2 1\n";
+    }
+    FakeInputSink sink;
+    bool ok = true;
+    try {
+      infomap::input::parseNetworkInput(path, sink, defaultInputOptions);
+    } catch (const std::runtime_error&) {
+      ok = false;
+    }
+    std::remove(path.c_str());
+    return ok;
+  };
+
+  CHECK(parses("1"));
+  CHECK(parses("0"));
+  CHECK(parses("4294967295")); // the largest id that fits
+  CHECK_FALSE(parses("-2"));
+  CHECK_FALSE(parses("4294967296")); // one past the top, previously wrapped to 0
+  CHECK_FALSE(parses("2x"));
+  CHECK_FALSE(parses("1.5"));
+}
+
+TEST_CASE("JSON node and state weights must be finite and non-negative [fast][core][parser][json]")
+{
+  // The text parser rejects a negative *Vertices weight and the repo's own schema
+  // sets weight.minimum 0, but the SAX parser stored it verbatim. addPhysicalNode
+  // assigns it as-is -- unlike addLink, the documented funnel that rejects these --
+  // so the run failed later in the flow guard, with a message about bipartite
+  // teleportation that has nothing to do with the cause.
+  const auto parses = [](const std::string& body) {
+    const std::string path = "json_weight_sign_test.json";
+    {
+      std::ofstream out(path.c_str());
+      out << body;
+    }
+    FakeInputSink sink;
+    bool ok = true;
+    try {
+      infomap::input::parseJsonNetworkInput(path, sink, defaultInputOptions);
+    } catch (const std::runtime_error&) {
+      ok = false;
+    }
+    std::remove(path.c_str());
+    return ok;
+  };
+
+  const std::string header = R"({"format":"infomap-network","version":"1.0",)";
+
+  CHECK(parses(header + R"("nodes":[{"id":1,"weight":2.0}],"edges":[{"source":1,"target":2}]})"));
+  CHECK(parses(header + R"("nodes":[{"id":1,"weight":0.0}],"edges":[{"source":1,"target":2}]})"));
+  CHECK_FALSE(parses(header + R"("nodes":[{"id":1,"weight":-1.0}],"edges":[{"source":1,"target":2}]})"));
+  CHECK_FALSE(parses(header + R"("states":[{"id":1,"node":1,"weight":-2.5}],"links":[{"source":1,"target":2}]})"));
+}
+
+TEST_CASE("Matchable multilayer ids reject a physical id that would wrap [fast][core][crash]")
+{
+  // The state id is `physId << (ceil(log2(N)) + 1) | layerId`, and only layerId was
+  // checked. With N = 2 the shift is 2, so 2147483748 << 2 is 400 -- exactly
+  // 100 << 2. addMultilayerNode then aliased the second physical node onto the
+  // first: a node vanished from the partition and every flow moved, at exit 0.
+  Config config;
+  config.silent = true;
+  config.matchableMultilayerIds = 2;
+  Network network(config);
+
+  network.addMultilayerLink(1, 100, 1, 7, 1.0);
+  CHECK_THROWS_AS(network.addMultilayerLink(1, 2147483748u, 1, 7, 1.0), std::runtime_error);
+
+  // The bound is the shift, not an arbitrary ceiling: the largest id that still
+  // fits is accepted.
+  Config safeConfig;
+  safeConfig.silent = true;
+  safeConfig.matchableMultilayerIds = 2;
+  Network safeNetwork(safeConfig);
+  const unsigned int largestFitting = (1u << 30) - 1;
+  CHECK_NOTHROW(safeNetwork.addMultilayerLink(1, largestFitting, 1, 7, 1.0));
+  CHECK_THROWS_AS(safeNetwork.addMultilayerLink(1, 1u << 30, 1, 7, 1.0), std::runtime_error);
+}
+
+TEST_CASE("A largest-layer-id that would shift past 32 bits is rejected [fast][core][config]")
+{
+  // ceil(log2(N)) + 1 >= 32 is undefined behaviour, and in practice changed the
+  // flows even for single-digit node ids at exit 0.
+  Config config;
+  config.silent = true;
+  config.noFileOutput = true;
+  config.matchableMultilayerIds = 1u << 31;
+  CHECK_THROWS_AS(config.adaptDefaults(), std::runtime_error);
+
+  Config atTheBound;
+  atTheBound.silent = true;
+  atTheBound.noFileOutput = true;
+  atTheBound.matchableMultilayerIds = 1u << 30;
+  CHECK_NOTHROW(atTheBound.adaptDefaults());
+}

--- a/test/cpp/test_network.cpp
+++ b/test/cpp/test_network.cpp
@@ -1130,8 +1130,16 @@ TEST_CASE("A shift past 32 bits reports the shift, not an id bound of zero [fast
     FAIL("expected the out-of-range shift to be rejected");
   } catch (const std::runtime_error& e) {
     const std::string message = e.what();
+    MESSAGE(message);
     CHECK(message.find("32-bit") != std::string::npos);
     CHECK(message.find("must be below 0") == std::string::npos);
+    // The bound is spelled out, not left as an expression for the reader to
+    // evaluate: "reduce it so ceil(log2(largest layer id)) + 1 is below 32" is a
+    // constant dressed as homework, and the sibling message in Config already
+    // prints the number.
+    const std::string bound = std::to_string(Config::maxMatchableMultilayerIds);
+    CHECK(message.find(bound) != std::string::npos);
+    CHECK(message.find("log2") == std::string::npos);
   }
 }
 

--- a/test/python/test_add_links.py
+++ b/test/python/test_add_links.py
@@ -192,3 +192,46 @@ def test_add_links_rejects_invalid_numpy_shapes(make_infomap):
 
     with pytest.raises(ValueError, match="32-bit or 64-bit"):
         im.add_links(np.array([[1, 2]], dtype=np.uint16))
+
+
+# A link array reaches C++ as a raw buffer plus only its dtype kind and itemsize, and
+# readUnaligned memcpys into a native-endian value -- so a non-native array was
+# reinterpreted byte-swapped with no exception and no warning: this 6-node, 7-link
+# network read as 1 node and 1 link with codelength 0 (#909).
+def test_add_links_result_is_independent_of_byte_order(make_infomap):
+    np = pytest.importorskip("numpy")
+
+    links = np.array([[1, 2], [1, 3], [2, 3], [4, 5], [4, 6], [5, 6], [3, 4]])
+
+    results = {}
+    for dtype in ("<f8", ">f8", "<i4", ">i4", ">f4"):
+        im = make_infomap(seed=42)
+        im.add_links(links.astype(dtype))
+        result = im.run()
+        results[dtype] = (
+            result.num_nodes,
+            result.num_links,
+            round(result.codelength, 9),
+        )
+
+    native = results["<f8"]
+    assert native[0] == 6, f"expected the 6-node network, got {native}"
+    for dtype, value in results.items():
+        assert value == native, f"{dtype} gave {value}, native gave {native}"
+
+
+def test_add_links_byte_order_independence_holds_for_weights(make_infomap):
+    np = pytest.importorskip("numpy")
+
+    links = np.array([[1, 2, 2.5], [2, 3, 0.5], [1, 3, 1.0]])
+
+    outcomes = []
+    for dtype in ("<f8", ">f8"):
+        im = make_infomap(seed=42)
+        im.add_links(links.astype(dtype))
+        result = im.run()
+        outcomes.append(
+            (result.num_nodes, result.num_links, round(result.codelength, 9))
+        )
+
+    assert outcomes[0] == outcomes[1], f"byte order changed the result: {outcomes}"

--- a/test/python/test_add_links.py
+++ b/test/python/test_add_links.py
@@ -214,7 +214,12 @@ def test_add_links_result_is_independent_of_byte_order(make_infomap):
             round(result.codelength, 9),
         )
 
-    native = results["<f8"]
+    # Derived, not assumed: "<f8" is non-native on a big-endian host, and using it
+    # as the reference there would compare every dtype against a byte-swapped
+    # baseline -- the test would agree with itself while every result was wrong.
+    native_key = np.dtype("f8").str
+    assert native_key in results, f"native dtype {native_key} not among {list(results)}"
+    native = results[native_key]
     assert native[0] == 6, f"expected the 6-node network, got {native}"
     for dtype, value in results.items():
         assert value == native, f"{dtype} gave {value}, native gave {native}"


### PR DESCRIPTION
Closes #909. Four intake paths accepted a value they should have refused, and each accepted value then changed *which network was analysed*, at exit 0. In every case a sibling path in the same codebase already validated correctly.

## 1. Negative node ids wrapped

`istream >> unsigned` accepts a leading `-` and stores the value modulo 2^32, so a `*Vertices` line `-2` became 4294967294:

```
$ ./Infomap vneg.net out -o tree        # 3 nodes, 1 module in the file
exit=0
1:1 0.5 "2" 2                           # node 2 silently lost its name
2:1 0   "b" 4294967294                  # a phantom zero-flow node in its own module
```

The link and `*States` rows never had this, because they parse ids by hand. The same rule now applies to `*Vertices`, `--meta-data` and the `.clu` reader, through one shared `io::parseNonNegativeInteger`, and the message names the token:

```
Error: Can't parse node id '-2' from line '-2 "b"': expected a non-negative integer no greater than 4294967295
```

## 2. JSON node and state weights

Stored verbatim, while the text parser rejects a negative `*Vertices` weight and the repo's own normative schema sets `weight.minimum: 0`.

Worth noting the issue's symptom is stale: since #917 this no longer yields a NaN codelength — the flow post-condition catches it — but it fails with *"Degenerate flow … for example a directed flow model with recorded teleportation on a bipartite network"*, which has nothing to do with a negative weight. Now rejected at parse time, naming the weight.

## 3. `--matchable-multilayer-ids` shift overflow

The state id is `physId << (ceil(log2(N)) + 1) | layerId`, and only `layerId` was checked. With `N = 2` — the value the existing tests use — the shift is 2, so `2147483748 << 2` is `400`, and so is `100 << 2`. `addMultilayerNode` then aliased the second physical node onto the first:

| | node 7 | node 100 | node 2147483748 |
|---|---|---|---|
| default | 0.508108 | 0.337269 | 0.154623 |
| `--matchable-multilayer-ids 2` | 0.508108 | 0.491892 | **gone** |

The safe range with `N = 2` is only `[0, 2^30)`, which ordinary ids can exceed. The physical id is now checked against the shift, and `N` is bounded so the shift count cannot reach 32 — that was undefined behaviour, and it moved the flows even for single-digit ids while exiting 0.

## 4. NumPy byte order

Link arrays reach C++ as a raw buffer plus only the dtype's kind and itemsize, and `readUnaligned` memcpys into a native-endian value:

```
before:  <f8 -> 6 nodes, 7 links, L=2.320730
         >f8 -> 1 node,  1 link,  L=0.000000
after:   <f8 >f8 <i4 >i4 >f4 all -> 6 nodes, 7 links, L=2.320730
```

Converted to native order rather than rejected: the values are identical and the array was going to be copied anyway. Both entry paths go through it — the 32/64-bit path bypassed the shared helper.

## Verification

Every case is pinned by a test that fails without its fix. Confirmed by stashing the source changes and re-running: 3 C++ cases fail, and both NumPy cases fail.

The boundaries are tested too, not just the failures: the largest id that still fits is accepted, `4294967295` parses while `4294967296` does not, weight `0` is fine, and `N = 2^30` is allowed while `2^31` is not.

`make test-native`, `make test-python` (818 passed), `make test-sanitizers`, `make test-binding-options-freshness`, `make test-python-typecheck` and `make format-native-check` all exit 0.
