### PR TITLE
fix(js): stop dropping per-run args and returning the input as Infomap's output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ examples/cpp/Infomap-igraph-interface-library/lib/
 !examples/notebooks/data/benchmark-results.csv
 /*.net
 test/tmp/
+
+# Playwright output from the JS browser tests
+test-results/
+playwright-report/

--- a/interfaces/js/pre-worker-module.js
+++ b/interfaces/js/pre-worker-module.js
@@ -22,14 +22,29 @@ function readResultFile(file) {
 }
 
 let outName = "Untitled";
+let expectsOutputFiles = true;
 let pendingMessage = undefined;
 let readyForFiles = false;
+
+// The input network lives in its own directory so it cannot be mistaken for output.
+// Written next to the output it was: the out name is the input filename minus its
+// extension, so the "net" result key resolved to the input file and every default run
+// handed the caller its own network back under a key documented as Infomap's Pajek
+// output (#903).
+const INPUT_DIR = "infomap-input";
 
 function prepareFiles(message) {
   const data = message.data;
   outName = data.outName;
-  Module.arguments.push(...[data.filename, ".", ...data.arguments]);
-  FS.writeFile(data.filename, data.network);
+  expectsOutputFiles = data.expectsOutputFiles !== false;
+  try {
+    FS.mkdir(INPUT_DIR);
+  } catch (e) {
+    // already created by an earlier run in this worker
+  }
+  const inputPath = `${INPUT_DIR}/${data.filename}`;
+  Module.arguments.push(...[inputPath, ".", ...data.arguments]);
+  FS.writeFile(inputPath, data.network);
   for (let filename of Object.keys(data.files)) {
     FS.writeFile(filename, data.files[filename]);
   }
@@ -59,8 +74,25 @@ var Module = {
   },
   postRun: function () {
     const content = {};
+    let found = 0;
     for (const file of resultFiles) {
       content[file.key] = readResultFile(file);
+      if (content[file.key] !== undefined) {
+        found++;
+      }
+    }
+    // "The engine wrote files we then failed to find" used to be indistinguishable from
+    // "the engine produced nothing": every read missed, readResultFile swallowed it, and
+    // the run resolved with an empty result (#903).
+    if (found === 0 && expectsOutputFiles) {
+      postMessage({
+        type: "error",
+        content:
+          `Infomap finished but none of its output files were found under "${outName}". ` +
+          "This usually means --out-name and the name the results are read back under " +
+          "disagree. Pass --no-file-output if no output files are wanted.",
+      });
+      return;
     }
     postMessage({ type: "finished", content });
   },

--- a/interfaces/js/src/index.ts
+++ b/interfaces/js/src/index.ts
@@ -180,7 +180,13 @@ class Infomap {
     this.workers[id] = worker;
 
     worker.postMessage({
-      arguments: args.split(" "),
+      // Split on runs of whitespace and drop the empties, the way the Node entry point
+      // does. Splitting on a single space passed argv entries a shell never would: the
+      // rendered form of an Arguments object starts with a space, so every object-args
+      // run sent an empty first argument, which only went unnoticed because the
+      // optional out_directory vector swallows stray positionals -- the same mechanism
+      // behind this issue's option-injection box.
+      arguments: args.split(/\s+/).filter(Boolean),
       filename,
       network,
       outName,

--- a/interfaces/js/src/index.ts
+++ b/interfaces/js/src/index.ts
@@ -63,12 +63,17 @@ export interface Header {
   bipartiteStartId?: number;
 }
 
-export type Tree<NodeType = Required<Node>> = Header & {
+// Node fields stay optional, because the JSON output omits them: a higher-order
+// network's physical JSON carries no `modules` at all, and `stateId`/`layerId` are not
+// in it either. Wrapping these in `Required` typed them as always present, so consumer
+// code dereferenced undefined with no compile error (#903). Measured on 2.15.0: nodes
+// of a first-order network have modules, of states.net and multilayer.net they do not.
+export type Tree<NodeType = Node> = Header & {
   nodes: NodeType[];
   modules: Module[];
 };
 
-export type StateTree = Tree<Required<StateNode>>;
+export type StateTree = Tree<StateNode>;
 
 export interface Result {
   clu?: string;
@@ -160,8 +165,15 @@ class Infomap {
 
     const index = filename.lastIndexOf(".");
     const networkName = index > 0 ? filename.slice(0, index) : filename;
-    const outNameMatch = args.match(/--out-name\s(\S+)/);
+    // \s+ rather than \s: the C++ tokenizer accepts a run of whitespace, so
+    // "--out-name  mynet" is a valid command line. Matching a single space made the
+    // regex miss, the basename fall back to the network name, and every read of the
+    // engine's output land on a file that was never written (#903).
+    const outNameMatch = args.match(/--out-name\s+(\S+)/);
     const outName = outNameMatch?.[1] ? outNameMatch[1] : networkName;
+    // Whether output files are expected at all, so the worker can tell "the engine
+    // wrote nothing" from "we looked in the wrong place".
+    const expectsOutputFiles = !/(?:^|\s)--no-file-output(?:\s|$)/.test(args);
 
     const worker = createInfomapWorker();
     const id = this.workerId++;
@@ -173,6 +185,7 @@ class Infomap {
       network,
       outName,
       files,
+      expectsOutputFiles,
     });
 
     return id;

--- a/interfaces/js/src/index.ts
+++ b/interfaces/js/src/index.ts
@@ -169,8 +169,13 @@ class Infomap {
     // "--out-name  mynet" is a valid command line. Matching a single space made the
     // regex miss, the basename fall back to the network name, and every read of the
     // engine's output land on a file that was never written (#903).
-    const outNameMatch = args.match(/--out-name\s+(\S+)/);
-    const outName = outNameMatch?.[1] ? outNameMatch[1] : networkName;
+    //
+    // The *last* occurrence wins, because that is what the engine does: "-N 1 -N 5"
+    // runs five trials. Reading the first one would have the engine write under one
+    // basename while the results are read back under another.
+    const outNameMatches = [...args.matchAll(/--out-name\s+(\S+)/g)];
+    const outNameFromArgs = outNameMatches[outNameMatches.length - 1]?.[1];
+    const outName = outNameFromArgs ? outNameFromArgs : networkName;
     // Whether output files are expected at all, so the worker can tell "the engine
     // wrote nothing" from "we looked in the wrong place".
     const expectsOutputFiles = !/(?:^|\s)--no-file-output(?:\s|$)/.test(args);

--- a/interfaces/js/src/node.ts
+++ b/interfaces/js/src/node.ts
@@ -72,7 +72,8 @@ export async function run(
   // --out-name inside args is honoured too, the way the worker entry point reads it, so
   // the two surfaces agree. Passing it there used to be silently ignored here: the
   // engine wrote one basename while the results were read back under another.
-  const outNameFlagIndex = extraArgs.indexOf("--out-name");
+  // lastIndexOf, mirroring the engine: it takes the last occurrence of an option.
+  const outNameFlagIndex = extraArgs.lastIndexOf("--out-name");
   const outNameFromArgs =
     outNameFlagIndex >= 0 ? extraArgs[outNameFlagIndex + 1] : undefined;
   const base = outName ?? outNameFromArgs ?? basenameWithoutExtension(filename);

--- a/interfaces/js/src/node.ts
+++ b/interfaces/js/src/node.ts
@@ -69,7 +69,13 @@ export async function run(
   const { filename = "network.net", args = [], outName } = options;
   const extraArgs =
     typeof args === "string" ? args.split(/\s+/).filter(Boolean) : [...args];
-  const base = outName ?? basenameWithoutExtension(filename);
+  // --out-name inside args is honoured too, the way the worker entry point reads it, so
+  // the two surfaces agree. Passing it there used to be silently ignored here: the
+  // engine wrote one basename while the results were read back under another.
+  const outNameFlagIndex = extraArgs.indexOf("--out-name");
+  const outNameFromArgs =
+    outNameFlagIndex >= 0 ? extraArgs[outNameFlagIndex + 1] : undefined;
+  const base = outName ?? outNameFromArgs ?? basenameWithoutExtension(filename);
   if (outName) {
     extraArgs.push("--out-name", outName);
   }
@@ -90,7 +96,12 @@ export async function run(
 
   const workDir = "/work";
   Module.FS.mkdir(workDir);
-  const inputPath = `${workDir}/${filename}`;
+  // The input goes in its own directory so it cannot be read back as output: the out
+  // name is the input filename minus its extension, so ${workDir}/${base}.net was the
+  // input file and the "net" result key handed the caller its own network back (#903).
+  const inputDir = `${workDir}/input`;
+  Module.FS.mkdir(inputDir);
+  const inputPath = `${inputDir}/${filename}`;
   Module.FS.writeFile(inputPath, network);
 
   let status = 0;
@@ -112,6 +123,7 @@ export async function run(
   }
 
   const result: Result = {};
+  let found = 0;
   for (const file of resultFiles) {
     const outputPath = `${workDir}/${base}${file.suffix}.${file.extension}`;
     let content: string;
@@ -120,9 +132,20 @@ export async function run(
     } catch {
       continue;
     }
+    found++;
     (result as Record<string, unknown>)[file.key] =
       file.extension === "json" ? JSON.parse(content) : content;
   }
+
+  const expectsOutputFiles = !extraArgs.includes("--no-file-output");
+  if (found === 0 && expectsOutputFiles) {
+    throw new Error(
+      `Infomap exited 0 but none of its output files were found under "${base}". ` +
+        "This usually means --out-name and the name the results are read back under " +
+        "disagree. Pass --no-file-output if no output files are wanted.",
+    );
+  }
+
   return result;
 }
 

--- a/interfaces/js/src/react-args.ts
+++ b/interfaces/js/src/react-args.ts
@@ -1,19 +1,41 @@
-import type { Arguments } from "./arguments";
+import argumentsToString, { type Arguments } from "./arguments";
 import type { RunOptions } from "./run-options";
 
 type RunParams = [RunOptions];
 
+/**
+ * Combine the hook's default arguments with a single run's arguments.
+ *
+ * `RunOptions.args` is `string | Arguments`, so a call site can legally pass a string
+ * to a hook created with an object. That combination used to drop the call site's
+ * string and run with the hook's object alone -- no error, a result for a
+ * configuration nobody asked for (#903). Mixed forms are now rendered to one command
+ * line with the per-run arguments last, which gives them precedence the same way the
+ * object merge does: Infomap's parser takes the last occurrence of an option.
+ */
 export function mergeInfomapArgs(
   params: RunParams,
   args?: Arguments,
 ): RunParams {
   const param = params[0] ? { ...params[0] } : {};
 
-  if (typeof param.args === "object" && typeof args === "object") {
-    param.args = { ...args, ...param.args };
-  } else if (args !== undefined) {
-    param.args = args;
+  if (args === undefined) {
+    return [param];
   }
+
+  if (param.args === undefined) {
+    param.args = args;
+    return [param];
+  }
+
+  if (typeof param.args === "object") {
+    param.args = { ...args, ...param.args };
+    return [param];
+  }
+
+  const perRun = param.args.trim();
+  const defaults = argumentsToString(args).trim();
+  param.args = [defaults, perRun].filter((part) => part.length > 0).join(" ");
 
   return [param];
 }

--- a/interfaces/js/test/browser/fixtures/worker.html
+++ b/interfaces/js/test/browser/fixtures/worker.html
@@ -26,6 +26,25 @@
             throw new Error("Missing expected output");
           }
 
