### PR TITLE
fix: configure the super-level objective from the run, not from defaults

### DIFF
--- a/src/core/BiasedMapEquation.h
+++ b/src/core/BiasedMapEquation.h
@@ -193,6 +193,23 @@ public:
     m_totalDegree = other.m_totalDegree;
     m_numNodes = other.m_numNodes;
   }
+
+  // Copy what the objective minimises from a parent objective. The super-level Infomap is built
+  // without memory, which today means from a default Config, so its objective would otherwise run
+  // with the entropy correction off and no module-count preference however the run was configured.
+  // findHierarchicalSuperModules then weighed that uncorrected super codelength against this
+  // objective's corrected index codelength and could accept a super level that makes the tree
+  // worse than the two-level partition the same trial had just found (#904).
+  //
+  // Only the objective's own parameters travel. The flow model deliberately does not: the super
+  // network's node flows are aggregated module enter flows that already carry teleportation, so
+  // handing the super objective a recordedTeleportation of true would count it twice.
+  void setObjectiveParametersFrom(const BiasedMapEquation& other)
+  {
+    preferredNumModules = other.preferredNumModules;
+    useEntropyBiasCorrection = other.useEntropyBiasCorrection;
+    entropyBiasCorrectionMultiplier = other.entropyBiasCorrectionMultiplier;
+  }
 };
 
 } // namespace infomap

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -313,6 +313,11 @@ private:
                              .setNonMainConfig(*this)
                              .inheritRuntimeContext(*this);
     superInfomap.m_optimizer->inheritNetworkPropertiesFrom(*m_optimizer);
+    // getNewInfomapInstanceWithoutMemory builds the objective from a default Config, so unlike a
+    // sub-Infomap this one has to be told what to minimise. findHierarchicalSuperModules compares
+    // its codelength directly against this instance's index codelength, and the two are only
+    // comparable when both objectives are configured alike (#904).
+    superInfomap.m_optimizer->inheritObjectiveParametersFrom(*m_optimizer);
     return superInfomap;
   }
 

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -77,6 +77,8 @@ public:
 
   void inheritNetworkPropertiesFrom(const InfomapOptimizerBase& parent) override;
 
+  void inheritObjectiveParametersFrom(const InfomapOptimizerBase& parent) override;
+
 protected:
   unsigned int numActiveModules() const override { return m_infomap->activeNetwork().size() - m_emptyModules.size(); }
 
@@ -242,6 +244,21 @@ inline void InfomapOptimizer<BiasedMapEquation>::inheritNetworkPropertiesFrom(co
   // the same entropy bias correction normalization the shared static used to provide.
   if (const auto* p = dynamic_cast<const InfomapOptimizer<BiasedMapEquation>*>(&parent))
     m_objective.setNetworkPropertiesFrom(p->m_objective);
+}
+
+template <typename Objective>
+inline void InfomapOptimizer<Objective>::inheritObjectiveParametersFrom(const InfomapOptimizerBase& /*parent*/)
+{
+}
+
+template <>
+inline void InfomapOptimizer<BiasedMapEquation>::inheritObjectiveParametersFrom(const InfomapOptimizerBase& parent)
+{
+  // The super-level instance is the only one whose objective is not built from the run's own
+  // Config, so it is the only one that needs this. The parent is a BiasedMapEquation optimizer
+  // here for the same reason as above: the super objective is always this one.
+  if (const auto* p = dynamic_cast<const InfomapOptimizer<BiasedMapEquation>*>(&parent))
+    m_objective.setObjectiveParametersFrom(p->m_objective);
 }
 
 template <>

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -255,8 +255,11 @@ template <>
 inline void InfomapOptimizer<BiasedMapEquation>::inheritObjectiveParametersFrom(const InfomapOptimizerBase& parent)
 {
   // The super-level instance is the only one whose objective is not built from the run's own
-  // Config, so it is the only one that needs this. The parent is a BiasedMapEquation optimizer
-  // here for the same reason as above: the super objective is always this one.
+  // Config, so it is the only one that needs this. The super objective is always this one, but the
+  // parent's is not: a memory, meta-data or regularized-multilayer run has a different objective
+  // at the level above, the cast then fails, and nothing is inherited. That is the status quo for
+  // those runs -- only BiasedMapEquation implements the correction and the module-count preference
+  // at all, which is the separate open box in #904.
   if (const auto* p = dynamic_cast<const InfomapOptimizer<BiasedMapEquation>*>(&parent))
     m_objective.setObjectiveParametersFrom(p->m_objective);
 }

