### PR TITLE
fix: stop handing Python and R objects that outlive the memory they point at

### DIFF
--- a/interfaces/R/infomap/R/Infomap.R
+++ b/interfaces/R/infomap/R/Infomap.R
@@ -1407,7 +1407,17 @@ InfomapClass <- R6::R6Class(
     #' @field swig The underlying SWIG-generated InfomapWrapper handle.
     swig = function() private$.swig,
     #' @field network The underlying Network reference.
-    network = function() private$.swig$network(),
+    #'
+    #' The handle carries a reference to its owner, so it stays valid for as long as it
+    #' is reachable. Without it the handle was a non-owning pointer into the C++ Network
+    #' held by the SWIG wrapper: once this object became unreachable the wrapper was
+    #' finalised and reads through the handle touched freed memory, returning plausible
+    #' wrong values (numNodes 11 for a three-node network) or aborting R (#900).
+    network = function() {
+      handle <- private$.swig$network()
+      attr(handle, "infomap_owner") <- private$.swig
+      handle
+    },
     #' @field codelength Total (hierarchical) codelength.
     codelength = function() private$.swig$codelength(),
     #' @field codelengths Codelength of each trial.

--- a/interfaces/R/infomap/man/Infomap.Rd
+++ b/interfaces/R/infomap/man/Infomap.Rd
@@ -59,7 +59,13 @@ im$modules
 \describe{
 \item{\code{swig}}{The underlying SWIG-generated InfomapWrapper handle.}
 
-\item{\code{network}}{The underlying Network reference.}
+\item{\code{network}}{The underlying Network reference.
+
+The handle carries a reference to its owner, so it stays valid for as long as it
+is reachable. Without it the handle was a non-owning pointer into the C++ Network
+held by the SWIG wrapper: once this object became unreachable the wrapper was
+finalised and reads through the handle touched freed memory, returning plausible
+wrong values (numNodes 11 for a three-node network) or aborting R (#900).}
 
 \item{\code{codelength}}{Total (hierarchical) codelength.}
 

--- a/interfaces/python/src/infomap/_core.py
+++ b/interfaces/python/src/infomap/_core.py
@@ -45,6 +45,19 @@ from ._bindings import run as run  # module-level engine function (CLI driver)
 from .errors import _translate_engine_errors
 
 
+def _with_owner(proxy, owner):
+    """Keep `owner` alive for as long as `proxy` is reachable.
+
+    The network accessors hand out a SWIG proxy over a C++ member of the wrapper, with
+    thisown false and no lifetime tie declared anywhere in interfaces/swig. Once the
+    owning object became unreachable the wrapper was deleted and every read through the
+    proxy was a use-after-free -- silent when the freed page still held the old values,
+    a segfault otherwise (#900).
+    """
+    proxy._infomap_owner = owner
+    return proxy
+
+
 class Core:
     def __init__(self, args):
         # Argument/config errors ("Unrecognized option: ...", option

--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -20,6 +20,7 @@ from ._core import (
     InfomapLeafModuleIterator,
     InfoNode,
     _with_inferred_flow_model,
+    _with_owner,
     apply_initial_partition,
 )
 from ._core import build_info as _engine_build_info
@@ -2362,7 +2363,7 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
     @property
     def network(self):
         """Get the internal network."""
-        return self._core.network()
+        return _with_owner(self._core.network(), self._core)
 
     @property
     def codelength(self):

--- a/interfaces/python/src/infomap/_results.py
+++ b/interfaces/python/src/infomap/_results.py
@@ -249,7 +249,11 @@ class _LeafIterWrapper:
         while not self.it.isEnd() and not self.it.isLeaf():
             self.it.stepForward()
         if not self.it.isEnd():
-            return self.it
+            # A position, not the live cursor: returning self.it made every element of
+            # list(...) the same iterator, exhausted by the time the list was read, so
+            # collecting yielded a row of None. Copies were not self-contained until the
+            # physical iterator's nodes got shared ownership (#900).
+            return self.it.copy()
         raise StopIteration
 
 

--- a/interfaces/python/src/infomap/network.py
+++ b/interfaces/python/src/infomap/network.py
@@ -29,7 +29,7 @@ import os
 import warnings
 from typing import TYPE_CHECKING, Any
 
-from ._core import Core, _with_inferred_flow_model, apply_initial_partition
+from ._core import Core, _with_inferred_flow_model, _with_owner, apply_initial_partition
 from ._logging import engine_log_routing as _engine_log_routing
 from ._logging import is_routed as _is_log_routed
 from ._network_input import add_bulk_links as _add_bulk_links
@@ -884,7 +884,7 @@ class Network(_NetworkWritersMixin):
         work identically when building onto a :class:`Network` or an
         :class:`Infomap`.
         """
-        return self._core.network()
+        return _with_owner(self._core.network(), self._core)
 
     @property
     def bipartite_start_id(self) -> int:

--- a/src/core/iterators/InfomapIterator.cpp
+++ b/src/core/iterators/InfomapIterator.cpp
@@ -149,7 +149,7 @@ InfomapIterator& InfomapLeafIterator::operator++() noexcept
 
 InfomapIterator& InfomapIteratorPhysical::operator++() noexcept
 {
-  if (m_physNodes.empty()) {
+  if (!m_physNodes || m_physNodes->empty()) {
     // Iterate modules
     InfomapIterator::operator++();
     if (isEnd()) {
@@ -160,7 +160,24 @@ InfomapIterator& InfomapIteratorPhysical::operator++() noexcept
       auto firstLeafIt = *this;
       // If on a leaf node, loop through and aggregate to physical nodes
       while (!isEnd() && m_current->isLeaf()) {
-        auto ret = m_physNodes.insert(std::make_pair(m_current->physicalId, InfoNode(*m_current)));
+        if (!m_physNodes)
+          resetPhysNodes();
+        // Detach the copy's sibling and child links before it can be destroyed anywhere.
+        // InfoNode's copy constructor takes them verbatim and ~InfoNode unlinks through
+        // them, so destroying such an aggregate writes into the engine's live tree -- on
+        // a traversal documented as read-only, and into freed memory if a position
+        // outlives the engine (#900). Detaching after insert() would miss the case where
+        // the key is already present: insert then destroys the copy it was handed, links
+        // and all. The parent stays, since the path needs it.
+        InfoNode physCopy(*m_current);
+        physCopy.previous = nullptr;
+        physCopy.next = nullptr;
+        physCopy.firstChild = nullptr;
+        physCopy.lastChild = nullptr;
+        physCopy.collapsedFirstChild = nullptr;
+        physCopy.collapsedLastChild = nullptr;
+
+        auto ret = m_physNodes->insert(std::make_pair(m_current->physicalId, physCopy));
         auto& physNode = ret.first->second;
         if (ret.second) {
           // New physical node, use same parent as the state leaf node
@@ -180,19 +197,24 @@ InfomapIterator& InfomapIteratorPhysical::operator++() noexcept
       m_depth = firstLeafIt.m_depth;
       m_moduleIndex = firstLeafIt.m_moduleIndex;
       // Set current node to the first physical node
-      m_physIter = m_physNodes.begin();
+      m_physIter = m_physNodes->begin();
+      // m_path/m_depth above came from a base copy, so re-anchor before handing out a
+      // position that points into these nodes.
+      anchorPhysNodes();
       m_current = &m_physIter->second;
     }
   } else {
     // Iterate physical nodes instead of leaf state nodes
     ++m_physIter;
     ++m_path.back();
-    if (m_physIter == m_physNodes.end()) {
-      // End of leaf nodes
-      m_physNodes.clear();
+    if (m_physIter == m_physNodes->end()) {
       m_path.pop_back();
       // reset iterator to the one after the leaf nodes
       *this = m_oldIter;
+      // Fresh storage rather than clear(): a position handed out earlier points into
+      // these nodes and keeps them alive through its own anchor. After the assignment
+      // above, which copies m_oldIter's empty anchor over this one.
+      resetPhysNodes();
     } else {
       // Set iterator node to the currently iterated physical node
       m_current = &m_physIter->second;

--- a/src/core/iterators/InfomapIterator.h
+++ b/src/core/iterators/InfomapIterator.h
@@ -12,6 +12,7 @@
 
 #include <vector>
 #include <map>
+#include <memory>
 #include <cmath>
 
 namespace infomap {

--- a/src/core/iterators/InfomapIterator.h
+++ b/src/core/iterators/InfomapIterator.h
@@ -31,6 +31,12 @@ protected:
   unsigned int m_moduleIndex = 0;
   std::vector<unsigned int> m_path; // The tree path to current node (indexing starting from one!)
   unsigned int m_depth = 0;
+  // Keeps storage that m_current may point into alive for as long as this position
+  // exists. copy() and operator++(int) return the *base* class by value, so a derived
+  // iterator holding its own nodes is sliced -- and the surviving m_current pointed into
+  // storage that died with the temporary. Anchoring it here means the slice keeps it
+  // (#900). Empty for iterators that only point into the engine's own tree.
+  std::shared_ptr<void> m_positionStorage;
 
 public:
   InfomapIterator() = default;
@@ -213,9 +219,25 @@ public:
  */
 struct InfomapIteratorPhysical : public InfomapIterator {
 protected:
-  std::map<unsigned int, InfoNode> m_physNodes;
-  std::map<unsigned int, InfoNode>::iterator m_physIter;
+  using PhysNodes = std::map<unsigned int, InfoNode>;
+  // Shared, so a copied or sliced position keeps the very nodes it points at rather than
+  // a deep copy its iterators do not belong to: the defaulted copy left m_current and
+  // m_physIter bound to the source's map, which is why comparing a copied iterator's
+  // position against its own end() compared iterators from two different maps (#900).
+  std::shared_ptr<PhysNodes> m_physNodes;
+  PhysNodes::iterator m_physIter;
   InfomapIterator m_oldIter;
+
+  //! Fresh storage for the next leaf module, leaving any handed-out position untouched.
+  void resetPhysNodes()
+  {
+    m_physNodes = std::make_shared<PhysNodes>();
+    anchorPhysNodes();
+  }
+
+  //! Point the base's anchor at this iterator's nodes. Called again after every
+  //! assignment from a base iterator, which copies the base's empty anchor over ours.
+  void anchorPhysNodes() { m_positionStorage = m_physNodes; }
 
 public:
   InfomapIteratorPhysical() {}
@@ -272,8 +294,10 @@ public:
   InfomapLeafIteratorPhysical(InfoNode* nodePointer, int moduleIndexLevel = -1)
       : InfomapIteratorPhysical(nodePointer, moduleIndexLevel) { init(); }
 
-  InfomapLeafIteratorPhysical(const InfomapLeafIteratorPhysical& other)
-      : InfomapIteratorPhysical(other) { init(); }
+  // No init() here: a copy has to stand where the source stands. init() advances past
+  // non-leaves, so on a leaf position it is a no-op and on any other position it moves
+  // the copy somewhere the source never was (#900).
+  InfomapLeafIteratorPhysical(const InfomapLeafIteratorPhysical& other) = default;
 
   ~InfomapLeafIteratorPhysical() override = default;
   InfomapLeafIteratorPhysical(InfomapLeafIteratorPhysical&&) = default;

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -127,6 +127,59 @@ TEST_CASE("Tree cluster-data fixture initializes a multi-level tree [fast][core]
   infomap::test::checkRunSanity(im);
 }
 
+TEST_CASE("A physical traversal leaves the engine's tree untouched [fast][core][partition][tree]")
+{
+  // InfomapIteratorPhysical stores InfoNode *copies* of live leaves, and InfoNode's copy
+  // constructor takes the sibling pointers verbatim while ~InfoNode unlinks through them.
+  // Destroying those copies therefore wrote into the engine's own nodes on a traversal
+  // documented as read-only -- and into freed memory if a position outlived the engine
+  // (#900).
+  auto im = infomap::test::makeRunningInfomap([&](InfomapWrapper& infomap) {
+    infomap.readInputData(infomap::test::repoPath("test/fixtures/networks/states.net"));
+  });
+
+  struct Links {
+    const infomap::InfoNode* previous;
+    const infomap::InfoNode* next;
+    const infomap::InfoNode* parent;
+    const infomap::InfoNode* firstChild;
+  };
+  std::map<unsigned int, Links> before;
+  for (auto it = im->iterLeafNodes(); !it.isEnd(); ++it) {
+    const auto& node = *it;
+    before[node.stateId] = { node.previous, node.next, node.parent, node.firstChild };
+  }
+  REQUIRE(before.size() == 6);
+
+  {
+    // A full physical walk, and positions kept past the end of it.
+    std::vector<infomap::InfomapIterator> kept;
+    for (auto it = im->iterTreePhysical(); !it.isEnd(); ++it)
+      kept.push_back(it.copy());
+    CHECK(kept.size() > 0);
+    // Every kept position still resolves, and resolves to what it did when it was taken,
+    // rather than pointing into storage the source iterator dropped when it left the leaf
+    // module. Reading the values matters: a dangling pointer is still non-null, so only
+    // the sanitizer or the value catches it.
+    std::vector<unsigned int> keptPhysicalIds;
+    for (const auto& position : kept) {
+      REQUIRE(position.current() != nullptr);
+      if (position.current()->isLeaf())
+        keptPhysicalIds.push_back(position.current()->physicalId);
+    }
+    CHECK(keptPhysicalIds == std::vector<unsigned int> { 1, 2, 3, 1, 4, 5 });
+  }
+
+  for (auto it = im->iterLeafNodes(); !it.isEnd(); ++it) {
+    const auto& node = *it;
+    const auto& links = before.at(node.stateId);
+    CHECK(node.previous == links.previous);
+    CHECK(node.next == links.next);
+    CHECK(node.parent == links.parent);
+    CHECK(node.firstChild == links.firstChild);
+  }
+}
+
 TEST_CASE("A physical tree that cannot express the partition says so [fast][core][partition][parser]")
 {
   // A physical .tree has one row per (module, physical node) and no state ids, so when a

--- a/test/python/test_binding_lifetimes.py
+++ b/test/python/test_binding_lifetimes.py
@@ -1,0 +1,108 @@
+"""Objects handed across the SWIG boundary must not outlive what they point at.
+
+Two kinds did: iterator positions collected from a physical tree pointed into per-iterator
+storage the source dropped a step later, and the network accessors handed out a non-owning
+proxy with no tie to its owner. Both read freed heap from ordinary code -- silently when
+the page still held the old values, which is how a partition full of zeros reached a user
+about to publish it (#900).
+"""
+
+from __future__ import annotations
+
+import gc
+import weakref
+
+import infomap
+import pytest
+
+pytestmark = pytest.mark.fast
+
+STATE_NETWORK = "test/fixtures/networks/states.net"
+
+
+def _state_run():
+    im = infomap.Infomap(silent=True, seed=7)
+    im.read_file(STATE_NETWORK)
+    im.run()
+    return im
+
+
+def test_collected_physical_tree_positions_match_eager_reads():
+    """list(...) is the natural idiom and used to yield zeros on a higher-order network."""
+    im = _state_run()
+
+    collected = [
+        (node.node_id, node.flow)
+        for node in list(im.get_tree(states=False))
+        if node.is_leaf
+    ]
+    eager = [
+        (node.node_id, node.flow) for node in im.get_tree(states=False) if node.is_leaf
+    ]
+
+    assert collected == eager
+    assert [node_id for node_id, _ in collected] == [1, 2, 3, 1, 4, 5]
+    assert all(flow > 0 for _, flow in collected)
+
+
+def test_collected_physical_nodes_match_eager_reads():
+    """The deprecated accessor filtered the tree and handed out the live cursor itself."""
+    im = _state_run()
+
+    collected = [(node.node_id, node.flow) for node in list(im.physical_nodes)]
+    eager = [(node.node_id, node.flow) for node in im.physical_nodes]
+
+    assert collected == eager
+    assert [node_id for node_id, _ in collected] == [1, 2, 3, 1, 4, 5]
+
+
+def test_sorting_collected_positions_sees_real_flows():
+    """Sorting on a collected position's flow sorted on garbage keys."""
+    im = _state_run()
+
+    by_flow = sorted(
+        (node for node in list(im.get_tree(states=False)) if node.is_leaf),
+        key=lambda node: -node.flow,
+    )
+
+    assert all(node.flow > 0 for node in by_flow)
+    assert {node.node_id for node in by_flow} == {1, 2, 3, 4, 5}
+
+
+def test_network_proxy_keeps_its_owner_alive():
+    """A helper that returns im.network and drops the instance is ordinary code."""
+    core_ref = None
+
+    def helper():
+        nonlocal core_ref
+        im = infomap.Infomap(silent=True)
+        im.add_links(((1, 2), (2, 3), (3, 1)))
+        im.run()
+        core_ref = weakref.ref(im._core)
+        return im.network
+
+    network = helper()
+    gc.collect()
+
+    assert core_ref() is not None, (
+        "the owner was collected while its proxy was still held"
+    )
+    assert network.numNodes() == 3
+    assert network.numLinks() == 3
+
+
+def test_network_proxy_from_the_network_surface_keeps_its_owner():
+    core_ref = None
+
+    def helper():
+        nonlocal core_ref
+        net = infomap.Network()
+        net.add_links(((1, 2), (2, 3)))
+        core_ref = weakref.ref(net._core)
+        return net.network
+
+    network = helper()
+    gc.collect()
+
+    assert core_ref() is not None
+    assert network.numNodes() == 3


### PR DESCRIPTION
Closes #900 — all four boxes. Every one reproduced before being fixed, and three of the
four were silent rather than crashing, which is the worse failure.

## Collected positions read freed storage

```
list(im.get_tree(states=False))   [(0, 0.0), (0, 0.0), (0, 0.0), (0, 0.0), (0, 0.0), (0, 0.0)]
iterating it directly             [(1, 0.1667), (2, 0.1667), (3, 0.1667), (1, 0.1667), (4, 0.1667), (5, 0.1667)]
```

`copy()` and `operator++(int)` declare the **base** iterator as their return type, so the
physical iterator holding its own nodes was sliced and the surviving `m_current` aimed at
a map that died with the temporary. The defaulted copy constructor left `m_current` and
`m_physIter` bound to the *source's* map as well.

The nodes now have shared ownership, anchored in the base class so a slice keeps them
alive, and leaving a leaf module allocates fresh storage instead of clearing what a
handed-out position may still hold. So `list(...)`, `sorted(..., key=lambda n: -n.flow)`
and any DataFrame build agree with reading eagerly.

## A read-only traversal wrote into the engine's tree

The same storage holds `InfoNode` copies of live leaves, and `InfoNode`'s copy constructor
takes `previous`/`next`/`firstChild` verbatim while `~InfoNode` unlinks through them. The
copies are detached before they can be destroyed anywhere — including by an `insert()`
that discards the value it was handed, which my first attempt missed and the new test
caught:

| | before | after |
| --- | --- | --- |
| leaf pointers after a physical walk (ASan build) | 4 assertions fail, `nullptr == 0x61c000000080` | unchanged |
| anchor removed, same test | — | `AddressSanitizer: heap-use-after-free in InfoNode::isLeaf` |

So the sanitizer leg guards both halves from now on.

## The network proxy outlived its owner

```python
network = helper()          # helper builds an Infomap, returns im.network
gc.collect()
network.numNodes()
```

Before: the SWIG wrapper was collected (verified with a weakref) and the read went to
freed memory — returning the old values here, garbage elsewhere. R was worse: with the
owner collected, `numNodes` returned **11** for a three-node network.

Both Python surfaces and R's active binding now carry their owner, so the handle keeps
what it points at alive. R's man page is regenerated for the new field docs.

## And a workaround that had become the bug

`_LeafIterWrapper.__next__` returned the live cursor rather than a position, so every
element of `list(im.physical_nodes)` was the same exhausted iterator — a row of `None`.
The comment above it said `iterLeafNodesPhysical` was "unreliable in python", which was
true precisely because copies were not self-contained. They are now, so the wrapper
returns a position.

## Verification

Five Python tests, one C++ test, each mutation-checked — removing the anchor, the detach,
the owner reference or the position copy each fails its own test. `make test-native` 26 of
26, `pytest -m fast` 645, `make test-r` green, all four freshness gates green, and the new
C++ test clean under `-DINFOMAP_ENABLE_SANITIZERS=ON`.

One scope note: `InfoNode` stays copy-constructible and copy-assignable, since the
iterator's `map<unsigned, InfoNode>` requires it.