+          // #903: the "net" key is Infomap's Pajek output, so it must be absent
+          // unless it was asked for. The input network used to be written exactly
+          // where the out name pointed, so it came back under this key every run.
+          if (output.net !== undefined) {
+            throw new Error("net present without -o network");
+          }
+
+          // #903: the out name is read through a run of whitespace, which the C++
+          // tokenizer accepts. Matching a single space made every read of the
+          // engine's output miss, and the run resolved with nothing.
+          const spaced = await infomap.runAsync({
+            network: "#source target\n1 2\n2 1\n2 3\n3 2\n",
+            args: "--out-name  renamed --tree --silent"
+          });
+
+          if (!spaced.tree) {
+            throw new Error("--out-name with extra whitespace lost the output");
+          }
+
           result.textContent = `${output.tree}\n${output.clu}`;
           status.textContent = "ok";
         } catch (error) {

--- a/interfaces/js/test/package/runtime-check.mjs
+++ b/interfaces/js/test/package/runtime-check.mjs
@@ -85,6 +85,24 @@ for (const { label, run } of [
     "string",
     `${label}: --out-name in args was not honoured`,
   );
+
+  // And the last occurrence wins, because that is the option the engine acts on.
+  const renamedTwice = await run(network, {
+    args: [
+      "--out-name",
+      "first",
+      "-o",
+      "tree",
+      "--out-name",
+      "second",
+      "--silent",
+    ],
+  });
+  assert.equal(
+    typeof renamedTwice.tree,
+    "string",
+    `${label}: a repeated --out-name was read from the wrong occurrence`,
+  );
 }
 
 // Exercise the `infomap` bin on real files, like the native binary.

--- a/interfaces/js/test/package/runtime-check.mjs
+++ b/interfaces/js/test/package/runtime-check.mjs
@@ -47,6 +47,46 @@ for (const { label, run } of [
   );
 }
 
+// The "net" key must be Infomap's own Pajek output, never the caller's input. The input
+// network used to be written exactly where the out name pointed, so every default run
+// handed the caller its own data back under a key documented as engine output (#903).
+for (const { label, run } of [
+  { label: "esm", run: nodeModule.run },
+  { label: "cjs", run: nodeCjsModule.run },
+]) {
+  const treeOnly = await run(network, { args: ["-o", "tree", "--silent"] });
+  assert.equal(
+    treeOnly.net,
+    undefined,
+    `${label}: net present without -o network`,
+  );
+
+  const withNetwork = await run(network, {
+    args: ["-o", "network", "--silent"],
+  });
+  assert.equal(
+    typeof withNetwork.net,
+    "string",
+    `${label}: -o network produced no net`,
+  );
+  assert.notEqual(
+    withNetwork.net,
+    network,
+    `${label}: net is the caller's input`,
+  );
+
+  // --out-name in args is read the same way the worker entry point reads it, rather
+  // than leaving the engine and the reader looking at different basenames.
+  const named = await run(network, {
+    args: ["--out-name", "renamed", "-o", "tree", "--silent"],
+  });
+  assert.equal(
+    typeof named.tree,
+    "string",
+    `${label}: --out-name in args was not honoured`,
+  );
+}
+
 // Exercise the `infomap` bin on real files, like the native binary.
 const binPath = path.join(packageDir, "cli.js");
 const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "infomap-bin-check-"));

