### PR TITLE
test: compile the C++ test targets with the OpenMP flags they branch on

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ function(infomap_json_array output_name field_name)
 endfunction()
 
 infomap_json_array(INFOMAP_COMPILE_FLAGS cmake_compile_flags)
+infomap_json_array(INFOMAP_OPENMP_COMPILE_FLAGS cmake_openmp_compile_flags)
 infomap_json_array(INFOMAP_LINK_FLAGS link_flags)
 infomap_json_array(INFOMAP_ENABLED_FEATURE_DEFINES enabled_feature_defines)
 
@@ -114,6 +115,12 @@ target_include_directories(infomap_core PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/vend
 target_compile_features(infomap_core PUBLIC cxx_std_17)
 set_target_properties(infomap_core PROPERTIES CXX_EXTENSIONS OFF)
 target_compile_options(infomap_core PRIVATE ${INFOMAP_COMPILE_FLAGS})
+# OpenMP is PUBLIC while the rest of the policy stays PRIVATE, because it changes what
+# the sources *mean* rather than how well they are compiled: src/ and test/ both branch
+# on _OPENMP, so a consumer compiled without the flag silently drops those branches
+# while still linking libomp -- which is how every #ifdef _OPENMP test case in the
+# suite came to compile to nothing (#930).
+target_compile_options(infomap_core PUBLIC ${INFOMAP_OPENMP_COMPILE_FLAGS})
 target_compile_definitions(infomap_core PUBLIC ${INFOMAP_ENABLED_FEATURE_DEFINES})
 target_link_options(infomap_core PUBLIC ${INFOMAP_LINK_FLAGS})
 
@@ -166,6 +173,12 @@ if(BUILD_TESTING)
             PRIVATE
                 INFOMAP_TEST_ROOT="${CMAKE_CURRENT_SOURCE_DIR}"
         )
+        # Lets a test assert that the OpenMP flags actually reached this translation
+        # unit. Derived from the emitted flags rather than INFOMAP_USE_OPENMP, so a
+        # toolchain for which the policy emits nothing does not expect _OPENMP.
+        if(INFOMAP_OPENMP_COMPILE_FLAGS)
+            target_compile_definitions(${target_name} PRIVATE INFOMAP_TEST_EXPECT_OPENMP=1)
+        endif()
         target_link_libraries(${target_name} PRIVATE infomap_core)
         add_test(NAME ${target_name} COMMAND ${target_name})
         set_tests_properties(${target_name} PROPERTIES LABELS "${labels}")

--- a/scripts/build_config.py
+++ b/scripts/build_config.py
@@ -315,11 +315,18 @@ def resolve_build_config(
 
     openmp_compile_flags = []
     openmp_link_flags = []
+    # Everything a translation unit needs in order to see OpenMP, including the
+    # header search path: consumers of the library branch on _OPENMP too, so these
+    # have to travel with the interface rather than staying with the core's own
+    # compile line. Kept separate from platform_compile_flags, which carries the
+    # same include for reasons unrelated to OpenMP.
+    openmp_interface_compile_flags = []
     if openmp:
         if compiler_family == "clang":
             openmp_compile_flags.extend(["-Xpreprocessor", "-fopenmp"])
             openmp_link_flags.append("-lomp")
             if libomp_prefix:
+                openmp_interface_compile_flags.append(f"-I{libomp_prefix}/include")
                 platform_compile_flags.append(f"-I{libomp_prefix}/include")
                 platform_link_flags.append(f"-L{libomp_prefix}/lib")
         elif compiler_family in {"gnu", "unknown"}:
@@ -361,6 +368,9 @@ def resolve_build_config(
         "libomp_prefix": libomp_prefix,
         "deployment_target": deployment_target,
         "cmake_compile_flags": cmake_compile_flags,
+        "cmake_openmp_compile_flags": _dedupe(
+            openmp_compile_flags + openmp_interface_compile_flags
+        ),
         "compile_flags": compile_flags,
         "link_flags": link_flags,
     }
@@ -424,6 +434,7 @@ def main():
             "libomp_prefix",
             "deployment_target",
             "cmake_compile_flags",
+            "cmake_openmp_compile_flags",
             "compile_flags",
             "link_flags",
         ],

--- a/scripts/build_config.py
+++ b/scripts/build_config.py
@@ -318,8 +318,9 @@ def resolve_build_config(
     # Everything a translation unit needs in order to see OpenMP, including the
     # header search path: consumers of the library branch on _OPENMP too, so these
     # have to travel with the interface rather than staying with the core's own
-    # compile line. Kept separate from platform_compile_flags, which carries the
-    # same include for reasons unrelated to OpenMP.
+    # compile line. The libomp include path is therefore recorded twice on purpose --
+    # here for the propagated OpenMP surface, and in platform_compile_flags for the
+    # core's own compile line, which is assembled from those instead.
     openmp_interface_compile_flags = []
     if openmp:
         if compiler_family == "clang":

--- a/test/cpp/test_thread_config.cpp
+++ b/test/cpp/test_thread_config.cpp
@@ -38,7 +38,9 @@ TEST_CASE("The OpenMP flags reach the test translation units [fast][core][thread
       "absent");
 #endif
 #else
-  WARN_MESSAGE(true, "build has no OpenMP; the _OPENMP-guarded cases are skipped by design");
+  // Informational only: MESSAGE rather than WARN_MESSAGE, so a build without OpenMP
+  // does not spend a warning on something that is working as intended.
+  MESSAGE("build has no OpenMP; the _OPENMP-guarded cases are skipped by design");
 #endif
 }
 

