### PR TITLE
fix: seed every trial the same way, in every mode

### DIFF
--- a/interfaces/python/source/workflows/hpc.md
+++ b/interfaces/python/source/workflows/hpc.md
@@ -48,6 +48,12 @@ Two strategies cover most HPC use cases:
 Both strategies produce the same result as a sequential run with the same
 seed, total trial count, and algorithm settings.
 
+That equivalence rests on one rule, which holds in every mode: the trial at
+global index *j* runs with seed `base_seed + j`. So a trial is identified by
+its seed alone — it does not matter whether it was produced sequentially, by
+`parallel_trials`, or by a shard at an offset — and the seed a run reports for
+a trial (in `trial_results` and `timing_json`) re-runs exactly that trial.
+
 ## Trials as independent work units
 
 Each task runs `num_trials` trials of its own (the *per-shard* count), and

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -740,16 +740,21 @@ private:
   // derives it the same way, so "the trial with seed s" names one run whether it
   // was produced serially, by --parallel-trials, or by a shard at an offset.
   //
-  // Kept at the config field's own width. The engine is narrower -- every route
-  // into it takes unsigned int (`BasicRandom(unsigned int)` on construction,
-  // `Random::seed(unsigned int)` from reseed and from setNonMainConfig) -- so the
-  // RNG only ever sees the low 32 bits. That narrowing is uniform, which is what
-  // makes the reported seed usable: a standalone run with the value recorded here
-  // narrows to the same engine seed and reproduces the trial, and the recursion
-  // reading the config field cannot end up on a different stream than the engine.
-  // The one visible consequence is aliasing -- seeds congruent mod 2^32 name the
-  // same run -- which follows from Config::seedToRandomNumberGenerator being
-  // wider than the engine, not from anything about per-trial seeding.
+  // Kept at the config field's own width. Every route into the engine takes
+  // unsigned int (`BasicRandom(unsigned int)` on construction,
+  // `Random::seed(unsigned int)` from reseed and from setNonMainConfig), so the
+  // RNG only ever sees the low 32 bits of the seed.
+  //
+  // Whether that discards anything depends on the platform:
+  // Config::seedToRandomNumberGenerator is `unsigned long`, which is 64-bit on
+  // LP64 (Linux, macOS) and 32-bit on LLP64 (Windows). On Windows the field is
+  // exactly the engine's width and no seed can outrun it. On LP64 the narrowing
+  // is real but uniform, which is what keeps the reported seed usable: a
+  // standalone run given the value recorded here narrows to the same engine seed
+  // and reproduces the trial, and the recursion reading the config field cannot
+  // land on a different stream than the engine. The one visible consequence
+  // there is aliasing -- seeds congruent mod 2^32 name the same run -- which
+  // follows from the width mismatch, not from anything about per-trial seeding.
   unsigned long trialSeed(unsigned int trialIndex) const
   {
     return m_baseSeed + m_infomap.trialOffset + trialIndex;

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -188,6 +188,29 @@ namespace {
   }
 #endif
 
+  // The serial trial loop moves the config seed to the current trial's seed (see
+  // RunSession::seedTrial), but everything downstream of the loop -- the run
+  // manifest, the config fingerprint, the shard file's base_seed -- must report
+  // the seed the user asked for. Give it back on the way out, including when a
+  // trial throws or the run is interrupted.
+  class ScopedConfigSeed {
+  public:
+    explicit ScopedConfigSeed(Config& config)
+        : m_config(config), m_previous(config.seedToRandomNumberGenerator) {}
+
+    ~ScopedConfigSeed()
+    {
+      m_config.seedToRandomNumberGenerator = m_previous;
+    }
+
+    ScopedConfigSeed(const ScopedConfigSeed&) = delete;
+    ScopedConfigSeed& operator=(const ScopedConfigSeed&) = delete;
+
+  private:
+    Config& m_config;
+    unsigned long m_previous;
+  };
+
 } // namespace
 
 class InfomapBase::RunSession {
@@ -339,6 +362,11 @@ private:
       return runTrialsInParallel();
     }
 