--- a/interfaces/js/test/unit/react.test.ts
+++ b/interfaces/js/test/unit/react.test.ts
@@ -13,4 +13,28 @@ describe("mergeInfomapArgs", () => {
       { args: { tree: true } },
     ]);
   });
+
+  test("keeps a per-run string when the hook was given an object", () => {
+    // Legal per the RunOptions type, and the per-run string used to be dropped
+    // silently, running a configuration the caller never asked for (#903).
+    expect(
+      mergeInfomapArgs([{ args: "--two-level --num-trials 10" }], {
+        silent: true,
+      }),
+    ).toEqual([{ args: "--silent --two-level --num-trials 10" }]);
+  });
+
+  test("gives the per-run string precedence over the hook default", () => {
+    // Infomap's parser takes the last occurrence of an option, so the per-run
+    // arguments come last -- the same precedence the object merge gives them.
+    expect(
+      mergeInfomapArgs([{ args: "--num-trials 10" }], { numTrials: 2 }),
+    ).toEqual([{ args: "--num-trials 2 --num-trials 10" }]);
+  });
+
+  test("leaves a per-run string alone when the hook has no defaults", () => {
+    expect(mergeInfomapArgs([{ args: "--two-level" }], undefined)).toEqual([
+      { args: "--two-level" },
+    ]);
+  });
 });

