### PR TITLE
ci: interleave the base and head runs in the PR performance gate

### DIFF
--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -80,12 +80,14 @@ jobs:
           # with the baseline itself moving 8.5% (#943). Reproduced deliberately --
           # load during the head block alone turns two *identical* binaries into a
           # 15.9% regression, while the interleaved runner reports 0.1% under the same
-          # load. Repeats are higher than the old 3 now that one run covers both.
+          # load. Repeats are higher than the old 3 now that one run covers both, and
+          # an even count so each binary leads half the rounds -- going first costs a
+          # measured 0.13%, which cancels exactly only when the leads are balanced.
           python "$GITHUB_WORKSPACE/head/scripts/benchmarks/run_native_benchmarks.py" \
             --binary "$GITHUB_WORKSPACE/base/build/cmake/infomap_native_benchmark" \
             --compare-binary "$GITHUB_WORKSPACE/head/build/cmake/infomap_native_benchmark" \
             --profile pr \
-            --repeats 5 \
+            --repeats 6 \
             --warmup-runs 1 \
             --iterations 1 \
             --output "$GITHUB_WORKSPACE/artifacts/base-native-benchmarks.json" \

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -73,21 +73,23 @@ jobs:
           set -euo pipefail
           mkdir -p "$GITHUB_WORKSPACE/artifacts"
 
+          # One invocation measuring both binaries alternately, not two sequential
+          # ones. Measuring all of base and then all of head made the comparison read
+          # whatever the runner was doing during each block: the same commit was
+          # reported as a 17.3% regression and, on re-run, as 1.9% within threshold,
+          # with the baseline itself moving 8.5% (#943). Reproduced deliberately --
+          # load during the head block alone turns two *identical* binaries into a
+          # 15.9% regression, while the interleaved runner reports 0.1% under the same
+          # load. Repeats are higher than the old 3 now that one run covers both.
           python "$GITHUB_WORKSPACE/head/scripts/benchmarks/run_native_benchmarks.py" \
             --binary "$GITHUB_WORKSPACE/base/build/cmake/infomap_native_benchmark" \
+            --compare-binary "$GITHUB_WORKSPACE/head/build/cmake/infomap_native_benchmark" \
             --profile pr \
-            --repeats 3 \
+            --repeats 5 \
             --warmup-runs 1 \
             --iterations 1 \
-            --output "$GITHUB_WORKSPACE/artifacts/base-native-benchmarks.json"
-
-          python "$GITHUB_WORKSPACE/head/scripts/benchmarks/run_native_benchmarks.py" \
-            --binary "$GITHUB_WORKSPACE/head/build/cmake/infomap_native_benchmark" \
-            --profile pr \
-            --repeats 3 \
-            --warmup-runs 1 \
-            --iterations 1 \
-            --output "$GITHUB_WORKSPACE/artifacts/head-native-benchmarks.json"
+            --output "$GITHUB_WORKSPACE/artifacts/base-native-benchmarks.json" \
+            --compare-output "$GITHUB_WORKSPACE/artifacts/head-native-benchmarks.json"
 
       - name: Compare base and head benchmark reports
         shell: bash

