### PR TITLE
fix: refuse a run whose module flow went negative, not just its node flow

### DIFF
--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -782,9 +782,12 @@ private:
   //
   // Checked once per trial on the finished tree rather than after every consolidation: a walk over
   // the modules costs nothing next to the search, and a codelength is only reported from here on.
-  void checkNoNegativeModuleFlow() const
+  //
+  // Takes the tree to walk rather than reading m_infomap: under --parallel-trials the trial runs on
+  // a worker instance, and checking the main instance's tree would check an unpartitioned one.
+  void checkNoNegativeModuleFlow(InfoNode& root) const
   {
-    for (auto it = m_infomap.root().begin_post_depth_first(); !it.isEnd(); ++it) {
+    for (auto it = root.begin_post_depth_first(); !it.isEnd(); ++it) {
       const auto& node = *it;
       if (node.isLeaf())
         continue;
@@ -973,7 +976,7 @@ private:
     if (infomap.haveHardPartition())
       infomap.restoreHardPartition();
 
-    checkNoNegativeModuleFlow();
+    checkNoNegativeModuleFlow(infomap.root());
   }
 
   void finishTrial(unsigned int trialIndex, Stopwatch& timer, Result& result)

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -785,6 +785,14 @@ private:
   //
   // Takes the tree to walk rather than reading m_infomap: under --parallel-trials the trial runs on
   // a worker instance, and checking the main instance's tree would check an unpartitioned one.
+  //
+  // Running after restoreHardPartition() rather than before is deliberate, and does not check a
+  // different tree than the codelength was computed from. A collapsed hard-partition super-node has
+  // its child chain swapped out, so firstChild is null and it is a leaf while collapsed -- skipped
+  // here either way -- and the restore only splices the original leaves into its place. Measured on
+  // a hard partition of ninetriangles.net: same four modules at the same depths with bit-identical
+  // flow, enter and exit flow before and after; only childDegree() changes (1 super-node child to 9
+  // real ones), and reporting the real count in the message is the more useful of the two.
   void checkNoNegativeModuleFlow(InfoNode& root) const
   {
     for (auto it = root.begin_post_depth_first(); !it.isEnd(); ++it) {

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -737,19 +737,26 @@ private:
   // feature nodes at flow 0 with negative enter/exit flow, and the two-level index codelength
   // came out at 1.1e-16 -- no cost at all for entering either of two modules (#957). An error
   // rather than a warning: there is no reading of the map equation under which this is a result.
+  // Not an exact zero bound: the flow models accumulate, so a value a few epsilons below zero is
+  // rounding, not a broken distribution.
+  static constexpr double negativeFlowTolerance = -1e-10;
+
+  static const char* negativeFlowQuantity(const FlowData& data) noexcept
+  {
+    if (data.flow < negativeFlowTolerance)
+      return "flow";
+    if (data.enterFlow < negativeFlowTolerance)
+      return "enter flow";
+    if (data.exitFlow < negativeFlowTolerance)
+      return "exit flow";
+    return nullptr;
+  }
+
   void checkNoNegativeFlow() const
   {
-    // Not an exact zero bound: the flow models accumulate, so a value a few epsilons below zero
-    // is rounding, not a broken distribution.
-    constexpr double tolerance = -1e-10;
-
     for (const auto* leafNode : m_infomap.leafNodes()) {
       const auto& data = leafNode->data;
-      const char* quantity = data.flow < tolerance
-          ? "flow"
-          : data.enterFlow < tolerance ? "enter flow"
-          : data.exitFlow < tolerance  ? "exit flow"
-                                       : nullptr;
+      const char* quantity = negativeFlowQuantity(data);
       if (quantity == nullptr)
         continue;
 
@@ -763,6 +770,40 @@ private:
                                      data.flow,
                                      data.enterFlow,
                                      data.exitFlow));
+    }
+  }
+
+  // The same invariant one level up. A module's enter/exit flow is not the sum of its leaves': the
+  // optimizer maintains it incrementally and removes the teleportation internal to the module, and
+  // that removal can over-subtract even when every leaf is sound. On a bipartite network under
+  // --regularized this left modules at enter/exit -0.00121 and the resulting per-module codelength
+  // negative, which showed up only as a small disagreement between two evaluations of the same
+  // partition rather than as a failure (#958).
+  //
+  // Checked once per trial on the finished tree rather than after every consolidation: a walk over
+  // the modules costs nothing next to the search, and a codelength is only reported from here on.
+  void checkNoNegativeModuleFlow() const
+  {
+    for (auto it = m_infomap.root().begin_post_depth_first(); !it.isEnd(); ++it) {
+      const auto& node = *it;
+      if (node.isLeaf())
+        continue;
+
+      const char* quantity = negativeFlowQuantity(node.data);
+      if (quantity == nullptr)
+        continue;
+
+      throw InfomapError(ExitCode::InternalError,
+                         fmt::format(FMT_STRING("Negative {} on a module at depth {} with {} children: flow {:g}, "
+                                                "enter flow {:g}, exit flow {:g}. These are probabilities, so no codelength "
+                                                "is defined. Every leaf node's flow is sound here, so this is a bug in how "
+                                                "module flow is accumulated for this combination of input and flow model."),
+                                     quantity,
+                                     it.depth(),
+                                     node.childDegree(),
+                                     node.data.flow,
+                                     node.data.enterFlow,
+                                     node.data.exitFlow));
     }
   }
 
@@ -931,6 +972,8 @@ private:
 
     if (infomap.haveHardPartition())
       infomap.restoreHardPartition();
+
+    checkNoNegativeModuleFlow();
   }
 
   void finishTrial(unsigned int trialIndex, Stopwatch& timer, Result& result)

--- a/test/fixtures/networks/bipartite_uneven.net
+++ b/test/fixtures/networks/bipartite_uneven.net
@@ -1,15 +1,16 @@
-# A bipartite network whose two sides differ in size: three primary nodes and four
-# feature nodes, each primary node sharing one feature with each of its neighbours.
-# Small enough to reason about the flow by hand, and under --regularized the module
-# enter/exit flow accumulated over it goes negative (#958).
+# A bipartite network whose two sides differ in size: three primary nodes (1-3) and four
+# feature nodes (4-7), each primary node sharing one feature with each of its neighbours.
+# Naming follows examples/networks/bipartite.net -- ids from the *Bipartite index up are
+# the feature side. Small enough to reason about the flow by hand, and under --regularized
+# the module enter/exit flow accumulated over it goes negative (#958).
 *Vertices 7
-1 "f1"
-2 "f2"
-3 "f3"
-4 "p1"
-5 "p2"
-6 "p3"
-7 "p4"
+1 "Node 1"
+2 "Node 2"
+3 "Node 3"
+4 "Feature 1"
+5 "Feature 2"
+6 "Feature 3"
+7 "Feature 4"
 *Bipartite 4
 1 4
 1 5

--- a/test/fixtures/networks/bipartite_uneven.net
+++ b/test/fixtures/networks/bipartite_uneven.net
@@ -1,0 +1,19 @@
+# A bipartite network whose two sides differ in size: three primary nodes and four
+# feature nodes, each primary node sharing one feature with each of its neighbours.
+# Small enough to reason about the flow by hand, and under --regularized the module
+# enter/exit flow accumulated over it goes negative (#958).
+*Vertices 7
+1 "f1"
+2 "f2"
+3 "f3"
+4 "p1"
+5 "p2"
+6 "p3"
+7 "p4"
+*Bipartite 4
+1 4
+1 5
+2 5
+2 6
+3 6
+3 7

--- a/test/python/test_flow.py
+++ b/test/python/test_flow.py
@@ -76,6 +76,34 @@ def test_bipartite_regularized_partition_scores_the_same_when_read_back(
     assert rescored.codelength == pytest.approx(result.codelength)
 
 
+def test_negative_module_flow_is_an_error(network_fixture_path):
+    # One level up from the leaf check: a module's enter/exit flow is not the sum of its
+    # leaves', because the optimizer maintains it incrementally and removes the teleportation
+    # internal to the module. That removal can over-subtract even when every leaf is sound,
+    # and on this network under --regularized it leaves a module at enter/exit -0.00121 with
+    # a negative codelength. Before the check that surfaced only as a 0.0007 disagreement
+    # between two evaluations of the same partition (#958).
+    net = infomap.Network.from_file(str(network_fixture_path("bipartite_uneven.net")))
+
+    with pytest.raises(infomap.InfomapError, match=r"Negative enter flow on a module"):
+        net.run(regularized=True, two_level=True, seed=7, num_trials=1)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#958: module enter/exit flow still goes negative on bipartite input under "
+    "--regularized, so the run is refused rather than reporting a codelength built on it. "
+    "Drop this marker when the accumulation is fixed -- an unexpected pass means it is.",
+)
+def test_bipartite_uneven_regularized_yields_a_codelength(network_fixture_path):
+    # Stated as what should happen rather than as the current error, so this turns red the
+    # moment #958 is fixed instead of having to be rewritten.
+    net = infomap.Network.from_file(str(network_fixture_path("bipartite_uneven.net")))
+    result = net.run(regularized=True, two_level=True, seed=7, num_trials=1)
+
+    assert result.codelength > 0.0
+
+
 def test_flow_convergence_is_visible_on_the_result():
     # A failed power iteration means the flow is not the network's stationary
     # distribution, so the codelength describes something else. It used to be reported

--- a/test/python/test_flow.py
+++ b/test/python/test_flow.py
@@ -89,6 +89,23 @@ def test_negative_module_flow_is_an_error(network_fixture_path):
         net.run(regularized=True, two_level=True, seed=7, num_trials=1)
 
 
+def test_negative_module_flow_is_an_error_under_parallel_trials(network_fixture_path):
+    # The trial runs on a worker instance under --parallel-trials, so a check reading the main
+    # instance would walk an unpartitioned tree and pass every time. That is the path where a
+    # silent wrong codelength is worst -- it reported 0.9210660968 here -- so cover it
+    # separately from the serial one above.
+    net = infomap.Network.from_file(str(network_fixture_path("bipartite_uneven.net")))
+
+    with pytest.raises(infomap.InfomapError, match=r"Negative enter flow on a module"):
+        net.run(
+            regularized=True,
+            two_level=True,
+            seed=7,
+            num_trials=4,
+            parallel_trials=True,
+        )
+
+
 @pytest.mark.xfail(
     strict=True,
     reason="#958: module enter/exit flow still goes negative on bipartite input under "


### PR DESCRIPTION
Progress on #958, and the finding is that the remaining disagreement is **still negative flow** — one level up from where #961 fixed it.

#961 is merged, and this is rebased onto it: what is left here is the module-level check, the fixture and the tests.

## What the remaining gap turned out to be

After #961 the two evaluations of the 7-node bipartite case still differed by 0.000712. Dumping the recompute per node:

```
NODE root=1 leafmod=0 deg=2 flow=1                enter=0                exit=0                L=0.0013931597
NODE root=0 leafmod=1 deg=5 flow=0.666666666667   enter=-0.00121127896   exit=-0.00121127896   L=0.6649175711
NODE root=0 leafmod=1 deg=2 flow=0.333333333333   enter=0.1663638469     exit=0.1663638469     L=0.4586676943
```

A **module** with negative enter and exit flow, while every leaf is sound — so #961's check does not see it. A module's enter/exit flow is not the sum of its leaves': the optimizer maintains it incrementally and removes the teleportation internal to the module, and that removal can over-subtract.

Exactly the same cancellation that hid #957: the total stayed plausible and the discrepancy showed up as 0.0007 between two evaluations rather than as a failure.

## What this PR does

Applies your rule one level up: negative flow is an error, module flow included. Checked once per trial on the finished tree — a walk over the modules costs nothing next to the search, and a codelength is only reported from there on.

Of the three bipartite networks available to me, two trigger it and now fail loudly with the module's depth, child count and all three values:

| network | before | now |
| --- | --- | --- |
| `test/fixtures/networks/bipartite_uneven.net` (new fixture) | 1.125690156 vs 1.124978425 | refused |
| `examples/notebooks/data/Fonseca-Ganade-weighted.net` (#958's reproducer) | 0.911004678 vs 3.244230171 | refused |
| `examples/networks/bipartite.net` | already agreed after #961 | unchanged, 0.7991539547 |

Nothing shipped changes: neither `examples/notebooks/6.2 Bipartite Networks.ipynb` nor the rendered `docs/flow-models/bipartite` page uses `--regularized`, and I checked every `.net` under `test/fixtures/networks` and `examples/networks` — none of them trigger it. `make test-native` 26/26 and the full Python suite (850 passed, 2 skipped for missing torch) are unaffected.

## The check has to walk the trial's own tree

Worth calling out because the first version of it was wrong in a way that testing the serial path could not show. Under `--parallel-trials` a trial runs on a worker instance — `executeTrial(worker)` — so a check that reads `m_infomap` walks the main instance's tree, which no trial has partitioned. The guard passed unconditionally there.

That is the path where the silent codelength is worst, and it was silent: the new fixture reported 0.9210660968 under four parallel trials while a module sat at enter/exit -0.00121. The check now takes the tree to walk, as `calcCodelengthOnTree` already does two lines up, and the parallel path is covered alongside the serial one.

## What this does not do

It does not fix the accumulation, so it does not close #958. The test asserting that the run yields a codelength is `xfail(strict=True)`, so it turns red the moment the accumulation is fixed instead of needing to be rewritten — an unexpected pass is the signal.

## What I ruled out along the way

- **Renormalizing the teleport weights** over the coded nodes after #961's uncoding. They sum to 0.428571 there, not 1, and the enter/exit terms read a node's weight against an implied total of 1, so this looked like the cause. It is not: normalizing them made the negative worse (-0.00121 to -0.00422, two modules instead of one) and moved the codelength substantially, so it changes the model rather than repairing an inconsistency. Not included.
- **The `link.flow *= 2` doubling** in the same adjustment, which the code flags with two of its own `TODO: Should flow double before moving to nodes, does it cancel out in normalization?` comments. Removing it collapses the partition to a single module, so it cannot be evaluated as a drop-in and the question is a flow-model one rather than a bug fix.

Both are recorded on #958.

## Tests

Three in `test/python/test_flow.py`, next to the existing bipartite cases: the error is raised for the new fixture serially and under `--parallel-trials`, plus the xfail above. Removing the check fails the first two and makes the third an `XPASS(strict)` — so both directions are covered.
