### PR TITLE
fix: make distributed runs publishable, verifiable and interruptible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,15 @@ if(BUILD_TESTING)
     set_tests_properties(shell_completion PROPERTIES LABELS "fast;core;parser;cli")
 
     add_test(
+        NAME interrupted_artifact
+        COMMAND
+            "${Python3_EXECUTABLE}"
+            "${CMAKE_CURRENT_SOURCE_DIR}/test/scripts/check_interrupted_artifact.py"
+            "$<TARGET_FILE:infomap_cli>"
+    )
+    set_tests_properties(interrupted_artifact PROPERTIES LABELS "core;cli;crash")
+
+    add_test(
         NAME help_contract
         COMMAND
             "${Python3_EXECUTABLE}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,7 +235,8 @@ if(BUILD_TESTING)
             "${CMAKE_CURRENT_SOURCE_DIR}/test/scripts/check_interrupted_artifact.py"
             "$<TARGET_FILE:infomap_cli>"
     )
-    set_tests_properties(interrupted_artifact PROPERTIES LABELS "core;cli;crash")
+    # 77 = skipped: the script needs POSIX signal delivery, which Windows does not have.
+    set_tests_properties(interrupted_artifact PROPERTIES LABELS "core;cli;crash" SKIP_RETURN_CODE 77)
 
     add_test(
         NAME help_contract

--- a/interfaces/python/src/infomap/merge.py
+++ b/interfaces/python/src/infomap/merge.py
@@ -133,9 +133,15 @@ def _load_shard(path: str) -> dict:
 
 
 def _validate_consistent(shards: Sequence[tuple[str, dict]]) -> None:
-    """All shards must share the same non-empty network + config fingerprint."""
+    """All shards must share the same network, configuration and Infomap build.
+
+    ``infomap_version`` is checked alongside the fingerprints because a different
+    build can partition the same network differently -- a fixed bug changes results
+    exactly as much as a changed option does -- and the field was handed to us and
+    then ignored.
+    """
     first_path, first = shards[0]
-    for field in ("network_fingerprint", "config_fingerprint"):
+    for field in ("network_fingerprint", "config_fingerprint", "infomap_version"):
         value = first.get(field, "")
         if not value:
             raise MergeError(
@@ -172,6 +178,21 @@ def _covered_indices(shards: Sequence[tuple[str, dict]]) -> set:
     return {int(t["trial"]) for _, s in shards for t in s["trials"]}
 
 
+def _duplicate_indices(shards: Sequence[tuple[str, dict]]) -> dict[int, list[str]]:
+    """Global trial indices claimed more than once, mapped to the shards claiming them.
+
+    Shards that overlap -- or that were all launched with the same --trial-offset --
+    contribute fewer independent trials than the executions suggest, while the gap
+    check below sees a contiguous range and reports the budget as complete. Four
+    shards of two trials each at offset 0 merged as "2 trials from 4 shard(s)".
+    """
+    claims: dict[int, list[str]] = {}
+    for path, shard in shards:
+        for trial in shard["trials"]:
+            claims.setdefault(int(trial["trial"]), []).append(path)
+    return {index: paths for index, paths in claims.items() if len(paths) > 1}
+
+
 def _resolve_best_tree(shard_path: str, best_tree_file: str) -> str:
     """Resolve best_tree_file relative to the shard JSON's directory."""
     if not best_tree_file:
@@ -184,37 +205,63 @@ def _resolve_best_tree(shard_path: str, best_tree_file: str) -> str:
     return os.path.join(os.path.dirname(shard_path), best_tree_file)
 
 
-def _write_clu_from_tree(tree_path: str, clu_path: str) -> None:
-    """Derive a .clu (node -> top-level module + flow) from a .tree file.
+def _parse_tree_row(line: str) -> tuple[str, str, list[str]] | None:
+    """Split a .tree leaf row into (path, flow, trailing ids), or None if it is not one.
 
-    .tree node lines are ``path flow "name" node_id``; the top-level module is
-    the first component of the colon-separated path. We read node_id (last
-    token), flow (second token) and path (first token); the name is ignored.
+    Rows are ``path flow "name" id...``, and the name is taken from the first quote to
+    the last, the same rule Infomap's own tree parser uses. Splitting on whitespace and
+    indexing from the left breaks on a name containing a space; taking the last token
+    breaks on a state row, where the trailing ids are ``state_id node_id [layer_id]``.
     """
-    # node_id may be a non-numeric label, so it stays str when not all-digits.
-    rows: list[tuple[int | str, int, str]] = []
+    head, quote, rest = line.partition('"')
+    if not quote:
+        return None
+    name_end = rest.rfind('"')
+    if name_end < 0:
+        return None
+    head_tokens = head.split()
+    if len(head_tokens) < 2:
+        return None
+    trailing = rest[name_end + 1 :].split()
+    if not trailing:
+        return None
+    return head_tokens[0], head_tokens[1], trailing
+
+
+def _write_clu_from_tree(tree_path: str, clu_path: str, states: bool = False) -> None:
+    """Derive a .clu from a .tree, mirroring the columns Infomap writes itself.
+
+    Physical: ``# node_id module flow``. State-level: ``# state_id module flow node_id
+    [layer_id]``, keyed on the state id -- a higher-order network's physical rows repeat
+    the same node id under several modules, so a .clu keyed on it cannot express the
+    partition at all (#906).
+    """
+    rows: list[tuple[str, int, str, list[str]]] = []
     with open(tree_path, encoding="utf-8") as fh:
         for line in fh:
             line = line.strip()
             if not line or line.startswith("#"):
                 continue
-            tokens = line.split()
-            if len(tokens) < 4:
-                continue  # not a leaf node line
-            path, flow, node_id = tokens[0], tokens[1], tokens[-1]
+            parsed = _parse_tree_row(line)
+            if parsed is None:
+                continue
+            path, flow, trailing = parsed
             try:
                 top_module = int(path.split(":")[0])
             except ValueError:
                 continue
-            rows.append(
-                (int(node_id) if node_id.isdigit() else node_id, top_module, flow)
-            )
+            rows.append((trailing[0], top_module, flow, trailing[1:]))
+
+    header = (
+        "# state_id module flow node_id layer_id" if states else "# node_id module flow"
+    )
     tmp_path = clu_path + ".tmp"
     with open(tmp_path, "w", encoding="utf-8") as out:
         out.write("# produced by infomap.merge\n")
-        out.write("# node_id module flow\n")
-        for node_id, module, flow in rows:
-            out.write(f"{node_id} {module} {flow}\n")
+        out.write(header + "\n")
+        for key, module, flow, extra in rows:
+            trailing = (" " + " ".join(extra)) if states and extra else ""
+            out.write(f"{key} {module} {flow}{trailing}\n")
     os.replace(tmp_path, clu_path)  # atomic on POSIX/Windows
 
 
@@ -268,6 +315,23 @@ def merge_trial_results(
             f"'{winner_tree}'"
         )
 
+    # Independence check: the same global trial index in two shards is the same trial
+    # run twice, not two trials, so the effective budget is smaller than it looks.
+    duplicates = _duplicate_indices(shards)
+    if duplicates:
+        shown = sorted(duplicates)[:10]
+        detail = ", ".join(
+            f"{index} in {len(duplicates[index])} shards" for index in shown
+        )
+        msg = (
+            f"{len(duplicates)} global trial index(es) claimed by more than one shard "
+            f"({detail}{', …' if len(duplicates) > len(shown) else ''}); the shards "
+            "overlap, so they contribute fewer independent trials than they ran"
+        )
+        if require_complete:
+            raise MergeError(msg)
+        print(f"Warning: {msg}", file=sys.stderr)
+
     # Completeness check over the global trial range.
     covered = _covered_indices(shards)
     max_index = max(covered)
@@ -296,6 +360,29 @@ def merge_trial_results(
         os.makedirs(os.path.dirname(clu_out) or ".", exist_ok=True)
         _write_clu_from_tree(winner_tree, clu_out)
         outputs.append(clu_out)
+
+    # Higher-order shards also record the state-level tree, which is the partition the
+    # run actually found: the physical one is a projection that repeats a node id across
+    # modules. Published alongside so a distributed higher-order analysis is recoverable
+    # at all (#906).
+    winner_states_tree = winner_shard.get("best_states_tree_file", "")
+    if winner_states_tree:
+        states_tree = _resolve_best_tree(shard_path, winner_states_tree)
+        if not os.path.isfile(states_tree):
+            raise MergeError(
+                f"winning trial's state-level tree does not exist or is not a file: "
+                f"'{states_tree}'"
+            )
+        if "tree" in formats:
+            states_tree_out = out_name + "_states.tree"
+            states_tmp = states_tree_out + ".tmp"
+            shutil.copyfile(states_tree, states_tmp)
+            os.replace(states_tmp, states_tree_out)
+            outputs.append(states_tree_out)
+        if "clu" in formats:
+            states_clu_out = out_name + "_states.clu"
+            _write_clu_from_tree(states_tree, states_clu_out, states=True)
+            outputs.append(states_clu_out)
 
     return {
         "trial": int(winner["trial"]),

--- a/interfaces/python/src/infomap/merge.py
+++ b/interfaces/python/src/infomap/merge.py
@@ -231,8 +231,8 @@ def _parse_tree_row(line: str) -> tuple[str, str, list[str]] | None:
 def _write_clu_from_tree(tree_path: str, clu_path: str, states: bool = False) -> None:
     """Derive a .clu from a .tree, mirroring the columns Infomap writes itself.
 
-    Physical: ``# node_id module flow``. State-level: ``# state_id module flow node_id
-    [layer_id]``, keyed on the state id -- a higher-order network's physical rows repeat
+    Physical: ``# node_id module flow``. State-level: ``# state_id module flow node_id``
+    plus ``layer_id`` when the rows carry one, keyed on the state id -- a higher-order network's physical rows repeat
     the same node id under several modules, so a .clu keyed on it cannot express the
     partition at all (#906).
     """
@@ -252,9 +252,15 @@ def _write_clu_from_tree(tree_path: str, clu_path: str, states: bool = False) ->
                 continue
             rows.append((trailing[0], top_module, flow, trailing[1:]))
 
-    header = (
-        "# state_id module flow node_id layer_id" if states else "# node_id module flow"
-    )
+    if states:
+        # Infomap's own _states.clu adapts its columns: a memory network's state rows are
+        # "state_id node_id" while multilayer adds the layer. Advertising layer_id
+        # unconditionally would name a column the rows do not have.
+        trailing_columns = max((len(extra) for _, _, _, extra in rows), default=0)
+        names = ["node_id", "layer_id"][:trailing_columns]
+        header = " ".join(["# state_id", "module", "flow", *names])
+    else:
+        header = "# node_id module flow"
     tmp_path = clu_path + ".tmp"
     with open(tmp_path, "w", encoding="utf-8") as out:
         out.write("# produced by infomap.merge\n")

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1000,6 +1000,20 @@ public:
           m_infomap.writeTree(treeAbsPath, false);
         }
 
+        // For higher-order input the physical tree is a projection: the same node id
+        // appears under several modules, so it cannot express the partition that was
+        // found. Write the state-level companion too, since this file is the only
+        // artifact infomap.merge reads and --no-final-output (which the HPC recipe
+        // prescribes) means nothing else writes it (#906).
+        std::string statesTreeAbsPath;
+        if (m_infomap.haveMemory()) {
+          statesTreeAbsPath = outputFilenameForResultKey(treeBasename + "_states", "tree");
+          if (!pathExists(statesTreeAbsPath) || m_infomap.overwriteOutput()) {
+            auto outputTimer = m_timing.scope("output_s");
+            m_infomap.writeTree(statesTreeAbsPath, true);
+          }
+        }
+
         // Store the tree path relative to the results file's directory, so the
         // merge tool can resolve it from wherever the results file lives.
         std::string resultsDir;
@@ -1007,15 +1021,19 @@ public:
         if (lastSlash != std::string::npos) {
           resultsDir = m_infomap.trialResultsPath.substr(0, lastSlash + 1);
         }
-        if (!resultsDir.empty() && treeAbsPath.substr(0, resultsDir.size()) == resultsDir) {
-          // Tree lives under the results directory — store the relative remainder.
-          trialResultsFile.bestTreeFile = treeAbsPath.substr(resultsDir.size());
-        } else {
-          // Results file is in the CWD (resultsDir empty) or an unrelated
-          // directory: the tree path as written (relative to the CWD) is correct.
-          // Stripping to a basename here would drop the output-directory prefix.
-          trialResultsFile.bestTreeFile = treeAbsPath;
-        }
+        const auto relativeToResults = [&resultsDir](const std::string& path) {
+          if (!resultsDir.empty() && path.substr(0, resultsDir.size()) == resultsDir) {
+            // File lives under the results directory — store the relative remainder.
+            return path.substr(resultsDir.size());
+          }
+          // Results file is in the CWD (resultsDir empty) or an unrelated directory: the
+          // path as written (relative to the CWD) is correct. Stripping to a basename
+          // here would drop the output-directory prefix.
+          return path;
+        };
+        trialResultsFile.bestTreeFile = relativeToResults(treeAbsPath);
+        if (!statesTreeAbsPath.empty())
+          trialResultsFile.bestStatesTreeFile = relativeToResults(statesTreeAbsPath);
       }
 
       writeJsonReport(m_infomap.trialResultsPath, serializeTrialResults(trialResultsFile), m_infomap.overwriteOutput());

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -474,6 +474,12 @@ private:
           if (worker.printAllTrials && m_numTrials > 1) {
             std::lock_guard<std::mutex> lock(outputMutex);
             auto outputTimer = m_timing.scope("output_s");
+            // Record this worker's one trial before it writes, so the header's
+            // "trials N of M" describes the file. The worker never pushes into
+            // m_codelengths itself -- that happens on the serial path -- and an
+            // artifact that reported 0 trials would be worse than none (#906).
+            if (worker.m_codelengths.empty())
+              worker.m_codelengths.push_back(trialCodelength);
             worker.writeResult(static_cast<int>(m_infomap.trialOffset + trialIndex + 1));
           }
 

--- a/src/io/Config.h
+++ b/src/io/Config.h
@@ -72,7 +72,7 @@ struct Config {
   double metaDataRate = 1.0;
   bool unweightedMetaData = false;
   unsigned int numMetaDataDimensions = 0;
-  bool clusterDataIsHard = false; // FIXME Not used
+  bool clusterDataIsHard = false; // Keep the initial partition instead of optimizing it away
   bool assignToNeighbouringModule = false;
   bool noInfomap = false;
 

--- a/src/io/Output.cpp
+++ b/src/io/Output.cpp
@@ -123,6 +123,7 @@ std::string getOutputFileHeader(const InfomapBase& im, const StateNetwork& netwo
                                 "# ./Infomap {}\n"
                                 "# started at {}\n"
                                 "# completed in {:g} s\n"
+                                "# trials {} of {}\n"
                                 "# partitioned into {} levels with {} top modules\n"
                                 "# codelength {:g} bits\n"
                                 "# relative codelength savings {:g}%\n"
@@ -131,6 +132,15 @@ std::string getOutputFileHeader(const InfomapBase& im, const StateNetwork& netwo
                      im.parsedString,
                      io::stringify(im.getStartDate()),
                      im.getElapsedTime().getElapsedTimeInSec(),
+                     // Trials that actually produced this tree, against the budget that
+                     // was asked for. An interrupted run leaves a complete, well-formed
+                     // best-of-k artifact whose command line claims the full budget, and
+                     // nothing else in the file said otherwise -- a pipeline collecting
+                     // *.tree could not tell a 500-trial search from an aborted one
+                     // (#906). Written on every artifact, so it needs no rewriting at
+                     // interrupt time, when doing work is least reliable.
+                     im.codelengths().size(),
+                     im.numTrials,
                      im.maxTreeDepth(),
                      im.numTopModules(),
                      im.codelength(),

--- a/src/io/RunMetadata.cpp
+++ b/src/io/RunMetadata.cpp
@@ -134,6 +134,10 @@ std::string canonicalConfigJson(const Config& config)
   json["flow_model"] = flowModelToString(config.flowModel);
   json["directed"] = config.directed;
   addCanonicalNumber(json, "seed", config.seedToRandomNumberGenerator);
+#if INFOMAP_FEATURE_LOSSY_MAP_EQUATION
+  json["lossy"] = config.lossy;
+  addCanonicalNumber(json, "lossy_lambda", config.lossyLambda);
+#endif
   json["two_level"] = config.twoLevel;
   json["no_infomap"] = config.noInfomap;
   json["regularized"] = config.regularized;
@@ -155,6 +159,11 @@ std::string canonicalConfigJson(const Config& config)
   json["bipartite"] = config.bipartite;
   json["bipartite_teleportation"] = config.bipartiteTeleportation;
   json["cluster_data"] = config.clusterDataFile;
+  // Whether that initial partition is kept or optimized away, and where nodes the file
+  // does not mention end up: both change the partition, and both were missing, so two
+  // shards that disagreed on them fingerprinted identically and merged (#906).
+  json["cluster_data_is_hard"] = config.clusterDataIsHard;
+  json["assign_to_neighbouring_module"] = config.assignToNeighbouringModule;
   json["meta_data"] = config.metaDataFile;
   addCanonicalNumber(json, "meta_data_rate", config.metaDataRate);
   json["meta_data_unweighted"] = config.unweightedMetaData;
@@ -182,6 +191,7 @@ std::string canonicalConfigJson(const Config& config)
   addCanonicalNumber(json, "multilayer_relax_limit_up", config.multilayerRelaxLimitUp);
   addCanonicalNumber(json, "multilayer_relax_limit_down", config.multilayerRelaxLimitDown);
   addCanonicalNumber(json, "multilayer_js_relax_rate", config.multilayerJSRelaxRate);
+  json["multilayer_relax_to_self"] = config.multilayerRelaxToSelf;
   json["multilayer_relax_by_jsd"] = config.multilayerRelaxByJensenShannonDivergence;
   addCanonicalNumber(json, "multilayer_js_relax_limit", config.multilayerJSRelaxLimit);
   json["no_coarse_tune"] = config.noCoarseTune;

--- a/src/io/TrialResults.cpp
+++ b/src/io/TrialResults.cpp
@@ -35,6 +35,8 @@ std::string serializeTrialResults(const TrialResultsFile& r)
   json["trial_offset"] = r.trialOffset;
   json["num_trials"] = r.numTrials;
   json["best_tree_file"] = r.bestTreeFile;
+  if (!r.bestStatesTreeFile.empty())
+    json["best_states_tree_file"] = r.bestStatesTreeFile;
 
   Json trials = Json::array();
   for (const auto& t : r.trials) {

--- a/src/io/TrialResults.h
+++ b/src/io/TrialResults.h
@@ -33,6 +33,11 @@ struct TrialResultsFile {
   unsigned int trialOffset = 0;
   unsigned int numTrials = 0;
   std::string bestTreeFile; // path relative to this results file's directory
+  // The state-level companion for higher-order input, same relative form. Empty for
+  // first-order networks. Without it a distributed higher-order run published only the
+  // physical projection, where one node id appears in several modules, and the merged
+  // .clu inherited that (#906).
+  std::string bestStatesTreeFile;
   std::vector<TrialResultEntry> trials;
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,6 +68,10 @@ int run(const std::string& flags)
     // not abort the next one at its first checkpoint.
     g_cliInterruptRequested = 0;
     std::signal(SIGINT, cliHandleInterrupt);
+    // SIGTERM too: SLURM time limits, `timeout`, preemption and the OOM killer all send
+    // it, and it was unhandled, so the process died at whatever point it had reached and
+    // left an artifact nothing had a chance to describe (#906).
+    std::signal(SIGTERM, cliHandleInterrupt);
     im.setInterruptHandler(&cliInterruptPoll);
 #else
     if (g_runInterruptCallback != nullptr)

--- a/test/cpp/test_output_view.cpp
+++ b/test/cpp/test_output_view.cpp
@@ -125,6 +125,25 @@ TEST_CASE("OutputView applies bipartite leaf filtering [fast][core][output]")
   CHECK(physicalIds == std::vector<unsigned int> { 1, 2, 3 });
 }
 
+TEST_CASE("The tree header records how many trials produced it [fast][core][output]")
+{
+  // The header recorded the requested --num-trials and an elapsed time but never the
+  // trials that actually ran, so the artifact an interrupted run leaves behind was
+  // indistinguishable from a complete search (#906).
+  auto im = infomap::test::makeRunningInfomap(
+      [&](InfomapWrapper& infomap) { infomap.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net")); },
+      "--num-trials 3");
+
+  const std::string treePath = "trial_count_header.tree";
+  std::remove(treePath.c_str());
+  infomap::writeTree(*im, im->network(), treePath, false);
+
+  const auto tree = infomap::test::readTextFile(treePath);
+  CHECK(tree.find("# trials 3 of 3") != std::string::npos);
+
+  std::remove(treePath.c_str());
+}
+
 TEST_CASE("A node name with a quote survives the tree and csv writers [fast][core][output][parser]")
 {
   // The writers emit the name between quotes with no escaping. The csv row then had one

--- a/test/python/test_config_fingerprint_coverage.py
+++ b/test/python/test_config_fingerprint_coverage.py
@@ -30,6 +30,12 @@ KEY_OVERRIDES = {
     "--to-nodes": "teleport_to_nodes",
     "--converge": "converge_trials",
     "--markov-time": "markov_time",
+    # The manifest namespaces this one, matching the Config member and saying lambda of
+    # what: a bare "lambda" in a configuration record names nothing. Only present in the
+    # catalog when INFOMAP_FEATURE_LOSSY_MAP_EQUATION is compiled in, so a default build
+    # never reaches this entry -- it is here so a lossy build does not trip over the
+    # flag-to-key convention.
+    "--lambda": "lossy_lambda",
 }
 
 # Deliberately outside the fingerprint, with the reason. Anything else must be covered.

--- a/test/python/test_config_fingerprint_coverage.py
+++ b/test/python/test_config_fingerprint_coverage.py
@@ -1,0 +1,94 @@
+"""The config fingerprint has to cover every option that can change the partition.
+
+It is the only thing standing between a distributed run and merging shards that were run
+with different algorithms, and it is enumerated by hand in ``canonicalConfigJson``. Four
+options had been missed, so shards that disagreed on them fingerprinted identically and
+merged without complaint (#906). This test walks the generated parameter catalog, so a
+new option fails it until it is either covered or listed below with a reason.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import infomap
+import pytest
+
+pytestmark = pytest.mark.fast
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CATALOG = REPO_ROOT / "interfaces" / "js" / "generated" / "parameters.json"
+
+# Groups whose options change what the algorithm computes. Input options are covered by
+# the network fingerprint instead, except where they change interpretation rather than
+# content -- those are asserted individually further down.
+RESULT_AFFECTING_GROUPS = ("Algorithm", "Accuracy")
+
+# Options whose fingerprint key is not the flag name with dashes swapped for underscores.
+KEY_OVERRIDES = {
+    "--to-nodes": "teleport_to_nodes",
+    "--converge": "converge_trials",
+    "--markov-time": "markov_time",
+}
+
+# Deliberately outside the fingerprint, with the reason. Anything else must be covered.
+INTENTIONALLY_EXCLUDED = {
+    "--num-trials": "names which slice of one budget a shard ran, not what it ran",
+    "--trial-offset": "same: shards differ here by construction",
+}
+
+
+def _fingerprint_config(tmp_path: Path) -> dict:
+    """Run Infomap once and return the canonical config object from its manifest."""
+    manifest = tmp_path / "manifest.json"
+    im = infomap.Infomap(
+        silent=True,
+        options=infomap.Options(manifest_json=str(manifest)),
+    )
+    im.add_links(((1, 2), (2, 3), (3, 1)))
+    im.run()
+    return json.loads(manifest.read_text())["config"]
+
+
+def _flag_to_key(flag: str) -> str:
+    return KEY_OVERRIDES.get(flag, flag.lstrip("-").replace("-", "_"))
+
+
+def test_every_result_affecting_option_is_in_the_fingerprint(tmp_path):
+    config = _fingerprint_config(tmp_path)
+    catalog = json.loads(CATALOG.read_text())
+
+    uncovered = []
+    for parameter in catalog:
+        flag = parameter["long"]
+        if parameter["group"] not in RESULT_AFFECTING_GROUPS:
+            continue
+        if flag in INTENTIONALLY_EXCLUDED:
+            continue
+        if _flag_to_key(flag) not in config:
+            uncovered.append(f"{flag} (expected key {_flag_to_key(flag)!r})")
+
+    assert not uncovered, (
+        "these options can change the partition but are missing from the config "
+        "fingerprint, so two shards that disagree on them would merge:\n  "
+        + "\n  ".join(sorted(uncovered))
+        + "\n\nAdd them to canonicalConfigJson, or list them in "
+        "INTENTIONALLY_EXCLUDED with the reason."
+    )
+
+
+def test_interpretation_changing_input_options_are_in_the_fingerprint(tmp_path):
+    """Input options that change how the same file is read, not which file is read.
+
+    The network fingerprint covers the file's content, so most Input options need no
+    entry -- but these decide what the engine does with it, and both were missing.
+    """
+    config = _fingerprint_config(tmp_path)
+
+    for key in (
+        "cluster_data",
+        "cluster_data_is_hard",
+        "assign_to_neighbouring_module",
+    ):
+        assert key in config, f"{key} is missing from the config fingerprint"

--- a/test/python/test_merge.py
+++ b/test/python/test_merge.py
@@ -130,6 +130,133 @@ def test_merge_refuses_config_fingerprint_mismatch(tmp_path):
         merge_trial_results([str(tmp_path / "*.json")], out_name=str(tmp_path / "o"))
 
 
+def test_merge_publishes_the_state_level_artifacts(tmp_path):
+    """A higher-order shard records both trees; both have to reach the merged output.
+
+    The physical tree is a projection that repeats a node id across modules, so the .clu
+    derived from it cannot express the partition — and it was the only thing merge wrote
+    (#906).
+    """
+    shard = _shard(
+        tmp_path, "s", offset=0, trials=[(0, 2.5)], best_tree_modules={1: 1, 2: 2}
+    )
+    data = json.loads(Path(shard).read_text())
+    states_name = "s_trial_0_states.tree"
+    (tmp_path / states_name).write_text(
+        "# path flow name state_id node_id layer_id\n"
+        '1:1 0.25 "a" 0 1 1\n'
+        '1:2 0.25 "b" 1 2 1\n'
+        '2:1 0.25 "a" 2 1 2\n'
+        '2:2 0.25 "b" 3 2 2\n'
+    )
+    data["best_states_tree_file"] = states_name
+    Path(shard).write_text(json.dumps(data))
+
+    summary = merge_trial_results([shard], out_name=str(tmp_path / "out"))
+
+    states_tree = tmp_path / "out_states.tree"
+    states_clu = tmp_path / "out_states.clu"
+    assert states_tree.exists()
+    assert states_clu.exists()
+    assert str(states_tree) in summary["outputs"]
+    assert str(states_clu) in summary["outputs"]
+
+    # Keyed on the state id, with the physical id and layer kept, the way Infomap writes
+    # its own _states.clu. Node 1 appears twice, under different modules — which is
+    # exactly what the physical clu cannot say.
+    rows = [
+        line.split()
+        for line in states_clu.read_text().splitlines()
+        if line and not line.startswith("#")
+    ]
+    assert rows[0] == ["0", "1", "0.25", "1", "1"]
+    assert rows[2] == ["2", "2", "0.25", "1", "2"]
+
+
+def test_clu_derivation_survives_a_space_in_a_node_name(tmp_path):
+    """Rows are ``path flow "name" id``, and the name may contain spaces."""
+    shard = _shard(
+        tmp_path, "s", offset=0, trials=[(0, 2.5)], best_tree_modules={1: 1, 2: 2}
+    )
+    tree = tmp_path / json.loads(Path(shard).read_text())["best_tree_file"]
+    tree.write_text(
+        '# path flow name node_id\n1:1 0.5 "gene X, alias" 1\n2:1 0.5 "plain" 2\n'
+    )
+
+    merge_trial_results([shard], out_name=str(tmp_path / "out"))
+
+    rows = [
+        line.split()
+        for line in (tmp_path / "out.clu").read_text().splitlines()
+        if line and not line.startswith("#")
+    ]
+    assert rows == [["1", "1", "0.5"], ["2", "2", "0.5"]]
+
+
+def test_merge_refuses_overlapping_shard_ranges(tmp_path):
+    """Four shards that all ran trials 0-1 are eight executions, not eight trials.
+
+    The completeness check looks for gaps in [0, max], which overlapping shards do not
+    have, so --require-complete-trials reported success while the effective budget was a
+    quarter of the intended one (#906).
+    """
+    shards = [
+        _shard(
+            tmp_path,
+            f"s{i}",
+            offset=0,
+            trials=[(0, 2.5), (1, 2.4)],
+            best_tree_modules={1: 1, 2: 1, 3: 2},
+        )
+        for i in range(4)
+    ]
+
+    with pytest.raises(MergeError, match="claimed by more than one shard"):
+        merge_trial_results(
+            shards, out_name=str(tmp_path / "out"), require_complete=True
+        )
+
+
+def test_overlapping_shard_ranges_warn_without_require_complete(tmp_path, capsys):
+    """Without the flag the merge still runs, but says the shards overlap."""
+    shards = [
+        _shard(
+            tmp_path,
+            f"s{i}",
+            offset=0,
+            trials=[(0, 2.5), (1, 2.4)],
+            best_tree_modules={1: 1, 2: 1, 3: 2},
+        )
+        for i in range(2)
+    ]
+
+    summary = merge_trial_results(shards, out_name=str(tmp_path / "out"))
+
+    assert summary["num_trials"] == 2
+    assert "claimed by more than one shard" in capsys.readouterr().err
+
+
+def test_merge_refuses_shards_from_different_builds(tmp_path):
+    """A different Infomap build can partition the same network differently.
+
+    The field was recorded in every shard and never read, so shards from two builds
+    merged silently -- a fixed bug changes results exactly as much as a changed option
+    does (#906).
+    """
+    first = _shard(
+        tmp_path, "a", offset=0, trials=[(0, 2.5)], best_tree_modules={1: 1, 2: 1, 3: 2}
+    )
+    second = _shard(
+        tmp_path, "b", offset=1, trials=[(1, 2.4)], best_tree_modules={1: 1, 2: 2, 3: 2}
+    )
+    data = json.loads(Path(second).read_text())
+    data["infomap_version"] = "some-other-build"
+    Path(second).write_text(json.dumps(data))
+
+    with pytest.raises(MergeError, match="infomap_version mismatch"):
+        merge_trial_results([first, second], out_name=str(tmp_path / "out"))
+
+
 def test_merge_refuses_network_fingerprint_mismatch(tmp_path):
     _shard(
         tmp_path,

--- a/test/python/test_merge.py
+++ b/test/python/test_merge.py
@@ -173,6 +173,35 @@ def test_merge_publishes_the_state_level_artifacts(tmp_path):
     assert rows[2] == ["2", "2", "0.25", "1", "2"]
 
 
+def test_states_clu_header_matches_the_row_width(tmp_path):
+    """A memory network's state rows have no layer, and the header must not claim one.
+
+    Infomap's own _states.clu writes "# state_id module flow node_id" for memory input
+    and appends layer_id only for multilayer, so a fixed header described a column the
+    rows did not have.
+    """
+    shard = _shard(
+        tmp_path, "s", offset=0, trials=[(0, 2.5)], best_tree_modules={1: 1, 2: 2}
+    )
+    data = json.loads(Path(shard).read_text())
+    states_name = "s_trial_0_states.tree"
+    # state_id node_id, no layer: what a memory network's tree looks like.
+    (tmp_path / states_name).write_text(
+        '# path flow name state_id node_id\n1:1 0.5 "i" 1 1\n2:1 0.5 "j" 2 2\n'
+    )
+    data["best_states_tree_file"] = states_name
+    Path(shard).write_text(json.dumps(data))
+
+    merge_trial_results([shard], out_name=str(tmp_path / "out"))
+
+    lines = (tmp_path / "out_states.clu").read_text().splitlines()
+    header = next(line for line in lines if line.startswith("# state_id"))
+    rows = [line.split() for line in lines if line and not line.startswith("#")]
+
+    assert header == "# state_id module flow node_id"
+    assert all(len(row) == len(header.split()) - 1 for row in rows)
+
+
 def test_clu_derivation_survives_a_space_in_a_node_name(tmp_path):
     """Rows are ``path flow "name" id``, and the name may contain spaces."""
     shard = _shard(

--- a/test/scripts/check_interrupted_artifact.py
+++ b/test/scripts/check_interrupted_artifact.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""An interrupted run must leave an artifact that cannot pass for a complete one.
+
+updateBestResult rewrites the tree after every improving trial, so a run killed partway
+leaves a complete, well-formed best-of-k file. Its header recorded the requested
+--num-trials and an elapsed time, but never how many trials had actually run, so a
+pipeline collecting *.tree could not tell a 500-trial search from an aborted one. SIGTERM
+-- SLURM time limits, `timeout`, preemption, the OOM killer -- was not handled at all
+(#906).
+
+Checks, for both SIGINT and SIGTERM:
+  * the process shuts down through the cancellation seam rather than dying on the signal
+  * the artifact's header reports fewer trials than were asked for
+"""
+
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REQUESTED_TRIALS = 5000
+
+
+def _write_network(path: Path) -> None:
+    """A network big enough that 5000 trials cannot finish while we wait."""
+    lines = ["*Vertices 400"]
+    lines += [f'{i} "n{i}"' for i in range(1, 401)]
+    lines.append("*Edges")
+    for i in range(1, 401):
+        for offset in (1, 2, 7):
+            target = (i + offset - 1) % 400 + 1
+            if target != i:
+                lines.append(f"{i} {target}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _trials_in_header(tree_path: Path) -> tuple[int, int] | None:
+    for line in tree_path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("# trials "):
+            parts = line.split()
+            return int(parts[2]), int(parts[4])
+        if not line.startswith("#"):
+            break
+    return None
+
+
+def _run_and_signal(binary: str, sig: int, work: Path) -> tuple[int, Path]:
+    out_dir = work / f"out_{sig}"
+    out_dir.mkdir()
+    process = subprocess.Popen(
+        [
+            binary,
+            str(work / "net.net"),
+            str(out_dir),
+            "--num-trials",
+            str(REQUESTED_TRIALS),
+            "--seed",
+            "1",
+            "--silent",
+            "--tree",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+    )
+    tree = out_dir / "net.tree"
+    # Wait until at least one trial has been published, so there is an artifact to judge.
+    deadline = time.time() + 60
+    while time.time() < deadline and not tree.exists():
+        if process.poll() is not None:
+            break
+        time.sleep(0.05)
+    process.send_signal(sig)
+    try:
+        process.wait(timeout=60)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        raise SystemExit(f"signal {sig} did not stop the run within 60 s") from None
+    return process.returncode, tree
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: check_interrupted_artifact.py <infomap-binary>", file=sys.stderr)
+        return 2
+    binary = argv[1]
+
+    with tempfile.TemporaryDirectory() as tmp:
+        work = Path(tmp)
+        _write_network(work / "net.net")
+
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            code, tree = _run_and_signal(binary, sig, work)
+
+            if code == -int(sig):
+                print(
+                    f"signal {sig} killed the process outright (rc {code}); it has to go "
+                    "through the cancellation seam so the run can shut down cleanly",
+                    file=sys.stderr,
+                )
+                return 1
+            if code == 0:
+                print(f"signal {sig} was ignored: the run exited 0", file=sys.stderr)
+                return 1
+
+            if not tree.exists():
+                # Nothing published yet is a legitimate outcome on a fast machine; there
+                # is then no artifact that could be mistaken for a complete one.
+                print(f"signal {sig}: no artifact was published, nothing to confuse")
+                continue
+
+            header = _trials_in_header(tree)
+            if header is None:
+                print(
+                    f"signal {sig}: the artifact's header has no '# trials N of M' line, "
+                    "so it cannot be told apart from a complete run",
+                    file=sys.stderr,
+                )
+                return 1
+            ran, requested = header
+            if requested != REQUESTED_TRIALS:
+                print(
+                    f"signal {sig}: header requested {requested}, expected {REQUESTED_TRIALS}",
+                    file=sys.stderr,
+                )
+                return 1
+            if ran >= requested:
+                print(
+                    f"signal {sig}: header claims {ran} of {requested} trials ran, but the "
+                    "run was interrupted",
+                    file=sys.stderr,
+                )
+                return 1
+            print(
+                f"signal {sig}: rc {code}, artifact reports {ran} of {requested} trials"
+            )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/test/scripts/check_interrupted_artifact.py
+++ b/test/scripts/check_interrupted_artifact.py
@@ -89,11 +89,22 @@ def _run_and_signal(binary: str, sig: int, work: Path) -> tuple[int, Path, bool]
     return process.returncode, tree, delivered
 
 
+# ctest reports this return code as a skip rather than a pass.
+SKIP_RETURN_CODE = 77
+
+
 def main(argv: list[str]) -> int:
     if len(argv) != 2:
         print("usage: check_interrupted_artifact.py <infomap-binary>", file=sys.stderr)
         return 2
     binary = argv[1]
+
+    if sys.platform == "win32":
+        # Windows has no POSIX signal delivery: send_signal(SIGTERM) maps to
+        # TerminateProcess, which the process cannot handle, so there is no clean
+        # shutdown to test. Skipped rather than quietly passing.
+        print("skipped: POSIX signal delivery only")
+        return SKIP_RETURN_CODE
 
     with tempfile.TemporaryDirectory() as tmp:
         work = Path(tmp)

--- a/test/scripts/check_interrupted_artifact.py
+++ b/test/scripts/check_interrupted_artifact.py
@@ -46,7 +46,7 @@ def _trials_in_header(tree_path: Path) -> tuple[int, int] | None:
     return None
 
 
-def _run_and_signal(binary: str, sig: int, work: Path) -> tuple[int, Path]:
+def _run_and_signal(binary: str, sig: int, work: Path) -> tuple[int, Path, bool]:
     out_dir = work / f"out_{sig}"
     out_dir.mkdir()
     process = subprocess.Popen(
@@ -71,19 +71,22 @@ def _run_and_signal(binary: str, sig: int, work: Path) -> tuple[int, Path]:
         if process.poll() is not None:
             break
         time.sleep(0.05)
-    # The run can finish in the race between the poll above and the signal below; a
-    # ProcessLookupError there would make this test flaky rather than informative.
+    delivered = False
     if process.poll() is None:
         try:
             process.send_signal(sig)
+            delivered = True
         except ProcessLookupError:
+            # The run finished between the poll above and this call. Reported back as
+            # "not delivered" so the caller skips its checks instead of reading the
+            # clean exit as a signal that was ignored.
             pass
     try:
         process.wait(timeout=60)
     except subprocess.TimeoutExpired:
         process.kill()
         raise SystemExit(f"signal {sig} did not stop the run within 60 s") from None
-    return process.returncode, tree
+    return process.returncode, tree, delivered
 
 
 def main(argv: list[str]) -> int:
@@ -97,7 +100,15 @@ def main(argv: list[str]) -> int:
         _write_network(work / "net.net")
 
         for sig in (signal.SIGINT, signal.SIGTERM):
-            code, tree = _run_and_signal(binary, sig, work)
+            code, tree, delivered = _run_and_signal(binary, sig, work)
+
+            if not delivered:
+                # The whole budget finished before the signal could be sent. Nothing was
+                # interrupted, so there is no artifact here that could be mistaken for a
+                # complete run -- and reading the clean exit as "the signal was ignored"
+                # would be a false failure on a fast machine.
+                print(f"signal {sig}: the run finished before it could be interrupted")
+                continue
 
             if code == -int(sig):
                 print(

--- a/test/scripts/check_interrupted_artifact.py
+++ b/test/scripts/check_interrupted_artifact.py
@@ -71,7 +71,13 @@ def _run_and_signal(binary: str, sig: int, work: Path) -> tuple[int, Path]:
         if process.poll() is not None:
             break
         time.sleep(0.05)
-    process.send_signal(sig)
+    # The run can finish in the race between the poll above and the signal below; a
+    # ProcessLookupError there would make this test flaky rather than informative.
+    if process.poll() is None:
+        try:
+            process.send_signal(sig)
+        except ProcessLookupError:
+            pass
     try:
         process.wait(timeout=60)
     except subprocess.TimeoutExpired:


### PR DESCRIPTION
Closes #906 — all four boxes.

## The state-level partition was never published

The shard best-tree writer hard-coded `states=false`, so for higher-order input the file
recorded in `best_tree_file` — the only artifact `infomap.merge` reads — was the physical
projection, where the same node id appears under several modules:

```
multilayer_trial_1.tree          1:1 … 1   and   2:1 … 1      ← node 1 in two modules
multilayer_trial_1_states.tree   1:1 … state 0, node 1
                                 2:1 … state 3, node 1        ← the actual assignment
```

Under the HPC recipe's `--no-final-output` nothing else wrote the companion, so a
distributed higher-order analysis was unrecoverable. Both trees are written and recorded
(`best_states_tree_file`) now, and merge publishes `<out>_states.tree` and
`<out>_states.clu` — keyed on the state id with the physical id and layer kept, matching
Infomap's own `_states.clu` columns.

## The consistency check could not fail on the options that matter

Four options were missing from the fingerprint: `multilayer_relax_to_self`,
`assign_to_neighbouring_module`, `cluster_data_is_hard` and the lossy pair. Measured
before and after on two shards differing only in `--multilayer-relax-to-self`:

| | before | after |
| --- | --- | --- |
| shard A | `2bad1d58b47b0665` | `e39e6570abc1126c` |
| shard B | `2bad1d58b47b0665` | `d2d522203009a425` |
| `merge` | merged both, picked a "global best" across two models | refuses with a fingerprint mismatch |

Enumerating by hand is what let them slip, so a test now walks the generated parameter
catalog: every option in the Algorithm and Accuracy groups must appear in the fingerprint
or be listed as excluded with a reason. Removing `multilayer_relax_to_self` again makes
it fail by name. Two of my own four candidate gaps turned out to be false alarms
(`--to-nodes` is there as `teleport_to_nodes`, `--converge` as `converge_trials`), which
is exactly why the check is mechanical now.

While there: `Config.h`'s `// FIXME Not used` on `clusterDataIsHard` is stale — three
call sites pass it to `initPartition`, so it does change the partition.

## merge now reads what it was always handed

Shards claiming the same global trial index are the same trial run twice:

```
before: Merged 2 trials from 4 shard(s).   ← --require-complete-trials, exit 0
after:  Error: 2 global trial index(es) claimed by more than one shard
        (0 in 4 shards, 1 in 4 shards); the shards overlap, so they contribute
        fewer independent trials than they ran
```

Without the flag it warns and merges, as with missing indices. And `infomap_version` is
compared like the fingerprints, because a different build can partition the same network
differently — I have changed results twice this week, so shards from two builds are not
interchangeable.

## An interrupted run says so

The header now records the trials that actually produced the file:

```
complete:     # trials 5 of 5
SIGINT:       # trials 8 of 5000     (rc 130)
SIGTERM:      # trials 8 of 5000     (rc 130, was 143 — killed mid-write)
```

Recording it at write time rather than rewriting the header on interrupt is deliberate:
the artifact describes itself, and no work is needed at the moment when doing work is
least reliable. SIGTERM now goes through the same cancellation seam as Ctrl-C, so SLURM
time limits, `timeout`, preemption and the OOM killer shut the run down.

Note this covers the native CLI. The pip console script routes interrupts through
Python's own handling, where SIGTERM does not raise by default — worth a look separately
if the SLURM recipe is ever run through it.

## Verification

Six new tests plus a ctest that signals the real binary and reads the header it leaves
behind. Each is mutation-checked: dropping the header line, the SIGTERM registration, the
states publishing, or a fingerprint field each fail their test. `make test-native` 100% of
26 (the new ctest included), `pytest -m fast` 640 passed, both freshness gates green.