+    // The serial paths below reseed the config per trial; give the run's base
+    // seed back once the loop is done. Constructed before the first seedTrial,
+    // so what it captures is the base seed.
+    const ScopedConfigSeed scopedSeed(m_infomap);
+
     if (m_convergeTrials) {
       runTrialsUntilConverged(result);
     } else {
@@ -402,7 +430,7 @@ private:
       workerConfig.numTrials = 1;
       workerConfig.parallelTrials = false;
       workerConfig.innerParallelization = false;
-      workerConfig.seedToRandomNumberGenerator = m_infomap.seedToRandomNumberGenerator + static_cast<unsigned int>(workerIndex);
+      workerConfig.seedToRandomNumberGenerator = m_baseSeed + static_cast<unsigned int>(workerIndex);
 
       InfomapBase worker(workerConfig);
       worker.m_initialPartition = m_infomap.m_initialPartition;
@@ -413,10 +441,9 @@ private:
       for (unsigned int trialIndex = static_cast<unsigned int>(workerIndex); trialIndex < m_numTrials; trialIndex += numWorkers) {
         try {
           Log::ScopedMute muteWorkerLogs;
-          const auto globalIndex = m_infomap.trialOffset + trialIndex;
-          const auto trialSeed = m_infomap.seedToRandomNumberGenerator + globalIndex;
-          worker.seedToRandomNumberGenerator = trialSeed;
-          worker.reseed(trialSeed);
+          const auto seed = trialSeed(trialIndex);
+          worker.seedToRandomNumberGenerator = seed;
+          worker.reseed(static_cast<unsigned int>(seed));
           int threadNumber = 0;
 #ifdef _OPENMP
           threadNumber = omp_get_thread_num();
@@ -442,12 +469,12 @@ private:
           const auto trialTime = trialTimer.getElapsedTimeInSec();
           codelengths[trialIndex] = trialCodelength;
           numTopModules[trialIndex] = trialTopModules;
-          m_timing.recordTrial(trialIndex, threadNumber, trialSeed, trialTime, trialCodelength, trialTopModules, trialNumLevels);
+          m_timing.recordTrial(trialIndex, threadNumber, seed, trialTime, trialCodelength, trialTopModules, trialNumLevels);
 
           if (worker.printAllTrials && m_numTrials > 1) {
             std::lock_guard<std::mutex> lock(outputMutex);
             auto outputTimer = m_timing.scope("output_s");
-            worker.writeResult(static_cast<int>(globalIndex + 1));
+            worker.writeResult(static_cast<int>(m_infomap.trialOffset + trialIndex + 1));
           }
 
           std::lock_guard<std::mutex> lock(bestResultMutex);
@@ -709,14 +736,49 @@ private:
 #endif
   }
 
-  bool isShardingMode() const { return m_infomap.trialOffset > 0 || !m_infomap.trialResultsPath.empty(); }
+  // The seed of the trial at global index `trialOffset + trialIndex`. Every mode
+  // derives it the same way, so "the trial with seed s" names one run whether it
+  // was produced serially, by --parallel-trials, or by a shard at an offset.
+  //
+  // Kept at the config field's own width. The engine is narrower -- every route
+  // into it takes unsigned int (`BasicRandom(unsigned int)` on construction,
+  // `Random::seed(unsigned int)` from reseed and from setNonMainConfig) -- so the
+  // RNG only ever sees the low 32 bits. That narrowing is uniform, which is what
+  // makes the reported seed usable: a standalone run with the value recorded here
+  // narrows to the same engine seed and reproduces the trial, and the recursion
+  // reading the config field cannot end up on a different stream than the engine.
+  // The one visible consequence is aliasing -- seeds congruent mod 2^32 name the
+  // same run -- which follows from Config::seedToRandomNumberGenerator being
+  // wider than the engine, not from anything about per-trial seeding.
+  unsigned long trialSeed(unsigned int trialIndex) const
+  {
+    return m_baseSeed + m_infomap.trialOffset + trialIndex;
+  }
+
+  // Reseed for every trial, in every mode.
+  //
+  // This used to happen only in "sharding mode" (trialOffset > 0 or a
+  // --trial-results path given), which made the presence of an output flag
+  // decide whether the trials were independently seeded or one continuous RNG
+  // stream. Adding --trial-results therefore changed the published partition,
+  // and the per-trial seeds reported in --timing-json named seeds that never
+  // ran their trial. Both are fixed by seeding unconditionally.
+  //
+  // Set the config field as well as the engine: the recursive partition builds
+  // its sub-Infomaps with setNonMainConfig, which seeds each one from
+  // Config::seedToRandomNumberGenerator, so an engine-only reseed would leave
+  // the whole recursion on the base seed and make shard trial i differ from the
+  // same trial run any other way. runTrials restores the base seed afterwards.
+  void seedTrial(unsigned int trialIndex)
+  {
+    const auto seed = trialSeed(trialIndex);
+    m_infomap.seedToRandomNumberGenerator = seed;
+    m_infomap.reseed(static_cast<unsigned int>(seed));
+  }
 
   void runTrial(unsigned int trialIndex, Result& result)
   {
-    if (isShardingMode()) {
-      const unsigned int globalSeed = static_cast<unsigned int>(m_infomap.seedToRandomNumberGenerator + (m_infomap.trialOffset + trialIndex));
-      m_infomap.reseed(globalSeed);
-    }
+    seedTrial(trialIndex);
     m_infomap.removeModules();
     auto startDate = Date();
     Stopwatch timer(true);
@@ -805,8 +867,10 @@ private:
           << " | codelength " << io::toPrecision(m_infomap.m_hierarchicalCodelength) << "\n";
     m_infomap.m_codelengths.push_back(m_infomap.m_hierarchicalCodelength);
     m_infomap.m_numTopModules.push_back(m_infomap.numTopModules());
-    const unsigned long globalSeed = m_infomap.seedToRandomNumberGenerator + (m_infomap.trialOffset + trialIndex);
-    m_timing.recordTrial(trialIndex, 0, globalSeed, timer.getElapsedTimeInSec(), m_infomap.m_hierarchicalCodelength, m_infomap.numTopModules(), m_infomap.numLevels());
+    // From trialSeed, not from the live config field: seedTrial has already moved
+    // that field to this trial's seed, so recomputing from it would double-count
+    // the global index.
+    m_timing.recordTrial(trialIndex, 0, trialSeed(trialIndex), timer.getElapsedTimeInSec(), m_infomap.m_hierarchicalCodelength, m_infomap.numTopModules(), m_infomap.numLevels());
 
     if (m_infomap.printAllTrials && m_numTrials > 1) {
       auto outputTimer = m_timing.scope("output_s");
@@ -887,7 +951,7 @@ public:
       trialResultsFile.networkFingerprint = networkFingerprint(m_infomap.networkFile);
       trialResultsFile.configFingerprint = configFingerprint(m_infomap.getConfig());
       trialResultsFile.infomapVersion = INFOMAP_VERSION;
-      trialResultsFile.baseSeed = m_infomap.seedToRandomNumberGenerator;
+      trialResultsFile.baseSeed = m_baseSeed;
       trialResultsFile.trialOffset = m_infomap.trialOffset;
       trialResultsFile.numTrials = m_numTrials;
 
@@ -955,6 +1019,9 @@ private:
   TimingRegistry& m_timing;
   RunReportNetwork m_reportNetwork;
   const unsigned int m_numTrials = m_infomap.numTrials;
+  // Captured before the first trial reseeds the config field, so the run keeps a
+  // stable notion of "the seed the user asked for".
+  const unsigned long m_baseSeed = m_infomap.seedToRandomNumberGenerator;
   const bool m_convergeTrials = m_infomap.convergeTrials;
   unsigned int m_trialsRun = m_infomap.numTrials; // actual count; equals m_numTrials unless --converge stops early
   bool m_autoStopped = false;

--- a/src/io/RunMetadata.cpp
+++ b/src/io/RunMetadata.cpp
@@ -116,6 +116,20 @@ std::string canonicalConfigJson(const Config& config)
   // settings, so it stays stable when the same input is referenced via a
   // different path. The cluster/meta-data paths below have no separate content
   // fingerprint, so they remain the only available signal and are kept.
+  //
+  // How the trial budget is *divided* is deliberately excluded -- numTrials and
+  // trialOffset name which slice of one budget a run executed, not what it
+  // executed. infomap.merge requires all shards of a run to share this
+  // fingerprint, and shards differ in exactly those two fields, so including
+  // them would reject every legitimate distributed run. The base seed is
+  // included, and seeding is per-trial and offset-derived (see
+  // RunSession::trialSeed), so shards that agree here really are slices of the
+  // same sequence of trials.
+  //
+  // Output-only settings are excluded because they cannot change the result.
+  // That held for trialResultsPath only after #905: it used to switch the
+  // per-trial reseeding on, which made two runs with the same fingerprint
+  // publish different partitions.
   addCanonicalNumber(json, "additional_input_count", config.additionalInput.size());
   json["flow_model"] = flowModelToString(config.flowModel);
   json["directed"] = config.directed;

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -6,6 +6,7 @@
 #include "TestUtils.h"
 
 #include <algorithm>
+#include <limits>
 #include <map>
 #include <set>
 #include <sstream>
@@ -1109,29 +1110,42 @@ TEST_CASE("Every trial is reproducible from the seed reported for it [fast][core
 
   SUBCASE("the contract survives a base seed wider than the engine")
   {
-    // Config::seedToRandomNumberGenerator is unsigned long but every route into
-    // the RNG takes unsigned int, so the engine only sees the low 32 bits. The
-    // narrowing has to stay uniform, or the seed this run reports would name a
-    // trial it cannot reproduce. The base is picked so the run straddles 2^32:
-    // trial 2 lands exactly on the wrap and narrows to engine seed 0.
-    constexpr unsigned long wideBase = 4294967294ul; // 2^32 - 2
-    const auto wide = runCycle(seedAndTrials(wideBase, numTrials));
-    REQUIRE(wide.size() == numTrials);
-    REQUIRE(std::set<double>(wide.begin(), wide.end()).size() > 1);
+    // Every route into the RNG takes unsigned int (BasicRandom's constructor,
+    // Random::seed from reseed and from setNonMainConfig), so the engine only
+    // ever sees the low 32 bits of Config::seedToRandomNumberGenerator. Where
+    // that field is wider, the narrowing has to stay uniform, or the seed a run
+    // reports would name a trial it cannot reproduce.
+    //
+    // Guarded because the field is `unsigned long`, whose width is not fixed:
+    // 64-bit on LP64 (Linux, macOS), 32-bit on LLP64 (Windows). On Windows it is
+    // exactly the engine's width, no seed above UINT_MAX is representable, and
+    // there is nothing here to test -- running it anyway wraps the base and asks
+    // for `--seed 0`, which the parser rejects (min is 1).
+    if (sizeof(unsigned long) > sizeof(unsigned int)) {
+      // Derived rather than written as a literal or a shift: `1ul << 32` is
+      // undefined where unsigned long is 32 bits, even on the branch not taken.
+      const unsigned long twoPow32 = static_cast<unsigned long>(std::numeric_limits<unsigned int>::max()) + 1ul;
+      // Straddles the wrap: trial 2 lands on 2^32 and narrows to engine seed 0.
+      const unsigned long wideBase = twoPow32 - 2ul;
 
-    for (unsigned int i = 0; i < numTrials; ++i) {
-      const auto standalone = runCycle(seedAndTrials(wideBase + i, 1));
-      REQUIRE(standalone.size() == 1);
-      CHECK(standalone[0] == doctest::Approx(wide[i]));
+      const auto wide = runCycle(seedAndTrials(wideBase, numTrials));
+      REQUIRE(wide.size() == numTrials);
+      REQUIRE(std::set<double>(wide.begin(), wide.end()).size() > 1);
+
+      for (unsigned int i = 0; i < numTrials; ++i) {
+        const auto standalone = runCycle(seedAndTrials(wideBase + i, 1));
+        REQUIRE(standalone.size() == 1);
+        CHECK(standalone[0] == doctest::Approx(wide[i]));
+      }
+
+      // The aliasing the width mismatch implies, pinned so it stays deliberate:
+      // seeds congruent mod 2^32 are the same run.
+      const auto low = runCycle(seedAndTrials(1ul, 1));
+      const auto aliased = runCycle(seedAndTrials(1ul + twoPow32, 1));
+      REQUIRE(low.size() == 1);
+      REQUIRE(aliased.size() == 1);
+      CHECK(aliased[0] == doctest::Approx(low[0]));
     }
-
-    // The aliasing this width mismatch implies, pinned so it stays deliberate:
-    // seeds congruent mod 2^32 are the same run.
-    const auto low = runCycle(seedAndTrials(1, 1));
-    const auto aliased = runCycle(seedAndTrials(1ul + (1ul << 32), 1));
-    REQUIRE(low.size() == 1);
-    REQUIRE(aliased.size() == 1);
-    CHECK(aliased[0] == doctest::Approx(low[0]));
   }
 }
 

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -1016,6 +1016,125 @@ TEST_CASE("Sharding-mode serial reseed makes trial i reproducible by global inde
   CHECK(runTrialAt(5) > 0.0);
 }
 
+// The per-trial seed contract (#905): trial i of a run is the trial with seed
+// base + trialOffset + i, whichever mode produced it, and nothing that only
+// affects output may change which trials run.
+//
+// These need a network whose trials actually differ. A plain cycle has many
+// near-degenerate partitions -- where the module boundaries fall depends on the
+// random visit order -- so its per-trial codelengths spread out. The shipped
+// fixtures all converge to the same optimum on every trial and would satisfy
+// every check below vacuously.
+namespace seedcontract {
+
+constexpr unsigned int numCycleNodes = 60;
+constexpr unsigned int numTrials = 8;
+constexpr unsigned int baseSeed = 3;
+
+std::vector<double> runCycle(const std::string& flags)
+{
+  InfomapWrapper im("--silent --no-file-output " + flags);
+  for (unsigned int i = 0; i < numCycleNodes; ++i) {
+    im.addLink(i, (i + 1) % numCycleNodes);
+  }
+  im.run();
+  return im.codelengths();
+}
+
+std::string seedAndTrials(unsigned long seed, unsigned int trials)
+{
+  return "--seed " + std::to_string(seed) + " --num-trials " + std::to_string(trials);
+}
+
+} // namespace seedcontract
+
+TEST_CASE("Every trial is reproducible from the seed reported for it [fast][core][partition][sharding][merge]")
+{
+  using namespace seedcontract;
+
+  const auto sequential = runCycle(seedAndTrials(baseSeed, numTrials));
+  REQUIRE(sequential.size() == numTrials);
+  // Precondition: the trials differ, so a broken seeding regime can be detected
+  // at all. Without it every comparison below would pass on any implementation.
+  REQUIRE(std::set<double>(sequential.begin(), sequential.end()).size() > 1);
+
+  SUBCASE("a standalone run at seed base+i reproduces trial i")
+  {
+    // Before the fix the default serial path ran one continuous RNG stream
+    // through all trials, so the seed reported for trial i named a seed that
+    // trial never used.
+    for (unsigned int i = 0; i < numTrials; ++i) {
+      const auto standalone = runCycle(seedAndTrials(baseSeed + i, 1));
+      REQUIRE(standalone.size() == 1);
+      CHECK(standalone[0] == doctest::Approx(sequential[i]));
+    }
+  }
+
+  SUBCASE("a shard at global index i reproduces trial i")
+  {
+    // Sharded serial trials used to reseed only the engine and leave
+    // Config::seedToRandomNumberGenerator at the base seed, so every
+    // sub-Infomap of the recursive partition kept seeding from the base.
+    for (unsigned int i = 0; i < numTrials; ++i) {
+      const auto shard = runCycle(seedAndTrials(baseSeed, 1) + " --trial-offset " + std::to_string(i));
+      REQUIRE(shard.size() == 1);
+      CHECK(shard[0] == doctest::Approx(sequential[i]));
+    }
+  }
+
+  SUBCASE("--parallel-trials runs the same trials as the sequential path")
+  {
+    const auto parallel = runCycle(seedAndTrials(baseSeed, numTrials) + " --parallel-trials");
+    REQUIRE(parallel.size() == numTrials);
+    for (unsigned int i = 0; i < numTrials; ++i) {
+      CHECK(parallel[i] == doctest::Approx(sequential[i]));
+    }
+  }
+
+  SUBCASE("shards partition the sequential run's trials")
+  {
+    // The equivalence interfaces/python/source/workflows/hpc.md promises: any
+    // partition of [0, N) reproduces the trials of a single --num-trials N run.
+    std::vector<double> merged;
+    for (unsigned int offset = 0; offset < numTrials; offset += 2) {
+      const auto shard = runCycle(seedAndTrials(baseSeed, 2) + " --trial-offset " + std::to_string(offset));
+      REQUIRE(shard.size() == 2);
+      merged.insert(merged.end(), shard.begin(), shard.end());
+    }
+    REQUIRE(merged.size() == numTrials);
+    for (unsigned int i = 0; i < numTrials; ++i) {
+      CHECK(merged[i] == doctest::Approx(sequential[i]));
+    }
+  }
+
+  SUBCASE("the contract survives a base seed wider than the engine")
+  {
+    // Config::seedToRandomNumberGenerator is unsigned long but every route into
+    // the RNG takes unsigned int, so the engine only sees the low 32 bits. The
+    // narrowing has to stay uniform, or the seed this run reports would name a
+    // trial it cannot reproduce. The base is picked so the run straddles 2^32:
+    // trial 2 lands exactly on the wrap and narrows to engine seed 0.
+    constexpr unsigned long wideBase = 4294967294ul; // 2^32 - 2
+    const auto wide = runCycle(seedAndTrials(wideBase, numTrials));
+    REQUIRE(wide.size() == numTrials);
+    REQUIRE(std::set<double>(wide.begin(), wide.end()).size() > 1);
+
+    for (unsigned int i = 0; i < numTrials; ++i) {
+      const auto standalone = runCycle(seedAndTrials(wideBase + i, 1));
+      REQUIRE(standalone.size() == 1);
+      CHECK(standalone[0] == doctest::Approx(wide[i]));
+    }
+
+    // The aliasing this width mismatch implies, pinned so it stays deliberate:
+    // seeds congruent mod 2^32 are the same run.
+    const auto low = runCycle(seedAndTrials(1, 1));
+    const auto aliased = runCycle(seedAndTrials(1ul + (1ul << 32), 1));
+    REQUIRE(low.size() == 1);
+    REQUIRE(aliased.size() == 1);
+    CHECK(aliased[0] == doctest::Approx(low[0]));
+  }
+}
+
 TEST_CASE("Hierarchical partition is invariant to the OpenMP thread count [fast][core][partition][threads]")
 {
   // The recursive partition runs sub-modules as parallel tasks. Results must

--- a/test/cpp/test_trial_results.cpp
+++ b/test/cpp/test_trial_results.cpp
@@ -13,8 +13,10 @@
 #include "Infomap.h"
 #include "TestUtils.h"
 
-#include <string>
 #include <cstdio>
+#include <set>
+#include <string>
+#include <utility>
 
 using namespace infomap;
 using infomap::test::readTextFile;
@@ -54,6 +56,45 @@ TEST_CASE("serializeTrialResults emits the documented JSON fields [fast][core][m
   empty.networkFingerprint = "h";
   const std::string emptyJson = serializeTrialResults(empty);
   CHECK(emptyJson.find("\"trials\":[]") != std::string::npos);
+}
+
+TEST_CASE("--trial-results records the run without changing it [fast][core][merge]")
+{
+  // --trial-results is documented as an output artifact, but it used to gate the
+  // per-trial reseeding: with it the run reseeded per trial, without it a single
+  // RNG stream ran through all trials, and the two published different
+  // partitions (#905). A cycle is used because its trials genuinely differ --
+  // see the seed-contract cases in test_partition.cpp.
+  const std::string resultsPath = "tr_output_flag_inert.json";
+  std::remove(resultsPath.c_str());
+
+  auto runCycle = [](const std::string& extraFlags) {
+    InfomapWrapper im("--silent --no-file-output --seed 3 --num-trials 8 " + extraFlags);
+    for (unsigned int i = 0; i < 60; ++i) {
+      im.addLink(i, (i + 1) % 60);
+    }
+    im.run();
+    return std::make_pair(im.codelengths(), im.getMultilevelModules(false));
+  };
+
+  const auto without = runCycle("");
+  const auto with = runCycle("--trial-results " + resultsPath);
+
+  // Preconditions, both of which this test would otherwise pass vacuously on:
+  // the trials have to differ for a seeding regression to be observable at all,
+  // and the shard file has to have been written -- if --trial-results were ever
+  // suppressed (by --no-file-output or anything else) the flag would be a no-op
+  // and the partitions would match trivially.
+  REQUIRE(infomap::pathExists(resultsPath));
+  REQUIRE(without.first.size() == 8);
+  REQUIRE(std::set<double>(without.first.begin(), without.first.end()).size() > 1);
+
+  for (std::size_t i = 0; i < without.first.size(); ++i) {
+    CHECK(with.first[i] == doctest::Approx(without.first[i]));
+  }
+  CHECK(with.second == without.second);
+
+  std::remove(resultsPath.c_str());
 }
 
 TEST_CASE("Shard run emits trial-results JSON and best-tree file; --no-final-output suppresses aggregate [fast][core][merge]")


### PR DESCRIPTION
## Summary

Per-trial reseeding was gated on `trialOffset > 0 || !trialResultsPath.empty()` (`src/core/InfomapBase.cpp`), so an **output** flag decided whether trials were independently seeded or one continuous RNG stream ran through all of them. `RunSession::seedTrial` now seeds every trial in every mode.

The sharded path also reseeded only the engine and left `Config::seedToRandomNumberGenerator` at the base seed — the field the recursive partition's sub-Infomaps seed from via `setNonMainConfig`. Both fields are now set, matching what the parallel-trials path already did. A `ScopedConfigSeed` gives the base seed back when the trial loop finishes, so the manifest, the config fingerprint and the shard file's `base_seed` still report the seed the user asked for, including when a trial throws or the run is interrupted.

All four items of #905 fall out:

| | before | after |
| --- | --- | --- |
| `--trial-results` leaves the run alone | per-trial codelengths differ | identical |
| a reported seed re-runs its trial | 3 of 6 mismatch | 6 of 6 |
| serial / parallel / sharded / standalone | 3 of 8 indices disagree | all agree |
| the equivalence `hpc.md` documents | does not hold | holds |

Two deliberate departures from the issue's suggested fix:

- **`trialOffset` was not added to `canonicalConfigJson`.** `merge.py:_validate_consistent` requires all shards of a run to share `config_fingerprint`, and shards differ in exactly `trialOffset` and `numTrials`. Including them would reject every legitimate distributed run. Those two fields name *which slice* of one budget a run executed, not what it executed; the comment in `RunMetadata.cpp` now says so. `trialResultsPath` stays excluded too, but correctly now — after this change it really is output-only.
- **The docs needed no correction.** The claims in `hpc.md:48` and `merge.py:5-7` become true by the code fix, which is the resolution the issue itself prefers. `hpc.md` gains the seed rule stated explicitly instead.

Fixes #905

## Verification

- `make test-native` — green.
- `make test-python-unit` — 824 passed, 2 skipped (missing `torch`, unrelated).
- **The new tests fail without the fix.** Built a baseline binary from `d55c236`, reverted only the `src/` changes, and reran: 23 of 62 assertions fail in `test_partition.cpp`, and `test_trial_results.cpp` fails including the partition comparison. Both pass with the fix.
- Behaviour on shipped inputs is unchanged: best-of-10 at `--seed 42` is bit-identical across all 20 networks in `examples/networks` and `test/fixtures/networks`.
- Repeated `run()` on the same instance reproduces its first result, confirming the base-seed restore.
- `make format-native-check` clean for the touched files.

What was **not** verified locally:

- `make build-docs` does not complete in the environment this was prepared in: all six `-W`-promoted warnings are intersphinx inventory fetches failing against a restricted network (`docs.python.org`, `numpy.org`, `pandas.pydata.org`, `docs.scipy.org`, `networkx.org`, `python.igraph.org`). The site itself builds — every page is read and written and the search index is dumped — and no warning names the edited `hpc.md`. The CI `docs` job is the real gate here.
- The R and JavaScript suites. Neither surface is touched, and both exercise the same C++ core the native and Python suites cover, but CI is the first place they run.

## Notes

The regression tests use a 60-node cycle. That is deliberate: a cycle has many near-degenerate partitions, so where the module boundaries land depends on the random visit order and the per-trial codelengths genuinely spread out. Every shipped fixture converges to the same optimum on all trials and would satisfy each assertion vacuously — a test on one of them would pass against the unfixed code.

This is a determinism change, so per `AGENTS.md` it is worth being explicit about the blast radius: the seeding regime on the default serial `-N k` path changes, which means the *sequence* of trials a run executes is different from before. The best-of-N result is what users publish, and it is unchanged on every shipped network. Runs that pinned a specific trial's codelength from `--timing-json` on the old default path will see different per-trial values — those values were the unreproducible ones this change fixes.

One side effect worth knowing: `InfomapOptimizer.h:777` derives the inner-parallelization per-node RNGs from the config seed, which on the default serial path was previously the same value for every trial. It now varies per trial, so `--inner-parallelization` trials are independent in the same sense the others are.

Two pre-existing `format-native-check` violations remain in `src/io/ParameterCatalog.cpp` (`T Config::* member`); they are on `master` too and look like a clang-format version difference, so they are untouched here.

Not addressed, and unrelated to this change: the checkbox for item 3 of #899 (bipartite dangling redistribution) is still unticked even though #945 landed it.