### PR TITLE
fix: redistribute dangling flow on bipartite input in the directed model

### DIFF
--- a/src/utils/FlowCalculator.cpp
+++ b/src/utils/FlowCalculator.cpp
@@ -168,6 +168,19 @@ FlowCalculator::FlowCalculator(StateNetwork& network, const Config& config)
     }
   });
 
+  // The directed model normally finds the dangling nodes as a prefix of nodeFlow,
+  // having ordered them first above. Bipartite input keeps the network's node order,
+  // since the feature side is identified by an index range, so nonDanglingStartIndex
+  // stays 0 and their positions have to be collected here instead -- out-degree is
+  // only known now that the links have been counted.
+  if (network.isBipartite() && config.flowModel == FlowModel::directed) {
+    for (unsigned int i = 0; i < numNodes; ++i) {
+      if (nodeOutDegree[i] == 0) {
+        danglingIndices.push_back(i);
+      }
+    }
+  }
+
   bool normalizeNodeFlow = false;
 
   switch (config.flowModel) {
@@ -369,6 +382,24 @@ IterationResult powerIterate(const Config& config, double alpha, Iteration&& ite
   return { alpha, beta, iterations, err, converged };
 }
 
+double FlowCalculator::accumulateDanglingRank() const noexcept
+{
+  // Two ways of locating the dangling nodes, one fast and one general. The directed
+  // model orders them first, making their flow a prefix; bipartite input cannot use
+  // that ordering, so their positions were collected explicitly. An empty list means
+  // the prefix form applies -- including the case of no dangling nodes at all, where
+  // both forms sum to zero.
+  if (danglingIndices.empty()) {
+    return std::accumulate(cbegin(nodeFlow), cbegin(nodeFlow) + nonDanglingStartIndex, 0.0);
+  }
+
+  double sum = 0.0;
+  for (const auto i : danglingIndices) {
+    sum += nodeFlow[i];
+  }
+  return sum;
+}
+
 void FlowCalculator::calcDirectedFlow(const StateNetwork& network, const Config& config) noexcept
 {
   m_flowMethod = "directed links";
@@ -407,7 +438,7 @@ void FlowCalculator::calcDirectedFlow(const StateNetwork& network, const Config&
 
   // Calculate PageRank
   const auto iteration = [&](const auto iter, const double alpha, const double beta) {
-    danglingRank = std::accumulate(cbegin(nodeFlow), cbegin(nodeFlow) + nonDanglingStartIndex, 0.0);
+    danglingRank = accumulateDanglingRank();
 
     // Flow from teleportation
     const auto teleportationFlow = alpha + beta * danglingRank;
@@ -551,7 +582,7 @@ void FlowCalculator::calcDirectedRelaxToSelfFlow(const StateNetwork& network, co
   };
 
   const auto iteration = [&](const auto iter, const double alpha, const double beta) {
-    danglingRank = std::accumulate(cbegin(nodeFlow), cbegin(nodeFlow) + nonDanglingStartIndex, 0.0);
+    danglingRank = accumulateDanglingRank();
     const auto teleportationFlow = alpha + beta * danglingRank;
     for (unsigned int i = 0; i < numNodes; ++i) {
       nodeFlowTmp[i] = teleportationFlow * nodeTeleportWeights[i];
@@ -1172,22 +1203,12 @@ void FlowCalculator::calcDirectedBipartiteFlow(const StateNetwork& network, cons
     }
   }
 
-  std::vector<unsigned int> danglingIndices;
-  for (size_t i = 0; i < numNodes; ++i) {
-    if (nodeOutDegree[i] == 0) {
-      danglingIndices.push_back(i);
-    }
-  }
-
   std::vector<double> nodeFlowTmp(numNodes, 0.0);
   double danglingRank;
 
   // Calculate two-step PageRank
   const auto iteration = [&](const auto iter, const double alpha, const double beta) {
-    danglingRank = 0.0;
-    for (const auto& i : danglingIndices) {
-      danglingRank += nodeFlow[i];
-    }
+    danglingRank = accumulateDanglingRank();
 
     // Flow from teleportation
     const auto teleportationFlow = alpha + beta * danglingRank;

--- a/src/utils/FlowCalculator.h
+++ b/src/utils/FlowCalculator.h
@@ -52,7 +52,11 @@ private:
   void addFlowNote(const std::string& note);
   void recordPageRank(unsigned int iterations, double error, bool converged) noexcept;
 
+  double accumulateDanglingRank() const noexcept;
+
   unsigned int numNodes;
+  //! One past the last dangling node, for the directed model's dangling-first
+  //! ordering. Zero when that ordering was not applied -- see danglingIndices.
   unsigned int nonDanglingStartIndex = 0;
   unsigned int bipartiteStartIndex = 0;
   unsigned int bipartiteLinkStartIndex = 0;
@@ -69,6 +73,10 @@ private:
   std::vector<double> exitFlow;
   std::vector<double> sumLinkOutWeight;
   std::vector<unsigned int> nodeOutDegree;
+  //! Positions of the dangling nodes when they are not a prefix of nodeFlow.
+  //! Bipartite input keeps the network's node order, because the feature side is
+  //! identified by an index range, so the dangling-first ordering is unavailable.
+  std::vector<unsigned int> danglingIndices;
   using FlowLink = detail::FlowLink;
   std::vector<FlowLink> flowLinks;
 

--- a/test/cpp/test_flow.cpp
+++ b/test/cpp/test_flow.cpp
@@ -749,6 +749,20 @@ void addCanonicalBipartiteLinks(InfomapWrapper& im)
   im.addLink(3, 5);
 }
 
+// The same links as addCanonicalBipartiteLinks plus one from the feature side back to
+// the primary side, and without the bipartite declaration. A file whose links all run
+// one way leaves the omitted dangling redistribution as a uniform scale factor, which
+// the projection's renormalisation cancels; the back-link makes the dangling mass
+// matter, which is what #899 is about.
+void addBipartiteLinksWithFeedback(InfomapWrapper& im)
+{
+  im.addLink(1, 4);
+  im.addLink(2, 4);
+  im.addLink(2, 5, 0.25);
+  im.addLink(3, 5);
+  im.addLink(4, 1);
+}
+
 TEST_CASE("Degenerate flow is rejected instead of reported as a zero codelength [fast][core][flow]")
 {
   // Each of these left node flow all-zero or NaN and still reported
@@ -789,7 +803,10 @@ TEST_CASE("skip-adjust-bipartite-flow keeps its documented unnormalized flow [fa
 
   im.run();
 
-  infomap::test::checkApproxCodelength(im.codelength(), 0.04164969778);
+  // Raised from 0.04164969778 when #899's dangling redistribution was restored: the
+  // link flows now carry the 1/(1 - danglingRank) scaling the node flows already had,
+  // so the exit flows -- and with them the module codelength -- are no longer deflated.
+  infomap::test::checkApproxCodelength(im.codelength(), 0.2776646519);
 }
 
 TEST_CASE("A link-free network keeps its trivial zero-flow result [fast][core][flow]")
@@ -808,6 +825,46 @@ TEST_CASE("A link-free network keeps its trivial zero-flow result [fast][core][f
   CHECK(singleNode.numLeafNodes() == 1);
 }
 
+TEST_CASE("Directed bipartite flow matches the same links without the bipartite declaration [fast][core][flow]")
+{
+  // The bipartite declaration decides how flow is *reported* -- which nodes are the
+  // feature side, and whether their flow is folded onto the primary side -- not how
+  // the power iteration distributes it. With the fold opted out, the two runs must
+  // therefore agree exactly. They did not (#899): the directed model finds its
+  // dangling nodes as a prefix of the flow vector, an ordering bipartite input cannot
+  // use because its feature side is identified by an index range, so the dangling
+  // mass was never redistributed and the iteration converged somewhere else -- or
+  // rather did not converge, exhausting --max-flow-iterations on a five-node network.
+  //
+  // Asserted as an equivalence rather than against pinned numbers, so the test states
+  // the property instead of recording today's output.
+  InfomapWrapper bipartite(infomap::test::defaultFlags("-N 1 --seed 7 --two-level --directed --skip-adjust-bipartite-flow"));
+  bipartite.network().setBipartiteStartId(4);
+  addBipartiteLinksWithFeedback(bipartite);
+  bipartite.run();
+
+  InfomapWrapper plain(infomap::test::defaultFlags("-N 1 --seed 7 --two-level --directed"));
+  addBipartiteLinksWithFeedback(plain);
+  plain.run();
+
+  CHECK(bipartite.codelength() == doctest::Approx(plain.codelength()).epsilon(1e-10));
+
+  std::map<unsigned int, double> plainFlow;
+  for (auto it = plain.iterLeafNodes(); !it.isEnd(); ++it) {
+    const auto& node = *it;
+    plainFlow[node.physicalId] = node.data.flow;
+  }
+
+  unsigned int comparedNodes = 0;
+  for (auto it = bipartite.iterLeafNodes(); !it.isEnd(); ++it) {
+    const auto& node = *it;
+    REQUIRE(plainFlow.count(node.physicalId) == 1);
+    CHECK(node.data.flow == doctest::Approx(plainFlow[node.physicalId]).epsilon(1e-10));
+    ++comparedNodes;
+  }
+  CHECK(comparedNodes == 5);
+}
+
 TEST_CASE("Ordinary bipartite runs are unaffected by the flow post-condition [fast][core][flow]")
 {
   InfomapWrapper undirected(infomap::test::defaultFlags("-N 1 --seed 7"));
@@ -818,7 +875,11 @@ TEST_CASE("Ordinary bipartite runs are unaffected by the flow post-condition [fa
   InfomapWrapper directed(infomap::test::defaultFlags("-N 1 --seed 7 --directed"));
   addCanonicalBipartiteLinks(directed);
   directed.run();
-  infomap::test::checkApproxCodelength(directed.codelength(), 0.4729743142);
+  // Raised from 0.4729743142 with #899's fix, for the same reason as above. The node
+  // flows are unchanged here -- every link in this network runs one way, so the
+  // omitted redistribution was a uniform scale the projection cancelled -- but the
+  // link flows were uniformly too small, which is what the codelength reads.
+  infomap::test::checkApproxCodelength(directed.codelength(), 1.2649313331);
 }
 
 } // namespace

--- a/test/python/test_flow.py
+++ b/test/python/test_flow.py
@@ -30,7 +30,11 @@ def test_skip_adjust_bipartite_flow_still_runs(example_network_path):
         num_trials=1,
     )
 
-    assert result.codelength == pytest.approx(0.04164969778)
+    # Raised from 0.04164969778 when #899's dangling redistribution was restored:
+    # the link flows now carry the 1/(1 - danglingRank) scaling the node flows
+    # already had, so the exit flows are no longer deflated. The flow still sums to
+    # less than one, which is what this test is about.
+    assert result.codelength == pytest.approx(0.2776646519)
 
 
 def test_precomputed_requirements(make_infomap, example_network_path):


### PR DESCRIPTION
Third box of #899. Not a full fix for the issue — four boxes remain, so this does
not close it.

## The defect

`FlowCalculator` orders dangling nodes first for the directed model and then finds
them as a prefix of the flow vector. Bipartite input cannot use that ordering,
because its feature side is identified by an index range and node order must be
preserved, so `nonDanglingStartIndex` stayed 0 and the prefix sum always returned
zero. No dangling mass was recycled through the teleportation distribution.

No unusual flags needed — a bipartite file and `-d`:

```bash
printf '*Bipartite 4\n1 4\n2 4\n2 5 0.25\n3 5\n4 1\n' > bp.net && ./Infomap bp.net out -d
```

## The fix

Collect the dangling positions explicitly when the ordering is unavailable, and
route all three power iterations through one accumulator. `calcDirectedBipartiteFlow`
already did it this way with a private copy of the list, which is now shared — the
definition of "dangling" as out-degree zero lived in three places, and the copy that
went through node order was the broken one.

## Verification

Against the code path that was never broken, not against pinned numbers. With the
projection opted out, declaring a network bipartite must not change how the power
iteration distributes flow — only how it is reported. So the same links with and
without the declaration have to agree:

| | node flows (n4 / n1 / n5) | link flows |
| --- | --- | --- |
| plain directed | 0.483307 / 0.457870 / 0.0588235 | 0.047059, 0.011765, 0.457870, 0.436248, 0.047059 |
| bipartite, before | 0.450829 / 0.432056 / 0.0441176 | 0.035294, 0.008824, 0.432056, 0.415535, 0.035294 |
| bipartite, after | **exactly the plain values** | **exactly the plain values** |

The iteration converges again: 400 iterations at error 3.4e-2 before, 195 at
9.9e-16 after, on a five-node network. The canonical example goes from 400
iterations at error 5.6e-1 to 202 at 8.9e-16.

Unchanged, as they must be: the non-bipartite directed path, `--bipartite-teleportation`
(the path whose duplicate list was removed — byte-identical output), and undirected runs.

The new test asserts the equivalence rather than a magic number, so it states the
property instead of recording today's output. Mutation-checked: forcing the
accumulator back onto the prefix path fails the flow suite; reverting passes it.

## This changes reported codelengths, upwards

The link flows were missing the `1/(1 - danglingRank)` scaling the node flows
already had, which deflated the exit flows and with them the module codelength.
The canonical bipartite example reported **0.472974 bits against a one-level
codelength of 1.576621** — a 70% saving that was not real; it now reports
1.264931. Node flows there are unchanged, because every link in that file runs one
way, so the omission was a uniform scale the projection cancelled; the link flows
were not scale-invariant.

Two tests pinned the deflated values (`test_flow.cpp`, `test/python/test_flow.py`)
and are updated with the reason. The undirected expectation sitting next to one of
them is unchanged at 1.478406227.

Investigated rather than left open. #899's item 3 quoted expected node flows of
0.894118 / 0.058824 / 0.047059 for the projected run, and the corrected pipeline gives
0.927372 / 0.040349 / 0.032279. The projection turned out to be self-consistent: hand-computing
it from the pre-projection state (own flow + every incident link flow, then normalise by the
sum 1.457870) reproduces the implementation to every printed digit, and the reported one-level
codelength 0.447636 is exactly the entropy of those three flows. The quoted numbers were mine
and they were wrong — 0.058824 and 0.047059 are the *unnormalised* values of n2 and n3, and
0.894118 is `1 - 0.058824 - 0.047059`, i.e. the total fixed by subtraction instead of division;
the quoted 0.592 was then the entropy of that mis-assembled triple. #899's item text is
corrected and the derivation is in its comments.

That did surface one real question, which is about semantics rather than arithmetic and is filed
as #946: the projection adds a node's own flow *and* its incident link flows, which cancels
exactly for undirected input (verified strength-proportional to six digits) but computes
`2·in + out` for directed input. The code's own TODO asks exactly this. Deliberately untouched
here.

Suites: `make test-native` (all green, 0 failed), `pytest -m fast` 635 passed
against a freshly built extension, ruff/clang-format/pre-commit clean.
