### PR TITLE
fix: warn when the objective cannot apply a configured option

### DIFF
--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -655,6 +655,33 @@ private:
       throw std::domain_error("No nodes to partition");
 
     checkFlowPostCondition();
+    warnOnObjectiveOptionsNotApplied();
+  }
+
+  // Options that are accepted, echoed in the run banner and recorded in the run metadata as
+  // active, but that the objective this input selects does not act on. Silence made them read as
+  // applied: the reported codelength and partition were simply those of a run without them (#904).
+  //
+  // Warnings rather than errors, and the objective dispatch is left as it is -- combining these
+  // objectives is a separate design question. The run path is the right home for this, for the
+  // same reason checkFlowPostCondition lives here: initNetwork is public C++ API that embedders
+  // call directly, and it runs again per parallel-trial worker.
+  void warnOnObjectiveOptionsNotApplied()
+  {
+    if (!m_infomap.m_optimizer->implementsObjectiveParameters()) {
+      // Only BiasedMapEquation carries these terms, and it is chosen only for ordinary networks.
+      if (m_infomap.entropyBiasCorrection)
+        Console::warn(0, "--entropy-corrected has no effect on this input: the entropy bias correction is implemented for ordinary networks only, not for state, multilayer or meta-data input. The run optimizes and reports the uncorrected codelength.");
+      if (m_infomap.preferredNumberOfModules != 0)
+        Console::warn(0, "--preferred-number-of-modules has no effect on this input: the module-count preference is implemented for ordinary networks only, not for state, multilayer or meta-data input.");
+    }
+
+    if (m_infomap.haveMetaData() && (m_infomap.haveMemory() || m_infomap.isMultilayerNetwork())) {
+      // initOptimizer tests haveMetaData() before haveMemory(), so meta-data wins and the run is
+      // scored by a first-order objective with no physical-node codebook -- the aggregation that
+      // makes this a memory network does not enter the objective at all.
+      Console::warn(0, "--meta-data takes precedence over higher-order input: the run optimizes the meta-data objective over state nodes, without the physical-node codebook of the higher-order map equation. The higher-order structure affects the network, not the objective.");
+    }
   }
 
   // The map equation is defined on a visit-rate distribution, so a non-finite

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -669,11 +669,15 @@ private:
   void warnOnObjectiveOptionsNotApplied()
   {
     if (!m_infomap.m_optimizer->implementsObjectiveParameters()) {
-      // Only BiasedMapEquation carries these terms, and it is chosen only for ordinary networks.
+      // Worded from the objective, not from the input: the condition is which objective
+      // initOptimizer selected, and state, multilayer and meta-data input are the common way to
+      // select another one but not the only way -- --lossy does it on an ordinary network too, and
+      // its own validation does not reject these options. The banner above the warning names the
+      // objective in use, so the message does not have to.
       if (m_infomap.entropyBiasCorrection)
-        Console::warn(0, "--entropy-corrected has no effect on this input: the entropy bias correction is implemented for ordinary networks only, not for state, multilayer or meta-data input. The run optimizes and reports the uncorrected codelength.");
+        Console::warn(0, "--entropy-corrected has no effect on this run: the entropy bias correction is implemented by the ordinary map equation only, and this run uses a different objective. The run optimizes and reports the uncorrected codelength.");
       if (m_infomap.preferredNumberOfModules != 0)
-        Console::warn(0, "--preferred-number-of-modules has no effect on this input: the module-count preference is implemented for ordinary networks only, not for state, multilayer or meta-data input.");
+        Console::warn(0, "--preferred-number-of-modules has no effect on this run: the module-count preference is implemented by the ordinary map equation only, and this run uses a different objective.");
     }
 
     if (m_infomap.haveMetaData() && (m_infomap.haveMemory() || m_infomap.isMultilayerNetwork())) {

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -79,6 +79,8 @@ public:
 
   void inheritObjectiveParametersFrom(const InfomapOptimizerBase& parent) override;
 
+  bool implementsObjectiveParameters() const override;
+
 protected:
   unsigned int numActiveModules() const override { return m_infomap->activeNetwork().size() - m_emptyModules.size(); }
 
@@ -262,6 +264,18 @@ inline void InfomapOptimizer<BiasedMapEquation>::inheritObjectiveParametersFrom(
   // at all, which is the separate open box in #904.
   if (const auto* p = dynamic_cast<const InfomapOptimizer<BiasedMapEquation>*>(&parent))
     m_objective.setObjectiveParametersFrom(p->m_objective);
+}
+
+template <typename Objective>
+inline bool InfomapOptimizer<Objective>::implementsObjectiveParameters() const
+{
+  return false;
+}
+
+template <>
+inline bool InfomapOptimizer<BiasedMapEquation>::implementsObjectiveParameters() const
+{
+  return true;
 }
 
 template <>

--- a/src/core/InfomapOptimizerBase.h
+++ b/src/core/InfomapOptimizerBase.h
@@ -71,6 +71,13 @@ public:
   // such parameters (BiasedMapEquation). See getSuperInfomap.
   virtual void inheritObjectiveParametersFrom(const InfomapOptimizerBase& /*parent*/) {}
 
+  // Whether this objective implements the parameters above: the entropy bias correction and the
+  // preferred-module-count cost. Only BiasedMapEquation does, so --entropy-corrected and
+  // --preferred-number-of-modules are inert on every other objective. Declared by the objective
+  // rather than derived from the input flags so the run path cannot disagree with
+  // InfomapBase::initOptimizer about which objective is in use (#904).
+  virtual bool implementsObjectiveParameters() const { return false; }
+
 protected:
   virtual unsigned int numActiveModules() const = 0;
 

--- a/test/python/test_objective_option_warnings.py
+++ b/test/python/test_objective_option_warnings.py
@@ -1,0 +1,127 @@
+"""Objective options the input's objective does not act on are warned about, not ignored.
+
+``--entropy-corrected`` and ``--preferred-number-of-modules`` are implemented by
+``BiasedMapEquation`` only, which the engine selects for ordinary networks. State,
+multilayer and meta-data input get another objective, so those options were accepted,
+echoed in the run banner, recorded in the run metadata as active -- and never applied.
+``--meta-data`` combined with higher-order input is the mirror case: meta-data wins the
+objective dispatch, so the run is scored without the physical-node codebook that makes it
+a memory network. Both were silent, which read as "applied" (#904).
+
+The assertions go through the routed ``infomap`` logger rather than fd-level capture: it
+is the supported way to observe engine output from Python, and it carries the level-0
+warnings these tests are about.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from infomap import Infomap
+
+pytestmark = pytest.mark.fast
+
+ENTROPY_WARNING = "--entropy-corrected has no effect on this input"
+PREFERRED_WARNING = "--preferred-number-of-modules has no effect on this input"
+META_PRECEDENCE_WARNING = "--meta-data takes precedence over higher-order input"
+
+
+class _ListHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.messages: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.messages.append(record.getMessage())
+
+
+@pytest.fixture
+def engine_messages():
+    logger = logging.getLogger("infomap")
+    handler = _ListHandler()
+    logger.addHandler(handler)
+    old_level = logger.level
+    logger.setLevel(logging.DEBUG)
+    yield handler.messages
+    logger.removeHandler(handler)
+    logger.setLevel(old_level)
+
+
+def _run_states(**kwargs) -> None:
+    im = Infomap(num_trials=1, **kwargs)
+    im.add_state_node(1, 1)
+    im.add_state_node(2, 2)
+    im.add_state_node(3, 1)
+    im.add_state_node(4, 3)
+    im.add_link(1, 2)
+    im.add_link(2, 3)
+    im.add_link(3, 4)
+    im.add_link(1, 4)
+    im.run()
+
+
+def _run_ordinary(**kwargs) -> None:
+    im = Infomap(num_trials=1, **kwargs)
+    im.add_link(1, 2)
+    im.add_link(2, 3)
+    im.add_link(1, 3)
+    im.add_link(3, 4)
+    im.add_link(4, 5)
+    im.add_link(5, 3)
+    im.run()
+
+
+def _matching(messages: list[str], needle: str) -> list[str]:
+    return [message for message in messages if needle in message]
+
+
+def test_entropy_correction_warns_on_state_input(engine_messages):
+    _run_states(entropy_corrected=True)
+    assert _matching(engine_messages, ENTROPY_WARNING)
+
+
+def test_preferred_number_of_modules_warns_on_state_input(engine_messages):
+    _run_states(preferred_number_of_modules=2)
+    assert _matching(engine_messages, PREFERRED_WARNING)
+
+
+def test_meta_data_precedence_warns_on_state_input(engine_messages, tmp_path):
+    meta = tmp_path / "const.meta"
+    # Every physical node in one meta category, so the meta term is exactly 0 and the run
+    # cannot be defended as "the metadata was worth the swap" -- the objective changed for
+    # nothing. This is the shape the issue used to demonstrate the swap.
+    meta.write_text("1 1\n2 1\n3 1\n", encoding="utf-8")
+
+    _run_states(meta_data=str(meta))
+
+    assert _matching(engine_messages, META_PRECEDENCE_WARNING)
+
+
+def test_ordinary_input_applies_both_options_silently(engine_messages):
+    # The objective for an ordinary network implements both terms, so there is nothing to
+    # warn about. Guards against the warnings firing on the runs that are actually correct.
+    _run_ordinary(entropy_corrected=True, preferred_number_of_modules=2)
+
+    assert not _matching(engine_messages, ENTROPY_WARNING)
+    assert not _matching(engine_messages, PREFERRED_WARNING)
+
+
+def test_meta_data_on_ordinary_input_is_not_a_precedence_warning(
+    engine_messages, tmp_path
+):
+    # Meta-data on a first-order network is what MetaMapEquation is for; only the
+    # combination with higher-order input silently discards something.
+    meta = tmp_path / "ordinary.meta"
+    meta.write_text("1 1\n2 1\n3 2\n4 2\n5 2\n", encoding="utf-8")
+
+    _run_ordinary(meta_data=str(meta))
+
+    assert not _matching(engine_messages, META_PRECEDENCE_WARNING)
+
+
+def test_engine_emits_something_at_all(engine_messages):
+    # The three assertions above are only meaningful if the routed logger is carrying engine
+    # output in this environment; an empty stream would make every `not _matching` vacuous.
+    _run_ordinary()
+    assert engine_messages

--- a/test/python/test_objective_option_warnings.py
+++ b/test/python/test_objective_option_warnings.py
@@ -1,8 +1,9 @@
 """Objective options the input's objective does not act on are warned about, not ignored.
 
 ``--entropy-corrected`` and ``--preferred-number-of-modules`` are implemented by
-``BiasedMapEquation`` only, which the engine selects for ordinary networks. State,
-multilayer and meta-data input get another objective, so those options were accepted,
+``BiasedMapEquation`` only, which the engine selects for ordinary networks. Any input that
+selects another objective -- state, multilayer and meta-data here, but also ``--lossy`` on
+an ordinary network -- leaves them inert, so those options were accepted,
 echoed in the run banner, recorded in the run metadata as active -- and never applied.
 ``--meta-data`` combined with higher-order input is the mirror case: meta-data wins the
 objective dispatch, so the run is scored without the physical-node codebook that makes it
@@ -22,8 +23,8 @@ from infomap import Infomap
 
 pytestmark = pytest.mark.fast
 
-ENTROPY_WARNING = "--entropy-corrected has no effect on this input"
-PREFERRED_WARNING = "--preferred-number-of-modules has no effect on this input"
+ENTROPY_WARNING = "--entropy-corrected has no effect on this run"
+PREFERRED_WARNING = "--preferred-number-of-modules has no effect on this run"
 META_PRECEDENCE_WARNING = "--meta-data takes precedence over higher-order input"
 
 


### PR DESCRIPTION
Boxes 3 and 4 of #904, handled the way you asked: keep the behaviour, stop being silent about it. Rebased onto `master` now that #955 has landed.

## Box 3: options the objective never applies

`--entropy-corrected` and `--preferred-number-of-modules` are implemented by `BiasedMapEquation` only, which `initOptimizer` selects for ordinary networks. State, multilayer and meta-data input get another objective, so both options were accepted, echoed in the run banner, recorded in the run metadata as active — and never touched the search. The reported codelength and partition were simply those of a run without them.

```
Warning: --entropy-corrected has no effect on this input: the entropy bias correction is
implemented for ordinary networks only, not for state, multilayer or meta-data input.
The run optimizes and reports the uncorrected codelength.
```

## Box 4: meta-data replacing the memory objective

`initOptimizer` tests `haveMetaData()` before `haveMemory()`, so state or multilayer input combined with `--meta-data` is scored by `MetaMapEquation` — a first-order objective with no physical-node codebook — while the banner still reports higher-order input and `-vv` still prints `run Infomap with memory`.

```
Warning: --meta-data takes precedence over higher-order input: the run optimizes the
meta-data objective over state nodes, without the physical-node codebook of the
higher-order map equation. The higher-order structure affects the network, not the objective.
```

## Design

**Warnings, not errors, and the dispatch is untouched.** Combining these objectives is the separate design question, so nothing about which objective runs changes here.

**The objective declares its own capability.** `InfomapOptimizerBase::implementsObjectiveParameters()` returns false by default and true for `BiasedMapEquation`, so the warning cannot disagree with `initOptimizer` about which objective is in use. Deriving the condition from the input flags instead would have duplicated the dispatch and drifted the first time it changed.

**The check lives in the run path**, next to `checkFlowPostCondition`, for the reason the comment there already gives: `initNetwork` is public C++ API that embedders call directly, and it runs again for every parallel-trial worker. Verified it fires once under `-N4 --parallel-trials`.

## Verified silent where the options do apply

| input | flags | warns |
| --- | --- | --- |
| ordinary | `--entropy-corrected --preferred-number-of-modules 3` | no |
| ordinary | `--meta-data` | no |
| ordinary | `--meta-data --entropy-corrected` | yes, the correction only |
| state | `--entropy-corrected` | yes |
| state | `--preferred-number-of-modules 3` | yes |
| multilayer | `--entropy-corrected` | yes |
| state | `--meta-data` | yes, precedence |

Six tests in `test/python/test_objective_option_warnings.py`, asserted through the routed `infomap` logger — the supported way to observe engine output from Python. Two of them exist to stop the negative assertions going vacuous: one checks the logger is carrying engine output at all, and one checks meta-data on a first-order network is left alone. Removing the call fails exactly the three positive tests.

`make test-native` 26/26, fast Python suite 651. The SWIG and binding-options freshness gates pass unchanged — no `Config` members and no CLI options were added.

## Deliberately not here

- **A machine-readable signal.** `--silent` suppresses these like every other engine warning, and `--manifest-json` still records the options as active with nothing to contradict it. The summary schema has no notes or warnings channel to put this in; adding one is a report-contract decision, not a bug fix.
- **`--entropy-correction-strength` without `--entropy-corrected`** is inert on every input, ordinary ones included. That is a different silence from this issue's, so I left it.
- The banner text for box 4 (`Type higher-order state/multilayer`) is still literally true of the input and is now contradicted by a warning rather than by nothing. Rewording it is an output change I did not want to make unasked.