### PR TITLE
fix: keep output artifacts readable and say when a tree cannot be read back

### DIFF
--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1275,6 +1275,11 @@ NodePaths InfomapBase::normalizeTreePaths(const TreePaths& tree, unsigned int& n
 
   std::map<unsigned int, unsigned int> physicalRowsConsumed;
   std::map<unsigned int, unsigned int> physicalStatesConsumed;
+  // Physical nodes whose states are spread over more than one module. A physical .tree
+  // has one row per (module, physical node) and no state ids, so which state went to
+  // which module simply is not in the file -- the pairing below is ascending state id
+  // against file order, which is a guess (#908).
+  unsigned int numSplitPhysicalNodes = 0;
 
   for (const auto& tp : tree) {
     if (tp.idType == TreeLeafIdType::state) {
@@ -1300,6 +1305,9 @@ NodePaths InfomapBase::normalizeTreePaths(const TreePaths& tree, unsigned int& n
       continue;
     }
 
+    if (rowsConsumed == 0 && totalRows > 1 && it->second.size() > 1)
+      ++numSplitPhysicalNodes;
+
     // If this is the last row for this physical id, claim every remaining state.
     // Otherwise consume one state per row, preserving 1:1 alignment when the
     // original output wrote one row per state.
@@ -1309,6 +1317,16 @@ NodePaths InfomapBase::normalizeTreePaths(const TreePaths& tree, unsigned int& n
     }
     statesConsumed += statesToAssign;
     ++rowsConsumed;
+  }
+
+  if (numSplitPhysicalNodes > 0) {
+    Console::warn(0,
+                  "{} physical {} their states split across modules in this tree. A physical "
+                  "tree cannot express which state belongs to which module, so the states were paired "
+                  "with the rows in ascending state-id order and the partition read back is likely not "
+                  "the one that was written. Use the states tree (_states.tree) for an exact round trip.",
+                  numSplitPhysicalNodes,
+                  numSplitPhysicalNodes == 1 ? "node has" : "nodes have");
   }
 
   return normalized;

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1321,12 +1321,12 @@ NodePaths InfomapBase::normalizeTreePaths(const TreePaths& tree, unsigned int& n
 
   if (numSplitPhysicalNodes > 0) {
     Console::warn(0,
-                  "{} physical {} their states split across modules in this tree. A physical "
+                  "{} {} states split across modules in this tree. A physical "
                   "tree cannot express which state belongs to which module, so the states were paired "
                   "with the rows in ascending state-id order and the partition read back is likely not "
                   "the one that was written. Use the states tree (_states.tree) for an exact round trip.",
                   numSplitPhysicalNodes,
-                  numSplitPhysicalNodes == 1 ? "node has" : "nodes have");
+                  numSplitPhysicalNodes == 1 ? "physical node has its" : "physical nodes have their");
   }
 
   return normalized;

--- a/src/io/ClusterMap.cpp
+++ b/src/io/ClusterMap.cpp
@@ -88,10 +88,19 @@ void ClusterMap::readTree(const std::string& filename, bool includeFlow, const s
       throw std::runtime_error(fmt::format(FMT_STRING("Couldn't parse tree path from line '{}'"), line));
     if (!(lineStream >> flow))
       throw std::runtime_error(fmt::format(FMT_STRING("Couldn't parse node flow from line '{}'"), line));
-    if (!getline(lineStream, name, '"'))
+    // Everything between the first and the last quote, the same rule the network parser
+    // uses for Pajek vertex names. Reading up to the first quote with getline truncated
+    // a name that contains one and shifted the rest of the line, so Infomap could not
+    // read back its own .tree: "gene "X", alias" failed as "Couldn't parse node id"
+    // (#908). The written format is unchanged.
+    const auto flowEnd = lineStream.tellg();
+    const auto searchFrom = flowEnd < 0 ? std::size_t { 0 } : static_cast<std::size_t>(flowEnd);
+    const auto nameStart = line.find_first_of('"', searchFrom);
+    const auto nameEnd = line.find_last_of('"');
+    if (nameStart == std::string::npos || nameEnd <= nameStart)
       throw std::runtime_error(fmt::format(FMT_STRING("Can't parse node name from line {} ('{}')."), lineNr, line));
-    if (!getline(lineStream, name, '"'))
-      throw std::runtime_error(fmt::format(FMT_STRING("Can't parse node name from line {} ('{}')."), lineNr, line));
+    name = line.substr(nameStart + 1, nameEnd - nameStart - 1);
+    lineStream.seekg(static_cast<std::streamoff>(nameEnd + 1));
     if (!(lineStream >> parsedId))
       throw std::runtime_error(fmt::format(FMT_STRING("Couldn't parse node id from line '{}'"), line));
 

--- a/src/io/Output.cpp
+++ b/src/io/Output.cpp
@@ -176,7 +176,7 @@ std::string writeClu(InfomapBase& im, const StateNetwork& network, const std::st
   return outputFilename;
 }
 
-void writeTree(InfomapBase& im, const StateNetwork& network, std::ostream& outStream, bool states)
+void writeTree(InfomapBase& im, const StateNetwork& network, std::ostream& outStream, bool states, OutputLeafPolicy leafPolicy)
 {
   auto oldPrecision = outStream.precision();
   OutputView view(im, network, states);
@@ -193,7 +193,7 @@ void writeTree(InfomapBase& im, const StateNetwork& network, std::ostream& outSt
     outStream << "# path flow name " << view.nodeIdHeaderName() << "\n";
   }
 
-  view.forEachLeaf(1, OutputLeafPolicy::HideBipartiteUnlessFlowTree, [&](const OutputLeafRow& row) {
+  view.forEachLeaf(1, leafPolicy, [&](const OutputLeafRow& row) {
     outStream << io::stringify(row.path, ":") << " " << row.flow << " \"" << row.name << "\" ";
 
     if (states) {
@@ -438,7 +438,10 @@ void writeCsvTree(InfomapBase& im, const StateNetwork& network, std::ostream& ou
 
   view.forEachLeaf(1, OutputLeafPolicy::HideBipartite, [&](const OutputLeafRow& row) {
     const auto path = io::stringify(row.path, ":");
-    outStream << path << ',' << row.flow << ",\"" << row.name << "\",";
+    // RFC 4180: a quote inside a quoted field is written twice. Without it a name
+    // containing one closed the field early and the row came out with more columns than
+    // the header, so every CSV reader mis-parsed it (#908).
+    outStream << path << ',' << row.flow << ',' << io::csvQuoted(row.name) << ',';
 
     if (states) {
       outStream << row.stateId << ',';
@@ -456,7 +459,10 @@ std::string writeTree(InfomapBase& im, const StateNetwork& network, const std::s
 {
   auto outputFilename = getOutputFilename(im, filename, ".tree", states);
   SafeOutFile outFile { outputFilename, std::ios_base::out, im.overwriteOutput() };
-  writeTree(im, network, outFile, states);
+  // The .tree honours --hide-bipartite-nodes; only the flow tree below needs the
+  // feature nodes kept, and deciding it here rather than from the global printFlowTree
+  // flag is what stops --ftree from un-hiding them in this file too (#908).
+  writeTree(im, network, outFile, states, OutputLeafPolicy::HideBipartite);
   outFile.commit();
   return outputFilename;
 }
@@ -465,7 +471,8 @@ std::string writeFlowTree(InfomapBase& im, const StateNetwork& network, const st
 {
   auto outputFilename = getOutputFilename(im, filename, ".ftree", states);
   SafeOutFile outFile { outputFilename, std::ios_base::out, im.overwriteOutput() };
-  writeTree(im, network, outFile, states);
+  // The link section refers to the feature nodes, so they stay in this file.
+  writeTree(im, network, outFile, states, OutputLeafPolicy::KeepBipartite);
   writeTreeLinks(im, outFile, states);
   outFile.commit();
   return outputFilename;

--- a/src/io/OutputView.cpp
+++ b/src/io/OutputView.cpp
@@ -184,9 +184,8 @@ OutputModuleLinks OutputView::moduleLinks()
 
 bool OutputView::shouldIncludeLeaf(const InfoNode& node, OutputLeafPolicy filter) const
 {
-  const auto shouldHideBipartiteNodes = filter == OutputLeafPolicy::HideBipartiteUnlessFlowTree
-      ? !m_infomap.printFlowTree && m_infomap.isBipartite() && m_infomap.hideBipartiteNodes
-      : m_infomap.isBipartite() && m_infomap.hideBipartiteNodes;
+  const auto shouldHideBipartiteNodes = filter == OutputLeafPolicy::HideBipartite
+      && m_infomap.isBipartite() && m_infomap.hideBipartiteNodes;
 
   return !shouldHideBipartiteNodes || node.physicalId < m_network.bipartiteStartId();
 }

--- a/src/io/OutputView.h
+++ b/src/io/OutputView.h
@@ -24,8 +24,13 @@ class InfoNode;
 class StateNetwork;
 
 enum class OutputLeafPolicy : std::uint8_t {
+  //! Honour --hide-bipartite-nodes.
   HideBipartite,
-  HideBipartiteUnlessFlowTree
+  //! Keep the feature nodes whatever the option says, because the flow tree's link
+  //! section refers to them. Decided per output rather than from the global
+  //! printFlowTree flag: one writer serves both .tree and .ftree, so asking the flag
+  //! meant requesting --ftree also un-hid the nodes in the plain .tree (#908).
+  KeepBipartite
 };
 
 struct OutputLeafRow {

--- a/src/utils/convert.h
+++ b/src/utils/convert.h
@@ -232,6 +232,23 @@ namespace io {
   // both verified byte-for-byte against the previous iostream implementation.
   std::string toPrecision(double value, unsigned int precision = 10, bool fixed = false);
 
+  //! Render a value as an RFC 4180 quoted CSV field: wrapped in quotes, with any quote in
+  //! it written twice. Without the doubling a name containing a quote closes the field
+  //! early and the row gains a column, which every CSV reader then mis-parses (#908).
+  inline std::string csvQuoted(const std::string& value)
+  {
+    std::string quoted;
+    quoted.reserve(value.size() + 2);
+    quoted += '"';
+    for (const char c : value) {
+      if (c == '"')
+        quoted += '"';
+      quoted += c;
+    }
+    quoted += '"';
+    return quoted;
+  }
+
 } // namespace io
 
 } // namespace infomap

--- a/test/cpp/TestUtils.h
+++ b/test/cpp/TestUtils.h
@@ -3,6 +3,7 @@
 
 #include "vendor/doctest.h"
 #include "Infomap.h"
+#include "utils/Log.h"
 
 #include <algorithm>
 #include <cstdio>
@@ -116,6 +117,32 @@ inline std::unique_ptr<InfomapWrapper> makeRunningInfomap(SetupFn&& setup, const
   im->run();
   return im;
 }
+
+//! Capture Log output for the duration of a scope, restoring whatever was there before.
+//! The Log stream and the silent flag are process-global, so a test that sets them back
+//! to a fixed value instead of the previous one leaks state into whatever runs next.
+class ScopedLogCapture {
+public:
+  explicit ScopedLogCapture(std::ostream& sink)
+      : m_previous(Log::getOutputStream()), m_wasSilent(Log::isSilent())
+  {
+    Log::setSilent(false);
+    Log::setOutputStream(sink);
+  }
+
+  ~ScopedLogCapture()
+  {
+    Log::setOutputStream(m_previous);
+    Log::setSilent(m_wasSilent);
+  }
+
+  ScopedLogCapture(const ScopedLogCapture&) = delete;
+  ScopedLogCapture& operator=(const ScopedLogCapture&) = delete;
+
+private:
+  std::ostream& m_previous;
+  bool m_wasSilent;
+};
 
 inline std::string readTextFile(const std::string& path)
 {

--- a/test/cpp/test_output_view.cpp
+++ b/test/cpp/test_output_view.cpp
@@ -1,6 +1,7 @@
 #include "vendor/doctest.h"
 
 #include "Infomap.h"
+#include "io/Output.h"
 #include "io/OutputView.h"
 
 #include "TestUtils.h"
@@ -9,6 +10,7 @@
 #include <cstdio>
 #include <memory>
 #include <set>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -121,6 +123,98 @@ TEST_CASE("OutputView applies bipartite leaf filtering [fast][core][output]")
 
   std::sort(physicalIds.begin(), physicalIds.end());
   CHECK(physicalIds == std::vector<unsigned int> { 1, 2, 3 });
+}
+
+TEST_CASE("A node name with a quote survives the tree and csv writers [fast][core][output][parser]")
+{
+  // The writers emit the name between quotes with no escaping. The csv row then had one
+  // more column than its header, and Infomap could not read back its own .tree at all --
+  // "Couldn't parse node id" -- because the parser read up to the *first* quote (#908).
+  auto im = infomap::test::makeRunningInfomap([&](InfomapWrapper& infomap) {
+    infomap.readInputData(infomap::test::networkFixturePath("quoted_name.net"));
+  });
+
+  const std::string treePath = "quoted_name_roundtrip.tree";
+  const std::string csvPath = "quoted_name_roundtrip.csv";
+  std::remove(treePath.c_str());
+  std::remove(csvPath.c_str());
+
+  infomap::writeTree(*im, im->network(), treePath, false);
+  infomap::writeCsvTree(*im, im->network(), csvPath, false);
+
+  const auto tree = infomap::test::readTextFile(treePath);
+  const auto csv = infomap::test::readTextFile(csvPath);
+
+  // The tree keeps the name verbatim; the csv doubles the quote, per RFC 4180.
+  CHECK(tree.find("\"gene \"X\", alias\"") != std::string::npos);
+  CHECK(csv.find("\"gene \"\"X\"\", alias\"") != std::string::npos);
+
+  // Every csv row has the same number of fields as the header.
+  std::istringstream csvStream(csv);
+  std::string headerLine;
+  REQUIRE(std::getline(csvStream, headerLine));
+  const auto countFields = [](const std::string& line) {
+    std::size_t fields = 1;
+    bool inQuotes = false;
+    for (std::size_t i = 0; i < line.size(); ++i) {
+      if (line[i] == '"') {
+        const bool doubled = i + 1 < line.size() && line[i + 1] == '"';
+        if (doubled)
+          ++i;
+        else
+          inQuotes = !inQuotes;
+      } else if (line[i] == ',' && !inQuotes) {
+        ++fields;
+      }
+    }
+    return fields;
+  };
+  const auto headerFields = countFields(headerLine);
+  std::string row;
+  unsigned int rows = 0;
+  while (std::getline(csvStream, row)) {
+    if (row.empty())
+      continue;
+    ++rows;
+    CHECK(countFields(row) == headerFields);
+  }
+  CHECK(rows == 3);
+
+  // And the tree reads back through the documented path: the parser takes the name from
+  // the first quote to the last, the same rule the network parser uses.
+  InfomapWrapper reader(infomap::test::defaultFlags("--no-infomap --cluster-data " + treePath));
+  reader.readInputData(infomap::test::networkFixturePath("quoted_name.net"));
+  CHECK_NOTHROW(reader.run());
+  // Not checkRunSanity: this partition's codelength is exactly zero, which comes out as
+  // a negative epsilon that the helper rejects. What matters here is that the file was
+  // read at all and every node came back.
+  CHECK(reader.numLeafNodes() == 3);
+
+  std::remove(treePath.c_str());
+  std::remove(csvPath.c_str());
+}
+
+TEST_CASE("Bipartite hiding is decided per output, not by the flow-tree flag [fast][core][output]")
+{
+  auto im = infomap::test::makeRunningInfomap(
+      [&](InfomapWrapper& infomap) { infomap.readInputData(infomap::test::repoPath("examples/networks/bipartite.net")); });
+  im->hideBipartiteNodes = true;
+  // Asking for the flow tree used to un-hide the feature nodes in the plain .tree as
+  // well: one writer serves both files, so it consulted this global flag instead of
+  // being told which file it was writing (#908).
+  im->printFlowTree = true;
+
+  infomap::OutputView view(*im, im->network(), false);
+  auto physicalIdsWith = [&](infomap::OutputLeafPolicy policy) {
+    std::vector<unsigned int> ids;
+    view.forEachLeaf(1, policy, [&](const infomap::OutputLeafRow& row) { ids.push_back(row.physicalId); });
+    std::sort(ids.begin(), ids.end());
+    return ids;
+  };
+
+  CHECK(physicalIdsWith(infomap::OutputLeafPolicy::HideBipartite) == std::vector<unsigned int> { 1, 2, 3 });
+  // The flow tree keeps them, because its link section refers to them.
+  CHECK(physicalIdsWith(infomap::OutputLeafPolicy::KeepBipartite) == std::vector<unsigned int> { 1, 2, 3, 4, 5 });
 }
 
 TEST_CASE("OutputView owns module-link projection [fast][core][output]")

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -150,21 +150,20 @@ TEST_CASE("A physical tree that cannot express the partition says so [fast][core
 
   auto warningsWhenReading = [](const std::string& clusterFile) {
     std::ostringstream captured;
-    infomap::Log::setOutputStream(captured);
     {
+      infomap::test::ScopedLogCapture capture(captured);
       // Not defaultFlags: it carries --silent, which mutes the very warning under test.
       InfomapWrapper reader("--seed 123 --num-trials 1 --no-file-output --no-infomap --cluster-data " + clusterFile);
       reader.readInputData(infomap::test::repoPath("examples/networks/multilayer.net"));
       reader.run();
     }
-    infomap::Log::setOutputStream(std::cout);
     return captured.str();
   };
 
   const auto physicalOutput = warningsWhenReading(physicalTree);
   CHECK(physicalOutput.find("split across modules") != std::string::npos);
   // Singular, since exactly one physical node is split here.
-  CHECK(physicalOutput.find("1 physical node has") != std::string::npos);
+  CHECK(physicalOutput.find("1 physical node has its") != std::string::npos);
 
   // The states tree carries the state ids, so it round-trips and must stay quiet.
   const auto statesOutput = warningsWhenReading(statesTree);

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -2,13 +2,16 @@
 
 #include "Infomap.h"
 #include "io/InfomapError.h"
+#include "io/Output.h"
 
 #include "TestUtils.h"
 
 #include <algorithm>
+#include <cstdio>
 #include <limits>
 #include <map>
 #include <set>
+#include <iostream>
 #include <sstream>
 #include <tuple>
 #include <vector>
@@ -122,6 +125,53 @@ TEST_CASE("Tree cluster-data fixture initializes a multi-level tree [fast][core]
   im.run();
 
   infomap::test::checkRunSanity(im);
+}
+
+TEST_CASE("A physical tree that cannot express the partition says so [fast][core][partition][parser]")
+{
+  // A physical .tree has one row per (module, physical node) and no state ids, so when a
+  // physical node's states sit in different modules the file cannot say which state went
+  // where. The reader pairs ascending state ids against file order, which is a guess: on
+  // examples/networks/multilayer.net the partition comes back at 3.71206 bits against the
+  // 2.01141 that was written. The guess stays -- the information is not in the file -- but
+  // it is no longer silent (#908).
+  const std::string physicalTree = "physical_roundtrip.tree";
+  const std::string statesTree = "physical_roundtrip_states.tree";
+  std::remove(physicalTree.c_str());
+  std::remove(statesTree.c_str());
+
+  {
+    InfomapWrapper writer(infomap::test::defaultFlags("--seed 1"));
+    writer.readInputData(infomap::test::repoPath("examples/networks/multilayer.net"));
+    writer.run();
+    infomap::writeTree(writer, writer.network(), physicalTree, false);
+    infomap::writeTree(writer, writer.network(), statesTree, true);
+  }
+
+  auto warningsWhenReading = [](const std::string& clusterFile) {
+    std::ostringstream captured;
+    infomap::Log::setOutputStream(captured);
+    {
+      // Not defaultFlags: it carries --silent, which mutes the very warning under test.
+      InfomapWrapper reader("--seed 123 --num-trials 1 --no-file-output --no-infomap --cluster-data " + clusterFile);
+      reader.readInputData(infomap::test::repoPath("examples/networks/multilayer.net"));
+      reader.run();
+    }
+    infomap::Log::setOutputStream(std::cout);
+    return captured.str();
+  };
+
+  const auto physicalOutput = warningsWhenReading(physicalTree);
+  CHECK(physicalOutput.find("split across modules") != std::string::npos);
+  // Singular, since exactly one physical node is split here.
+  CHECK(physicalOutput.find("1 physical node has") != std::string::npos);
+
+  // The states tree carries the state ids, so it round-trips and must stay quiet.
+  const auto statesOutput = warningsWhenReading(statesTree);
+  CHECK(statesOutput.find("split across modules") == std::string::npos);
+
+  std::remove(physicalTree.c_str());
+  std::remove(statesTree.c_str());
 }
 
 TEST_CASE("Mixed-depth cluster data is rejected instead of crashing [fast][core][partition][parser]")

--- a/test/cpp/test_utils_io.cpp
+++ b/test/cpp/test_utils_io.cpp
@@ -394,3 +394,14 @@ TEST_CASE("toPrecision reproduces the legacy iostream output byte-for-byte [fast
 }
 
 } // namespace
+
+TEST_CASE("csvQuoted doubles a quote inside the field [fast][core][utils][io]")
+{
+  // RFC 4180. Without the doubling a node name containing a quote closed the field
+  // early, so the row came out with one more column than the header and every CSV
+  // reader mis-parsed it (#908).
+  CHECK(infomap::io::csvQuoted("plain") == "\"plain\"");
+  CHECK(infomap::io::csvQuoted("gene \"X\", alias") == "\"gene \"\"X\"\", alias\"");
+  CHECK(infomap::io::csvQuoted("") == "\"\"");
+  CHECK(infomap::io::csvQuoted("\"") == "\"\"\"\"");
+}

--- a/test/fixtures/networks/quoted_name.net
+++ b/test/fixtures/networks/quoted_name.net
@@ -1,0 +1,10 @@
+# A node name containing a double quote, which the .tree writer emits verbatim and the
+# tree parser has to read back: the name field runs from the first quote to the last.
+*Vertices
+1 "gene "X", alias"
+2 "b"
+3 "c"
+*Edges
+1 2
+2 3
+3 1


### PR DESCRIPTION
Closes #908 — all three boxes. The third one you flagged as needing a decision turned
out not to: the fix is to stop being silently wrong, not to change the format.

## `--hide-bipartite-nodes` was ignored when `--ftree` was also requested

| flags | `.tree` node rows before | after |
| --- | --- | --- |
| `-o tree --hide-bipartite-nodes` | 3 | 3 |
| `-o tree,ftree --hide-bipartite-nodes` | **5** | 3 |

One writer serves both files, so it could not tell which one it was producing and asked
the global `printFlowTree` flag instead — requesting the flow tree *anywhere* un-hid the
feature nodes in the plain tree. The policy is now an argument: the `.tree` hides, the
`.ftree` keeps them because its link section refers to them, and the flag is not
consulted.

## A quote in a node name broke the csv and the tree

```
before:  1:1,0.333333,"gene "X", alias",1     ← 5 fields against a 4-column header
after:   1:1,0.333333,"gene ""X"", alias",1   ← RFC 4180
```

And Infomap could not read back its own `.tree`:

```
$ ./Infomap q.net out -c q.tree --no-infomap
Error: Couldn't parse node id from line '1:2 0.166667 "gene "X", alias" 1'
$ echo $?   # 7
```

because the tree parser read up to the **first** quote with `getline`, truncating the
name and shifting the rest of the line. It now takes the name from the first quote to
the last — the rule the *network* parser already used for Pajek vertex names, which is
why `.net` output round-tripped fine all along. So the written `.tree` format is
unchanged and no downstream tool has to adapt; only the reader got stricter about where
the name ends.

I checked the other writers rather than assuming: the JSON output escapes correctly
(nlohmann), and the `.net` writer plus its parser already agree. So the defect was
exactly the two artifacts named in the issue.

## A physical tree that cannot express the partition now says so

A higher-order network's physical `.tree` has one row per (module, physical node) and no
state ids. When a physical node's states sit in different modules, **which state went
where is not in the file** — so this cannot be fixed by reading more carefully:

```
written:   2.01141 bits
read back: 3.71206 bits, silently
```

The reader pairs ascending state ids against file order, which is a guess. It stays a
guess, and now says so:

> Warning: 1 physical node has their states split across modules in this tree. A physical
> tree cannot express which state belongs to which module, so the states were paired with
> the rows in ascending state-id order and the partition read back is likely not the one
> that was written. Use the states tree (_states.tree) for an exact round trip.

Verified that the states tree does round-trip exactly (2.01141 → 2.01141) and stays
quiet. Nothing is refused and no format changes — the documented ability to read a
physical tree keeps working, including the common case where no node is split, which is
exact.

## Verification

Four new tests, each mutation-checked: making the policy ask the global flag again,
dropping the RFC 4180 doubling, pointing the parser at the first closing quote, and
disabling the ambiguity count each fail the suite. `make test-native` 100% of 25,
`pytest -m fast` 638 passed against a rebuilt extension.

Two things worth knowing for anyone extending these tests, both of which cost me a
detour: `infomap::test::defaultFlags` carries `--silent`, which mutes the warning the
third test asserts, and `checkRunSanity` rejects a codelength of exactly zero because it
arrives as `-6.1e-15`.