### PR TITLE
perf: let callers pre-size the link build buffer

### DIFF
--- a/interfaces/R/generated/infomap.R
+++ b/interfaces/R/generated/infomap.R
@@ -17012,6 +17012,25 @@ attr(`StateNetwork_addLinks`, 'returnType') = 'void'
 attr(`StateNetwork_addLinks`, "inputTypes") = c('_p_infomap__StateNetwork', 'integer', 'integer', '_p_std__vectorT_double_t')
 class(`StateNetwork_addLinks`) = c("SWIGFunction", class('StateNetwork_addLinks'))
 
+# Start of StateNetwork_reserveLinks
+
+`StateNetwork_reserveLinks` = function(self, numAdditionalLinks)
+{
+  if (inherits(self, "ExternalReference")) self = slot(self,"ref"); 
+  numAdditionalLinks = as.integer(numAdditionalLinks);
+  
+  if(length(numAdditionalLinks) > 1) {
+    warning("using only the first element of numAdditionalLinks");
+  };
+  
+  ;.Call('R_swig_StateNetwork_reserveLinks', self, numAdditionalLinks, PACKAGE='infomap');
+  
+}
+
+attr(`StateNetwork_reserveLinks`, 'returnType') = 'void'
+attr(`StateNetwork_reserveLinks`, "inputTypes") = c('_p_infomap__StateNetwork', 'integer')
+class(`StateNetwork_reserveLinks`) = c("SWIGFunction", class('StateNetwork_reserveLinks'))
+
 # Start of StateNetwork_removeLink
 
 `StateNetwork_removeLink` = function(self, sourceId, targetId, .copy = FALSE)