--- a/src/core/InfomapOptimizerBase.h
+++ b/src/core/InfomapOptimizerBase.h
@@ -65,6 +65,12 @@ public:
   // uses them (BiasedMapEquation).
   virtual void inheritNetworkPropertiesFrom(const InfomapOptimizerBase& /*parent*/) {}
 
+  // Propagate the objective's own parameters -- what it minimises, as opposed to the network
+  // it minimises over -- from a parent optimizer. Needed by the super-level instance, which is
+  // built without memory and therefore from a default Config. No-op unless the objective has
+  // such parameters (BiasedMapEquation). See getSuperInfomap.
+  virtual void inheritObjectiveParametersFrom(const InfomapOptimizerBase& /*parent*/) {}
+
 protected:
   virtual unsigned int numActiveModules() const = 0;
 

--- a/test/cpp/test_map_equation_invariants.cpp
+++ b/test/cpp/test_map_equation_invariants.cpp
@@ -127,6 +127,40 @@ TEST_CASE("Entropy correction steers the search, not just the report [core][mape
   CHECK(uncorrected != corrected);
 }
 
+// The super-level Infomap is built without memory, which means from a default Config, so its
+// objective ran with the entropy correction off and no module-count preference however the run was
+// configured (#904). findHierarchicalSuperModules compares that codelength straight against the
+// main objective's index codelength, so an uncorrected super solution could read as an improvement,
+// be consolidated, and leave the trial describing the network in more bits than the two-level
+// partition it had already found and thrown away (measured on this input: 3.7885 against 3.7421).
+//
+// Asserted as the user-visible invariant rather than on the internal comparison: the hierarchical
+// search starts from the two-level solution and only ever adds levels that shorten the description,
+// so it must not come back with a worse codelength than a two-level run of the same trial. Note
+// that --preferred-number-of-levels deliberately breaks this invariant (#308 lets a depth
+// preference accept a longer description), which is why no depth preference is set here.
+TEST_CASE("Super level never leaves the trial worse than its own two-level solution [core][mapeq][entropy-corrected]")
+{
+  const auto codelengthOf = [](const std::string& flags) {
+    InfomapWrapper im(defaultFlags("--seed 3 " + flags));
+    im.readInputData(repoPath("examples/networks/ninetriangles.net"));
+    im.run();
+    return im.codelength();
+  };
+
+  const double twoLevel = codelengthOf("--two-level --entropy-corrected");
+  const double hierarchical = codelengthOf("--entropy-corrected");
+
+  INFO("two-level=" << twoLevel << " hierarchical=" << hierarchical);
+  CHECK(hierarchical <= twoLevel + 1e-12);
+
+  // Guard against the invariant holding for the wrong reason: it is trivially true if the
+  // correction is so weak here that both runs return the plain-map-equation solution.
+  const double uncorrected = codelengthOf("--two-level");
+  INFO("uncorrected two-level=" << uncorrected);
+  CHECK(twoLevel > uncorrected);
+}
+
 // Follow-ups (not reproduced here): #831 (two-level initPartition/consolidate
 // reentrancy corrupting the recomputed codelength after a prior multi-level
 // trial) and #837 (hierarchical super-step degrading a two-level memory

--- a/test/cpp/test_map_equation_invariants.cpp
+++ b/test/cpp/test_map_equation_invariants.cpp
@@ -1,5 +1,7 @@
 #include "TestUtils.h"
 
+#include <cmath>
+
 // Invariant tests for the map-equation objective family.
 //
 // After a search, the optimizer's *tracked* codelength (getCodelength(), updated