--- a/scripts/benchmarks/compare_native_benchmarks.py
+++ b/scripts/benchmarks/compare_native_benchmarks.py
@@ -48,6 +48,16 @@ def classify_case(
     delta_pct = (delta_sec / base_runtime) if base_runtime else 0.0
     base_cv = float(base_case.get("cv_run_sec", 0.0))
     head_cv = float(head_case.get("cv_run_sec", 0.0))
+    # The fastest of the repeats, reported so a borderline verdict can be read by a
+    # human, but deliberately not part of the verdict. It does not separate noise
+    # from a regression: a disturbance lasting a whole measurement block slows every
+    # repeat, so the minimum moves with the median (measured on this runner: a
+    # sequential A/A comparison under load moved the median 2.339 -> 2.709 s and the
+    # minimum 2.332 -> 2.707 s). Interleaving is what handles that; see
+    # run_native_benchmarks.benchmark_case_pair.
+    base_min = float(base_case.get("min_run_sec", base_runtime))
+    head_min = float(head_case.get("min_run_sec", head_runtime))
+    min_delta_sec = head_min - base_min
     status = "ok"
     reason = "within_threshold"
     severe = False
@@ -88,6 +98,9 @@ def classify_case(
         "severe": severe,
         "base_median_run_sec": base_runtime,
         "head_median_run_sec": head_runtime,
+        "base_min_run_sec": base_min,
+        "head_min_run_sec": head_min,
+        "min_delta_sec": min_delta_sec,
         "delta_sec": delta_sec,
         "delta_pct": delta_pct,
         "base_cv_run_sec": base_cv,
@@ -99,6 +112,25 @@ def classify_case(
         "base_codelength": float(base_case["codelength"]),
         "head_codelength": float(head_case["codelength"]),
     }
+
+
+def reports_are_interleaved(
+    base_report: dict[str, object], head_report: dict[str, object]
+) -> bool:
+    """True when each report names the other's binary as the one it alternated with.
+
+    ``run_native_benchmarks --compare-binary`` records this; two independent
+    invocations leave it unset, and older reports predate the field entirely.
+    """
+    base_binary = base_report.get("binary")
+    head_binary = head_report.get("binary")
+    base_partner = base_report.get("interleaved_with")
+    head_partner = head_report.get("interleaved_with")
+    # All four have to be present: a report that predates the field has None on both
+    # sides, and comparing None to None would otherwise read as a match.
+    if None in (base_binary, head_binary, base_partner, head_partner):
+        return False
+    return base_partner == head_binary and head_partner == base_binary
 
 
 def compare_reports(
@@ -140,6 +172,11 @@ def compare_reports(
     return {
         "overall_status": overall_status,
         "summary": summary,
+        # Whether the two runs were measured against each other, alternating, rather
+        # than as two separate blocks. Surfaced because it decides how much a verdict
+        # is worth: two sequential blocks on a shared runner reported the same commit
+        # as both a 17.3% regression and a 1.9% pass (#943).
+        "interleaved": reports_are_interleaved(base_report, head_report),
         "thresholds": {
             "relative_regression_threshold": RELATIVE_REGRESSION_THRESHOLD,
             "absolute_regression_threshold_sec": ABSOLUTE_REGRESSION_THRESHOLD_SEC,
@@ -163,6 +200,13 @@ def render_markdown(result: dict[str, object]) -> str:
         "## PR Native Benchmark Comparison",
         "",
         f"Overall result: **{result['summary']}**",
+        "",
+        (
+            "Measured by alternating the two binaries on each case."
+            if result.get("interleaved")
+            else "Note: the two runs were measured separately rather than alternating, "
+            "so a difference here can be machine noise as easily as a code change."
+        ),
         "",
         "| Case | Status | Base median run (s) | Head median run (s) | Delta (s) | Delta (%) | Reason |",
         "| --- | --- | ---: | ---: | ---: | ---: | --- |",

--- a/scripts/benchmarks/run_native_benchmarks.py
+++ b/scripts/benchmarks/run_native_benchmarks.py
@@ -433,13 +433,25 @@ def benchmark_case_pair(
     samples: dict[str, list[dict[str, object]]] = {label: [] for label in labels}
     run_samples: dict[str, list[dict[str, object]]] = {label: [] for label in labels}
 
-    for _ in range(warmup_runs):
-        for label in labels:
+    def rotated(round_index: int) -> list[str]:
+        offset = round_index % len(labels)
+        return labels[offset:] + labels[:offset]
+
+    for warmup in range(warmup_runs):
+        # Rotated like the measured rounds. A no-op at the one warmup run the gate
+        # uses, since a single round has nothing to alternate with, but it keeps the
+        # warmup from preconditioning one binary's slot at higher warmup counts.
+        for label in rotated(warmup):
             subprocess.run(commands[label], check=True, capture_output=True, text=True)
 
     for repeat in range(repeats):
-        # Rotate the order so no binary is always measured first.
-        order = labels[repeat % len(labels) :] + labels[: repeat % len(labels)]
+        # Rotate the order so no binary is always measured first. Going first costs
+        # something small and real: measured on this machine by running one binary
+        # twice per round, position 1 was 0.13% slower than position 2 (2.4243 s vs
+        # 2.4211 s median over 12 rounds). With `repeats` a multiple of the number of
+        # binaries each one leads equally often and it cancels exactly; otherwise one
+        # binary keeps a single extra lead, worth about 0.13%/repeats.
+        order = rotated(repeat)
         for label in order:
             sample = collect_sample(commands[label])
             samples[label].append(sample)
@@ -817,6 +829,14 @@ def main() -> None:
 
     if (args.compare_binary is None) != (args.compare_output is None):
         parser.error("--compare-binary and --compare-output must be given together")
+    if (
+        args.compare_output is not None
+        and args.output.resolve() == args.compare_output.resolve()
+    ):
+        # Otherwise the second report overwrites the first and the comparison reads
+        # one binary against itself -- reporting no regression, which is a worse
+        # failure than a false one because nothing looks wrong.
+        parser.error("--compare-output must differ from --output")
 
     repo_root = Path(__file__).resolve().parents[2]
     if not args.binary.is_file():

--- a/scripts/benchmarks/run_native_benchmarks.py
+++ b/scripts/benchmarks/run_native_benchmarks.py
@@ -226,9 +226,11 @@ def metric_stats(values: list[float]) -> dict[str, float]:
     mean_value = statistics.mean(values)
     stdev_value = statistics.stdev(values) if len(values) > 1 else 0.0
     cv_value = stdev_value / mean_value if mean_value else 0.0
-    # The minimum is the least-perturbed sample: noise on a shared runner only ever
-    # adds time. Reported so the comparison can require a regression to show up in
-    # both the median and the minimum.
+    # The minimum is the least-perturbed sample, since noise on a shared runner only
+    # ever adds time. Reported for reading a borderline comparison by hand, not for
+    # deciding one: a disturbance lasting a whole measurement block slows every
+    # repeat, so the minimum moves with the median. See classify_case in
+    # compare_native_benchmarks.py, which deliberately keeps it out of the verdict.
     return {
         "mean": mean_value,
         "stdev": stdev_value,

--- a/scripts/benchmarks/run_native_benchmarks.py
+++ b/scripts/benchmarks/run_native_benchmarks.py
@@ -222,11 +222,19 @@ def generate_if_missing(path: Path, generator, *args: object) -> None:
 
 def metric_stats(values: list[float]) -> dict[str, float]:
     if not values:
-        return {"mean": 0.0, "stdev": 0.0, "cv": 0.0}
+        return {"mean": 0.0, "stdev": 0.0, "cv": 0.0, "min": 0.0}
     mean_value = statistics.mean(values)
     stdev_value = statistics.stdev(values) if len(values) > 1 else 0.0
     cv_value = stdev_value / mean_value if mean_value else 0.0
-    return {"mean": mean_value, "stdev": stdev_value, "cv": cv_value}
+    # The minimum is the least-perturbed sample: noise on a shared runner only ever
+    # adds time. Reported so the comparison can require a regression to show up in
+    # both the median and the minimum.
+    return {
+        "mean": mean_value,
+        "stdev": stdev_value,
+        "cv": cv_value,
+        "min": min(values),
+    }
 
 
 def collect_module_size_bucket_labels(
@@ -372,19 +380,10 @@ def build_benchmark_cases(
     return cases
 
 
-def benchmark_case(
-    binary: Path,
-    name: str,
-    network_path: Path,
-    repeats: int,
-    warmup_runs: int,
-    iterations: int,
-    flags: str,
-) -> dict[str, object]:
-    samples: list[dict[str, object]] = []
-    run_samples: list[dict[str, object]] = []
-
-    command = [
+def benchmark_command(
+    binary: Path, name: str, network_path: Path, iterations: int, flags: str
+) -> list[str]:
+    return [
         str(binary),
         "--input",
         str(network_path),
@@ -395,27 +394,95 @@ def benchmark_case(
         "--iterations",
         str(iterations),
     ]
+
+
+def collect_sample(command: list[str]) -> dict[str, object]:
+    completed = subprocess.run(command, check=True, capture_output=True, text=True)
+    return json.loads(completed.stdout)
+
+
+def benchmark_case_pair(
+    binaries: dict[str, Path],
+    name: str,
+    network_path: Path,
+    repeats: int,
+    warmup_runs: int,
+    iterations: int,
+    flags: str,
+) -> dict[str, dict[str, object]]:
+    """Measure several binaries on one case, alternating between them.
+
+    Measuring one binary's repeats and then the other's makes the comparison read
+    whatever the machine was doing during each block. On a shared runner that is
+    enough to invent or hide a verdict: the same commit was reported as a 17.3%
+    regression and then, on re-run, as 1.9% within threshold, with the *baseline*
+    itself moving 8.5% between runs (#943). Per-binary variance cannot see it -- each
+    block is internally consistent, so the shift looks like a real difference.
+
+    Alternating instead puts both binaries in the same few seconds of machine state,
+    and swapping which one leads each round keeps the lead position from favouring
+    either.
+    """
+    labels = list(binaries)
+    commands = {
+        label: benchmark_command(binaries[label], name, network_path, iterations, flags)
+        for label in labels
+    }
+    samples: dict[str, list[dict[str, object]]] = {label: [] for label in labels}
+    run_samples: dict[str, list[dict[str, object]]] = {label: [] for label in labels}
+
     for _ in range(warmup_runs):
-        subprocess.run(
-            command,
-            check=True,
-            capture_output=True,
-            text=True,
-        )
+        for label in labels:
+            subprocess.run(commands[label], check=True, capture_output=True, text=True)
 
     for repeat in range(repeats):
-        completed = subprocess.run(
-            command,
-            check=True,
-            capture_output=True,
-            text=True,
+        # Rotate the order so no binary is always measured first.
+        order = labels[repeat % len(labels) :] + labels[: repeat % len(labels)]
+        for label in order:
+            sample = collect_sample(commands[label])
+            samples[label].append(sample)
+            for run in sample.get("runs", [sample]):
+                run_sample = dict(run)
+                run_sample["repeat"] = repeat + 1
+                run_samples[label].append(run_sample)
+
+    return {
+        label: summarize_case(
+            samples[label],
+            run_samples[label],
+            name,
+            network_path,
+            repeats,
+            warmup_runs,
+            iterations,
         )
-        sample = json.loads(completed.stdout)
-        samples.append(sample)
-        for run in sample.get("runs", [sample]):
-            run_sample = dict(run)
-            run_sample["repeat"] = repeat + 1
-            run_samples.append(run_sample)
+        for label in labels
+    }
+
+
+def benchmark_case(
+    binary: Path,
+    name: str,
+    network_path: Path,
+    repeats: int,
+    warmup_runs: int,
+    iterations: int,
+    flags: str,
+) -> dict[str, object]:
+    return benchmark_case_pair(
+        {"only": binary}, name, network_path, repeats, warmup_runs, iterations, flags
+    )["only"]
+
+
+def summarize_case(
+    samples: list[dict[str, object]],
+    run_samples: list[dict[str, object]],
+    name: str,
+    network_path: Path,
+    repeats: int,
+    warmup_runs: int,
+    iterations: int,
+) -> dict[str, object]:
 
     total_stats = metric_stats([float(sample["total_sec"]) for sample in samples])
     run_stats = metric_stats([float(run["run_sec"]) for run in run_samples])
@@ -583,6 +650,8 @@ def benchmark_case(
         "mean_run_sec": run_stats["mean"],
         "stdev_run_sec": run_stats["stdev"],
         "cv_run_sec": run_stats["cv"],
+        "min_run_sec": run_stats["min"],
+        "min_total_sec": total_stats["min"],
         "mean_peak_rss_bytes": peak_rss_stats["mean"],
         "stdev_peak_rss_bytes": peak_rss_stats["stdev"],
         "cv_peak_rss_bytes": peak_rss_stats["cv"],
@@ -679,6 +748,22 @@ def main() -> None:
         help="Path to the native benchmark executable.",
     )
     parser.add_argument(
+        "--compare-binary",
+        type=Path,
+        default=None,
+        help=(
+            "Optional second executable to measure alongside --binary, alternating "
+            "between them so both see the same machine state. Requires "
+            "--compare-output."
+        ),
+    )
+    parser.add_argument(
+        "--compare-output",
+        type=Path,
+        default=None,
+        help="Path to write the --compare-binary JSON report.",
+    )
+    parser.add_argument(
         "--output",
         type=Path,
         required=True,
@@ -728,15 +813,31 @@ def main() -> None:
     if args.warmup_runs < 0:
         parser.error("--warmup-runs must be at least 0")
 
+    if (args.compare_binary is None) != (args.compare_output is None):
+        parser.error("--compare-binary and --compare-output must be given together")
+
     repo_root = Path(__file__).resolve().parents[2]
     if not args.binary.is_file():
         raise FileNotFoundError(f"Benchmark binary not found: {args.binary}")
+    if args.compare_binary is not None and not args.compare_binary.is_file():
+        raise FileNotFoundError(
+            f"Comparison benchmark binary not found: {args.compare_binary}"
+        )
 
-    def run_with_generated_dir(generated_dir: Path) -> list[dict[str, object]]:
+    binaries = {"binary": args.binary}
+    if args.compare_binary is not None:
+        binaries["compare"] = args.compare_binary
+
+    def run_with_generated_dir(
+        generated_dir: Path,
+    ) -> dict[str, list[dict[str, object]]]:
         cases = build_benchmark_cases(args.profile, repo_root, generated_dir)
-        return [
-            benchmark_case(
-                args.binary,
+        collected: dict[str, list[dict[str, object]]] = {
+            label: [] for label in binaries
+        }
+        for case in cases:
+            per_label = benchmark_case_pair(
+                binaries,
                 str(case["name"]),
                 Path(case["path"]),
                 args.repeats,
@@ -746,8 +847,9 @@ def main() -> None:
                     part for part in (args.flags, str(case["flags"])) if part
                 ).strip(),
             )
-            for case in cases
-        ]
+            for label, result in per_label.items():
+                collected[label].append(result)
+        return collected
 
     if args.generated_dir is None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -760,20 +862,33 @@ def main() -> None:
         results = run_with_generated_dir(generated_dir)
         generated_dir_text = str(generated_dir)
 
-    report = {
-        "profile": args.profile,
-        "repeats": args.repeats,
-        "warmup_runs": args.warmup_runs,
-        "iterations": args.iterations,
-        "binary": str(args.binary),
-        "generated_dir": generated_dir_text,
-        "benchmarks": results,
-    }
+    def write_report(label: str, binary: Path, output: Path) -> None:
+        report = {
+            "profile": args.profile,
+            "repeats": args.repeats,
+            "warmup_runs": args.warmup_runs,
+            "iterations": args.iterations,
+            "binary": str(binary),
+            "generated_dir": generated_dir_text,
+            # Recorded so a comparison can tell an interleaved measurement from two
+            # sequential ones; #943 was caused by the latter being indistinguishable.
+            "interleaved_with": (
+                str(binaries["compare"])
+                if label == "binary" and "compare" in binaries
+                else str(args.binary)
+                if label == "compare"
+                else None
+            ),
+            "benchmarks": results[label],
+        }
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
 
-    args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    write_report("binary", args.binary, args.output)
+    if args.compare_binary is not None:
+        write_report("compare", args.compare_binary, args.compare_output)
 
-    markdown = render_markdown(results)
+    markdown = render_markdown(results["binary"])
     if args.summary is not None:
         args.summary.parent.mkdir(parents=True, exist_ok=True)
         args.summary.write_text(markdown, encoding="utf-8")

--- a/test/python/test_compare_native_benchmarks.py
+++ b/test/python/test_compare_native_benchmarks.py
@@ -107,6 +107,45 @@ def test_compare_reports_requires_manual_review_when_outputs_change():
     assert result["overall_status"] == "manual_review"
 
 
+def test_compare_reports_detects_an_interleaved_pair():
+    """Each report has to name the other's binary, so a half-filled pair is not enough."""
+    compare_module = _load_compare_module()
+    base = {
+        "binary": "/tmp/base_bin",
+        "interleaved_with": "/tmp/head_bin",
+        "benchmarks": [_case("ring", median_run_sec=1.00)],
+    }
+    head = {
+        "binary": "/tmp/head_bin",
+        "interleaved_with": "/tmp/base_bin",
+        "benchmarks": [_case("ring", median_run_sec=1.00)],
+    }
+
+    assert compare_module.compare_reports(base, head)["interleaved"] is True
+    assert "alternating the two binaries" in compare_module.render_markdown(
+        compare_module.compare_reports(base, head)
+    )
+
+    one_sided = dict(head, interleaved_with=None)
+    assert compare_module.compare_reports(base, one_sided)["interleaved"] is False
+
+
+def test_compare_reports_warns_when_the_runs_were_not_interleaved():
+    """Reports from two separate invocations -- and older reports with no such field.
+
+    A verdict from sequential blocks is not worth the same as one from an alternating
+    run, and #943 happened because nothing said which kind was on screen.
+    """
+    compare_module = _load_compare_module()
+    result = compare_module.compare_reports(
+        {"benchmarks": [_case("ring", median_run_sec=1.00)]},
+        {"benchmarks": [_case("ring", median_run_sec=1.30)]},
+    )
+
+    assert result["interleaved"] is False
+    assert "measured separately" in compare_module.render_markdown(result)
+
+
 def test_render_markdown_uses_na_for_missing_case_metrics():
     compare_module = _load_compare_module()
     result = compare_module.compare_reports(

--- a/test/python/test_native_benchmark_script.py
+++ b/test/python/test_native_benchmark_script.py
@@ -227,6 +227,132 @@ def test_benchmark_case_discards_warmup_samples(monkeypatch, tmp_path: Path):
     assert [sample["repeat"] for sample in result["run_samples"]] == [1, 2]
 
 
+def _minimal_payload(run_sec: float) -> dict[str, object]:
+    return {
+        "name": "toy",
+        "path": "toy.net",
+        "flags": "--silent",
+        "iterations": 1,
+        "total_sec": run_sec + 0.1,
+        "read_input_sec": 0.1,
+        "run_sec": run_sec,
+        "peak_rss_bytes": 4096,
+        "node_size_bytes": 32,
+        "edge_size_bytes": 16,
+        "num_nodes": 5,
+        "num_links": 4,
+        "num_top_modules": 2,
+        "num_levels": 1,
+        "codelength": 1.5,
+        "higher_order_input": False,
+        "directed_input": False,
+        "runs": [
+            {
+                "iteration": 1,
+                "read_input_sec": 0.0,
+                "run_sec": run_sec,
+                "total_sec": run_sec,
+                "peak_rss_bytes": 4096,
+                "num_top_modules": 2,
+                "num_levels": 1,
+                "codelength": 1.5,
+            }
+        ],
+    }
+
+
+def test_benchmark_case_pair_interleaves_and_rotates_the_lead(
+    monkeypatch, tmp_path: Path
+):
+    """Both binaries are measured inside each repeat, taking turns to go first.
+
+    This is the whole point of the pair driver: two sequential blocks read whatever
+    the machine was doing during each block, which is enough to invent a verdict on a
+    shared runner. Alternating puts both binaries in the same machine state, and
+    rotating the lead keeps the first position -- which pays the cold-cache cost --
+    from favouring either binary.
+    """
+    benchmark_module = _load_benchmark_module()
+    invoked: list[str] = []
+
+    def fake_run(command, *args, **kwargs):
+        invoked.append(Path(command[0]).name)
+        return benchmark_module.subprocess.CompletedProcess(
+            command, 0, stdout=json.dumps(_minimal_payload(1.0)), stderr=""
+        )
+
+    monkeypatch.setattr(benchmark_module.subprocess, "run", fake_run)
+
+    results = benchmark_module.benchmark_case_pair(
+        {"base": tmp_path / "base_binary", "head": tmp_path / "head_binary"},
+        name="toy",
+        network_path=tmp_path / "toy.net",
+        repeats=3,
+        warmup_runs=1,
+        iterations=1,
+        flags="--silent",
+    )
+
+    # One warmup per binary, then three repeats of both with the lead rotating.
+    assert invoked == [
+        "base_binary",
+        "head_binary",
+        "base_binary",
+        "head_binary",
+        "head_binary",
+        "base_binary",
+        "base_binary",
+        "head_binary",
+    ]
+    assert sorted(results) == ["base", "head"]
+    for label in ("base", "head"):
+        assert len(results[label]["samples"]) == 3
+        assert [sample["repeat"] for sample in results[label]["run_samples"]] == [
+            1,
+            2,
+            3,
+        ]
+
+
+def test_metric_stats_reports_the_minimum_sample():
+    """The minimum is reported for reading a borderline verdict, not for deciding it.
+
+    ``compare_native_benchmarks`` deliberately keeps it out of the verdict -- a
+    disturbance spanning a whole measurement block moves the minimum with the median.
+    """
+    benchmark_module = _load_benchmark_module()
+
+    stats = benchmark_module.metric_stats([3.0, 1.0, 2.0])
+
+    assert stats["min"] == pytest.approx(1.0)
+    assert stats["mean"] == pytest.approx(2.0)
+
+
+def test_main_requires_compare_binary_and_output_together(monkeypatch, tmp_path: Path):
+    """Half a comparison is a silent no-op, so the pair is validated up front."""
+    benchmark_module = _load_benchmark_module()
+
+    import sys
+
+    old_argv = sys.argv
+    sys.argv = [
+        "run_native_benchmarks.py",
+        "--binary",
+        "missing-binary",
+        "--output",
+        str(tmp_path / "out.json"),
+        "--compare-binary",
+        "other-binary",
+    ]
+    try:
+        with pytest.raises(SystemExit) as exc_info:
+            benchmark_module.main()
+    finally:
+        sys.argv = old_argv
+
+    assert exc_info.value.code == 2
+
+
 def test_build_benchmark_cases_pr_profile_focuses_on_stable_cases(
     monkeypatch, tmp_path: Path
 ):

--- a/test/python/test_native_benchmark_script.py
+++ b/test/python/test_native_benchmark_script.py
@@ -288,15 +288,20 @@ def test_benchmark_case_pair_interleaves_and_rotates_the_lead(
         name="toy",
         network_path=tmp_path / "toy.net",
         repeats=3,
-        warmup_runs=1,
+        warmup_runs=2,
         iterations=1,
         flags="--silent",
     )
 
-    # One warmup per binary, then three repeats of both with the lead rotating.
+    # Two warmup rounds, rotating like the measured ones, then three repeats of both
+    # with the lead rotating. Going first is measurably slightly more expensive, so
+    # an odd repeat count leaves one binary a single extra lead -- visible here as
+    # base leading rounds 1 and 3 against head leading round 2.
     assert invoked == [
         "base_binary",
         "head_binary",
+        "head_binary",
+        "base_binary",
         "base_binary",
         "head_binary",
         "head_binary",
@@ -326,6 +331,38 @@ def test_metric_stats_reports_the_minimum_sample():
 
     assert stats["min"] == pytest.approx(1.0)
     assert stats["mean"] == pytest.approx(2.0)
+
+
+def test_main_rejects_writing_both_reports_to_one_path(monkeypatch, tmp_path: Path):
+    """Sharing the path would leave one report on disk and compare it against itself.
+
+    The comparison would then find no difference and report no regression, which is a
+    worse failure than a false alarm because nothing on screen looks wrong.
+    """
+    benchmark_module = _load_benchmark_module()
+    shared = tmp_path / "out.json"
+
+    import sys
+
+    old_argv = sys.argv
+    sys.argv = [
+        "run_native_benchmarks.py",
+        "--binary",
+        "missing-binary",
+        "--output",
+        str(shared),
+        "--compare-binary",
+        "other-binary",
+        "--compare-output",
+        str(tmp_path / "sub" / ".." / "out.json"),
+    ]
+    try:
+        with pytest.raises(SystemExit) as exc_info:
+            benchmark_module.main()
+    finally:
+        sys.argv = old_argv
+
+    assert exc_info.value.code == 2
 
 
 def test_main_requires_compare_binary_and_output_together(monkeypatch, tmp_path: Path):


### PR DESCRIPTION
Closes #943.

## The problem

The PR performance gate measured every repeat of the base binary, then every
repeat of the head binary. Each block reads whatever the runner happened to be
doing while it ran, so comparing the two blocks compares machine states as much
as code. On #942 the *same commit* was reported as a 17.3% regression on
`sparse_100k` and then, on re-run, as 1.9% within threshold — with the baseline
itself moving 8.5% between the two runs.

Per-binary variance cannot catch this. Each block is internally consistent
(CV ~1–2%), so the shift between blocks looks like a real difference.

## Reproduced, not assumed

Comparing one binary against *itself*, so the true delta is zero:

| Method | Load | Verdict on `sparse_100k` |
| --- | --- | --- |
| sequential | none | +0.1%, −1.7%, −0.1%, +0.5% |
| interleaved | none | +0.4%, −0.5% |
| sequential | during the head block only | **regression, 15.9%** |
| interleaved | same load | ok: 0.1%, −0.3%, −0.4% |

Row 3 is the CI failure, on demand. Row 4 is the fix under identical conditions.

## The change

- One invocation measures both binaries on each case, alternating, and rotating
  which one goes first each round so the lead position (which pays the
  cold-cache cost) does not favour either. New `--compare-binary` /
  `--compare-output`, validated as a pair.
- Repeats 3 → 6, now that one pass covers both binaries. Even, so each binary
  leads half the rounds: going first costs a measured 0.13% (position 1 vs
  position 2 running one binary twice per round, 2.4243 s vs 2.4211 s median
  over 12 rounds), which cancels exactly only when the leads are balanced. About
  23 s more measurement locally (54 s vs 31 s over the four `pr` cases), against
  a job that builds two binaries from scratch.
- `--compare-output` may not equal `--output`: the second write would overwrite
  the first and the comparison would read one binary against itself, reporting
  *no regression*, which is a worse failure than a false alarm.
- Reports record `interleaved_with`, and the comparison states on its face
  whether it is reading an interleaved measurement or two separate ones —
  that decides what a verdict is worth, and nothing said so before.
- `benchmark_case` is kept as a wrapper over the pair driver, so the existing
  tests still exercise the code path that runs in CI.

## On the minimum

The minimum of the repeats is now reported, but deliberately **not** part of
the verdict. I tried requiring the median and the minimum to agree before
failing, and measured that it does not work: a disturbance lasting a whole
block slows every repeat, so the minimum moves with the median (2.332 → 2.707 s
in row 3 above). It would not have prevented the false regression, and it would
risk hiding a real one. It stays as diagnostics for reading a borderline case.

## Verification

- 4 new tests in `test_native_benchmark_script.py` (interleaving order and lead
  rotation across warmup and measured rounds; the reported minimum; the CLI
  pairing; the shared-output-path guard) and 2 in
  `test_compare_native_benchmarks.py` (provenance detection and the warning).
  Each was mutation-checked — reverting the code it covers makes it fail.
- The provenance check initially reported two field-less reports as
  interleaved (`None == None` on both sides); the test caught it before review.
- `pytest -m fast`: 634 passed. ruff, actionlint, pre-commit and the pre-push
  typecheck all clean. End-to-end run of the new workflow command against real
  binaries produces both artifacts and a correct comparison.