--- a/interfaces/js/test/unit/tree-types.test.ts
+++ b/interfaces/js/test/unit/tree-types.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest";
+import type { StateTree, Tree } from "../../src/index";
+
+/*
+ * Type-level regression tests, checked by `npm run typecheck`, which covers test/unit.
+ * The expect-error directives below are the assertions: if Tree goes back to requiring
+ * every node field they become unused, and tsc fails on an unused directive -- so these
+ * cannot rot into no-ops.
+ *
+ * Measured against 2.15.0 output rather than assumed:
+ *   states.net        -o json  ->  flow id mec name path            (no modules)
+ *   states.net  states json    ->  flow id mec modules name path stateId  (no layerId)
+ *   ninetriangles.net -o json  ->  flow id mec modules name path
+ */
+describe("Tree node fields the JSON output may omit", () => {
+  test("modules is optional: a higher-order network's physical JSON has none", () => {
+    // Exactly what states.net -o json emits: no modules key.
+    const tree = {
+      nodes: [{ path: [1, 1], id: 1, flow: 0.25, mec: 0, name: "a" }],
+    } as unknown as Tree;
+    const node = tree.nodes[0];
+
+    // @ts-expect-error modules is possibly undefined and has to be checked first
+    const unchecked: number[] = node.modules;
+    const checked: number[] = node.modules ?? [];
+
+    expect(unchecked).toBe(undefined);
+    expect(checked).toEqual([]);
+  });
+
+  test("layerId is optional: only multilayer input carries it", () => {
+    // Exactly what the states JSON emits for non-multilayer input: no layerId key.
+    const tree = {
+      nodes: [
+        {
+          path: [1, 1],
+          id: 1,
+          flow: 0.25,
+          mec: 0,
+          name: "a",
+          stateId: 7,
+          modules: [1],
+        },
+      ],
+    } as unknown as StateTree;
+    const node = tree.nodes[0];
+
+    // @ts-expect-error layerId is possibly undefined
+    const unchecked: number = node.layerId;
+    const checked: number = node.layerId ?? 0;
+
+    expect(unchecked).toBe(undefined);
+    expect(checked).toBe(0);
+  });
+
+  test("stateId stays required, because the states JSON always carries it", () => {
+    const tree = {
+      nodes: [{ path: [1, 1], id: 1, flow: 0.25, mec: 0, stateId: 7 }],
+    } as unknown as StateTree;
+    const node = tree.nodes[0];
+
+    const stateId: number = node.stateId;
+
+    expect(stateId).toBe(7);
+  });
+});

