### PR TITLE
fix: validate cluster-data tree shape and node membership before using it

### DIFF
--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1248,7 +1248,14 @@ InfomapBase& InfomapBase::initTree(const NodePaths& tree)
       maxDepth = std::max(maxDepth, static_cast<int>(nodePath.second.size()));
     }
   }
-  if (maxDepth == 2) {
+  // A deeper tree under --two-level takes the same route, keeping each leaf's top-level
+  // module and dropping the sub-module structure below it. That is the collapse the
+  // hierarchical path performs with removeSubModules, and doing it here means the
+  // objective is initialised by the branch that works: building the full tree and then
+  // running a two-level search over it left the search with the deeper tree's
+  // index/module codelengths, which it reported as 0 -- or, with the tuning loop
+  // enabled, aborted on "fineTune() called but numLevels != 2" (#898).
+  if (maxDepth == 2 || twoLevel) {
     std::map<unsigned int, unsigned int> clusterIds;
     for (const auto& nodePath : tree) {
       const auto nodeId = nodePath.first;
@@ -1256,6 +1263,50 @@ InfomapBase& InfomapBase::initTree(const NodePaths& tree)
       clusterIds[nodeId] = clusterId;
     }
     return initPartition(clusterIds, false);
+  }
+
+  // Refuse a module that would get both a leaf and a sub-module as children. The
+  // search never produces that shape -- checked across 205k leaves at depths 2 to 8 --
+  // and the code downstream assumes it cannot happen: the per-level aggregation used to
+  // dereference the leaf's null firstChild, the Newick writer emits an empty taxon for
+  // the leaf, and the objective gives the same partition two different codelengths
+  // depending on the order the rows appear in the file. Supporting the shape means
+  // deciding what the map equation is for a module that codes a leaf and a sub-module
+  // side by side, which is a modelling question rather than a fix, so the input is
+  // named and rejected instead of silently reinterpreted (#898). Note this runs after
+  // the two-level branch above, where the sub-module structure is dropped anyway.
+  std::map<Path, bool> prefixHasLeafChild;
+  std::map<Path, bool> prefixHasModuleChild;
+  for (const auto& nodePath : tree) {
+    const auto& path = nodePath.second;
+    if (path.size() < 2)
+      continue;
+    Path prefix;
+    for (size_t i = 0; i + 1 < path.size(); ++i) {
+      prefix.push_back(path[i]);
+      if (i + 2 == path.size())
+        prefixHasLeafChild[prefix] = true;
+      else
+        prefixHasModuleChild[prefix] = true;
+    }
+  }
+  for (const auto& it : prefixHasLeafChild) {
+    if (prefixHasModuleChild.count(it.first) == 0)
+      continue;
+    std::string modulePath;
+    for (const auto level : it.first) {
+      if (!modulePath.empty())
+        modulePath += ':';
+      modulePath += io::stringify(level);
+    }
+    throw InfomapError(ExitCode::InputError,
+                       fmt::format(FMT_STRING("Cluster data mixes depths under module {}: it has both a leaf node and a "
+                                              "sub-module as children. Infomap's own output never has that shape, and the "
+                                              "codelength of such a module is not defined, so the tree cannot be used as an "
+                                              "initial partition. Give every node under module {} the same depth, or pass "
+                                              "--two-level to keep only the top-level assignment."),
+                                   modulePath,
+                                   modulePath));
   }
 
   // Tear down the existing partition. Detach the leaves first so that the
@@ -1407,14 +1458,32 @@ InfomapBase& InfomapBase::initPartition(const std::map<unsigned int, unsigned in
   std::vector<unsigned int> modules(numNodes);
   std::vector<unsigned int> selectedNodes(numNodes, 0);
   unsigned int moduleIndex = 0;
+  unsigned int numClusterNodeIdsNotInNetwork = 0;
   for (const auto& it : clusterIdToNodeIds) {
     auto& nodes = it.second;
+    bool moduleHasMember = false;
     for (auto& nodeId : nodes) {
-      auto nodeIndex = nodeIdToIndex[nodeId];
-      modules[nodeIndex] = moduleIndex;
-      ++selectedNodes[nodeIndex];
+      // find, not operator[]: a node id the network does not have would otherwise be
+      // inserted with a default index of 0, quietly reassigning the *first* leaf node
+      // to this module and marking it as covered -- which also suppressed the note
+      // below about the nodes that really are missing an assignment (#898).
+      const auto nodeIndexIt = nodeIdToIndex.find(nodeId);
+      if (nodeIndexIt == nodeIdToIndex.end()) {
+        ++numClusterNodeIdsNotInNetwork;
+        continue;
+      }
+      modules[nodeIndexIt->second] = moduleIndex;
+      ++selectedNodes[nodeIndexIt->second];
+      moduleHasMember = true;
     }
-    ++moduleIndex;
+    // Only claim an index for a module that got a member, so a cluster whose ids are
+    // all unknown does not leave an empty module behind.
+    if (moduleHasMember)
+      ++moduleIndex;
+  }
+
+  if (numClusterNodeIdsNotInNetwork > 0) {
+    Console::note(1, "{} node ids in cluster file not found in network.", numClusterNodeIdsNotInNetwork);
   }
 
   unsigned int numNodesWithoutClusterInfo = static_cast<unsigned int>(
@@ -2635,8 +2704,22 @@ unsigned int InfomapBase::removeModules()
 
 unsigned int InfomapBase::removeSubModules(bool recalculateCodelengthOnTree)
 {
+  // Loop on "any top module still has a module child" for the reason removeModules
+  // gives above: numLevels() follows the firstChild chain only, so on a ragged tree it
+  // reports the leftmost branch's depth and this loop stopped while deeper branches
+  // were still nested. What came out was neither the two-level tree the caller asked
+  // for nor a codelength of it -- calcCodelengthOnTree below then scored a tree that
+  // still had sub-modules in it (#898).
+  auto anyModuleHasModuleChild = [this]() {
+    for (auto& module : m_root)
+      for (auto& child : module)
+        if (!child.isLeaf())
+          return true;
+    return false;
+  };
+
   unsigned int numLevelsDeleted = 0;
-  while (numLevels() > 2) {
+  while (anyModuleHasModuleChild()) {
     for (InfoNode& module : m_root)
       module.replaceChildrenWithGrandChildren();
     ++numLevelsDeleted;
@@ -3116,16 +3199,37 @@ void aggregatePerLevelCodelength(const InfoNode& parent, std::vector<detail::Per
   if (perLevelStat.size() < level + 1)
     perLevelStat.resize(level + 1);
 
-  if (parent.firstChild->isLeaf()) {
-    perLevelStat[level].numLeafNodes += parent.childDegree();
-    perLevelStat[level].leafLength += parent.codelength;
-    return;
+  // Classify each child on its own rather than reading the first one and assuming the
+  // rest match. A module with both kinds of child made this crash or lie depending on
+  // which came first (#898): a leaf after a sub-module was recursed into, dereferencing
+  // its null firstChild, while a leaf *before* one returned early and dropped every
+  // remaining sub-module subtree from the report.
+  unsigned int numLeafChildren = 0;
+  unsigned int numModuleChildren = 0;
+  for (const auto& child : parent) {
+    if (child.isLeaf())
+      ++numLeafChildren;
+    else
+      ++numModuleChildren;
   }
 
-  perLevelStat[level].numModules += parent.childDegree();
-  perLevelStat[level].indexLength += parent.codelength;
+  if (numLeafChildren > 0) {
+    perLevelStat[level].numLeafNodes += numLeafChildren;
+    // The codelength of coding these leaves belongs to this level. Charged once even
+    // when sub-modules sit alongside them, since it is the parent's own codelength.
+    perLevelStat[level].leafLength += parent.codelength;
+  }
+
+  if (numModuleChildren == 0)
+    return;
+
+  perLevelStat[level].numModules += numModuleChildren;
+  if (numLeafChildren == 0)
+    perLevelStat[level].indexLength += parent.codelength;
 
   for (auto& module : parent) {
+    if (module.isLeaf())
+      continue;
     if (module.getInfomapRoot() != nullptr)
       aggregatePerLevelCodelength(*module.getInfomapRoot(), perLevelStat, level + 1);
     else

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -1,6 +1,7 @@
 #include "vendor/doctest.h"
 
 #include "Infomap.h"
+#include "io/InfomapError.h"
 
 #include "TestUtils.h"
 
@@ -122,6 +123,119 @@ TEST_CASE("Tree cluster-data fixture initializes a multi-level tree [fast][core]
   infomap::test::checkRunSanity(im);
 }
 
+TEST_CASE("Mixed-depth cluster data is rejected instead of crashing [fast][core][partition][parser]")
+{
+  // A module with both a leaf and a sub-module as children used to segfault: the
+  // per-level aggregation read the first child, concluded "these are modules", and then
+  // recursed into the leaf, dereferencing its null firstChild. Reordering the same
+  // partition's rows gave the same tree two different codelengths instead (#898).
+  InfomapWrapper im(infomap::test::defaultFlags());
+  im.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+  im.initNetwork(im.network());
+
+  try {
+    im.initPartition(infomap::test::clusterFixturePath("twotriangles_mixed_depth.tree"), false, &im.network());
+    FAIL("expected mixed-depth cluster data to be rejected");
+  } catch (const infomap::InfomapError& e) {
+    CHECK(e.code() == infomap::ExitCode::InputError);
+    const std::string message(e.what());
+    CHECK(message.find("mixes depths") != std::string::npos);
+    // The offending module has to be named, or the user cannot find it in the file.
+    CHECK(message.find("module 1") != std::string::npos);
+  }
+}
+
+TEST_CASE("A two-level search from a deeper tree keeps its top level [fast][core][partition]")
+{
+  // --two-level with a deeper cluster tree reported codelength 0 on a tree that still
+  // had sub-modules in it, or aborted with "fineTune() called but numLevels != 2" once
+  // the tuning loop was allowed to run (#898). Both are gone: the supplied tree's top
+  // level becomes the starting partition, which is what --two-level means.
+  InfomapWrapper im(infomap::test::defaultFlags("--two-level"));
+  im.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+  im.initNetwork(im.network());
+
+  im.initPartition(infomap::test::clusterFixturePath("twotriangles_three_level.tree"), false, &im.network());
+
+  CHECK(im.numLevels() == 2);
+  CHECK(im.maxTreeDepth() == 2);
+  CHECK(im.numTopModules() == 2);
+
+  im.run();
+
+  infomap::test::checkRunSanity(im);
+  CHECK(im.codelength() > 0.0);
+  CHECK(im.maxTreeDepth() == 2);
+}
+
+TEST_CASE("removeSubModules flattens a ragged tree whose shallow branch comes first [fast][core][partition][tree]")
+{
+  // numLevels() follows the firstChild chain only, so with the shallow branch first it
+  // reports 2 for a three-level tree and the old `while (numLevels() > 2)` loop did
+  // nothing at all -- leaving sub-modules in place for calcCodelengthOnTree to score as
+  // if they were not there (#898).
+  InfomapWrapper im(infomap::test::defaultFlags());
+  im.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+  im.initNetwork(im.network());
+  im.initPartition(infomap::test::clusterFixturePath("twotriangles_ragged_branches.tree"), false, &im.network());
+
+  REQUIRE(im.maxTreeDepth() == 3);
+  // The shortcut this test exists for, pinned so the fixture keeps exercising it.
+  REQUIRE(im.numLevels() == 2);
+
+  im.removeSubModules(true);
+
+  CHECK(im.maxTreeDepth() == 2);
+  unsigned int numModules = 0;
+  for (auto& module : im.root()) {
+    ++numModules;
+    for (auto& child : module) {
+      CHECK(child.isLeaf());
+    }
+  }
+  CHECK(numModules == 2);
+}
+
+TEST_CASE("An unknown node id in cluster data leaves the partition alone [fast][core][partition][parser]")
+{
+  // std::map::operator[] inserted the unknown id with a default index of 0, so it
+  // reassigned the *first* leaf node to the stray module and marked it as covered,
+  // which also silenced the note about nodes genuinely missing an assignment (#898).
+  // Compared as a grouping rather than as raw module indices, which get renumbered:
+  // nodes are visited in state-id order and each new parent gets the next group number,
+  // so two runs agree exactly when they put the same nodes together.
+  auto groupingFrom = [](const std::string& clusterFile) {
+    InfomapWrapper im(infomap::test::defaultFlags("--no-infomap"));
+    im.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+    im.initNetwork(im.network());
+    im.initPartition(infomap::test::clusterFixturePath(clusterFile), false, &im.network());
+
+    std::map<unsigned int, const infomap::InfoNode*> parentByStateId;
+    for (auto it = im.iterLeafNodes(); !it.isEnd(); ++it) {
+      const auto& node = *it;
+      parentByStateId[node.stateId] = node.parent;
+    }
+
+    std::map<const infomap::InfoNode*, unsigned int> groupOfParent;
+    std::map<unsigned int, unsigned int> grouping;
+    for (const auto& it : parentByStateId) {
+      const auto inserted = groupOfParent.emplace(it.second, static_cast<unsigned int>(groupOfParent.size()));
+      grouping[it.first] = inserted.first->second;
+    }
+    return grouping;
+  };
+
+  const auto clean = groupingFrom("twotriangles_two_modules.clu");
+  const auto withUnknownId = groupingFrom("twotriangles_two_modules_unknown_id.clu");
+
+  REQUIRE(clean.size() == 6);
+  // Two groups of three, and the first leaf is not pulled out into the stray module.
+  CHECK(clean.at(1) == clean.at(2));
+  CHECK(clean.at(1) == clean.at(3));
+  CHECK(clean.at(1) != clean.at(4));
+  CHECK(withUnknownId == clean);
+}
+
 TEST_CASE("Tree cluster-data reinit and rerun stay stable on the same instance [fast][core][partition][lifecycle]")
 {
   InfomapWrapper im(infomap::test::defaultFlags());
@@ -178,6 +292,52 @@ TEST_CASE("Pretty per-level codelength renders a structured levels table [fast][
   CHECK(text.find("Total") != std::string::npos);
   CHECK(text.find("Per level number of modules") == std::string::npos);
   CHECK(text.find("2.700302") != std::string::npos);
+}
+
+TEST_CASE("Per-level aggregation survives a module with both kinds of child [fast][core][partition][output]")
+{
+  // Cluster data can no longer deliver this shape -- it is rejected at intake -- but the
+  // aggregation is a shared reporting path and used to read only the first child to
+  // decide whether a module holds leaves. A leaf sibling *after* a sub-module was then
+  // recursed into and its null firstChild dereferenced (SIGSEGV), while a leaf *before*
+  // one returned early and dropped every remaining sub-module from the table. Built by
+  // hand so the guarantee is pinned even though no input can reach it (#898).
+  InfoNode root;
+  auto* module = new InfoNode({}, 100);
+  auto* leafBeside = new InfoNode({}, 1);
+  auto* subModule = new InfoNode({}, 200);
+  auto* nestedLeafA = new InfoNode({}, 2);
+  auto* nestedLeafB = new InfoNode({}, 3);
+
+  root.addChild(module);
+  // Sub-module first, then the leaf: the order that used to crash.
+  module->addChild(subModule);
+  module->addChild(leafBeside);
+  subModule->addChild(nestedLeafA);
+  subModule->addChild(nestedLeafB);
+
+  std::ostringstream output;
+  unsigned int numLevels = 0;
+  CHECK_NOTHROW(numLevels = infomap::printPerLevelCodelength(root, output));
+
+  // Three levels of nodes, and every leaf accounted for: one beside the sub-module and
+  // two inside it.
+  CHECK(numLevels == 3);
+  std::vector<infomap::detail::PerLevelStat> stats;
+  infomap::aggregatePerLevelCodelength(root, stats);
+  unsigned int totalLeaves = 0;
+  for (const auto& stat : stats)
+    totalLeaves += stat.numLeafNodes;
+  CHECK(totalLeaves == 3);
+
+  root.releaseChildren();
+  module->releaseChildren();
+  subModule->releaseChildren();
+  delete nestedLeafA;
+  delete nestedLeafB;
+  delete subModule;
+  delete leafBeside;
+  delete module;
 }
 
 TEST_CASE("InfoNode hierarchy mutations preserve parentage and child order [fast][core][partition][tree]")

--- a/test/fixtures/clusters/twotriangles_mixed_depth.tree
+++ b/test/fixtures/clusters/twotriangles_mixed_depth.tree
@@ -1,0 +1,9 @@
+# path flow name state_id
+# Module 1 has both a leaf child and a sub-module child, a shape Infomap's own
+# output never has. Used to check that it is rejected rather than crashing.
+1:1 0.1 "A" 1
+1:2:1 0.1 "B" 2
+1:2:2 0.1 "C" 3
+2:1 0.1 "D" 4
+2:2 0.1 "E" 5
+2:3 0.1 "F" 6

--- a/test/fixtures/clusters/twotriangles_ragged_branches.tree
+++ b/test/fixtures/clusters/twotriangles_ragged_branches.tree
@@ -1,0 +1,11 @@
+# path flow name state_id
+# Ragged but not mixed: every module's children are all leaves or all modules, while
+# the branches end at different depths. Module 1 is listed first and is the shallow
+# one, so numLevels() -- which follows the firstChild chain -- reports 2 for a tree
+# that is 3 deep.
+1:1 0.1 "A" 1
+1:2 0.1 "B" 2
+1:3 0.1 "C" 3
+2:1:1 0.1 "D" 4
+2:1:2 0.1 "E" 5
+2:2:1 0.1 "F" 6

--- a/test/fixtures/clusters/twotriangles_two_modules_unknown_id.clu
+++ b/test/fixtures/clusters/twotriangles_two_modules_unknown_id.clu
@@ -1,0 +1,9 @@
+# state_id module
+# twotriangles_two_modules.clu plus one id the network does not have.
+1 1
+2 1
+3 1
+4 2
+5 2
+6 2
+99999 3


### PR DESCRIPTION
Closes #898 — all six boxes, though two of them by refusing the input rather than
supporting it. Details below so that distinction is not lost.

## One cause behind five defects

The tree code assumes every module's children are **all** leaves or **all**
sub-modules, and that depth can be read off the leftmost branch. The search always
produces trees like that — I checked across 205k leaves at depths 2 to 8, zero modules
with mixed children — so `--cluster-data` was the one way in for trees that are not.

## Mixed depth is now named and rejected

```
$ ./Infomap net6.net out -c mixed.tree --no-infomap
Error: Cluster data mixes depths under module 1: it has both a leaf node and a
sub-module as children. … Give every node under module 1 the same depth, or pass
--two-level to keep only the top-level assignment.
$ echo $?
2
```

Before: `exit=139`, `EXC_BAD_ACCESS` in `aggregatePerLevelCodelength`, empty output
directory.

Supporting the shape instead would mean deciding what the map equation is for a module
that codes a leaf and a sub-module side by side, and the current objective does not
answer that — **the same partition came out at 2.86612 or 2.7493 bits depending on the
order the rows appeared in the file.** That is a modelling question, not a fix, so the
input is refused with the reason and the way around it. `--two-level` still accepts such
a file, because it keeps only the top-level assignment.

This resolves three boxes at once: the segfault, the row-order dependence, and the
invalid Newick — an *empty taxon* where the leaf sibling should be, which is malformed
Newick, not just a missing leaf:

```
((((3:0.214286,2:0.142857):0.357143,):0.5,(4:…,5:…,6:…):0.5):1);
                                     ^ leaf 1 emitted as nothing
```

Verified the writer is correct for every shape the search can produce, uniform and
ragged alike: 27/27 and 100000/100000 leaves, zero empty taxa. So no writer change is
needed once the shape cannot arrive.

## The aggregation is fixed too, not just gated

It is a shared reporting path, so it should not depend on a gate elsewhere. It read only
the first child to decide whether a module holds leaves: a leaf *after* a sub-module was
recursed into and its null `firstChild` dereferenced, and a leaf *before* one returned
early, dropping every remaining sub-module from the table (31 leaves reported for a
36-node network). A hand-built tree pins the behaviour — reverting the fix **segfaults
the suite**.

## `removeSubModules` never flattened ragged trees

It looped on `numLevels()`, which follows the `firstChild` chain and carries a TODO
admitting it. With the shallow branch first it reports 2 for a three-level tree, so the
loop did nothing and `calcCodelengthOnTree` then scored a tree that still had
sub-modules in it. Now loops on the structure, exactly as its sibling `removeModules`
already does three lines above.

## `--two-level` with a deeper tree

Reported `Best codelength 0` with `Relative savings 100.00%`, or aborted with
`fineTune() called but numLevels != 2` once the tuning loop was allowed to run. The
collapse now happens at intake, where the two-level branch already keeps each leaf's
top-level module, so the objective is initialised by the path that works:

| | before | after |
| --- | --- | --- |
| `--two-level -c 3-level.tree --tune-iteration-limit 1` | 0 | 3.602572453 |
| same, tuning loop enabled | `logic_error` | 3.574118109 |

## An unknown node id no longer moves the first leaf

`nodeIdToIndex[nodeId]` — `std::map::operator[]` — inserted the unknown id with a
default index of **0**, moving the first leaf node into the stray module and marking it
as covered, which also silenced the note about nodes that genuinely had no assignment.
Now looked up with `find`, counted, and reported at `-v` alongside its sibling notes.

## Verification

Five new tests, each mutation-checked — reverting the code it covers makes it fail (the
aggregation one by segfault). Two measurement notes, since they cost me time: `cmake
--build build/cmake --target …` does **not** rebuild `infomap_core` in this tree, so an
early round of mutation checks silently tested stale binaries and looked like the tests
were green; `make test-native` does. And my first unknown-id test compared raw module
indices, which are renumbered — it passed against the buggy code until I rewrote it to
compare the grouping.

`make test-native` 100% of 25, `pytest -m fast` 635 passed against an extension rebuilt
from this branch, clang-format and pre-commit clean. R tests use `two_level` only with
plain edge lists, so they do not touch this path.