@@ -17556,7 +17575,7 @@ class(`StateNetwork_writePajekNetwork__SWIG_1`) = c("SWIGFunction", class('State
 setMethod('$', '_p_infomap__StateNetwork', function(x, name)
 
 {
-  accessorFuns = list('setConfig' = StateNetwork_setConfig, 'addStateNode' = StateNetwork_addStateNode, 'addNode' = StateNetwork_addNode, 'addPhysicalNode' = StateNetwork_addPhysicalNode, 'addName' = StateNetwork_addName, 'addLink' = StateNetwork_addLink, 'addLinks' = StateNetwork_addLinks, 'removeLink' = StateNetwork_removeLink, 'undirectedToDirected' = StateNetwork_undirectedToDirected, 'clear' = StateNetwork_clear, 'clearLinks' = StateNetwork_clearLinks, 'nodes' = StateNetwork_nodes, 'numNodes' = StateNetwork_numNodes, 'numPhysicalNodes' = StateNetwork_numPhysicalNodes, 'sumNodeWeight' = StateNetwork_sumNodeWeight, 'numAggregatedLinks' = StateNetwork_numAggregatedLinks, 'numLinks' = StateNetwork_numLinks, 'sumLinkWeight' = StateNetwork_sumLinkWeight, 'numSelfLinks' = StateNetwork_numSelfLinks, 'sumSelfLinkWeight' = StateNetwork_sumSelfLinkWeight, 'sumWeightedDegree' = StateNetwork_sumWeightedDegree, 'sumDegree' = StateNetwork_sumDegree, 'outWeights' = StateNetwork_outWeights, 'names' = StateNetwork_names, 'haveFlowConvergence' = StateNetwork_haveFlowConvergence, 'flowConverged' = StateNetwork_flowConverged, 'flowIterations' = StateNetwork_flowIterations, 'flowError' = StateNetwork_flowError, 'haveNodeWeights' = StateNetwork_haveNodeWeights, 'haveStateNodeWeights' = StateNetwork_haveStateNodeWeights, 'haveFileInput' = StateNetwork_haveFileInput, 'metaData' = StateNetwork_metaData, 'haveDirectedInput' = StateNetwork_haveDirectedInput, 'haveMemoryInput' = StateNetwork_haveMemoryInput, 'higherOrderInputMethodCalled' = StateNetwork_higherOrderInputMethodCalled, 'isBipartite' = StateNetwork_isBipartite, 'bipartiteStartId' = StateNetwork_bipartiteStartId, 'setBipartiteStartId' = StateNetwork_setBipartiteStartId, 'writeStateNetwork' = StateNetwork_writeStateNetwork, 'writePajekNetwork' = StateNetwork_writePajekNetwork);
+  accessorFuns = list('setConfig' = StateNetwork_setConfig, 'addStateNode' = StateNetwork_addStateNode, 'addNode' = StateNetwork_addNode, 'addPhysicalNode' = StateNetwork_addPhysicalNode, 'addName' = StateNetwork_addName, 'addLink' = StateNetwork_addLink, 'addLinks' = StateNetwork_addLinks, 'reserveLinks' = StateNetwork_reserveLinks, 'removeLink' = StateNetwork_removeLink, 'undirectedToDirected' = StateNetwork_undirectedToDirected, 'clear' = StateNetwork_clear, 'clearLinks' = StateNetwork_clearLinks, 'nodes' = StateNetwork_nodes, 'numNodes' = StateNetwork_numNodes, 'numPhysicalNodes' = StateNetwork_numPhysicalNodes, 'sumNodeWeight' = StateNetwork_sumNodeWeight, 'numAggregatedLinks' = StateNetwork_numAggregatedLinks, 'numLinks' = StateNetwork_numLinks, 'sumLinkWeight' = StateNetwork_sumLinkWeight, 'numSelfLinks' = StateNetwork_numSelfLinks, 'sumSelfLinkWeight' = StateNetwork_sumSelfLinkWeight, 'sumWeightedDegree' = StateNetwork_sumWeightedDegree, 'sumDegree' = StateNetwork_sumDegree, 'outWeights' = StateNetwork_outWeights, 'names' = StateNetwork_names, 'haveFlowConvergence' = StateNetwork_haveFlowConvergence, 'flowConverged' = StateNetwork_flowConverged, 'flowIterations' = StateNetwork_flowIterations, 'flowError' = StateNetwork_flowError, 'haveNodeWeights' = StateNetwork_haveNodeWeights, 'haveStateNodeWeights' = StateNetwork_haveStateNodeWeights, 'haveFileInput' = StateNetwork_haveFileInput, 'metaData' = StateNetwork_metaData, 'haveDirectedInput' = StateNetwork_haveDirectedInput, 'haveMemoryInput' = StateNetwork_haveMemoryInput, 'higherOrderInputMethodCalled' = StateNetwork_higherOrderInputMethodCalled, 'isBipartite' = StateNetwork_isBipartite, 'bipartiteStartId' = StateNetwork_bipartiteStartId, 'setBipartiteStartId' = StateNetwork_setBipartiteStartId, 'writeStateNetwork' = StateNetwork_writeStateNetwork, 'writePajekNetwork' = StateNetwork_writePajekNetwork);
   ;        idx = pmatch(name, names(accessorFuns));
   if(is.na(idx)) 
   return(callNextMethod(x, name));

--- a/interfaces/R/generated/infomap_wrap.cpp
+++ b/interfaces/R/generated/infomap_wrap.cpp
@@ -1824,6 +1824,9 @@ void addLinksFromNumpy2D(InfomapWrapper& infomap, PyObject* links, std::size_t n
 
   const auto* data = linksBuffer.data<char>();
   const auto rowStride = static_cast<std::size_t>(numColumns) * itemSize;
+  // The array's shape is the exact link count, so size the build buffer once
+  // instead of letting it double into place (see StateNetwork::reserveLinks).
+  infomap.network().reserveLinks(numRows);
   for (std::size_t i = 0; i < numRows; ++i) {
     const auto* row = data + i * rowStride;
     const auto source = readUnsignedId(row, dtypeKind, itemSize, "source id");
@@ -34688,6 +34691,49 @@ R_swig_StateNetwork_addLinks ( SEXP self, SEXP sourceIds, SEXP targetIds, SEXP w
 
 
 SWIGEXPORT SEXP
+R_swig_StateNetwork_reserveLinks ( SEXP self, SEXP numAdditionalLinks)
+{
+  {
+    infomap::StateNetwork *arg1 = 0 ;
+    std::size_t arg2 ;
+    void *argp1 = 0 ;
+    int res1 = 0 ;
+    int val2 ;
+    int ecode2 = 0 ;
+    unsigned int r_nprotect = 0;
+    SEXP r_ans = R_NilValue ;
+    VMAXTYPE r_vmax = vmaxget() ;
+    
+    res1 = SWIG_R_ConvertPtr(self, &argp1, SWIGTYPE_p_infomap__StateNetwork, 0 |  0 );
+    if (!SWIG_IsOK(res1)) {
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "StateNetwork_reserveLinks" "', argument " "1"" of type '" "infomap::StateNetwork *""'"); 
+    }
+    arg1 = reinterpret_cast< infomap::StateNetwork * >(argp1);
+    ecode2 = SWIG_AsVal_int(numAdditionalLinks, &val2);
+    if (!SWIG_IsOK(ecode2)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "StateNetwork_reserveLinks" "', argument " "2"" of type '" "std::size_t""'");
+    } 
+    arg2 = static_cast< std::size_t >(val2);
+    {
+      try {
+        (arg1)->reserveLinks(SWIG_STD_MOVE(arg2));
+      } catch (const std::exception& e) {
+        SWIG_exception(SWIG_RuntimeError, e.what());
+      }
+    }
+    r_ans = R_NilValue;
+    vmaxset(r_vmax);
+    if(r_nprotect)  Rf_unprotect(r_nprotect);
+    
+    return r_ans;
+    fail: SWIGUNUSED;
+  }
+  Rf_error("%s %s", SWIG_ErrorType(SWIG_lasterror_code), SWIG_lasterror_msg);
+  return R_NilValue;
+}
+
+
+SWIGEXPORT SEXP
 R_swig_StateNetwork_removeLink ( SEXP self, SEXP sourceId, SEXP targetId, SEXP s_swig_copy)
 {
   {
@@ -50633,6 +50679,7 @@ SWIGINTERN R_CallMethodDef CallEntries[] = {
    {"R_swig_InfomapIterator_previous_set", (DL_FUNC) &R_swig_InfomapIterator_previous_set, 2},
    {"R_swig_EdgeData_weight_set", (DL_FUNC) &R_swig_EdgeData_weight_set, 2},
    {"R_swig_InfomapIterator_infomapTree__SWIG_3", (DL_FUNC) &R_swig_InfomapIterator_infomapTree__SWIG_3, 2},
+   {"R_swig_StateNetwork_reserveLinks", (DL_FUNC) &R_swig_StateNetwork_reserveLinks, 2},
    {"R_swig_InfomapWrapper_iterLeafNodes__SWIG_1", (DL_FUNC) &R_swig_InfomapWrapper_iterLeafNodes__SWIG_1, 2},
    {"R_swig_InfoNode_begin_tree__SWIG_0", (DL_FUNC) &R_swig_InfoNode_begin_tree__SWIG_0, 3},
    {"R_swig_InfoNode_begin_tree__SWIG_1", (DL_FUNC) &R_swig_InfoNode_begin_tree__SWIG_1, 2},

--- a/interfaces/R/infomap/R/Infomap.R
+++ b/interfaces/R/infomap/R/Infomap.R
@@ -449,6 +449,23 @@ InfomapClass <- R6::R6Class(
       invisible(self)
     },
 
+    #' @description Pre-size the link build buffer for `num_links` further
+    #'   links. Optional. Links are stored in a buffer that grows by doubling,
+    #'   so building a large network reserves up to twice the memory it needs
+    #'   and copies the buffer on each growth; giving the count up front avoids
+    #'   both. Counts from the links already added, so it composes across calls.
+    #'   `add_links()` does this for you from the length of its input; call this
+    #'   directly when adding links one at a time with `add_link()`.
+    #' @param num_links Number of links about to be added.
+    #' @examples
+    #' im <- infomap()
+    #' im$reserve_links(3)
+    #' im$add_link(1, 2)
+    reserve_links = function(num_links) {
+      private$.swig$reserveLinks(num_links)
+      invisible(self)
+    },
+
     #' @description Add many links at once.
     #' @param links A list of vectors of the form `c(source, target, weight)`
     #'   (weight optional), or a 2- or 3-column matrix / data.frame whose

--- a/interfaces/R/infomap/man/Infomap.Rd
+++ b/interfaces/R/infomap/man/Infomap.Rd
@@ -53,6 +53,14 @@ im$run()
 im$num_top_modules
 im$codelength
 im$modules
+
+## ------------------------------------------------
+## Method `InfomapClass$reserve_links`
+## ------------------------------------------------
+
+im <- infomap()
+im$reserve_links(3)
+im$add_link(1, 2)
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
@@ -138,6 +146,7 @@ merged within a module).}
 \item \href{#method-Infomap-set_name}{\code{InfomapClass$set_name()}}
 \item \href{#method-Infomap-set_names}{\code{InfomapClass$set_names()}}
 \item \href{#method-Infomap-add_link}{\code{InfomapClass$add_link()}}
+\item \href{#method-Infomap-reserve_links}{\code{InfomapClass$reserve_links()}}
 \item \href{#method-Infomap-add_links}{\code{InfomapClass$add_links()}}
 \item \href{#method-Infomap-remove_link}{\code{InfomapClass$remove_link()}}
 \item \href{#method-Infomap-remove_links}{\code{InfomapClass$remove_links()}}
@@ -352,6 +361,39 @@ Add a link.
 }
 \if{html}{\out{</div>}}
 }
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Infomap-reserve_links"></a>}}
+\if{latex}{\out{\hypertarget{method-Infomap-reserve_links}{}}}
+\subsection{Method \code{reserve_links()}}{
+Pre-size the link build buffer for \code{num_links} further
+links. Optional. Links are stored in a buffer that grows by doubling,
+so building a large network reserves up to twice the memory it needs
+and copies the buffer on each growth; giving the count up front avoids
+both. Counts from the links already added, so it composes across calls.
+\code{add_links()} does this for you from the length of its input; call this
+directly when adding links one at a time with \code{add_link()}.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{InfomapClass$reserve_links(num_links)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{num_links}}{Number of links about to be added.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Examples}{
+\if{html}{\out{<div class="r example copy">}}
+\preformatted{im <- infomap()
+im$reserve_links(3)
+im$add_link(1, 2)
+}
+\if{html}{\out{</div>}}
+
+}
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Infomap-add_links"></a>}}

--- a/interfaces/python/generated/infomap_wrap.cpp
+++ b/interfaces/python/generated/infomap_wrap.cpp
@@ -3910,6 +3910,9 @@ void addLinksFromNumpy2D(InfomapWrapper& infomap, PyObject* links, std::size_t n
 
   const auto* data = linksBuffer.data<char>();
   const auto rowStride = static_cast<std::size_t>(numColumns) * itemSize;
+  // The array's shape is the exact link count, so size the build buffer once
+  // instead of letting it double into place (see StateNetwork::reserveLinks).
+  infomap.network().reserveLinks(numRows);
   for (std::size_t i = 0; i < numRows; ++i) {
     const auto* row = data + i * rowStride;
     const auto source = readUnsignedId(row, dtypeKind, itemSize, "source id");
@@ -40724,6 +40727,42 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_StateNetwork_reserveLinks(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  infomap::StateNetwork *arg1 = 0 ;
+  std::size_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  PyObject *swig_obj[2] ;
+  
+  (void)self;
+  if (!SWIG_Python_UnpackTuple(args, "StateNetwork_reserveLinks", 2, 2, swig_obj)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_infomap__StateNetwork, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "StateNetwork_reserveLinks" "', argument " "1"" of type '" "infomap::StateNetwork *""'"); 
+  }
+  arg1 = reinterpret_cast< infomap::StateNetwork * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(swig_obj[1], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "StateNetwork_reserveLinks" "', argument " "2"" of type '" "std::size_t""'");
+  } 
+  arg2 = static_cast< std::size_t >(val2);
+  {
+    try {
+      (arg1)->reserveLinks(SWIG_STD_MOVE(arg2));
+    } catch (const std::exception& e) {
+      SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_StateNetwork_removeLink(PyObject *self, PyObject *args) {
   PyObject *resultobj = 0;
   infomap::StateNetwork *arg1 = 0 ;
@@ -60682,6 +60721,7 @@ static PyMethodDef SwigMethods[] = {
 	 { "StateNetwork_addName", _wrap_StateNetwork_addName, METH_VARARGS, NULL},
 	 { "StateNetwork_addLink", _wrap_StateNetwork_addLink, METH_VARARGS, NULL},
 	 { "StateNetwork_addLinks", _wrap_StateNetwork_addLinks, METH_VARARGS, NULL},
+	 { "StateNetwork_reserveLinks", _wrap_StateNetwork_reserveLinks, METH_VARARGS, NULL},
 	 { "StateNetwork_removeLink", _wrap_StateNetwork_removeLink, METH_VARARGS, NULL},
 	 { "StateNetwork_undirectedToDirected", _wrap_StateNetwork_undirectedToDirected, METH_O, NULL},
 	 { "StateNetwork_clear", _wrap_StateNetwork_clear, METH_O, NULL},

--- a/interfaces/python/src/infomap/_facade.py
+++ b/interfaces/python/src/infomap/_facade.py
@@ -1374,6 +1374,38 @@ class Infomap(_InfomapResultsMixin, _InfomapWritersMixin):
         """
         self._core.addLink(source_id, target_id, weight)
 
+    def reserve_links(self, num_links: int) -> None:
+        """Pre-size the link build buffer for ``num_links`` further links.
+
+        Optional. Links are stored in a buffer that grows by doubling, so
+        building a large network reserves up to twice the memory it needs and
+        copies the buffer on each growth. Giving the count up front avoids both.
+        Counts from the links already added, so it composes across calls.
+
+        :meth:`add_links` does this for you from the length of its input; call it
+        directly when you add links one at a time and know the total in advance.
+
+        Examples
+        --------
+
+        >>> from infomap import Infomap
+        >>> im = Infomap()
+        >>> im.reserve_links(2)
+        >>> im.add_link(1, 2)
+        >>> im.add_link(1, 3)
+
+        See Also
+        --------
+        add_link
+        add_links
+
+        Parameters
+        ----------
+        num_links : int
+            Number of links about to be added.
+        """
+        self._core.reserveLinks(num_links)
+
     def add_links(self, links: Any) -> None:
         """Add several links.
 

--- a/interfaces/python/src/infomap/_swig.py
+++ b/interfaces/python/src/infomap/_swig.py
@@ -2116,6 +2116,9 @@ class StateNetwork(object):
     def addLinks(self, sourceIds, targetIds, weights):
         return _infomap.StateNetwork_addLinks(self, sourceIds, targetIds, weights)
 
+    def reserveLinks(self, numAdditionalLinks):
+        return _infomap.StateNetwork_reserveLinks(self, numAdditionalLinks)
+
     def removeLink(self, sourceId, targetId):
         return _infomap.StateNetwork_removeLink(self, sourceId, targetId)
 

--- a/interfaces/python/src/infomap/network.py
+++ b/interfaces/python/src/infomap/network.py
@@ -641,6 +641,35 @@ class Network(_NetworkWritersMixin):
         self._core.addLink(source_id, target_id, weight)
         return self
 
+    def reserve_links(self, num_links: int) -> Network:
+        """Pre-size the link build buffer for ``num_links`` further links.
+
+        Optional. Links are stored in a buffer that grows by doubling, so
+        building a large network reserves up to twice the memory it needs and
+        copies the buffer on each growth. Telling it the count up front avoids
+        both. Counts from the links already added, so it composes across calls.
+
+        :meth:`add_links` and the NumPy bulk path do this for you from the length
+        of what you pass; call it directly when you add links one at a time with
+        :meth:`add_link` and know the total in advance.
+
+        Parameters
+        ----------
+        num_links : int
+            Number of links about to be added.
+
+        Examples
+        --------
+        >>> from infomap import Network
+        >>> network = Network()
+        >>> network.reserve_links(2)              # doctest: +ELLIPSIS
+        <infomap.network.Network object at ...>
+        >>> _ = network.add_link(1, 2)
+        >>> _ = network.add_link(1, 3)
+        """
+        self._core.reserveLinks(num_links)
+        return self
+
     def add_links(self, links: Any) -> Network:
         """Add several links.
 

--- a/interfaces/swig/Infomap.i
+++ b/interfaces/swig/Infomap.i
@@ -200,6 +200,9 @@ void addLinksFromNumpy2D(InfomapWrapper& infomap, PyObject* links, std::size_t n
 
   const auto* data = linksBuffer.data<char>();
   const auto rowStride = static_cast<std::size_t>(numColumns) * itemSize;
+  // The array's shape is the exact link count, so size the build buffer once
+  // instead of letting it double into place (see StateNetwork::reserveLinks).
+  infomap.network().reserveLinks(numRows);
   for (std::size_t i = 0; i < numRows; ++i) {
     const auto* row = data + i * rowStride;
     const auto source = readUnsignedId(row, dtypeKind, itemSize, "source id");

--- a/src/core/StateNetwork.cpp
+++ b/src/core/StateNetwork.cpp
@@ -9,6 +9,7 @@
 
 #include "StateNetwork.h"
 #include "../utils/FlowCalculator.h"
+#include "../utils/Console.h"
 #include "../utils/Log.h"
 #include "../utils/format.h"
 #include "../io/SafeFile.h"
@@ -160,6 +161,11 @@ bool StateNetwork::addLink(unsigned int sourceId, unsigned int targetId, double 
     definalize(); // re-entered build (e.g. accumulate=true read, addLink after run)
   }
   ++m_rawLinkCount;
+  // Apply a reserveLinks hint here, on the first append, so that a mode-B
+  // (multilayer) input never reserves a buffer it will not use.
+  if (m_linkCountHint > 0 && m_linkBuffer.capacity() < m_linkCountHint) {
+    m_linkBuffer.reserve(m_linkCountHint);
+  }
   m_linkBuffer.push_back({ sourceId, targetId, weight });
   return true;
 }
@@ -205,11 +211,24 @@ bool StateNetwork::addLink(unsigned int sourceId, unsigned int targetId, unsigne
   return addLink(sourceId, targetId, static_cast<double>(weight));
 }
 
+void StateNetwork::reserveLinks(std::size_t numAdditionalLinks)
+{
+  // Room for this many *more* links, so repeated calls from successive batches
+  // compose. Largest hint wins; never shrink what is already reserved.
+  const std::size_t target = m_linkBuffer.size() + numAdditionalLinks;
+  if (target > m_linkCountHint) {
+    m_linkCountHint = target;
+  }
+}
+
 void StateNetwork::addLinks(const std::vector<unsigned int>& sourceIds, const std::vector<unsigned int>& targetIds, const std::vector<double>& weights)
 {
   if (sourceIds.size() != targetIds.size() || sourceIds.size() != weights.size()) {
     throw std::invalid_argument("sourceIds, targetIds, and weights must have the same length");
   }
+
+  // The batch knows exactly how many links it is about to add.
+  reserveLinks(sourceIds.size());
 
   for (std::size_t i = 0; i < sourceIds.size(); ++i) {
     addLink(sourceIds[i], targetIds[i], weights[i]);
@@ -291,6 +310,7 @@ bool StateNetwork::undirectedToDirected()
 
 void StateNetwork::clearLinks()
 {
+  m_linkCountHint = 0;
   // Release ALL link storage so none of it survives into the optimize phase.
   // releaseInputLinksIfCli() calls this before runTrials(); the pre-CSR build
   // freed its nested map here, so the CSR (and outWeights) must be freed too
@@ -317,6 +337,7 @@ void StateNetwork::clear()
   m_nodes.clear();
   NodeLinkMap().swap(m_nodeLinkMap);
   std::vector<LinkTriple>().swap(m_linkBuffer);
+  m_linkCountHint = 0;
   std::vector<unsigned int>().swap(m_nodeIds);
   std::vector<unsigned int>().swap(m_linkOffsets);
   std::vector<unsigned int>().swap(m_linkTargets);
@@ -540,11 +561,19 @@ void StateNetwork::buildCsrFromBuffer()
 
   // Free the build buffer + permutation before sizing the flow array, to keep
   // the transient peak down.
+  const std::size_t bufferCapacity = m_linkBuffer.capacity();
   std::vector<LinkTriple>().swap(m_linkBuffer);
   std::vector<unsigned int>().swap(order);
 
   m_numLinks = static_cast<unsigned int>(m_linkTargets.size());
   m_numAggregatedLinks = m_rawLinkCount - m_numLinks;
+  // The build buffer is the largest allocation on a big network, so report how
+  // well it was sized: slack means the reserve hint over-estimated, and a
+  // capacity above the next power of two below it means it doubled instead.
+  Console::detail(2, "link build buffer: {} links in a capacity of {} ({:.0f} MB, {:.1f}% slack)",
+                  m_rawLinkCount, bufferCapacity,
+                  static_cast<double>(bufferCapacity * sizeof(LinkTriple)) / (1024.0 * 1024.0),
+                  m_rawLinkCount > 0 ? 100.0 * (static_cast<double>(bufferCapacity) / m_rawLinkCount - 1.0) : 0.0);
   m_linkFlows.assign(m_linkTargets.size(), 0.0);
 
   // m_outWeights is deliberately NOT derived in mode A: first-order consumers

--- a/src/core/StateNetwork.h
+++ b/src/core/StateNetwork.h
@@ -107,6 +107,7 @@ protected:
   // --- Link build representations (one active per instance) ---
   NodeLinkMap m_nodeLinkMap; // mode B (multilayer) build rep
   mutable std::vector<LinkTriple> m_linkBuffer; // mode A (first-order) build rep
+  std::size_t m_linkCountHint = 0; // reserveLinks: applied on the first mode-A append
   bool m_useMapBuild = false; // true => mode B
   mutable bool m_linksFinalized = false;
   mutable unsigned int m_rawLinkCount = 0; // pre-aggregation occurrences (mode A)
@@ -183,6 +184,32 @@ public:
   bool addLink(unsigned int sourceId, unsigned int targetId, double weight = 1.0);
   bool addLink(unsigned int sourceId, unsigned int targetId, unsigned long weight);
   void addLinks(const std::vector<unsigned int>& sourceIds, const std::vector<unsigned int>& targetIds, const std::vector<double>& weights);
+
+  /**
+   * Pre-size the first-order link build buffer for `numAdditionalLinks` further links.
+   *
+   * The buffer is 16 B per link and is grown by push_back, so without a hint it
+   * doubles: at 1.5e9 links its capacity reaches 2^31 slots (34 GB) and the last
+   * reallocation holds the old and new arrays at once (~52 GB) to copy between
+   * them. One reserve up front removes both the slack and the copy, which at that
+   * scale is the largest single allocation in the whole run.
+   *
+   * Counts from the links already added, so it composes: every caller that knows
+   * how many links it is about to add can say so — the batch addLinks and the
+   * NumPy bulk path do it from their input's length, and an API client that knows
+   * its edge count can call it directly. Never shrinks an existing reservation,
+   * and takes the largest hint it is given.
+   *
+   * Reading from a file does not use this: the parser streams links without
+   * knowing how many are coming, and counting them first costs a second pass over
+   * the input (measured at +4% ingest CPU) for no reduction in a run's peak, which
+   * on a dense network is set by the node/link handoff rather than by this buffer.
+   *
+   * Applied on the first addLink rather than immediately, so a multilayer input —
+   * which aggregates into the nested map and never touches this buffer — does not
+   * reserve anything.
+   */
+  void reserveLinks(std::size_t numAdditionalLinks);
 
   /**
    * Remove link


### PR DESCRIPTION
## Problem

First-order links are staged in a `std::vector<LinkTriple>` — 16 B per link — grown by `push_back` with no reservation. libc++ doubles, so the buffer ends up holding up to 2× the memory it needs and copies itself on every growth. Measured (`std::vector` capacity after N `push_back`s):

| links | capacity | buffer |
|--:|--:|--:|
| 5.0M | 8,388,608 | 128 MB |
| 19.5M | 33,554,432 | 512 MB |
| 1.5e9 | 2,147,483,648 | **34.4 GB** (24 GB of data) |

At 1.5e9 links the last reallocation holds the old and the new array at once — **~52 GB** — to copy 17 GB between them. It is the largest single allocation in a run on a big network.

## Change

`StateNetwork::reserveLinks(numAdditionalLinks)` lets a caller that knows its link count size the buffer once:

- counts from the links already added, so successive batches compose;
- takes the largest hint it is given and never shrinks a reservation;
- is applied on the **first append**, not immediately, so a multilayer input — which aggregates into the nested map and never touches this buffer — reserves nothing.

Wired into the paths that already know their count, so existing callers get it for free:

- `addLinks(sources, targets, weights)` — from the vector length.
- The NumPy bulk path (`addLinksFromNumpy2D`) — from the array's shape.

Exposed for callers that add links one at a time from a known edge list:

- Python: `Infomap.reserve_links(n)` and `Network.reserve_links(n)`
- R: `im$reserve_links(n)`

Also reports the buffer's final sizing under `-vv`, so a bad hint is visible rather than silent:

```
link build buffer: 5000000 links in a capacity of 5500002 (84 MB, 10.0% slack)
```

## Why file input deliberately does not use this

The parser streams links through callbacks without knowing how many are coming, so the CLI would have to count them first. Measured cost of that extra pass on a 318 MB / 19.5M-link file, interleaved min-of-5: **+4.1% ingest CPU, +8.3% wall**.

What it would buy: the buffer drops 512 MB → 313 MB. What it would *not* buy: any reduction in the run's peak. At that density the peak is the **handoff** — the input CSR and the `InfoNode` leaf tree coexisting, ~1.7 GB — not the buffer, and the measured peak RSS moved by nothing distinguishable from noise (±200 MB run-to-run at that scale on the test machine). So the pass is not paid for today. It becomes worth revisiting when the handoff itself shrinks, at which point the count can come from a pass the ingest needs anyway rather than a dedicated one.

## Verification

- **Codelength unchanged** (this is allocation only): identical on science2001 `-d`, powergrid and air30k, `-N10 --seed 123`, against a binary built from the same base.
- `make test-native` — all C++ tests pass. 5 failures in this environment are a missing Python `jsonschema` module, present on a clean checkout too.
- `make test-python-swig-freshness`, `make test-r-swig-freshness`, `make test-r-man-freshness` — all report fresh; generated wrappers and `Infomap.Rd` are regenerated in this PR (R man pages with the pinned roxygen2 7.3.3).
- Not verified here: the Python editable install (`make dev-python-install`) fails in this environment on a pre-existing `project.license` / setuptools incompatibility — reproduced on a clean checkout — so the Python method is verified by the generated wrapper (`StateNetwork_reserveLinks`) and by compilation, not by an end-to-end call.