--- a/test/cpp/test_thread_config.cpp
+++ b/test/cpp/test_thread_config.cpp
@@ -5,12 +5,42 @@
 #include <cstdlib>
 #include <string>
 
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
 using infomap::readThreadSourcesFromEnv;
 using infomap::resolveThreadBudget;
 using infomap::ThreadBudget;
 using infomap::ThreadSource;
 using infomap::ThreadSources;
 using infomap::threadSourceName;
+
+TEST_CASE("The OpenMP flags reach the test translation units [fast][core][threads]")
+{
+  // Not a test of OpenMP itself but of the build: the suite has 21 `#ifdef _OPENMP`
+  // blocks, and until #930 none of them existed in any test binary. Only infomap_core
+  // was compiled with the flags, while libomp still linked in transitively -- so
+  // `otool -L` looked right, ctest reported success, and the thread-count invariance
+  // cases it claimed to run were absent from the binary.
+  //
+  // Deliberately outside `#ifdef _OPENMP`: a guard that only runs when the thing it
+  // guards is present is the exact failure being fixed. INFOMAP_TEST_EXPECT_OPENMP
+  // comes from the build policy's emitted flags, so builds that genuinely have no
+  // OpenMP skip the requirement instead of failing.
+#ifdef INFOMAP_TEST_EXPECT_OPENMP
+#ifdef _OPENMP
+  CHECK(omp_get_max_threads() >= 1);
+#else
+  FAIL(
+      "the build policy emitted OpenMP compile flags, but this translation unit was "
+      "compiled without them, so every #ifdef _OPENMP case in the suite is silently "
+      "absent");
+#endif
+#else
+  WARN_MESSAGE(true, "build has no OpenMP; the _OPENMP-guarded cases are skipped by design");
+#endif
+}
 
 TEST_CASE("Explicit --num-threads wins over every other source [fast][core][threads]")
 {


### PR DESCRIPTION
Closes #930.

## The defect

The build policy's compile flags are `PRIVATE` on `infomap_core` while its link flags
are `PUBLIC`. So libomp linked into every test binary — `otool -L` looked correct —
but `_OPENMP` was undefined in all 21 `#ifdef _OPENMP` blocks across
`test_flow.cpp`, `test_infomap_wrapper.cpp` and `test_partition.cpp`:

```
$ grep -c fopenmp build/cmake/CMakeFiles/*.dir/flags.make
infomap_core.dir:                 2
infomap_cpp_*_tests.dir:          0   (every one)
```

## Worse than dead code: vacuous assertions

The blocks sit **inside** test-case bodies, not around them, so nothing was missing
from the reports. The cases ran and passed while testing nothing:

```cpp
#ifdef _OPENMP
  omp_set_num_threads(1);
#endif
  const auto serialResult = runHierarchical();
#ifdef _OPENMP
  omp_set_num_threads(4);
#endif
  const auto parallelResult = runHierarchical();
```

*"Hierarchical partition is invariant to the OpenMP thread count"* compared a run at
the default thread count against another run at the default thread count. It could
not fail. Confirmed on the binary rather than by reading:

| build | `nm -u … | grep -c omp_set_num_threads` |
| --- | --- |
| before (and `-DINFOMAP_USE_OPENMP=OFF`) | 0 |
| after | 1 |

## The fix

`target_compile_options(infomap_core PUBLIC ${INFOMAP_OPENMP_COMPILE_FLAGS})` — OpenMP
becomes part of the interface while the rest of the policy stays private, because it
changes what the sources *mean* rather than how well they are compiled: `src/` and
`test/` both branch on `_OPENMP`.

The propagated set is a new `cmake_openmp_compile_flags` field from
`scripts/build_config.py`, and it includes libomp's **include directory**. That
matters: the include lived in the platform flags, so propagating only
`-Xpreprocessor -fopenmp` would leave a consumer that includes `<omp.h>` under the
guard failing to compile on macOS. Verified that no existing field of the emitted
payload changed.

## The guard against a repeat

A new test asserts the flags actually arrived, and sits deliberately **outside**
`#ifdef _OPENMP` — a guard that only runs when the thing it guards is present is the
exact failure being fixed. It keys off a define derived from the policy's emitted
flags, not from `INFOMAP_USE_OPENMP`, so a toolchain for which no flags are emitted
skips the requirement rather than failing.

Checked both directions:

- removing the propagation → `FATAL ERROR: the build policy emitted OpenMP compile
  flags, but this translation unit was compiled without them, so every #ifdef _OPENMP
  case in the suite is silently absent`, exit 1
- `-DINFOMAP_USE_OPENMP=OFF` → no flags, no define, 11/11 pass

## Result

All 15 previously vacuous cases pass now that they genuinely vary the thread count, so
the invariance they claim does hold — it had simply never been checked. `make
test-native` 100% of 25, `pytest -m fast` 629 passed against an extension rebuilt from
this branch, and the sanitizer configuration still configures, builds and passes.

## One thing found and deliberately not changed

The same `PRIVATE` split means consumer translation units get **none** of the policy
flags — `main.cpp`, `native_benchmark.cpp` and every test file compile with just
`-std=gnu++17 -arch arm64`: no `-O3`, no `-Wall -Wextra -Wshadow`, and with GNU
extensions on while the core has them off. OpenMP is the part that changes behaviour,
so it is the part this PR fixes; the rest is a preference question worth its own
discussion. Nothing user-visible hangs on it — the `compiled with OpenMP` banner comes
from `ProgramInterface.cpp` inside the core, so both the make-built and cmake-built CLI
report it correctly, and `main.cpp` only includes `<omp.h>` under the guard without
calling into it.