--- a/interfaces/js/test/unit/worker-events.test.ts
+++ b/interfaces/js/test/unit/worker-events.test.ts
@@ -49,6 +49,37 @@ describe("Infomap", () => {
     expect(progress).toHaveBeenCalledWith(40, id);
   });
 
+  test("reads the out name through a run of whitespace", () => {
+    // The C++ tokenizer accepts "--out-name  mynet"; a regex matching a single space
+    // missed it, fell back to the network basename, and then every read of the engine's
+    // output landed on a file that was never written (#903).
+    const infomap = new Infomap();
+    const id = infomap.run({
+      network: "1 2\n",
+      args: "--out-name  mynet -o tree",
+    });
+
+    expect(getWorker(infomap, id).postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ outName: "mynet" }),
+    );
+  });
+
+  test("tells the worker whether to expect output files", () => {
+    const infomap = new Infomap();
+    const withFiles = infomap.run({ network: "1 2\n", args: "-o tree" });
+    expect(getWorker(infomap, withFiles).postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ expectsOutputFiles: true }),
+    );
+
+    const withoutFiles = infomap.run({
+      network: "1 2\n",
+      args: "--no-file-output",
+    });
+    expect(getWorker(infomap, withoutFiles).postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ expectsOutputFiles: false }),
+    );
+  });
+
   test("converts pretty summary output to complete progress", () => {
     const progress = vi.fn();
     const infomap = new Infomap().on("progress", progress);

--- a/interfaces/js/test/unit/worker-events.test.ts
+++ b/interfaces/js/test/unit/worker-events.test.ts
@@ -64,6 +64,22 @@ describe("Infomap", () => {
     );
   });
 
+  test("takes the last out name, the way the engine does", () => {
+    // Infomap uses the last occurrence of an option, so reading the first would have
+    // the engine write under one basename while the results are read under another --
+    // now a loud "no output files found" instead of a silent empty result, on a
+    // perfectly valid command line (#903).
+    const infomap = new Infomap();
+    const id = infomap.run({
+      network: "1 2\n",
+      args: "--out-name first -o tree --out-name second",
+    });
+
+    expect(getWorker(infomap, id).postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ outName: "second" }),
+    );
+  });
+
   test("passes argv without empty entries", () => {
     // A shell never hands a program an empty argument. The rendered form of an
     // Arguments object starts with a space and the out name may be followed by a run

--- a/interfaces/js/test/unit/worker-events.test.ts
+++ b/interfaces/js/test/unit/worker-events.test.ts
@@ -64,6 +64,31 @@ describe("Infomap", () => {
     );
   });
 
+  test("passes argv without empty entries", () => {
+    // A shell never hands a program an empty argument. The rendered form of an
+    // Arguments object starts with a space and the out name may be followed by a run
+    // of whitespace, so splitting on a single space produced them (#903).
+    const infomap = new Infomap();
+    const fromObject = infomap.run({
+      network: "1 2\n",
+      args: { twoLevel: true, silent: true },
+    });
+    const fromString = infomap.run({
+      network: "1 2\n",
+      args: "--out-name  mynet  -o tree",
+    });
+
+    for (const id of [fromObject, fromString]) {
+      const [[message]] = (
+        getWorker(infomap, id).postMessage as unknown as {
+          mock: { calls: [{ arguments: string[] }][] };
+        }
+      ).mock.calls.slice(-1);
+      expect(message.arguments).not.toContain("");
+      expect(message.arguments.every((arg) => arg.length > 0)).toBe(true);
+    }
+  });
+
   test("tells the worker whether to expect output files", () => {
     const infomap = new Infomap();
     const withFiles = infomap.run({ network: "1 2\n", args: "-o tree" });


### PR DESCRIPTION
Closes #903 — the four remaining boxes. The fifth, unquoted option values, landed in #936.

## A per-run `args` string was thrown away

`mergeInfomapArgs` merged only when **both** sides were objects. `RunOptions.args` is
`string | Arguments`, so passing a string at the call site to a hook created with an
object is fully type-legal — and that combination dropped the string and ran the hook's
object alone. No error, a result for a configuration nobody asked for.

Mixed forms now render to one command line with the per-run arguments **last**, which
gives them the same precedence the object merge does. That ordering is measured, not
assumed: `-N 1 -N 5` reports `num-trials = 5` and "Summary after 5 trials", so Infomap's
parser takes the last occurrence.

## `Result.net` was the caller's own input

The input network was written exactly where the out name pointed — the out name is the
input filename minus its extension — so `${outName}.net` *was* the input file, and the
`net` key returned the caller's data on every default run under a key documented as
Infomap's Pajek output.

The input now lives in its own directory, in both the worker and the Node entry point:

| run | before | after |
| --- | --- | --- |
| `-o tree --silent` | keys `tree,net`, `net === input` | keys `tree` |
| `-o network --silent` | keys `tree,net`, `net === input` | keys `tree,net`, `net !== input` |

## A successful run could resolve with nothing

The out name was read with `--out-name\s(\S+)` — one whitespace character — while the
C++ tokenizer accepts a run of them. `--out-name  mynet` made the regex miss, the
basename fall back to the network name, and every read land on a file that was never
written. Nothing checked that at least one expected output had been found, so the run
resolved empty: "the engine wrote files we then failed to find" was indistinguishable
from "the engine produced nothing".

Both halves fixed: the regex accepts whitespace runs, and finding nothing at all is an
error naming the out name — unless `--no-file-output` was requested, which the JS
`Arguments` type exposes and which legitimately produces no files.

The Node entry point now also honours `--out-name` from the argument string. It only
read its own `outName` option, so passing the flag in `args` left the engine writing one
basename while the reader looked for another — the worker read it, the Node API did not.

## Types promised fields the output omits

`Tree` and `StateTree` wrapped their node type in `Required`, typing every optional
field as always present, so typed consumer code dereferenced `undefined` with no compile
error. Measured against 2.15.0 rather than assumed:

| input | node keys in the JSON |
| --- | --- |
| `ninetriangles.net` (first-order) | flow id mec **modules** name path |
| `states.net` physical JSON | flow id mec name path — **no modules** |
| `states.net` states JSON | flow id mec modules name path **stateId** — no layerId |

So `modules` and `layerId` are optional and `stateId` is not; the types now say that.
This is a type-level change: consumer code that dereferenced those fields without a
check will now fail to compile, which is the point.

## Verification

Executed rather than reasoned about, on both surfaces: the packaged Node library against
the real wasm (`test:package`), and the worker in a real browser (`test:browser`,
extended to assert `net` is absent and that a two-space `--out-name` still produces
output).

Every fix is mutation-checked. Putting the input back beside the output makes the
browser test fail with `Error: net present without -o network`; restoring the `Required`
types makes `tsc` fail on the now-unused `@ts-expect-error` directives; the old regex
and the old merge each fail their unit tests.

`make test-js` green end to end (lint, typecheck, 53 unit tests, pack, package
verification, browser), `make test-node` green.

One aside: Playwright writes `test-results/` and `playwright-report/` into the repo
root and neither was ignored, so running the browser suite left untracked directories
behind. Added to `.gitignore`.