@@ -155,10 +157,14 @@ TEST_CASE("Super level never leaves the trial worse than its own two-level solut
   CHECK(hierarchical <= twoLevel + 1e-12);
 
   // Guard against the invariant holding for the wrong reason: it is trivially true if the
-  // correction is so weak here that both runs return the plain-map-equation solution.
+  // correction is so weak here that both runs return the same solution anyway. Stated as a
+  // magnitude rather than an ordering on purpose -- the two values come from different objectives
+  // and possibly different partitions, so neither direction is guaranteed a priori, while a gap
+  // this size can only come from an active correction (it is 35/156 = 0.2244 bits here, the
+  // correction term for the nine-module partition both runs find).
   const double uncorrected = codelengthOf("--two-level");
   INFO("uncorrected two-level=" << uncorrected);
-  CHECK(twoLevel > uncorrected);
+  CHECK(std::abs(twoLevel - uncorrected) > 0.1);
 }
 
 // Follow-ups (not reproduced here): #831 (two-level initPartition/consolidate


### PR DESCRIPTION
The second box of #904: the super-level Infomap builds its objective from a default `Config`.

`getNewInfomapInstanceWithoutMemory` is the only way to get a memory-free instance, and it starts from `new InfomapBase()`. `InfomapOptimizer::init` latches `m_objective.init(infomap->getConfig())` right there in the constructor, so the objective reads the defaults; the `setNonMainConfig(*this)` that follows updates the instance's `Config` but never reaches the objective. The super level therefore searched with the entropy correction off, no module-count preference and the default multiplier no matter how the run was configured.

That matters because `findHierarchicalSuperModules` compares the super instance's codelength directly against the main objective's index codelength:

```cpp
bool improvedCodelength = superCodelength < oldIndexLength - minimumCodelengthImprovement + superPrefBias;
```

Two objectives, one comparison. On `examples/networks/ninetriangles.net` with `--entropy-corrected --seed 3` the super solution measured 0.8042 against an index codelength of 0.9874 and was consolidated as an improvement. Scored by the objective the run actually reports, the tree that came out costs **3.7885** — against **3.7421** for the two-level partition the same trial had found one step earlier and thrown away. The run printed the worse number as its result.

With both sides from the same objective the super codelength is 0.9901, the level is rejected, and the trial keeps 3.7421.

## What travels and what does not

Only the objective's own parameters: `preferredNumModules`, `useEntropyBiasCorrection`, `entropyBiasCorrectionMultiplier`. The flow model deliberately stays behind. The super network's node flows are aggregated module enter flows that already carry teleportation, so giving the super objective a `recordedTeleportation` of true would count it twice — the issue's own reading, and I left it alone.

The objective *class* is also unchanged: the super level keeps using `BiasedMapEquation` exactly as before. Passing the whole config to `initOptimizer` would have switched it to `MetaMapEquation` for `--meta-data` input, which is the combined-objective question the other two boxes are about.

## Blast radius

Nothing changes without `--entropy-corrected` or `--preferred-number-of-modules`: the three inherited values are then exactly the defaults the super objective already had. `make test-native` (26/26) and the fast Python suite (645) are unchanged.

## Test

One invariant in `test/cpp/test_map_equation_invariants.cpp`, asserted where a user would notice it: the hierarchical search starts from the two-level solution and only adds levels that shorten the description, so it must not return a worse codelength than a two-level run of the same trial. It has a second check that the correction is actually biting on this input, so it cannot pass by both runs degenerating to the plain solution, and a note that `--preferred-number-of-levels` breaks the invariant by design (#308) and is therefore not set.

Reverting the one-line inheritance call fails exactly this test and nothing else.

## Not in this PR

- **`--entropy-corrected` / `--preferred-number-of-modules` inert for state, multilayer and meta input**, and **`--meta-data` replacing the memory objective** — both need a combined objective, which is being handled separately.
- **The `--regularized` evaluation disagreement.** Investigated; it is a separate root cause from this one and needs a decision before anything changes. Findings posted on #904.