### PR TITLE
fix: refuse bipartite teleportation without return links and report flow convergence

### DIFF
--- a/interfaces/R/generated/infomap.R
+++ b/interfaces/R/generated/infomap.R
@@ -17295,6 +17295,58 @@ class(`StateNetwork_names__SWIG_1`) = c("SWIGFunction", class('StateNetwork_name
 }
 
 # Dispatch function
+# Start of StateNetwork_haveFlowConvergence
+
+`StateNetwork_haveFlowConvergence` = function(self, .copy = FALSE)
+{
+  if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
+  ;.Call('R_swig_StateNetwork_haveFlowConvergence', self, as.logical(.copy), PACKAGE='infomap');
+  
+}
+
+attr(`StateNetwork_haveFlowConvergence`, 'returnType') = 'logical'
+attr(`StateNetwork_haveFlowConvergence`, "inputTypes") = c('_p_infomap__StateNetwork')
+class(`StateNetwork_haveFlowConvergence`) = c("SWIGFunction", class('StateNetwork_haveFlowConvergence'))
+
+# Start of StateNetwork_flowConverged
+
+`StateNetwork_flowConverged` = function(self, .copy = FALSE)
+{
+  if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
+  ;.Call('R_swig_StateNetwork_flowConverged', self, as.logical(.copy), PACKAGE='infomap');
+  
+}
+
+attr(`StateNetwork_flowConverged`, 'returnType') = 'logical'
+attr(`StateNetwork_flowConverged`, "inputTypes") = c('_p_infomap__StateNetwork')
+class(`StateNetwork_flowConverged`) = c("SWIGFunction", class('StateNetwork_flowConverged'))
+
+# Start of StateNetwork_flowIterations
+
+`StateNetwork_flowIterations` = function(self, .copy = FALSE)
+{
+  if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
+  ;.Call('R_swig_StateNetwork_flowIterations', self, as.logical(.copy), PACKAGE='infomap');
+  
+}
+
+attr(`StateNetwork_flowIterations`, 'returnType') = 'integer'
+attr(`StateNetwork_flowIterations`, "inputTypes") = c('_p_infomap__StateNetwork')
+class(`StateNetwork_flowIterations`) = c("SWIGFunction", class('StateNetwork_flowIterations'))
+
+# Start of StateNetwork_flowError
+
+`StateNetwork_flowError` = function(self, .copy = FALSE)
+{
+  if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
+  ;.Call('R_swig_StateNetwork_flowError', self, as.logical(.copy), PACKAGE='infomap');
+  
+}
+
+attr(`StateNetwork_flowError`, 'returnType') = 'numeric'
+attr(`StateNetwork_flowError`, "inputTypes") = c('_p_infomap__StateNetwork')
+class(`StateNetwork_flowError`) = c("SWIGFunction", class('StateNetwork_flowError'))
+
 # Start of StateNetwork_haveNodeWeights
 
 `StateNetwork_haveNodeWeights` = function(self, .copy = FALSE)
@@ -17504,7 +17556,7 @@ class(`StateNetwork_writePajekNetwork__SWIG_1`) = c("SWIGFunction", class('State
 setMethod('$', '_p_infomap__StateNetwork', function(x, name)
 
 {
-  accessorFuns = list('setConfig' = StateNetwork_setConfig, 'addStateNode' = StateNetwork_addStateNode, 'addNode' = StateNetwork_addNode, 'addPhysicalNode' = StateNetwork_addPhysicalNode, 'addName' = StateNetwork_addName, 'addLink' = StateNetwork_addLink, 'addLinks' = StateNetwork_addLinks, 'removeLink' = StateNetwork_removeLink, 'undirectedToDirected' = StateNetwork_undirectedToDirected, 'clear' = StateNetwork_clear, 'clearLinks' = StateNetwork_clearLinks, 'nodes' = StateNetwork_nodes, 'numNodes' = StateNetwork_numNodes, 'numPhysicalNodes' = StateNetwork_numPhysicalNodes, 'sumNodeWeight' = StateNetwork_sumNodeWeight, 'numAggregatedLinks' = StateNetwork_numAggregatedLinks, 'numLinks' = StateNetwork_numLinks, 'sumLinkWeight' = StateNetwork_sumLinkWeight, 'numSelfLinks' = StateNetwork_numSelfLinks, 'sumSelfLinkWeight' = StateNetwork_sumSelfLinkWeight, 'sumWeightedDegree' = StateNetwork_sumWeightedDegree, 'sumDegree' = StateNetwork_sumDegree, 'outWeights' = StateNetwork_outWeights, 'names' = StateNetwork_names, 'haveNodeWeights' = StateNetwork_haveNodeWeights, 'haveStateNodeWeights' = StateNetwork_haveStateNodeWeights, 'haveFileInput' = StateNetwork_haveFileInput, 'metaData' = StateNetwork_metaData, 'haveDirectedInput' = StateNetwork_haveDirectedInput, 'haveMemoryInput' = StateNetwork_haveMemoryInput, 'higherOrderInputMethodCalled' = StateNetwork_higherOrderInputMethodCalled, 'isBipartite' = StateNetwork_isBipartite, 'bipartiteStartId' = StateNetwork_bipartiteStartId, 'setBipartiteStartId' = StateNetwork_setBipartiteStartId, 'writeStateNetwork' = StateNetwork_writeStateNetwork, 'writePajekNetwork' = StateNetwork_writePajekNetwork);
+  accessorFuns = list('setConfig' = StateNetwork_setConfig, 'addStateNode' = StateNetwork_addStateNode, 'addNode' = StateNetwork_addNode, 'addPhysicalNode' = StateNetwork_addPhysicalNode, 'addName' = StateNetwork_addName, 'addLink' = StateNetwork_addLink, 'addLinks' = StateNetwork_addLinks, 'removeLink' = StateNetwork_removeLink, 'undirectedToDirected' = StateNetwork_undirectedToDirected, 'clear' = StateNetwork_clear, 'clearLinks' = StateNetwork_clearLinks, 'nodes' = StateNetwork_nodes, 'numNodes' = StateNetwork_numNodes, 'numPhysicalNodes' = StateNetwork_numPhysicalNodes, 'sumNodeWeight' = StateNetwork_sumNodeWeight, 'numAggregatedLinks' = StateNetwork_numAggregatedLinks, 'numLinks' = StateNetwork_numLinks, 'sumLinkWeight' = StateNetwork_sumLinkWeight, 'numSelfLinks' = StateNetwork_numSelfLinks, 'sumSelfLinkWeight' = StateNetwork_sumSelfLinkWeight, 'sumWeightedDegree' = StateNetwork_sumWeightedDegree, 'sumDegree' = StateNetwork_sumDegree, 'outWeights' = StateNetwork_outWeights, 'names' = StateNetwork_names, 'haveFlowConvergence' = StateNetwork_haveFlowConvergence, 'flowConverged' = StateNetwork_flowConverged, 'flowIterations' = StateNetwork_flowIterations, 'flowError' = StateNetwork_flowError, 'haveNodeWeights' = StateNetwork_haveNodeWeights, 'haveStateNodeWeights' = StateNetwork_haveStateNodeWeights, 'haveFileInput' = StateNetwork_haveFileInput, 'metaData' = StateNetwork_metaData, 'haveDirectedInput' = StateNetwork_haveDirectedInput, 'haveMemoryInput' = StateNetwork_haveMemoryInput, 'higherOrderInputMethodCalled' = StateNetwork_higherOrderInputMethodCalled, 'isBipartite' = StateNetwork_isBipartite, 'bipartiteStartId' = StateNetwork_bipartiteStartId, 'setBipartiteStartId' = StateNetwork_setBipartiteStartId, 'writeStateNetwork' = StateNetwork_writeStateNetwork, 'writePajekNetwork' = StateNetwork_writePajekNetwork);
   ;        idx = pmatch(name, names(accessorFuns));
   if(is.na(idx)) 
   return(callNextMethod(x, name));

--- a/interfaces/R/generated/infomap_wrap.cpp
+++ b/interfaces/R/generated/infomap_wrap.cpp
@@ -35350,6 +35350,150 @@ R_swig_StateNetwork_names__SWIG_1 ( SEXP self, SEXP s_swig_copy)
 
 
 SWIGEXPORT SEXP
+R_swig_StateNetwork_haveFlowConvergence ( SEXP self, SEXP s_swig_copy)
+{
+  {
+    bool result;
+    infomap::StateNetwork *arg1 = 0 ;
+    void *argp1 = 0 ;
+    int res1 = 0 ;
+    unsigned int r_nprotect = 0;
+    SEXP r_ans = R_NilValue ;
+    VMAXTYPE r_vmax = vmaxget() ;
+    
+    res1 = SWIG_R_ConvertPtr(self, &argp1, SWIGTYPE_p_infomap__StateNetwork, 0 |  0 );
+    if (!SWIG_IsOK(res1)) {
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "StateNetwork_haveFlowConvergence" "', argument " "1"" of type '" "infomap::StateNetwork const *""'"); 
+    }
+    arg1 = reinterpret_cast< infomap::StateNetwork * >(argp1);
+    {
+      try {
+        result = (bool)((infomap::StateNetwork const *)arg1)->haveFlowConvergence();
+      } catch (const std::exception& e) {
+        SWIG_exception(SWIG_RuntimeError, e.what());
+      }
+    }
+    r_ans = Rf_ScalarLogical(result);
+    vmaxset(r_vmax);
+    if(r_nprotect)  Rf_unprotect(r_nprotect);
+    
+    return r_ans;
+    fail: SWIGUNUSED;
+  }
+  Rf_error("%s %s", SWIG_ErrorType(SWIG_lasterror_code), SWIG_lasterror_msg);
+  return R_NilValue;
+}
+
+
+SWIGEXPORT SEXP
+R_swig_StateNetwork_flowConverged ( SEXP self, SEXP s_swig_copy)
+{
+  {
+    bool result;
+    infomap::StateNetwork *arg1 = 0 ;
+    void *argp1 = 0 ;
+    int res1 = 0 ;
+    unsigned int r_nprotect = 0;
+    SEXP r_ans = R_NilValue ;
+    VMAXTYPE r_vmax = vmaxget() ;
+    
+    res1 = SWIG_R_ConvertPtr(self, &argp1, SWIGTYPE_p_infomap__StateNetwork, 0 |  0 );
+    if (!SWIG_IsOK(res1)) {
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "StateNetwork_flowConverged" "', argument " "1"" of type '" "infomap::StateNetwork const *""'"); 
+    }
+    arg1 = reinterpret_cast< infomap::StateNetwork * >(argp1);
+    {
+      try {
+        result = (bool)((infomap::StateNetwork const *)arg1)->flowConverged();
+      } catch (const std::exception& e) {
+        SWIG_exception(SWIG_RuntimeError, e.what());
+      }
+    }
+    r_ans = Rf_ScalarLogical(result);
+    vmaxset(r_vmax);
+    if(r_nprotect)  Rf_unprotect(r_nprotect);
+    
+    return r_ans;
+    fail: SWIGUNUSED;
+  }
+  Rf_error("%s %s", SWIG_ErrorType(SWIG_lasterror_code), SWIG_lasterror_msg);
+  return R_NilValue;
+}
+
+
+SWIGEXPORT SEXP
+R_swig_StateNetwork_flowIterations ( SEXP self, SEXP s_swig_copy)
+{
+  {
+    unsigned int result;
+    infomap::StateNetwork *arg1 = 0 ;
+    void *argp1 = 0 ;
+    int res1 = 0 ;
+    unsigned int r_nprotect = 0;
+    SEXP r_ans = R_NilValue ;
+    VMAXTYPE r_vmax = vmaxget() ;
+    
+    res1 = SWIG_R_ConvertPtr(self, &argp1, SWIGTYPE_p_infomap__StateNetwork, 0 |  0 );
+    if (!SWIG_IsOK(res1)) {
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "StateNetwork_flowIterations" "', argument " "1"" of type '" "infomap::StateNetwork const *""'"); 
+    }
+    arg1 = reinterpret_cast< infomap::StateNetwork * >(argp1);
+    {
+      try {
+        result = (unsigned int)((infomap::StateNetwork const *)arg1)->flowIterations();
+      } catch (const std::exception& e) {
+        SWIG_exception(SWIG_RuntimeError, e.what());
+      }
+    }
+    r_ans = SWIG_From_int(static_cast< int >(result));
+    vmaxset(r_vmax);
+    if(r_nprotect)  Rf_unprotect(r_nprotect);
+    
+    return r_ans;
+    fail: SWIGUNUSED;
+  }
+  Rf_error("%s %s", SWIG_ErrorType(SWIG_lasterror_code), SWIG_lasterror_msg);
+  return R_NilValue;
+}
+
+
+SWIGEXPORT SEXP
+R_swig_StateNetwork_flowError ( SEXP self, SEXP s_swig_copy)
+{
+  {
+    double result;
+    infomap::StateNetwork *arg1 = 0 ;
+    void *argp1 = 0 ;
+    int res1 = 0 ;
+    unsigned int r_nprotect = 0;
+    SEXP r_ans = R_NilValue ;
+    VMAXTYPE r_vmax = vmaxget() ;
+    
+    res1 = SWIG_R_ConvertPtr(self, &argp1, SWIGTYPE_p_infomap__StateNetwork, 0 |  0 );
+    if (!SWIG_IsOK(res1)) {
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "StateNetwork_flowError" "', argument " "1"" of type '" "infomap::StateNetwork const *""'"); 
+    }
+    arg1 = reinterpret_cast< infomap::StateNetwork * >(argp1);
+    {
+      try {
+        result = (double)((infomap::StateNetwork const *)arg1)->flowError();
+      } catch (const std::exception& e) {
+        SWIG_exception(SWIG_RuntimeError, e.what());
+      }
+    }
+    r_ans = SWIG_From_double(static_cast< double >(result));
+    vmaxset(r_vmax);
+    if(r_nprotect)  Rf_unprotect(r_nprotect);
+    
+    return r_ans;
+    fail: SWIGUNUSED;
+  }
+  Rf_error("%s %s", SWIG_ErrorType(SWIG_lasterror_code), SWIG_lasterror_msg);
+  return R_NilValue;
+}
+
+
+SWIGEXPORT SEXP
 R_swig_StateNetwork_haveNodeWeights ( SEXP self, SEXP s_swig_copy)
 {
   {
@@ -50327,6 +50471,7 @@ SWIGINTERN R_CallMethodDef CallEntries[] = {
    {"R_swig_new_InfomapIterator__SWIG_4", (DL_FUNC) &R_swig_new_InfomapIterator__SWIG_4, 1},
    {"R_swig_MemDeltaFlow_sumDeltaPlogpPhysFlow_get", (DL_FUNC) &R_swig_MemDeltaFlow_sumDeltaPlogpPhysFlow_get, 2},
    {"R_swig_InfomapParentIterator_inEdges", (DL_FUNC) &R_swig_InfomapParentIterator_inEdges, 2},
+   {"R_swig_StateNetwork_flowError", (DL_FUNC) &R_swig_StateNetwork_flowError, 2},
    {"R_swig_Config_bipartiteTeleportation_set", (DL_FUNC) &R_swig_Config_bipartiteTeleportation_set, 2},
    {"R_swig_LayerNode_node_get", (DL_FUNC) &R_swig_LayerNode_node_get, 2},
    {"R_swig_InfoNode_end_inEdge", (DL_FUNC) &R_swig_InfoNode_end_inEdge, 2},
@@ -50735,6 +50880,7 @@ SWIGINTERN R_CallMethodDef CallEntries[] = {
    {"R_swig_vector_uint___len__", (DL_FUNC) &R_swig_vector_uint___len__, 2},
    {"R_swig_Config_flowModelIsSet_get", (DL_FUNC) &R_swig_Config_flowModelIsSet_get, 2},
    {"R_swig_Config_clusterDataIsHard_set", (DL_FUNC) &R_swig_Config_clusterDataIsHard_set, 2},
+   {"R_swig_StateNetwork_flowIterations", (DL_FUNC) &R_swig_StateNetwork_flowIterations, 2},
    {"R_swig_Config_multilayerRelaxRate_set", (DL_FUNC) &R_swig_Config_multilayerRelaxRate_set, 2},
    {"R_swig_aggregatePerLevelCodelength__SWIG_0", (DL_FUNC) &R_swig_aggregatePerLevelCodelength__SWIG_0, 3},
    {"R_swig_vector_double_capacity", (DL_FUNC) &R_swig_vector_double_capacity, 2},
@@ -50964,6 +51110,7 @@ SWIGINTERN R_CallMethodDef CallEntries[] = {
    {"R_swig_new_vector_link_result__SWIG_3", (DL_FUNC) &R_swig_new_vector_link_result__SWIG_3, 2},
    {"R_swig_Config_stateInput_get", (DL_FUNC) &R_swig_Config_stateInput_get, 2},
    {"R_swig_InfomapIterator_outEdges", (DL_FUNC) &R_swig_InfomapIterator_outEdges, 2},
+   {"R_swig_StateNetwork_flowConverged", (DL_FUNC) &R_swig_StateNetwork_flowConverged, 2},
    {"R_swig_InfomapIterator___ref____SWIG_0", (DL_FUNC) &R_swig_InfomapIterator___ref____SWIG_0, 2},
    {"R_swig_vector_double___setslice__", (DL_FUNC) &R_swig_vector_double___setslice__, 4},
    {"R_swig_InfomapIterator___ref____SWIG_1", (DL_FUNC) &R_swig_InfomapIterator___ref____SWIG_1, 2},
@@ -51252,6 +51399,7 @@ SWIGINTERN R_CallMethodDef CallEntries[] = {
    {"R_swig_InfomapWrapper_getLinks", (DL_FUNC) &R_swig_InfomapWrapper_getLinks, 3},
    {"R_swig_InfomapParentIterator_end__SWIG_0", (DL_FUNC) &R_swig_InfomapParentIterator_end__SWIG_0, 2},
    {"R_swig_InfomapParentIterator_childIndex", (DL_FUNC) &R_swig_InfomapParentIterator_childIndex, 2},
+   {"R_swig_StateNetwork_haveFlowConvergence", (DL_FUNC) &R_swig_StateNetwork_haveFlowConvergence, 2},
    {"R_swig_InfomapBase_writeFlowTree__SWIG_2", (DL_FUNC) &R_swig_InfomapBase_writeFlowTree__SWIG_2, 2},
    {"R_swig_delete_InfomapIterator", (DL_FUNC) &R_swig_delete_InfomapIterator, 1},
    {"R_swig_Config_additionalInput_set", (DL_FUNC) &R_swig_Config_additionalInput_set, 2},

--- a/interfaces/python/generated/infomap_wrap.cpp
+++ b/interfaces/python/generated/infomap_wrap.cpp
@@ -41309,6 +41309,126 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_StateNetwork_haveFlowConvergence(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  infomap::StateNetwork *arg1 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  bool result;
+  
+  (void)self;
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__StateNetwork, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "StateNetwork_haveFlowConvergence" "', argument " "1"" of type '" "infomap::StateNetwork const *""'"); 
+  }
+  arg1 = reinterpret_cast< infomap::StateNetwork * >(argp1);
+  {
+    try {
+      result = (bool)((infomap::StateNetwork const *)arg1)->haveFlowConvergence();
+    } catch (const std::exception& e) {
+      SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+  }
+  resultobj = SWIG_From_bool(static_cast< bool >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_StateNetwork_flowConverged(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  infomap::StateNetwork *arg1 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  bool result;
+  
+  (void)self;
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__StateNetwork, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "StateNetwork_flowConverged" "', argument " "1"" of type '" "infomap::StateNetwork const *""'"); 
+  }
+  arg1 = reinterpret_cast< infomap::StateNetwork * >(argp1);
+  {
+    try {
+      result = (bool)((infomap::StateNetwork const *)arg1)->flowConverged();
+    } catch (const std::exception& e) {
+      SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+  }
+  resultobj = SWIG_From_bool(static_cast< bool >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_StateNetwork_flowIterations(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  infomap::StateNetwork *arg1 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  unsigned int result;
+  
+  (void)self;
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__StateNetwork, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "StateNetwork_flowIterations" "', argument " "1"" of type '" "infomap::StateNetwork const *""'"); 
+  }
+  arg1 = reinterpret_cast< infomap::StateNetwork * >(argp1);
+  {
+    try {
+      result = (unsigned int)((infomap::StateNetwork const *)arg1)->flowIterations();
+    } catch (const std::exception& e) {
+      SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+  }
+  resultobj = SWIG_From_unsigned_SS_int(static_cast< unsigned int >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_StateNetwork_flowError(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  infomap::StateNetwork *arg1 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  double result;
+  
+  (void)self;
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__StateNetwork, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "StateNetwork_flowError" "', argument " "1"" of type '" "infomap::StateNetwork const *""'"); 
+  }
+  arg1 = reinterpret_cast< infomap::StateNetwork * >(argp1);
+  {
+    try {
+      result = (double)((infomap::StateNetwork const *)arg1)->flowError();
+    } catch (const std::exception& e) {
+      SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+  }
+  resultobj = SWIG_From_double(static_cast< double >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_StateNetwork_haveNodeWeights(PyObject *self, PyObject *args) {
   PyObject *resultobj = 0;
   infomap::StateNetwork *arg1 = 0 ;
@@ -60579,6 +60699,10 @@ static PyMethodDef SwigMethods[] = {
 	 { "StateNetwork_sumDegree", _wrap_StateNetwork_sumDegree, METH_O, NULL},
 	 { "StateNetwork_outWeights", _wrap_StateNetwork_outWeights, METH_O, NULL},
 	 { "StateNetwork_names", _wrap_StateNetwork_names, METH_VARARGS, NULL},
+	 { "StateNetwork_haveFlowConvergence", _wrap_StateNetwork_haveFlowConvergence, METH_O, NULL},
+	 { "StateNetwork_flowConverged", _wrap_StateNetwork_flowConverged, METH_O, NULL},
+	 { "StateNetwork_flowIterations", _wrap_StateNetwork_flowIterations, METH_O, NULL},
+	 { "StateNetwork_flowError", _wrap_StateNetwork_flowError, METH_O, NULL},
 	 { "StateNetwork_haveNodeWeights", _wrap_StateNetwork_haveNodeWeights, METH_O, NULL},
 	 { "StateNetwork_haveStateNodeWeights", _wrap_StateNetwork_haveStateNodeWeights, METH_O, NULL},
 	 { "StateNetwork_haveFileInput", _wrap_StateNetwork_haveFileInput, METH_O, NULL},

--- a/interfaces/python/src/infomap/_swig.py
+++ b/interfaces/python/src/infomap/_swig.py
@@ -2167,6 +2167,18 @@ class StateNetwork(object):
     def names(self, *args):
         return _infomap.StateNetwork_names(self, *args)
 
+    def haveFlowConvergence(self):
+        return _infomap.StateNetwork_haveFlowConvergence(self)
+
+    def flowConverged(self):
+        return _infomap.StateNetwork_flowConverged(self)
+
+    def flowIterations(self):
+        return _infomap.StateNetwork_flowIterations(self)
+
+    def flowError(self):
+        return _infomap.StateNetwork_flowError(self)
+
     def haveNodeWeights(self):
         return _infomap.StateNetwork_haveNodeWeights(self)
 

--- a/interfaces/python/src/infomap/result.py
+++ b/interfaces/python/src/infomap/result.py
@@ -310,6 +310,9 @@ class Result(_ResultWritersMixin):
         "_num_nodes",
         "_num_physical_nodes",
         "_num_links",
+        "_flow_converged",
+        "_flow_iterations",
+        "_flow_error",
         "_index_codelength",
         "_module_codelength",
         "_one_level_codelength",
@@ -354,6 +357,12 @@ class Result(_ResultWritersMixin):
             self, "_num_physical_nodes", core.network().numPhysicalNodes()
         )
         object.__setattr__(self, "_num_links", core.network().numLinks())
+        # Power-iteration outcome. Flow models that need no power iteration leave
+        # these at "converged, zero iterations", so `not result.flow_converged` means
+        # a failure in every case rather than "no iteration ran".
+        object.__setattr__(self, "_flow_converged", core.network().flowConverged())
+        object.__setattr__(self, "_flow_iterations", core.network().flowIterations())
+        object.__setattr__(self, "_flow_error", core.network().flowError())
         object.__setattr__(self, "_index_codelength", core.getIndexCodelength())
         object.__setattr__(self, "_module_codelength", core.getModuleCodelength())
         object.__setattr__(self, "_one_level_codelength", core.getOneLevelCodelength())
@@ -567,6 +576,47 @@ class Result(_ResultWritersMixin):
     def num_links(self) -> int:
         """The number of links."""
         return self._num_links
+
+    @property
+    def flow_converged(self) -> bool:
+        """Whether the flow calculation's power iteration reached its tolerance.
+
+        ``False`` means the iteration hit ``max_flow_iterations`` with the error
+        still above ``flow_tolerance``, so the flow is not the network's stationary
+        distribution and every codelength derived from it describes something else.
+        The run still completes and writes output, so this is the only way an
+        automated consumer can tell (:attr:`flow_error` says by how much).
+
+        ``True`` for flow models that run no power iteration at all -- undirected
+        flow, for instance -- so ``not result.flow_converged`` always means a real
+        failure. :attr:`flow_iterations` is 0 in that case.
+
+        Examples
+        --------
+        >>> from infomap import Infomap, Options
+        >>> im = Infomap(silent=True)
+        >>> im.read_file("ninetriangles.net")
+        >>> result = im.run(options=Options(directed=True, max_flow_iterations=2))
+        >>> result.flow_converged
+        False
+        >>> result.flow_iterations
+        2
+        """
+        return self._flow_converged
+
+    @property
+    def flow_iterations(self) -> int:
+        """Power iterations the flow calculation used, or 0 if it ran none."""
+        return self._flow_iterations
+
+    @property
+    def flow_error(self) -> float:
+        """The power iteration's final error, 0.0 if it ran none.
+
+        Compare against the ``flow_tolerance`` option: an error above it with
+        :attr:`flow_converged` false says how far the flow is from stationary.
+        """
+        return self._flow_error
 
     @property
     def index_codelength(self) -> float:

--- a/interfaces/python/src/infomap/result.py
+++ b/interfaces/python/src/infomap/result.py
@@ -581,9 +581,11 @@ class Result(_ResultWritersMixin):
     def flow_converged(self) -> bool:
         """Whether the flow calculation's power iteration reached its tolerance.
 
-        ``False`` means the iteration hit ``max_flow_iterations`` with the error
-        still above ``flow_tolerance``, so the flow is not the network's stationary
-        distribution and every codelength derived from it describes something else.
+        ``False`` means the iteration's final error stayed above ``flow_tolerance``,
+        so the flow is not the network's stationary distribution and every codelength
+        derived from it describes something else. Reaching tolerance on the last
+        allowed iteration counts as converged; running out of iterations with the
+        error still too large does not.
         The run still completes and writes output, so this is the only way an
         automated consumer can tell (:attr:`flow_error` says by how much).
 

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -919,6 +919,10 @@ public:
       report.trials = m_trialsRun;
       report.bestTrial = result.bestTrialIndex + 1;
       report.autoStopped = m_autoStopped;
+      report.haveFlowConvergence = m_infomap.m_network.haveFlowConvergence();
+      report.flowConverged = m_infomap.m_network.flowConverged();
+      report.flowIterations = m_infomap.m_network.flowIterations();
+      report.flowError = m_infomap.m_network.flowError();
       report.trialCodelengths = m_infomap.m_codelengths;
       report.trialTopModules = m_infomap.m_numTopModules;
       writeJsonReport(m_infomap.summaryJsonPath, runSummaryReportJson(report), m_infomap.overwriteOutput());

--- a/src/core/StateNetwork.h
+++ b/src/core/StateNetwork.h
@@ -282,7 +282,8 @@ public:
   const std::map<unsigned int, std::string>& names() const { return m_names; }
   //! Whether a power iteration ran and recorded its outcome.
   bool haveFlowConvergence() const { return m_haveFlowConvergence; }
-  //! Whether that power iteration reached the flow tolerance before the iteration limit.
+  //! Whether the power iteration's final error is within the flow tolerance. True also
+  //! when tolerance is reached on the last allowed iteration, and when no iteration ran.
   bool flowConverged() const { return m_flowConverged; }
   unsigned int flowIterations() const { return m_flowIterations; }
   double flowError() const { return m_flowError; }

--- a/src/core/StateNetwork.h
+++ b/src/core/StateNetwork.h
@@ -139,6 +139,15 @@ protected:
   // while numPhysicalNodes() stays correct.
   unsigned int m_numPhysicalNodesFound = 0;
 
+  // Flow calculation outcome. Written by FlowCalculator, which is a friend, so the
+  // power iteration's result outlives the calculator and can reach the run reports --
+  // it used to exist only as a console line, invisible to every automated consumer
+  // (#899).
+  bool m_haveFlowConvergence = false;
+  bool m_flowConverged = true;
+  unsigned int m_flowIterations = 0;
+  double m_flowError = 0.0;
+
   // Bipartite
   unsigned int m_bipartiteStartId = 0;
 
@@ -271,6 +280,13 @@ public:
   }
   std::map<unsigned int, std::string>& names() { return m_names; }
   const std::map<unsigned int, std::string>& names() const { return m_names; }
+  //! Whether a power iteration ran and recorded its outcome.
+  bool haveFlowConvergence() const { return m_haveFlowConvergence; }
+  //! Whether that power iteration reached the flow tolerance before the iteration limit.
+  bool flowConverged() const { return m_flowConverged; }
+  unsigned int flowIterations() const { return m_flowIterations; }
+  double flowError() const { return m_flowError; }
+
   bool haveNodeWeights() const { return m_haveNodeWeights; }
   bool haveStateNodeWeights() const { return m_haveStateNodeWeights; }
   bool haveFileInput() const { return m_haveFileInput; }

--- a/src/io/RunReport.cpp
+++ b/src/io/RunReport.cpp
@@ -39,6 +39,13 @@ std::string runSummaryReportJson(const RunSummaryReport& report)
   json["trials"] = report.trials;
   json["best_trial"] = report.bestTrial;
   json["auto_stopped"] = report.autoStopped;
+  if (report.haveFlowConvergence) {
+    Json flow;
+    flow["converged"] = report.flowConverged;
+    flow["iterations"] = report.flowIterations;
+    flow["error"] = report.flowError;
+    json["flow"] = std::move(flow);
+  }
   json["trial_codelengths"] = report.trialCodelengths;
   json["trial_top_modules"] = report.trialTopModules;
   return dumpJsonLine(json);

--- a/src/io/RunReport.h
+++ b/src/io/RunReport.h
@@ -33,6 +33,13 @@ struct RunSummaryReport {
   unsigned int trials = 0;
   unsigned int bestTrial = 0;
   bool autoStopped = false; // --converge: trials stopped early on a codelength plateau
+  // Power-iteration outcome, emitted only when one ran. A failed iteration means the
+  // flow -- and therefore every codelength below -- is not the network's stationary
+  // distribution, which no automated consumer could see before (#899).
+  bool haveFlowConvergence = false;
+  bool flowConverged = true;
+  unsigned int flowIterations = 0;
+  double flowError = 0.0;
   std::vector<double> trialCodelengths;
   std::vector<unsigned int> trialTopModules;
 };

--- a/src/utils/FlowCalculator.cpp
+++ b/src/utils/FlowCalculator.cpp
@@ -363,6 +363,16 @@ void FlowCalculator::usePrecomputedFlow(const StateNetwork& network, const Confi
   }
 }
 
+// Converged means the error is within tolerance, not merely that the loop stopped before
+// the iteration limit. The two differ whenever the last allowed iteration is the one that
+// reaches tolerance: that was reported as a failure, with a warning to match, while the
+// error sat at 0. Shared by every power iteration here, because the predicate existed in
+// three copies and fixing one left the regularized model exporting the old answer (#899).
+inline bool errorWithinFlowTolerance(const Config& config, double err) noexcept
+{
+  return err <= config.flowTolerance;
+}
+
 struct IterationResult {
   double alpha;
   double beta;
@@ -391,12 +401,7 @@ IterationResult powerIterate(const Config& config, double alpha, Iteration&& ite
     ++iterations;
   } while (iterations < config.maxFlowIterations && (err > config.flowTolerance || iterations < config.minFlowIterations));
 
-  // Converged means the error is within tolerance, not merely that the loop stopped
-  // before the iteration limit. The two differ whenever the last allowed iteration is
-  // the one that reaches tolerance: that was reported as a failure, with the warning to
-  // match, while the error sat at 0. Since #899 exports this to the run report and the
-  // Python Result, a signal that cries wolf is worse than none.
-  const bool converged = err <= config.flowTolerance;
+  const bool converged = errorWithinFlowTolerance(config, err);
   if (!converged) {
     Log() << "\n";
     Console::warn(0, "PageRank calculation did not converge after {} iterations with error {:g}.", iterations, err);
@@ -782,8 +787,9 @@ void FlowCalculator::calcDirectedRegularizedFlow(const StateNetwork& network, co
     ++iterations;
   } while (iterations < config.maxFlowIterations && (err > config.flowTolerance || iterations < config.minFlowIterations));
 
-  recordPageRank(iterations, err, iterations < config.maxFlowIterations);
-  if (iterations >= config.maxFlowIterations) {
+  const bool converged = errorWithinFlowTolerance(config, err);
+  recordPageRank(iterations, err, converged);
+  if (!converged) {
     Log() << "\n";
     Console::warn(0, "PageRank calculation did not converge after {} iterations with error {:g}.", iterations, err);
   }
@@ -1042,7 +1048,11 @@ void FlowCalculator::calcDirectedRegularizedMultilayerFlow(const StateNetwork& n
     ++iterations;
   } while (iterations < config.maxFlowIterations && (err > config.flowTolerance || iterations < config.minFlowIterations));
 
-  if (iterations == config.maxFlowIterations && err > config.flowTolerance) {
+  // Recorded here too, so the exported outcome means the same thing for every flow
+  // model: this loop warned but reported nothing, leaving the run report without a flow
+  // object at all for regularized multilayer input.
+  recordPageRank(iterations, err, errorWithinFlowTolerance(config, err));
+  if (!errorWithinFlowTolerance(config, err)) {
     Console::warn(0, "PageRank calculation stopped after the maximum of {} iterations with diff {:g}.", iterations, err);
   }
 

--- a/src/utils/FlowCalculator.cpp
+++ b/src/utils/FlowCalculator.cpp
@@ -14,6 +14,7 @@
 #include "../utils/format.h"
 #include "../utils/infomath.h"
 #include "../core/StateNetwork.h"
+#include "../io/InfomapError.h"
 #include <cmath>
 #include <numeric>
 #include <limits>
@@ -201,6 +202,23 @@ FlowCalculator::FlowCalculator(StateNetwork& network, const Config& config)
     break;
   case FlowModel::directed:
     if (network.isBipartite() && config.bipartiteTeleportation) {
+      // The two-step walk needs a step back: the option's second half sends flow from
+      // the feature side to the primary side along explicit feature -> primary links.
+      // A canonical bipartite file has none -- every link runs primary -> feature -- so
+      // that half is a no-op and what comes out is not this flow model. Depending on the
+      // teleportation flags it was zero flow, NaN, or, with --to-nodes, the uniform
+      // teleport distribution with a plausible codelength and no warning: flow that
+      // ignores the network entirely (#899). Refused with the precondition named.
+      if (bipartiteLinkStartIndex == flowLinks.size()) {
+        throw InfomapError(ExitCode::InputError,
+                           fmt::format(FMT_STRING("--bipartite-teleportation needs links from the feature side back to the "
+                                                  "primary side, and all {} links in this network run from the primary side "
+                                                  "to the feature side. Without them the second step of the two-step walk "
+                                                  "has nothing to follow and the resulting flow does not describe the "
+                                                  "network. Drop --bipartite-teleportation to use the two-step projection "
+                                                  "instead, which handles this input."),
+                                       flowLinks.size()));
+      }
       calcDirectedBipartiteFlow(network, config);
     } else {
       if (config.regularized) {
@@ -373,7 +391,12 @@ IterationResult powerIterate(const Config& config, double alpha, Iteration&& ite
     ++iterations;
   } while (iterations < config.maxFlowIterations && (err > config.flowTolerance || iterations < config.minFlowIterations));
 
-  const bool converged = iterations < config.maxFlowIterations;
+  // Converged means the error is within tolerance, not merely that the loop stopped
+  // before the iteration limit. The two differ whenever the last allowed iteration is
+  // the one that reaches tolerance: that was reported as a failure, with the warning to
+  // match, while the error sat at 0. Since #899 exports this to the run report and the
+  // Python Result, a signal that cries wolf is worse than none.
+  const bool converged = err <= config.flowTolerance;
   if (!converged) {
     Log() << "\n";
     Console::warn(0, "PageRank calculation did not converge after {} iterations with error {:g}.", iterations, err);
@@ -1281,6 +1304,12 @@ void FlowCalculator::calcDirectedBipartiteFlow(const StateNetwork& network, cons
 
 void FlowCalculator::finalize(StateNetwork& network, const Config& config, bool normalizeNodeFlow) noexcept
 {
+  // Hand the power iteration's outcome to the network so it outlives this calculator.
+  network.m_haveFlowConvergence = m_havePageRank;
+  network.m_flowConverged = m_pageRankConverged;
+  network.m_flowIterations = m_pageRankIterations;
+  network.m_flowError = m_pageRankError;
+
   // TODO: Skip bipartite flow adjustment for directed / rawdir / .. ?
   if (network.isBipartite()) {
     addFlowNote("Using bipartite links");

--- a/src/utils/FlowCalculator.cpp
+++ b/src/utils/FlowCalculator.cpp
@@ -34,6 +34,17 @@ namespace {
   }
 #endif
 
+  // Converged means the error is within tolerance, not merely that the loop stopped
+  // before the iteration limit. The two differ whenever the last allowed iteration is
+  // the one that reaches tolerance: that was reported as a failure, with a warning to
+  // match, while the error sat at 0. Shared by every power iteration in this file,
+  // because the predicate existed in three copies and fixing one left the regularized
+  // model exporting the old answer (#899).
+  bool errorWithinFlowTolerance(const Config& config, double err) noexcept
+  {
+    return err <= config.flowTolerance;
+  }
+
 } // namespace
 
 template <typename T>
@@ -361,16 +372,6 @@ void FlowCalculator::usePrecomputedFlow(const StateNetwork& network, const Confi
       nodeFlow[i] /= sumFlow;
     }
   }
-}
-
-// Converged means the error is within tolerance, not merely that the loop stopped before
-// the iteration limit. The two differ whenever the last allowed iteration is the one that
-// reaches tolerance: that was reported as a failure, with a warning to match, while the
-// error sat at 0. Shared by every power iteration here, because the predicate existed in
-// three copies and fixing one left the regularized model exporting the old answer (#899).
-inline bool errorWithinFlowTolerance(const Config& config, double err) noexcept
-{
-  return err <= config.flowTolerance;
 }
 
 struct IterationResult {

--- a/test/cpp/test_flow.cpp
+++ b/test/cpp/test_flow.cpp
@@ -777,6 +777,71 @@ TEST_CASE("Degenerate flow is rejected instead of reported as a zero codelength 
   }
 }
 
+TEST_CASE("Bipartite teleportation names the links it needs [fast][core][flow]")
+{
+  // The option's second step sends flow from the feature side back to the primary side
+  // along explicit links. A canonical bipartite file has none, so that half was a no-op:
+  // depending on the teleportation flags the result was zero flow, NaN, or -- with
+  // --to-nodes -- the uniform teleport distribution with a plausible codelength and no
+  // warning at all, i.e. flow that ignores the network (#899).
+  for (const auto* flags : { "-N 1 --seed 7 --directed --bipartite-teleportation",
+                             "-N 1 --seed 7 --directed --recorded-teleportation --bipartite-teleportation",
+                             "-N 1 --seed 7 --directed --recorded-teleportation --to-nodes --bipartite-teleportation" }) {
+    InfomapWrapper im(infomap::test::defaultFlags(flags));
+    addCanonicalBipartiteLinks(im);
+
+    try {
+      im.run();
+      FAIL("expected bipartite teleportation without feature -> primary links to be rejected");
+    } catch (const infomap::InfomapError& e) {
+      CHECK(e.code() == infomap::ExitCode::InputError);
+      const std::string message(e.what());
+      // Naming the missing precondition is the point: "degenerate flow" pointed at the
+      // flow model when the cause is the input lacking return links.
+      CHECK(message.find("--bipartite-teleportation needs links") != std::string::npos);
+    }
+  }
+}
+
+TEST_CASE("Bipartite teleportation runs when the feature side links back [fast][core][flow]")
+{
+  // One return link per feature node, so the two-step walk can reach both primary
+  // nodes. With only one the walk can return to a single node, all flow concentrates
+  // there and the codelength collapses to zero -- reported today by the non-convergence
+  // and flow-sum warnings, which this PR also puts in the run report.
+  InfomapWrapper im(infomap::test::defaultFlags("-N 1 --seed 7 --two-level --directed --bipartite-teleportation"));
+  addCanonicalBipartiteLinks(im);
+  im.addLink(4, 1);
+  im.addLink(5, 3);
+
+  CHECK_NOTHROW(im.run());
+  infomap::test::checkRunSanity(im);
+  CHECK(im.codelength() > 0.0);
+  CHECK(im.network().flowConverged());
+}
+
+TEST_CASE("Reaching tolerance on the last allowed iteration counts as converged [fast][core][flow]")
+{
+  // converged used to mean "the loop stopped before the iteration limit", so a run whose
+  // final allowed iteration brought the error to zero was reported as a failure -- with
+  // the warning to match. Since the outcome now reaches the run report and the Python
+  // Result, a signal that cries wolf is worse than no signal (#899).
+  InfomapWrapper im(infomap::test::defaultFlags("-N 1 --seed 7 --directed --max-flow-iterations 2"));
+  im.addLink(1, 2);
+  im.addLink(2, 3);
+  im.addLink(3, 1);
+  im.addLink(3, 4);
+  im.addLink(4, 5);
+  im.addLink(5, 3);
+
+  im.run();
+
+  REQUIRE(im.network().haveFlowConvergence());
+  CHECK(im.network().flowIterations() == 2);
+  CHECK(im.network().flowError() <= 1e-15);
+  CHECK(im.network().flowConverged());
+}
+
 TEST_CASE("Degenerate flow reports an input error [fast][core][flow]")
 {
   InfomapWrapper im(infomap::test::defaultFlags("-N 1 --seed 7 --directed --recorded-teleportation"));

--- a/test/cpp/test_infomap_wrapper.cpp
+++ b/test/cpp/test_infomap_wrapper.cpp
@@ -622,6 +622,43 @@ TEST_CASE("Converge is deterministic for a given input and seed [fast][core][lif
   CHECK(first.second == doctest::Approx(second.second)); // same best codelength
 }
 
+TEST_CASE("The summary report carries the power iteration's outcome [fast][core][lifecycle][output][flow]")
+{
+  // A failed power iteration means the flow is not the network's stationary
+  // distribution, so no codelength below it describes the network. It was reported
+  // through exactly one channel -- a console line -- and --summary-json requires
+  // --silent, so the documented pipeline shape provably could not see it (#899).
+  const std::vector<std::string> paths = {
+    "run_report_flow_converged.json",
+    "run_report_flow_not_converged.json",
+  };
+  removeFiles(paths);
+
+  {
+    InfomapWrapper converged("--silent --seed 7 --directed --no-file-output --summary-json " + paths[0]);
+    infomap::test::addEdgeFixtureLinks(converged, "graphs/twotriangles_unweighted.edges");
+    converged.run();
+    const auto json = infomap::test::readTextFile(paths[0]);
+    CHECK(json.find("\"flow\":{\"converged\":true") != std::string::npos);
+    CHECK(json.find("\"iterations\":") != std::string::npos);
+    CHECK(json.find("\"error\":") != std::string::npos);
+  }
+
+  {
+    // Two iterations is not enough for this network to reach tolerance, so the run
+    // completes with a flow that is not stationary -- exactly the case that used to
+    // leave no trace in any file.
+    InfomapWrapper notConverged("--silent --seed 7 --directed --max-flow-iterations 2 --no-file-output --summary-json " + paths[1]);
+    notConverged.readInputData(infomap::test::repoPath("examples/networks/ninetriangles.net"));
+    notConverged.run();
+    const auto json = infomap::test::readTextFile(paths[1]);
+    CHECK(json.find("\"flow\":{\"converged\":false") != std::string::npos);
+    CHECK(json.find("\"iterations\":2,") != std::string::npos);
+  }
+
+  removeFiles(paths);
+}
+
 TEST_CASE("Run reports write machine-readable JSON with no-file-output [fast][core][lifecycle][output]")
 {
   const std::vector<std::string> paths = {

--- a/test/python/test_flow.py
+++ b/test/python/test_flow.py
@@ -37,6 +37,50 @@ def test_skip_adjust_bipartite_flow_still_runs(example_network_path):
     assert result.codelength == pytest.approx(0.2776646519)
 
 
+def test_flow_convergence_is_visible_on_the_result():
+    # A failed power iteration means the flow is not the network's stationary
+    # distribution, so the codelength describes something else. It used to be reported
+    # only as a console line, and --summary-json requires --silent, so no automated
+    # consumer could see it at all.
+    links = ((1, 2), (2, 3), (3, 1), (3, 4), (4, 5), (5, 3))
+
+    im = infomap.Infomap(silent=True, directed=True, max_flow_iterations=2)
+    im.add_links(links)
+    stopped_early = im.run()
+
+    converging = infomap.Infomap(silent=True, directed=True)
+    converging.add_links(links)
+    converged = converging.run()
+
+    assert converged.flow_converged is True
+    assert converged.flow_iterations > 0
+    # This network reaches tolerance within two iterations, so a truncated run is not a
+    # failure -- "converged" means the error is within tolerance, not that the loop
+    # stopped before the limit.
+    assert stopped_early.flow_iterations == 2
+    assert stopped_early.flow_converged is True
+
+
+def test_flow_convergence_reports_a_real_failure(example_network_path):
+    # Same options on a network that genuinely cannot reach tolerance in two iterations.
+    net = infomap.Network.from_file(str(example_network_path("ninetriangles.net")))
+    result = net.run(directed=True, max_flow_iterations=2, seed=7, num_trials=1)
+
+    assert result.flow_converged is False
+    assert result.flow_iterations == 2
+    assert result.flow_error > 0.0
+
+
+def test_undirected_flow_reports_no_power_iteration():
+    # Nothing to converge, so the flag must not read as a failure.
+    im = infomap.Infomap(silent=True)
+    im.add_links(((1, 2), (2, 3), (3, 1), (3, 4), (4, 5), (5, 3)))
+    result = im.run()
+
+    assert result.flow_converged is True
+    assert result.flow_iterations == 0
+
+
 def test_precomputed_requirements(make_infomap, example_network_path):
     im = make_infomap(flow_model="precomputed")
     im.read_file(str(example_network_path("twotriangles.net")))


### PR DESCRIPTION
Closes #899 — the last two boxes. Box 3 landed in #945, boxes 1 and 4 in #917.

## `--bipartite-teleportation` needs links a canonical file does not have

The option's second step sends flow from the feature side back to the primary side
along explicit links. A canonical bipartite file has none — every link runs
primary → feature — so that half was a no-op and what came out was not this flow model.
Measured on the shipped `examples/networks/bipartite.net`:

| flags | before | after |
| --- | --- | --- |
| `-d --bipartite-teleportation` | exit 2, "Degenerate flow" | exit 2, names the precondition |
| `-d -e --bipartite-teleportation` | exit 2, "Degenerate flow" | exit 2, names the precondition |
| `-d -e --to-nodes --bipartite-teleportation` | **exit 0, codelength 1.029878142, flows 0.333333 / 0.333333 / 0.333333** | exit 2, names the precondition |

The first two were already stopped by #917's guard, but with a message blaming the flow
model when the cause is the input. The third is the one that mattered: a plausible
codelength and node flows that are exactly the uniform teleport distribution — flow that
ignores the network, with nothing to signal it. The three primary nodes have different
degrees, so uniform flow is provably not this network's flow.

The option still works where its assumption holds: with a return link per feature node
the run is healthy (flow sums to 1, codelength 0.0833). With only *one* return link the
walk can reach a single primary node, all flow concentrates there and the codelength
collapses to −5.6e−17 — flagged today by the non-convergence and flow-sum warnings, and
now also in the run report, which is the other half of this PR.

## Non-convergence reaches machine-readable channels

A failed power iteration means the flow is not the network's stationary distribution, so
no codelength below it describes the network. It was reported through exactly one
channel — a console line — and since `--summary-json` requires `--silent`, the documented
pipeline shape provably could not see it.

```json
"flow":{"converged":false,"iterations":2,"error":0.21258327437906488}
```

and on the Python side:

```python
>>> result.flow_converged, result.flow_iterations, result.flow_error
(False, 2, 0.2126)
```

Flow models that run no power iteration report converged with zero iterations, so
`not result.flow_converged` always means a real failure rather than "none ran".

The manifest is deliberately **not** a channel for this: `runManifestJson` takes only the
`Config` and is fingerprinted, so a runtime outcome does not belong there. The exit code
is untouched — changing it would break scripts and is your call, not a bug fix.

## A third defect, found by exporting the second

`converged` meant "the loop stopped before the iteration limit", not "the error is within
tolerance":

```cpp
const bool converged = iterations < config.maxFlowIterations;
```

So a run whose last allowed iteration reached tolerance was reported as a failure, with
the warning to match, while the error sat at **exactly 0**. My own test caught it: a
five-node network at `--max-flow-iterations 2` converges with error 0 and was reported
as not converged. Exporting that to a report and a Python attribute would be worse than
exporting nothing, so the predicate now tests the error. Fewer spurious warnings; no
codelength changes.

## Surface and verification

The Python attributes come from four scalar accessors on `StateNetwork`, so the
regenerated SWIG wrappers grow by ~130 lines rather than gaining a new wrapped type.
All three freshness gates pass (Python SWIG, R SWIG, binding options).

Six tests — three C++, three Python — each mutation-checked: removing the precondition
check fails the suite, and restoring the old convergence predicate fails it too.
`make test-native` 100% of 25, `pytest -m fast` 638 passed, `make test-python-doctest`
40 passed. The docstring example goes through `Options`, which
`test_source_docstrings_avoid_direct_advanced_kwargs` insisted on and I had missed.