### PR TITLE
fix: stop --no-infomap recomputing a codelength the partition path already set

### DIFF
--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -857,8 +857,16 @@ private:
   {
     if (!infomap.noInfomap)
       infomap.runPartition();
-    else
+    else if (!infomap.haveModules()) {
+      // No partition was supplied, so nothing else has set the member: score the trivial tree.
       infomap.m_hierarchicalCodelength = infomap.calcCodelengthOnTree(infomap.root(), true);
+    }
+    // With a partition, the input path has already established it -- initTree with the same
+    // whole-tree recompute, initPartition(std::vector<unsigned int>&, bool) with the optimizer's
+    // tracked value after consolidateModules. Recomputing here overwrote the latter with a sum over
+    // module enter/exit flow that the cluster-id path never establishes: on bipartite input those
+    // values are negative, so a run reported 0.4973591381 for a tree it had just printed
+    // 0.7976667011 for, two of its three modules contributing negative codelengths (#957).
 
     if (infomap.haveHardPartition())
       infomap.restoreHardPartition();

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -858,15 +858,23 @@ private:
     if (!infomap.noInfomap)
       infomap.runPartition();
     else if (!infomap.haveModules()) {
-      // No partition was supplied, so nothing else has set the member: score the trivial tree.
+      // A tree with no module level, which without a supplied partition is every --no-infomap run:
+      // nothing has set the member, so score the trivial tree here.
       infomap.m_hierarchicalCodelength = infomap.calcCodelengthOnTree(infomap.root(), true);
     }
-    // With a partition, the input path has already established it -- initTree with the same
-    // whole-tree recompute, initPartition(std::vector<unsigned int>&, bool) with the optimizer's
-    // tracked value after consolidateModules. Recomputing here overwrote the latter with a sum over
-    // module enter/exit flow that the cluster-id path never establishes: on bipartite input those
-    // values are negative, so a run reported 0.4973591381 for a tree it had just printed
+    // Once the tree has modules the input path has established the member already -- initTree with
+    // this same whole-tree recompute, initPartition(std::vector<unsigned int>&, bool) with the
+    // optimizer's tracked value after consolidateModules. Recomputing here overwrote the latter with
+    // a sum over module enter/exit flow that the cluster-id path never establishes: on bipartite
+    // input those values are negative, so a run reported 0.4973591381 for a tree it had just printed
     // 0.7976667011 for, two of its three modules contributing negative codelengths (#957).
+    //
+    // The condition is the tree's shape, not "no partition was supplied", and the two part ways for
+    // a hard partition: initPartition collapses the modules into the leaf vector, so haveModules()
+    // is false again and this recompute still runs over the collapsed tree even though the member
+    // was set. That path keeps the behaviour it had before this branch existed. Nothing on the CLI
+    // or Python surface sets clusterDataIsHard -- only a C++ embedder can -- and there is no
+    // evidence its value is wrong, so narrowing it too would be an unverified change.
 
     if (infomap.haveHardPartition())
       infomap.restoreHardPartition();

--- a/test/python/test_no_infomap_rescoring.py
+++ b/test/python/test_no_infomap_rescoring.py
@@ -39,8 +39,8 @@ def test_bipartite_regularized_partition_rescores_to_the_same_codelength(
     result = im.run()
     modules = result.modules()
 
-    # Not a trivial partition, or the equality below could hold for a partition with no
-    # module boundaries to get the enter/exit flow of wrong.
+    # Not a trivial partition: with no module boundaries there is no enter/exit flow to get
+    # wrong, and the equality below would hold whatever the recompute did.
     assert len(set(modules.values())) > 1
     assert result.codelength > 0.0
 

--- a/test/python/test_no_infomap_rescoring.py
+++ b/test/python/test_no_infomap_rescoring.py
@@ -1,0 +1,75 @@
+"""Re-scoring a partition returns the codelength the partition actually has.
+
+``--no-infomap`` with a supplied partition used to overwrite the codelength the
+partition-input path had just established with a fresh whole-tree recompute. For a flat
+partition -- a ``.clu``, a two-level ``.tree``, or any tree under ``--two-level`` -- that
+recompute summed module enter/exit flow the cluster-id path never establishes, and on
+bipartite input those values are negative. A run then reported a codelength built from
+negative probabilities, lower than the one it had printed for the same tree (#957).
+
+Asserted as a round trip: scoring a partition Infomap just produced must return the number
+Infomap just reported for it.
+"""
+
+from __future__ import annotations
+
+import pytest
+from infomap import Infomap
+
+pytestmark = pytest.mark.fast
+
+
+def _rescore(network_path: str, modules: dict[int, int], **options) -> float:
+    im = Infomap(num_trials=1, silent=True, no_infomap=True, **options)
+    im.read_file(network_path)
+    im.run(initial_partition=modules)
+    return im.codelength
+
+
+def test_bipartite_regularized_partition_rescores_to_the_same_codelength(
+    example_network_path,
+):
+    # --regularized turns on recorded teleportation, which is what makes the module
+    # enter/exit flow of a bipartite network land negative in the recompute.
+    network = str(example_network_path("bipartite.net"))
+    options = {"two_level": True, "regularized": True, "seed": 7}
+
+    im = Infomap(num_trials=1, silent=True, **options)
+    im.read_file(network)
+    result = im.run()
+    modules = result.modules()
+
+    # Not a trivial partition, or the equality below could hold for a partition with no
+    # module boundaries to get the enter/exit flow of wrong.
+    assert len(set(modules.values())) > 1
+    assert result.codelength > 0.0
+
+    assert _rescore(network, modules, **options) == pytest.approx(result.codelength)
+
+
+def test_ordinary_network_partition_rescores_to_the_same_codelength(
+    example_network_path,
+):
+    # The same round trip on an input that never had the defect, so a regression that
+    # breaks re-scoring in general cannot hide behind the bipartite case above.
+    network = str(example_network_path("ninetriangles.net"))
+    options = {"two_level": True, "seed": 7}
+
+    im = Infomap(num_trials=1, silent=True, **options)
+    im.read_file(network)
+    result = im.run()
+    modules = result.modules()
+
+    assert len(set(modules.values())) > 1
+
+    assert _rescore(network, modules, **options) == pytest.approx(result.codelength)
+
+
+def test_no_infomap_without_a_partition_still_reports_one_level(example_network_path):
+    # The recompute is what scores the trivial tree when nothing supplied a partition, so
+    # that branch has to survive: every node in one module is the one-level codelength.
+    im = Infomap(num_trials=1, silent=True, no_infomap=True)
+    im.read_file(str(example_network_path("ninetriangles.net")))
+    result = im.run()
+
+    assert result.codelength == pytest.approx(im.one_level_codelength)


### PR DESCRIPTION
> **Correction, after Anton pushed back.** The original body claimed the recompute was wrong and the tracked value right. That is not supported: measurement shows **both** rest on the same negative module flow, and the tracked value merely hides it. This is a consistency fix, not a correctness fix. The root cause is below and belongs in #957. Do not merge this expecting the reported codelength on bipartite input to be correct afterwards.

## What this changes

`executeTrial` recomputed the hierarchical codelength over the whole tree whenever `--no-infomap` was set, overwriting whatever the partition-input path had already established:

```cpp
if (!infomap.noInfomap)
  infomap.runPartition();
else
  infomap.m_hierarchicalCodelength = infomap.calcCodelengthOnTree(infomap.root(), true);
```

Both partition paths already set that member — `initTree` with this same whole-tree recompute, `initPartition(std::vector<unsigned int>&, bool)` with the optimizer's tracked value after `consolidateModules`. The only case where nothing sets it is `--no-infomap` with no partition at all, so the recompute is now gated on that.

The effect is that scoring a partition returns the number the search reports for the same partition instead of a second, differently-derived one. On `examples/networks/bipartite.net -2 --regularized`: 0.4252773622 to 0.5939114118, which is what the same run prints as `Initial`.

## What this does not change, and why the original framing was wrong

On bipartite input **both** numbers are built on negative module enter/exit flow. Measured right after `consolidateModules` on that network:

```
after consolidateModules: index=1.110223025e-16 module=0.5939114118 total=0.5939114118
  MODULE flow=0.6694567655 enter=-0.1162787883 exit=-0.1162787883
  MODULE flow=0.3305432345 enter=-0.03897971386 exit=-0.03897971386
```

The tracked value does not avoid the negatives — its index term collapses to 1.1e-16 because of them, i.e. it charges no index cost at all for a two-module partition. The recompute exposes the same corruption as negative per-module terms. Neither is a trustworthy codelength here, so the round trip this PR restores is consistency between two equally affected numbers.

## The actual root cause, for #957

The bipartite feature nodes end up with zero flow but negative enter/exit flow, and every module containing one inherits it:

```
LEAF id=1 flow=0.3305432345 enter=0.3015321854  exit=0.3015321854
LEAF id=2 flow=0.338913531  enter=0.3275810899  exit=0.3275810899
LEAF id=3 flow=0.3305432345 enter=0.3015321854  exit=0.3015321854
LEAF id=4 flow=0            enter=-0.02901104907 exit=-0.02901104907
LEAF id=5 flow=0            enter=-0.01133244104 exit=-0.01133244104
```

It needs all three of: bipartite input, recorded teleportation, and the bipartite flow adjustment. Measured on the same network and partition:

| flags | leaves with negative enter/exit |
| --- | --- |
| none | 0 of 5 |
| `--regularized` | **2 of 5** |
| `--skip-adjust-bipartite-flow` | 0 of 5 |
| `--regularized --skip-adjust-bipartite-flow` | 0 of 5 |

`ninetriangles.net --regularized`: 0 of 27. So the adjustment that moves flow off the feature nodes zeroes their flow while leaving a teleportation-derived enter/exit contribution behind, and that contribution goes negative.

## Test

`test/python/test_no_infomap_rescoring.py` asserts the round trip — scoring a partition Infomap just produced returns the number Infomap just reported for it — on the bipartite case, on an ordinary network so a general regression cannot hide behind it, and on the no-partition branch so the surviving recompute stays covered. Reverting the gate fails exactly the bipartite case.

That invariant is worth having on its own terms and stays true once the flow bug is fixed. It does not establish either number as correct.

`make test-native` 26/26, fast Python suite 648.
