### PR TITLE
fix: stop the bipartite flow adjustment leaving negative enter/exit flow

### DIFF
--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -724,8 +724,46 @@ private:
     if (zeroFlowIsExpected)
       return;
 
+    checkNoNegativeFlow();
+
     if (std::abs(sumNodeFlow - 1.0) > 1e-10)
       Console::warn(0, "Total flow on nodes is {:g}, not 1. The reported codelength is scaled accordingly.", sumNodeFlow);
+  }
+
+  // A visit rate and a boundary-crossing rate are probabilities, so a negative one leaves every
+  // codelength downstream meaningless -- and it does not announce itself: plogp of a negative
+  // flow is not a number, but where the negative terms cancel the map equation quietly charges
+  // too little for a boundary that exists. The bipartite flow adjustment used to leave uncoded
+  // feature nodes at flow 0 with negative enter/exit flow, and the two-level index codelength
+  // came out at 1.1e-16 -- no cost at all for entering either of two modules (#957). An error
+  // rather than a warning: there is no reading of the map equation under which this is a result.
+  void checkNoNegativeFlow() const
+  {
+    // Not an exact zero bound: the flow models accumulate, so a value a few epsilons below zero
+    // is rounding, not a broken distribution.
+    constexpr double tolerance = -1e-10;
+
+    for (const auto* leafNode : m_infomap.leafNodes()) {
+      const auto& data = leafNode->data;
+      const char* quantity = data.flow < tolerance
+          ? "flow"
+          : data.enterFlow < tolerance ? "enter flow"
+          : data.exitFlow < tolerance  ? "exit flow"
+                                       : nullptr;
+      if (quantity == nullptr)
+        continue;
+
+      throw InfomapError(ExitCode::InternalError,
+                         fmt::format(FMT_STRING("Negative {} on node {}: flow {:g}, enter flow {:g}, exit flow {:g}. "
+                                                "These are probabilities, so no codelength is defined. This is a bug in the "
+                                                "flow calculation for this combination of input and flow model, not something "
+                                                "the input can be wrong about."),
+                                     quantity,
+                                     leafNode->stateId,
+                                     data.flow,
+                                     data.enterFlow,
+                                     data.exitFlow));
+    }
   }
 
   void releaseInputLinksIfCli()

--- a/src/utils/FlowCalculator.cpp
+++ b/src/utils/FlowCalculator.cpp
@@ -1326,6 +1326,23 @@ void FlowCalculator::finalize(StateNetwork& network, const Config& config, bool 
     addFlowNote("Using bipartite links");
 
     if (!config.skipAdjustBipartiteFlow && !config.bipartiteTeleportation) {
+      // A node that is not coded has no visit rate, and therefore no teleportation into it
+      // either. Clearing the node's flow while leaving its teleport flow and weight behind
+      // broke the invariant the enter/exit flow below rests on -- that a node's
+      // self-teleportation teleFlow * weight is part of its flow -- so the subtraction ran
+      // past zero: with --regularized on examples/networks/bipartite.net the two feature
+      // nodes came out at flow 0 and enter/exit -0.02901104907 = -(0.1232969585 *
+      // 0.2352941176), and every module containing one inherited a negative enter flow.
+      // The two-level index codelength then evaluated to 1.1e-16, charging nothing at all
+      // for entering either module (#957).
+      const auto uncode = [this](unsigned int nodeIndex) {
+        nodeFlow[nodeIndex] = 0.0;
+        if (!nodeTeleportFlow.empty())
+          nodeTeleportFlow[nodeIndex] = 0.0;
+        if (!nodeTeleportWeights.empty())
+          nodeTeleportWeights[nodeIndex] = 0.0;
+      };
+
       // Only links between ordinary nodes and feature nodes in bipartite network
       // Don't code feature nodes -> distribute all flow from those to ordinary nodes
       for (auto& link : flowLinks) {
@@ -1333,10 +1350,10 @@ void FlowCalculator::finalize(StateNetwork& network, const Config& config, bool 
 
         if (sourceIsFeature) {
           nodeFlow[link.target] += link.flow;
-          nodeFlow[link.source] = 0.0; // Doesn't matter if done multiple times on each node.
+          uncode(link.source); // Doesn't matter if done multiple times on each node.
         } else {
           nodeFlow[link.source] += link.flow;
-          nodeFlow[link.target] = 0.0; // Doesn't matter if done multiple times on each node.
+          uncode(link.target); // Doesn't matter if done multiple times on each node.
         }
         // TODO: Should flow double before moving to nodes, does it cancel out in normalization?
 

--- a/test/python/test_flow.py
+++ b/test/python/test_flow.py
@@ -37,6 +37,45 @@ def test_skip_adjust_bipartite_flow_still_runs(example_network_path):
     assert result.codelength == pytest.approx(0.2776646519)
 
 
+def test_bipartite_flow_adjustment_leaves_no_negative_enter_flow(example_network_path):
+    # The adjustment that moves flow off the feature nodes left their teleport flow and
+    # weight behind, and the self-teleportation removed from enter/exit flow then ran past
+    # the zero it had left: both feature nodes came out at flow 0 and enter/exit
+    # -(0.1232969585 * 0.2352941176) = -0.02901104907. Every module containing one inherited
+    # a negative enter flow, and the two-level index codelength evaluated to 1.1e-16 --
+    # charging nothing at all for entering either of two modules (#957).
+    #
+    # Asserted on the index term rather than on the total, because that is where the
+    # cancellation showed: the total stayed plausible while the index term vanished.
+    net = infomap.Network.from_file(str(example_network_path("bipartite.net")))
+    result = net.run(regularized=True, two_level=True, seed=7, num_trials=1)
+
+    assert len(set(result.modules().values())) == 2
+    assert result.index_codelength == pytest.approx(0.01551663112)
+    assert result.codelength == pytest.approx(0.7991539547)
+
+
+def test_bipartite_regularized_partition_scores_the_same_when_read_back(
+    example_network_path,
+):
+    # Two independent evaluations of one partition: the optimizer's tracked value, and a
+    # fresh recompute over the tree from the module enter/exit flow. Negative flow drove
+    # them apart -- 0.5939114118 against 0.4252773622 -- while they agree on every input
+    # whose flow is sound.
+    path = str(example_network_path("bipartite.net"))
+    options = {"regularized": True, "two_level": True, "seed": 7, "num_trials": 1}
+
+    im = infomap.Infomap(silent=True, **options)
+    im.read_file(path)
+    result = im.run()
+
+    rescored = infomap.Infomap(silent=True, no_infomap=True, **options)
+    rescored.read_file(path)
+    rescored.run(initial_partition=result.modules())
+
+    assert rescored.codelength == pytest.approx(result.codelength)
+
+
 def test_flow_convergence_is_visible_on_the_result():
     # A failed power iteration means the flow is not the network's stationary
     # distribution, so the codelength describes something else. It used to be reported


### PR DESCRIPTION
Closes #957 — the real bug behind it, not the symptom I originally filed.

## What was wrong

The bipartite flow adjustment in `FlowCalculator::finalize` moves flow off the feature nodes, on the stated ground that they are not coded:

```cpp
nodeFlow[link.target] += link.flow;
nodeFlow[link.source] = 0.0;
```

It cleared the node flow and left the teleport flow and weight behind. The enter/exit computation below it removes a node's self-teleportation on the assumption that `teleFlow * weight` is part of that node's flow:

```cpp
node.enterFlow = node.flow;
node.enterFlow -= node.teleFlow * node.weight;
```

With the flow gone the subtraction ran past zero. On `examples/networks/bipartite.net` with `--regularized`:

```
LEAF id=4 flow=0 enter=-0.02901104907 exit=-0.02901104907
LEAF id=5 flow=0 enter=-0.01133244104 exit=-0.01133244104
```

`-0.02901104907` is exactly `-(0.1232969585 * 0.2352941176)`, the node's teleport flow times its teleport weight. Every module containing a feature node inherited a negative enter flow.

**It did not announce itself.** The two-level index codelength for a two-module partition evaluated to `1.110223025e-16` — no cost at all for entering either module — while the total stayed plausible at 0.5939114118. Now 0.0155166 and 0.7991539547.

Three conditions were needed, which is why this sat undetected: bipartite input, recorded teleportation, and the adjustment itself. Same network and partition:

| flags | leaves with negative enter/exit |
| --- | --- |
| none | 0 of 5 |
| `--regularized` | **2 of 5** |
| `--skip-adjust-bipartite-flow` | 0 of 5 |
| `--regularized --skip-adjust-bipartite-flow` | 0 of 5 |

`ninetriangles.net --regularized`: 0 of 27.

## The fix

A node that is not coded has no visit rate, and therefore no teleportation into it either. The adjustment now clears the teleport flow and weight along with the flow, in the same loop and for the same reason.

## Negative flow is now an error

Per Anton: a visit rate and a boundary-crossing rate are probabilities, so there is no reading of the map equation under which a negative one is a result. `checkFlowPostCondition` refuses the run, naming the node and all three values, as an `InternalError` rather than an input one — the input cannot be wrong about this. Tolerance is `-1e-10` rather than exact zero, since the flow models accumulate and a few epsilons below zero is rounding.

The subtle part is why it has to be an error rather than a warning: `plogp` of a negative flow is not a number and would surface, but where the negative terms **cancel** the map equation quietly charges too little for a boundary that exists. That is what produced the 1.1e-16 index term instead of a NaN.

## What this resolves

Two independent evaluations of the same partition — the optimizer's tracked value and a fresh recompute over the tree from module enter/exit flow — now agree exactly on that network, where they differed by 0.5939114118 against 0.4252773622. That was #957's entire symptom, and it goes away without #959's gate: I measured the round trip on this branch, which does not contain it.

Two residuals remain and belong to #958, both smaller than before:

| case | before | after |
| --- | --- | --- |
| 7-node bipartite, two-level | large | 0.000712 |
| Fonseca-Ganade, multi-level | 3.91 | 2.33 |

So the negative flow was one contributor to #958, not the whole story. I have not touched that.

## Tests

Two in `test/python/test_flow.py`, next to the existing bipartite flow cases:

- the index codelength and total for that run, asserted on the **index** term specifically, because that is where the cancellation showed while the total stayed plausible;
- the round trip: scoring the partition the optimizer just produced returns the same number.

Both fail when the fix is reverted, and the first fails by raising the new `InfomapError` — so the mutation check covers the guard as well as the fix.

`make test-native` 26/26 and the fast Python suite (653) pass, which is the substantive check on the error: it fires on nothing in the suite.

## Note on #959

That PR stops `--no-infomap` deriving a second codelength for a partition instead of reporting the one the search reports. It is still a real consistency improvement, but with this landed it is no longer papering over anything — and my original description of it was wrong, which I have corrected there.
