### PR TITLE
docs: add atlas equation research note and prototypes

### DIFF
--- a/research/atlas-equation/README.md
+++ b/research/atlas-equation/README.md
@@ -32,16 +32,17 @@ mass, $\ell_i = -\log_2 P_i$. The consequences:
    serial commit pass: commits become **linearizable** — every committed move
    improves the true objective, at any thread count.
 
-In the prototype benchmark (undirected planted partition, 100k–200k nodes,
-4 cores), the fused parallel sweep under the atlas equation reaches
-**3.5–3.8× speedup on 4 threads with sequential-grade bookkeeping
-consistency** ($|L - \sum\delta| \lesssim 10^{-12}$), while the map
-equation with the faithful propose-parallel/commit-serial scheme reaches
-1.2–1.5× against the sequential baseline (its commit pass stays serial:
-28% of the sweep at 4 threads and growing with core count), and the map
-equation under the same two-lock scheme as the atlas equation loses
-consistency (drift $\sim 10^{-8}$, i.e. it no longer optimizes its own
-objective). Partition quality between the two objectives is statistically
+In the prototype benchmark (undirected planted partition, 200k nodes, 4
+cores, every mode driven to a verified single-move local optimum), the
+fused parallel sweep under the atlas equation cuts the top-level phase from
+7.4 s to 1.4 s on 4 threads **with sequential-grade bookkeeping
+consistency at every thread count** ($|L - \sum\delta| \lesssim 10^{-12}$),
+while the map equation with the faithful propose-parallel/commit-serial
+scheme reaches 2.3× against the sequential baseline (its commit pass stays
+a serial floor as cores grow, and snapshot staleness doubles its sweep
+count), and the map equation under the same two-lock scheme as the atlas
+equation loses consistency (drift $\sim 10^{-8}$, i.e. it no longer
+optimizes its own objective). Partition quality between the two objectives is statistically
 indistinguishable on the test suites (karate club: identical partition;
 ring of cliques: identical resolution behavior up to 256 cliques; planted
 partitions: equal recovery within noise).
@@ -379,46 +380,48 @@ throughout; `plogp` uses log2 as in `src/utils/infomath.h`.
 
 Planted partition, 200 blocks × 1000 nodes ($n = 2 \times 10^5$, ~1.2M
 edges, $k_{in} = 8$, nominal $k_{out} = 2$; the generator's two cross-block
-draws per node land closer to 4), Louvain from singletons, 4 cores.
-"L0 time" is the wall time of the top-level (leaf) local-moving phase — the
-phase that dominates large runs; consistency is
+draws per node land closer to 4), Louvain from singletons, 4 cores. Every
+level converges only when a full verification sweep over all nodes accepts
+nothing (§4), so all modes end at single-move local optima. "L0 time" is
+the wall time of the top-level (leaf) local-moving phase — the phase that
+dominates large runs — including the verification sweeps; consistency is
 $|L_{after} - (L_{before} + \sum \delta_{committed})|$ at the top level.
 
 | mode | threads | L0 time | L0 commit | final $L_M$ | modules | consistency |
 |:--|--:|--:|--:|--:|--:|--:|
-| seq-map                  | 1 | 1.114 s | — | 14.761 | 265 | $2 \times 10^{-12}$ |
-| seq-atlas                | 1 | 0.971 s | — | 14.758 | 242 | $3 \times 10^{-13}$ |
-| par-map (serial commit)  | 1 | 2.339 s | 0.240 s | 15.324 | 270 | $1 \times 10^{-12}$ |
-| par-map (serial commit)  | 2 | 1.458 s | 0.238 s | 15.324 | 270 | $1 \times 10^{-12}$ |
-| par-map (serial commit)  | 4 | 0.730 s | 0.207 s | 15.324 | 270 | $1 \times 10^{-12}$ |
-| par-atlas (two-lock)     | 1 | 0.973 s | — | 14.758 | 242 | $3 \times 10^{-13}$ |
-| par-atlas (two-lock)     | 2 | 0.580 s | — | 14.757 | 248 | $8 \times 10^{-13}$ |
-| par-atlas (two-lock)     | 4 | 0.276 s | — | 14.752 | 243 | $8 \times 10^{-13}$ |
-| par-map-twolock (unsound)| 2 | 0.536 s | — | 14.752 | 254 | $7 \times 10^{-9}$ |
-| par-map-twolock (unsound)| 4 | 0.250 s | — | 14.764 | 257 | $2 \times 10^{-8}$ |
+| seq-map                  | 1 | 6.43 s | — | 14.745 | 278 | $2 \times 10^{-12}$ |
+| seq-atlas                | 1 | 7.42 s | — | 14.743 | 250 | $3 \times 10^{-13}$ |
+| par-map (serial commit)  | 1 | 14.31 s | 0.34 s | 15.337 | 289 | $1 \times 10^{-12}$ |
+| par-map (serial commit)  | 2 | 6.55 s | 0.37 s | 15.337 | 289 | $1 \times 10^{-12}$ |
+| par-map (serial commit)  | 4 | 2.80 s | 0.32 s | 15.337 | 289 | $1 \times 10^{-12}$ |
+| par-atlas (two-lock)     | 1 | 7.43 s | — | 14.743 | 250 | $3 \times 10^{-13}$ |
+| par-atlas (two-lock)     | 2 | 2.42 s | — | 14.748 | 251 | $8 \times 10^{-13}$ |
+| par-atlas (two-lock)     | 4 | 1.36 s | — | 14.752 | 252 | $8 \times 10^{-13}$ |
+| par-map-twolock (unsound)| 2 | 2.88 s | — | 14.749 | 285 | $5 \times 10^{-9}$ |
+| par-map-twolock (unsound)| 4 | 1.42 s | — | 14.743 | 291 | $2 \times 10^{-8}$ |
 
 Readings:
 
-- **par-atlas**: 3.5× over its own 1-thread run (which matches seq-atlas
-  exactly — the locking discipline is free when uncontended), consistency at
-  the sequential level for every thread count, equal-or-better final
-  quality. The whole sweep — proposal and commit — parallelizes; there is no
-  serial floor.
+- **par-atlas**: 7.43 s → 1.36 s from 1 to 4 threads (the 1-thread run
+  matches seq-atlas — the locking discipline is free when uncontended),
+  with consistency at the sequential level for every thread count and
+  equal final quality. The whole sweep — proposal, commit, and the
+  verification sweeps — parallelizes; there is no serial floor. Wall-clock
+  ratios above ~4× fold in trajectory effects: the asynchronous schedule
+  changes which moves are proposed, so thread count alters the search path,
+  not just its speed.
 - **par-map (serial commit)**: the faithful scheme scales its proposal pass
-  but keeps a ~0.21 s serial commit pass — 28% of the sweep at 4 threads and
-  a hard Amdahl floor as cores grow — plus snapshot staleness (15 sweeps to
-  converge vs 9). Net speedup over seq-map: 1.5× at 4 threads. (The final-
-  quality gap of this mode is an artifact of this benchmark's plain Louvain
-  pipeline lacking Infomap's tuning iterations, not a claim about Infomap.)
+  but keeps a ~0.33 s serial commit pass as a hard Amdahl floor, and
+  snapshot staleness roughly doubles the sweeps to convergence (68 vs 32).
+  Net effect at 4 threads: 2.3× over seq-map. (The final-quality gap of
+  this mode is an artifact of this benchmark's plain Louvain pipeline
+  lacking Infomap's tuning iterations, not a claim about Infomap.)
 - **par-map-twolock**: scales like par-atlas but is unsound — the committed
   deltas drift from the true codelength change by $10^{-8}$, four orders of
   magnitude above everyone else's floating-point floor, and growing with
   contention. This isolates the cause: the same commit machinery is exact
   for the atlas equation and inexact for the map equation, so the obstacle
   is the objective's global term, nothing else.
-
-A 100-block ($10^5$ nodes) run shows the same pattern with 3.8× for
-par-atlas at 4 threads.
 
 ## 8. Integration path into Infomap
 
@@ -510,7 +513,7 @@ should precede any publication claim.
 # Math validation + quality experiments (pure stdlib, ~4 min; add --quick for ~40 s)
 python3 research/atlas-equation/prototype/atlas_prototype.py
 
-# Vectorized batch search (needs numpy + scipy; add --quick for ~10 s)
+# Vectorized batch search (needs numpy + scipy; add --quick for ~45 s)
 python3 research/atlas-equation/prototype/atlas_numpy.py
 
 # Parallel benchmark (standalone, needs OpenMP)

--- a/research/atlas-equation/README.md
+++ b/research/atlas-equation/README.md
@@ -12,16 +12,18 @@ replaced by **static module addresses** whose lengths are set by module flow
 mass, $\ell_i = -\log_2 P_i$. The consequences:
 
 1. **Same philosophy.** The objective is still an achievable per-step
-   description length of the random walk under a two-level codebook
-   structure: minimizing it finds modules in which flow persists.
+   description rate of the random walk under a two-level codebook structure
+   (in the same idealized coding sense as the map equation's entropy terms,
+   see §2): minimizing it finds modules in which flow persists.
 2. **Exactly characterized bias.** For every partition $\mathsf{M}$,
    $$L_A(\mathsf{M}) = L_M(\mathsf{M}) + q\, D_{KL}(\hat Q \,\|\, \hat P),$$
    where $L_M$ is the two-level map equation, $q$ is the total boundary
    flow, $\hat Q$ the distribution of module entries and $\hat P$ the
    distribution of module flow masses. The two objectives coincide exactly
-   when module usage is proportional to module size, and the maximal
-   possible gap shrinks with $q$ — i.e. the objectives agree increasingly
-   well on exactly the partitions both of them like.
+   when module usage is proportional to module mass, and the gap is at most
+   $q \log_2(1/\min_i P_i)$ — vanishing with the boundary flow on any
+   family of partitions whose module masses stay bounded below (not
+   uniformly over all partitions; see §3).
 3. **Additive separability.** $L_A = \sum_i g(P_i, Q_i^{in}, Q_i^{out})$ with
    no global term. A node move touches exactly two module terms. This is the
    property the map equation lacks (its single coupling term
@@ -108,10 +110,16 @@ length
 
 $$\ell_i = -\log_2 P_i .$$
 
-Since $\sum_i P_i = 1$, these lengths satisfy Kraft's inequality with
-equality, so a prefix code with (idealized real-valued) lengths $\ell_i$
-exists; the address book is complete and decodable. After each exit word the
-decoder reads the entered module's static address.
+These are idealized per-event information lengths, not literal binary
+codeword lengths: an individual prefix codeword cannot have length
+$-\log_2 0.3$. Since $\sum_i P_i = 1$ (Kraft equality for the address
+distribution), the *rate* $\sum_i Q_i^{in} \ell_i$ is achievable in the
+usual asymptotic sense — block or arithmetic coding over the event stream
+with per-event overhead vanishing in the block length. This is the same
+idealization the map equation already makes for all of its entropy terms;
+the atlas equation neither gains nor loses anything by it. Operationally:
+after each exit word the decoder reads the entered module's address,
+decodable from the module-mass table alone.
 
 **Objective** (the atlas equation):
 
@@ -147,7 +155,8 @@ forgoes is the information in *where* the walk crosses borders — and Theorem
 ## 3. Properties
 
 **Theorem 1 (validity and exact relation to the map equation).**
-$L_A$ is an achievable description length (Kraft equality above), and
+$L_A$ is an achievable description rate in the block-coding sense of §2 —
+the same sense in which $L_M$ is one — and
 
 $$
 L_A(\mathsf{M}) - L_M(\mathsf{M})
@@ -166,10 +175,13 @@ Corollaries:
   to module flow mass ($\hat Q = \hat P$). On the symmetric two-triangle
   example the gap is exactly $0$; on `ninetriangles.net` it is $0.0025$
   bits.
-- The gap is bounded by $q \cdot \max_i |\log_2(\hat Q_i / \hat P_i)|$: the
-  smaller the boundary flow — the better the partition, by both objectives'
-  standards — the smaller the maximal possible disagreement. The objectives
-  diverge only on partitions both of them dislike.
+- Since $\hat Q_i \le 1$, the gap obeys $q\,D_{KL}(\hat Q \| \hat P) \le
+  q \log_2(1/\min_i P_i)$. On any family of partitions whose smallest module
+  flow mass is bounded below, the disagreement therefore vanishes linearly
+  in the boundary flow $q$. This is a *conditional* guarantee: it is not
+  uniform over arbitrary partitions, because the mass of some module can
+  shrink as $q$ does — with $P_{min} \sim 2^{-1/q}$ the product stays
+  $\Theta(1)$ — so small boundary flow alone does not bound the gap.
 - The bias is interpretable and arguably useful: partitions in which a
   module's entry rate is disproportionate to its size (small, heavily
   trafficked pass-through modules) pay a surcharge of
@@ -269,6 +281,16 @@ disjoint batches): the accepted deltas of every batch sum to the true
 codelength change to machine precision, while the identical batch scheme
 under the map equation drifts by $\sim 10^{-3}$ bits per sweep — the
 vectorized twin of the two-lock-vs-global-term result in the C++ benchmark.
+
+A convergence caveat that applies to every design (and to dirty-node
+tracking in general, including the neighbour marking used by Infomap's move
+loops): marking only the mover's neighbours dirty is not sufficient for
+local optimality, because a move changes the aggregates of both endpoint
+modules and thereby stales the deltas of *non-adjacent* nodes that border
+them. Both prototype implementations therefore treat dirty tracking purely
+as an accelerator and confirm convergence with full verification sweeps: a
+level terminates only when a sweep over all nodes accepts nothing, so every
+reported partition is a genuine single-move local optimum.
 
 Two further structural benefits, independent of threading:
 

--- a/research/atlas-equation/README.md
+++ b/research/atlas-equation/README.md
@@ -677,25 +677,23 @@ with static addresses. For the broader landscape see the map-equation survey
 by Smiljanić, Blöcker, Holmgren, Edler, Neuman & Rosvall (*ACM Computing
 Surveys*, online-first; arXiv:2311.04036).
 
-**Cross-entropy readings of map-equation codes.** The "score a walk with a
-codebook it was not built for" move is already published: *flow divergence*
-(Blöcker & Scholtes, arXiv:2401.09052) measures the excess bits from
-describing a network's flow with **another partition's** codebooks, framed
-as relative entropy; *MapSim* (Blöcker, Smiljanić, Scholtes, Rosvall,
-*Proc. First Learning on Graphs Conference*, PMLR 198:52, 2022) uses
-map-equation coding rates as node similarities; *map equation centrality*
-(Blöcker, Nieves, Rosvall, *Appl. Netw. Sci.* 7:56, 2022) reads compression
-changes as a centrality.
+**Mismatched map-equation codebooks.** One precedent is directly on point:
+*flow divergence* (Blöcker & Scholtes, arXiv:2401.09052) scores a network's
+flow with **another partition's** codebooks and frames the excess bits as a
+relative entropy. That is the same move the atlas equation makes — price
+events with a code built for a different distribution and read the penalty as
+a KL term — applied there to comparing partitions rather than to defining an
+objective.
 
 **Novelty caveat.** What appears not to have been proposed is the specific
 combination: pricing module *entries* by the module-mass distribution
 $-\log_2 P_i$, chosen so that the objective becomes additively separable,
-together with the identity $L_A = L_M + q\,D_{KL}(\hat Q \| \hat P)$. The
-ingredients are all in the literature, though — mismatched-codebook
-cross-entropy in the three papers just cited, and partition-cost terms in
-the 2007 two-part MDL and in the SBM/MDL line (below). Any publication claim
-needs a careful check against those; the citations here were assembled from
-search metadata rather than from reading every paper end to end.
+together with the identity $L_A = L_M + q\,D_{KL}(\hat Q \| \hat P)$. Both
+ingredients have precedent, though — the mismatched-codebook relative entropy
+in flow divergence, and explicit partition-cost terms in the 2007 two-part
+MDL and in the SBM/MDL line (§10). Any publication claim needs a careful
+check against those; the citations here were assembled from search metadata
+rather than from reading every paper end to end.
 
 ## 10. Open questions
 

--- a/research/atlas-equation/README.md
+++ b/research/atlas-equation/README.md
@@ -259,6 +259,17 @@ available, in increasing order of throughput:
    for proposals, but with the guarantee that every commit improves the true
    objective.
 
+Design 2 has a second life as **vectorization**: a batch of accepted moves
+with pairwise-disjoint module pairs is exactly a "color", and applying it is
+a handful of numpy scatter-assignments — the after-aggregates of the touched
+modules are already known from the proposal step, so commit is `P[old] =
+old_p; P[new] = new_p; ...`. `prototype/atlas_numpy.py` implements the full
+search this way (sparse-matmul proposals over dirty nodes, greedy-maximal
+disjoint batches): the accepted deltas of every batch sum to the true
+codelength change to machine precision, while the identical batch scheme
+under the map equation drifts by $\sim 10^{-3}$ bits per sweep — the
+vectorized twin of the two-lock-vs-global-term result in the C++ benchmark.
+
 Two further structural benefits, independent of threading:
 
 - **No shared read-modify-write per move.** Even the sequential sweep stops
@@ -345,7 +356,8 @@ throughout; `plogp` uses log2 as in `src/utils/infomath.h`.
 ### 7.3 Parallel top-level search (`bench/parallel_bench.cpp`)
 
 Planted partition, 200 blocks × 1000 nodes ($n = 2 \times 10^5$, ~1.2M
-half-edges, $k_{in} = 8$, $k_{out} = 2$), Louvain from singletons, 4 cores.
+edges, $k_{in} = 8$, nominal $k_{out} = 2$; the generator's two cross-block
+draws per node land closer to 4), Louvain from singletons, 4 cores.
 "L0 time" is the wall time of the top-level (leaf) local-moving phase — the
 phase that dominates large runs; consistency is
 $|L_{after} - (L_{before} + \sum \delta_{committed})|$ at the top level.
@@ -475,6 +487,9 @@ should precede any publication claim.
 ```bash
 # Math validation + quality experiments (pure stdlib, ~4 min; add --quick for ~40 s)
 python3 research/atlas-equation/prototype/atlas_prototype.py
+
+# Vectorized batch search (needs numpy + scipy; add --quick for ~10 s)
+python3 research/atlas-equation/prototype/atlas_numpy.py
 
 # Parallel benchmark (standalone, needs OpenMP)
 make -C research/atlas-equation/bench run

--- a/research/atlas-equation/README.md
+++ b/research/atlas-equation/README.md
@@ -1,0 +1,484 @@
+# The atlas equation: a block-autonomous sibling of the map equation
+
+*Research note and prototype. Status: proposal, validated numerically at
+prototype scale; not integrated into the Infomap core.*
+
+## Summary
+
+The atlas equation is an information-theoretic, flow-based objective for
+community detection, built from the same coding philosophy as the map
+equation but with one deliberate change: the adaptive index codebook is
+replaced by **static module addresses** whose lengths are set by module flow
+mass, $\ell_i = -\log_2 P_i$. The consequences:
+
+1. **Same philosophy.** The objective is still an achievable per-step
+   description length of the random walk under a two-level codebook
+   structure: minimizing it finds modules in which flow persists.
+2. **Exactly characterized bias.** For every partition $\mathsf{M}$,
+   $$L_A(\mathsf{M}) = L_M(\mathsf{M}) + q\, D_{KL}(\hat Q \,\|\, \hat P),$$
+   where $L_M$ is the two-level map equation, $q$ is the total boundary
+   flow, $\hat Q$ the distribution of module entries and $\hat P$ the
+   distribution of module flow masses. The two objectives coincide exactly
+   when module usage is proportional to module size, and the maximal
+   possible gap shrinks with $q$ — i.e. the objectives agree increasingly
+   well on exactly the partitions both of them like.
+3. **Additive separability.** $L_A = \sum_i g(P_i, Q_i^{in}, Q_i^{out})$ with
+   no global term. A node move touches exactly two module terms. This is the
+   property the map equation lacks (its single coupling term
+   $\operatorname{plogp}(q)$ is repriced by *every* move), and it is what
+   makes the top-level search parallelize with per-module locks instead of a
+   serial commit pass: commits become **linearizable** — every committed move
+   improves the true objective, at any thread count.
+
+In the prototype benchmark (undirected planted partition, 100k–200k nodes,
+4 cores), the fused parallel sweep under the atlas equation reaches
+**3.5–3.8× speedup on 4 threads with sequential-grade bookkeeping
+consistency** ($|L - \sum\delta| \lesssim 10^{-12}$), while the map
+equation with the faithful propose-parallel/commit-serial scheme reaches
+1.2–1.5× against the sequential baseline (its commit pass stays serial:
+28% of the sweep at 4 threads and growing with core count), and the map
+equation under the same two-lock scheme as the atlas equation loses
+consistency (drift $\sim 10^{-8}$, i.e. it no longer optimizes its own
+objective). Partition quality between the two objectives is statistically
+indistinguishable on the test suites (karate club: identical partition;
+ring of cliques: identical resolution behavior up to 256 cliques; planted
+partitions: equal recovery within noise).
+
+The name: a *map* has one global legend that must be kept in sync with how
+often every region is visited; an *atlas* is a book of self-contained charts,
+each decodable on its own, with page numbers proportional to territory.
+
+## 1. Motivation: the map equation has exactly one global term
+
+The two-level map equation over a partition $\mathsf{M}$ of nodes
+$\alpha$ with visit rates $p_\alpha$, module flow masses
+$P_i = \sum_{\alpha \in i} p_\alpha$, module enter flows $Q_i^{in}$, exit
+flows $Q_i^{out}$, and total boundary flow $q = \sum_i Q_i^{in}$, expands
+(with $\operatorname{plogp}(x) = x \log_2 x$) to
+
+$$
+L_M(\mathsf{M}) =
+\underbrace{\operatorname{plogp}(q) - \sum_i \operatorname{plogp}(Q_i^{in})}_{\text{index codebook}}
+\; + \;
+\underbrace{\sum_i \Big[ \operatorname{plogp}(P_i + Q_i^{out}) - \operatorname{plogp}(Q_i^{out}) \Big] - \sum_\alpha \operatorname{plogp}(p_\alpha)}_{\text{module codebooks}} .
+$$
+
+Every term is a sum of per-module quantities **except**
+$\operatorname{plogp}(q)$. In the implementation this is explicit:
+`calculateCodelengthFromCodelengthTerms()` in `src/core/MapEquation.h`
+assembles the codelength from per-module sums plus the single global
+`enterFlow_log_enterFlow = plogp(enterFlow)`, and
+`updateCodelengthOnMovingNode()` ends by recomputing exactly that scalar
+after *every* accepted move.
+
+That one nonlinear global term is the entire reason the move loop resists
+parallelization:
+
+- The move delta (`getDeltaCodelengthOnMovingNode`) needs the current global
+  `enterFlow`; any concurrently committed move anywhere in the network
+  invalidates it.
+- Infomap's inner parallelization
+  (`InfomapOptimizer::tryMoveEachNodeIntoBestModuleInParallel`) therefore
+  splits each sweep into a **parallel, read-only proposal pass** against a
+  sweep-start snapshot and a **strictly serial commit pass** that rechecks
+  each proposal against the live state. The serial pass is Amdahl's-law
+  overhead that grows precisely when the sweep is productive (early sweeps
+  from singletons, i.e. the expensive top-level phase), and proposals go
+  stale across the barrier, costing extra sweeps.
+
+Conceptually the coupling is no accident: the index codebook is the
+*adaptive* (Shannon-optimal) code for module entries, and optimal adaptive
+codes need global usage statistics. The statistical coupling in the
+objective and the synchronization bottleneck in the search are the same
+thing. That suggests the fix belongs in the objective, not the algorithm.
+
+## 2. Definition
+
+**Setup.** Ergodic random walk with stationary visit rates $p_\alpha$,
+$\sum_\alpha p_\alpha = 1$ (for directed networks the usual
+teleportation-smoothed flows). Two-level partition $\mathsf{M}$; per module
+$i$: flow mass $P_i$, enter flow $Q_i^{in}$, exit flow $Q_i^{out}$.
+
+**Coding scheme.** As in the map equation, each module has a local codebook
+over its member nodes plus one exit word, used $P_i^{\circlearrowright} =
+P_i + Q_i^{out}$ per step, entropy-coded from module-local statistics. The
+change is the navigation between modules: instead of one adaptive index
+codebook over entries, module $i$ has a **static address**, a codeword of
+length
+
+$$\ell_i = -\log_2 P_i .$$
+
+Since $\sum_i P_i = 1$, these lengths satisfy Kraft's inequality with
+equality, so a prefix code with (idealized real-valued) lengths $\ell_i$
+exists; the address book is complete and decodable. After each exit word the
+decoder reads the entered module's static address.
+
+**Objective** (the atlas equation):
+
+$$
+L_A(\mathsf{M})
+= \sum_i Q_i^{in} \, \ell_i \; + \; \sum_i P_i^{\circlearrowright} H(\mathcal{P}^i)
+= \sum_i g\big(P_i, Q_i^{in}, Q_i^{out}\big) \; - \; \sum_\alpha \operatorname{plogp}(p_\alpha),
+$$
+
+with the per-module functional
+
+$$
+g(P, Q^{in}, Q^{out}) = -\,Q^{in} \log_2 P
+\; + \; \operatorname{plogp}(P + Q^{out}) - \operatorname{plogp}(Q^{out}),
+$$
+
+and the constant $-\sum_\alpha \operatorname{plogp}(p_\alpha)$ (node-level
+entropy, invariant under moves) kept for reporting so that $L_A$ is a true
+description length in bits per step. The module codebooks are *unchanged*
+from the map equation — they were already module-local, both statistically
+and algorithmically. Only cross-module navigation is made static.
+
+**Interpretation.** $-\log_2 P_i$ is the Shannon codeword length for the
+event "the walker is in module $i$" under the stationary distribution.
+Equivalently: the static code is the optimal entry code for a walker that,
+whenever it crosses a border, relocates according to the stationary
+distribution ("border teleportation"). The atlas equation is the codelength
+paid by a reader who models within-module dynamics exactly but treats
+cross-module transitions as memoryless relocation. What it deliberately
+forgoes is the information in *where* the walk crosses borders — and Theorem
+1 shows that is exactly the KL gap.
+
+## 3. Properties
+
+**Theorem 1 (validity and exact relation to the map equation).**
+$L_A$ is an achievable description length (Kraft equality above), and
+
+$$
+L_A(\mathsf{M}) - L_M(\mathsf{M})
+= q \, D_{KL}\big(\hat Q \,\|\, \hat P\big) \;\ge\; 0,
+\qquad \hat Q_i = Q_i^{in}/q, \quad \hat P_i = P_i .
+$$
+
+*Proof.* The module codebook terms are identical. The index terms differ by
+$-\sum_i Q_i^{in} \log_2 P_i - \big(\operatorname{plogp}(q) - \sum_i
+\operatorname{plogp}(Q_i^{in})\big) = q \sum_i \hat Q_i \log_2 (\hat Q_i /
+\hat P_i)$. $\blacksquare$
+
+Corollaries:
+
+- $L_A \ge L_M$ pointwise, with equality iff module usage is proportional
+  to module flow mass ($\hat Q = \hat P$). On the symmetric two-triangle
+  example the gap is exactly $0$; on `ninetriangles.net` it is $0.0025$
+  bits.
+- The gap is bounded by $q \cdot \max_i |\log_2(\hat Q_i / \hat P_i)|$: the
+  smaller the boundary flow — the better the partition, by both objectives'
+  standards — the smaller the maximal possible disagreement. The objectives
+  diverge only on partitions both of them dislike.
+- The bias is interpretable and arguably useful: partitions in which a
+  module's entry rate is disproportionate to its size (small, heavily
+  trafficked pass-through modules) pay a surcharge of
+  $\log_2(\hat Q_i / \hat P_i)$ bits per entry.
+
+**Theorem 2 (locality).** Moving node $v$ from module $a$ to module $b$
+changes only $g(a)$ and $g(b)$. The delta is computable from
+$(P, Q^{in}, Q^{out})$ of $a$ and $b$ plus $v$'s link flows to members of
+$a$ and $b$, in $O(\deg v)$; commit updates the two triples in $O(1)$.
+No global quantity exists.
+
+*Proof sketch.* For $c \notin \{a, b\}$: $P_c$ is unchanged, and
+$Q_c^{in/out}$ counts flow crossing $c$'s boundary, which depends only on
+membership of $c$ — unchanged by the move. The index term of $c$ is
+$-Q_c^{in} \log_2 P_c$, a function of $c$'s own aggregates only (this is
+where the map equation instead has the shared $\operatorname{plogp}(q)$).
+$\blacksquare$
+
+**Theorem 3 (lock-local, linearizable parallel search).** Run the local
+moving sweep concurrently; to commit a move $v: a \to b$, acquire the two
+module locks in id order, recheck the delta, apply, release. Then every
+committed move improves $L_A$ by more than the threshold $\varepsilon$, at
+any thread count, so the parallel search is monotone and terminates.
+
+*Proof sketch.* While holding both locks, membership of $a$ and $b$ cannot
+change (any move with an endpoint in $\{a,b\}$ needs one of the held locks).
+A concurrent move $u: c \to d$ with $c, d \notin \{a, b\}$ changes neither
+the aggregates of $a, b$ nor the classification of any of $v$'s neighbours
+as "in $a$", "in $b$", or "elsewhere" — a neighbour flipping between two
+"elsewhere" modules leaves the delta unchanged. Hence the recheck under the
+two locks is exact, the committed schedule is equivalent to some sequential
+order of strictly improving moves, and $L_A$ is bounded below.
+$\blacksquare$
+
+For the map equation the same argument fails at one point: the delta
+contains $\operatorname{plogp}(q_{after}) - \operatorname{plogp}(q)$, and
+$q$ is written by every committed move everywhere. The benchmark's negative
+control (`par-map-twolock`) makes this concrete: identical locking
+discipline, but the summed committed deltas drift from the true codelength
+change by $\sim 10^{-8}$ (and growing with contention), i.e. the search
+silently stops optimizing its own objective.
+
+**Extreme partitions.** One module: $q = 0$, so
+$L_A = L_M = -\sum_\alpha \operatorname{plogp}(p_\alpha)$ (the one-level
+codelength). All singletons (undirected, no self-links): $L_A = L_M + q\,
+D_{KL}$ as always; both are maximally penalized by boundary terms. There is
+no degenerate optimum introduced by the static addresses: growing a module
+shortens its address but inflates its module codebook, the same trade-off
+that balances the map equation.
+
+**Resolution behavior.** For $r$ equal modules the static address costs
+$\log_2 r$ bits per entry — the same $\log r$ growth as the map equation's
+index entropy $H(\hat Q) = \log_2 r$; the two objectives' merge conditions
+differ only through the KL term, which vanishes for symmetric structures.
+So the atlas equation inherits the map equation's mild, logarithmic
+resolution characteristics rather than modularity's square-root-of-total-
+weight limit.
+Empirically (prototype, ring of 5-cliques with unit links): both objectives
+keep one clique per module for $r = 4$ up to $r = 256$ without a single
+merge.
+
+## 4. Parallel search designs enabled
+
+Because all move-relevant state is the per-module triple
+$(P_i, Q_i^{in}, Q_i^{out})$ — exactly the `FlowData{flow, enterFlow,
+exitFlow}` Infomap already maintains per module — three sweep designs become
+available, in increasing order of throughput:
+
+1. **Serial commit (status quo).** The existing
+   propose-parallel/commit-serial pass works unchanged, but every recheck
+   loses its global dependency (per candidate: two evaluations of $g$ after
+   hoisting the old-module side, versus a 7-wide plogp batch *plus* the live
+   `enterFlow` read) and the "fast accept" condition (neither module touched
+   this sweep) can be tracked per module pair instead of per sweep. Fully
+   deterministic given the seed, independent of thread count.
+2. **Colored parallel commit.** Since a commit touches two modules only,
+   accepted proposals form a conflict graph over module pairs; color it and
+   apply colors in parallel batches. Deterministic *and* parallel commits,
+   at the cost of a coloring pass. Impossible for the map equation (every
+   pair of commits conflicts through $q$).
+3. **Fused two-lock sweep (maximum throughput).** Each thread proposes and
+   commits immediately under ordered per-module spinlocks with an exact
+   recheck (Theorem 3). No barriers, no proposal staleness across a commit
+   pass, monotone at any thread count. The committed *schedule* depends on
+   thread interleaving, so runs are not bit-reproducible across thread
+   counts — the same trade the current inner parallelization already makes
+   for proposals, but with the guarantee that every commit improves the true
+   objective.
+
+Two further structural benefits, independent of threading:
+
+- **No shared read-modify-write per move.** Even the sequential sweep stops
+  funneling every accepted move through one global scalar.
+- **Aggregation and deeper levels inherit the property.** Module aggregates
+  sum exactly under coarse-graining, so super-node moves at every
+  aggregation level have the same two-module locality.
+
+## 5. Hierarchical extension
+
+Two natural variants; both keep every leaf-module codebook adaptive:
+
+- **Atlas at the root only.** Replace just the top index codebook with
+  static addresses. This is the minimal change that removes the global
+  coupling: in the multilevel map equation, all module-of-modules codebooks
+  below the root are already local to their supermodule (their users are the
+  walkers inside it); only the root codebook is shared by everyone. Search
+  at every level then touches at most two supermodule chains, and the
+  top-level partition search — the phase that dominates wall time on large
+  networks — decouples entirely.
+- **Atlas everywhere (nested charts).** Give each submodule $s$ with parent
+  $m$ a static address of length $-\log_2 (P_s / P_m)$ within the parent's
+  chart. Full addresses then telescope: naming a leaf module from the root
+  costs $-\log_2 P_{leaf}$ regardless of depth, like arithmetic coding of
+  nested intervals. Conceptually cleaner; the treatment of exit words at
+  intermediate levels (adaptive, as in the map equation, or static against
+  the parent's residual mass) is a design detail to settle when formalizing
+  the multilevel version.
+
+The two-level core defined in §2 is the same under both variants.
+
+## 6. Directed networks and teleportation
+
+Nothing in §2 assumed undirectedness: enter and exit flows are tracked
+separately ($Q^{in}$ prices addresses, $Q^{out}$ prices exit words), and
+$p_\alpha$ comes from the usual teleportation-smoothed stationary flows. The
+`DeltaFlow` bookkeeping and `addTeleportationFlow` hooks in the optimizer
+apply verbatim — the delta corrections that Infomap applies symmetrically to
+module enter and exit flows carry over unchanged (validated numerically for
+directed flows in the prototype). Kraft-validity of the static addresses
+only needs $\sum_i P_i = 1$.
+
+## 7. Empirical validation
+
+All numbers below are reproducible with the two programs in this directory
+(pure-stdlib Python prototype; standalone C++17/OpenMP benchmark). Bits
+throughout; `plogp` uses log2 as in `src/utils/infomath.h`.
+
+### 7.1 Correctness of the math (`prototype/atlas_prototype.py`)
+
+- **Move deltas exact** for both objectives, undirected and directed random
+  networks, random partitions, 8 trials × 40 moves: max error $1.4 \times
+  10^{-15}$ against recompute-from-scratch.
+- **Theorem 1 identity** $L_A - L_M = q\,D_{KL}(\hat Q \| \hat P)$: residual
+  $< 10^{-15}$ in every trial.
+- **Baseline validated against the Infomap binary** (v2.15.0,
+  `--two-level`): prototype $L_M$ on the binary's partition matches the
+  reported codelength on `twotriangles.net` and `ninetriangles.net` to the
+  printed precision ($< 5 \times 10^{-6}$).
+
+### 7.2 Partition quality, atlas vs map equation
+
+- **Karate club** (20 seeds, best-of): both objectives select the *same*
+  3-module partition (NMI = 1.0), $L_M = 4.3118$, $L_A = 4.3227$ bits
+  (one-level reference 4.7044).
+- **Ring of 5-cliques**, $r \in \{4, \dots, 256\}$: optimal block size is
+  one clique per module for both objectives at every $r$ (no resolution
+  divergence).
+- **Planted partitions** (10 blocks × 100 nodes, $k_{in} = 8$, 3 seeds,
+  best-of, undirected):
+
+  | $k_{out}/k_{in}$ | NMI map | NMI atlas | modules map/atlas |
+  |---:|---:|---:|:---:|
+  | 0.0625 | 0.993 | 0.993 | 10 / 10 |
+  | 0.125  | 0.993 | 0.990 | 10 / 10 |
+  | 0.25   | 0.985 | 0.990 | 11 / 10 |
+  | 0.375  | 0.939 | 0.953 | 10 / 10 |
+  | 0.5    | 0.944 | 0.940 | 11 / 10 |
+
+  Directed planted partitions behave the same way (experiment 5 in the
+  prototype output), with measured KL gaps at the atlas optimum of
+  $0.002$–$0.035$ bits.
+
+### 7.3 Parallel top-level search (`bench/parallel_bench.cpp`)
+
+Planted partition, 200 blocks × 1000 nodes ($n = 2 \times 10^5$, ~1.2M
+half-edges, $k_{in} = 8$, $k_{out} = 2$), Louvain from singletons, 4 cores.
+"L0 time" is the wall time of the top-level (leaf) local-moving phase — the
+phase that dominates large runs; consistency is
+$|L_{after} - (L_{before} + \sum \delta_{committed})|$ at the top level.
+
+| mode | threads | L0 time | L0 commit | final $L_M$ | modules | consistency |
+|:--|--:|--:|--:|--:|--:|--:|
+| seq-map                  | 1 | 1.114 s | — | 14.761 | 265 | $2 \times 10^{-12}$ |
+| seq-atlas                | 1 | 0.971 s | — | 14.758 | 242 | $3 \times 10^{-13}$ |
+| par-map (serial commit)  | 1 | 2.339 s | 0.240 s | 15.324 | 270 | $1 \times 10^{-12}$ |
+| par-map (serial commit)  | 2 | 1.458 s | 0.238 s | 15.324 | 270 | $1 \times 10^{-12}$ |
+| par-map (serial commit)  | 4 | 0.730 s | 0.207 s | 15.324 | 270 | $1 \times 10^{-12}$ |
+| par-atlas (two-lock)     | 1 | 0.973 s | — | 14.758 | 242 | $3 \times 10^{-13}$ |
+| par-atlas (two-lock)     | 2 | 0.580 s | — | 14.757 | 248 | $8 \times 10^{-13}$ |
+| par-atlas (two-lock)     | 4 | 0.276 s | — | 14.752 | 243 | $8 \times 10^{-13}$ |
+| par-map-twolock (unsound)| 2 | 0.536 s | — | 14.752 | 254 | $7 \times 10^{-9}$ |
+| par-map-twolock (unsound)| 4 | 0.250 s | — | 14.764 | 257 | $2 \times 10^{-8}$ |
+
+Readings:
+
+- **par-atlas**: 3.5× over its own 1-thread run (which matches seq-atlas
+  exactly — the locking discipline is free when uncontended), consistency at
+  the sequential level for every thread count, equal-or-better final
+  quality. The whole sweep — proposal and commit — parallelizes; there is no
+  serial floor.
+- **par-map (serial commit)**: the faithful scheme scales its proposal pass
+  but keeps a ~0.21 s serial commit pass — 28% of the sweep at 4 threads and
+  a hard Amdahl floor as cores grow — plus snapshot staleness (15 sweeps to
+  converge vs 9). Net speedup over seq-map: 1.5× at 4 threads. (The final-
+  quality gap of this mode is an artifact of this benchmark's plain Louvain
+  pipeline lacking Infomap's tuning iterations, not a claim about Infomap.)
+- **par-map-twolock**: scales like par-atlas but is unsound — the committed
+  deltas drift from the true codelength change by $10^{-8}$, four orders of
+  magnitude above everyone else's floating-point floor, and growing with
+  contention. This isolates the cause: the same commit machinery is exact
+  for the atlas equation and inexact for the map equation, so the obstacle
+  is the objective's global term, nothing else.
+
+A 100-block ($10^5$ nodes) run shows the same pattern with 3.8× for
+par-atlas at 4 threads.
+
+## 8. Integration path into Infomap
+
+The objective drops into the existing static-dispatch pattern
+(`InfomapOptimizer<Objective>`; see the class comment in
+`src/core/MapEquation.h`):
+
+1. **`src/core/AtlasEquation.h`** — `class AtlasEquation final : private
+   MapEquation<>`, following `LossyMapEquation`'s structure, gated by an
+   `INFOMAP_FEATURE_ATLAS_EQUATION` macro while experimental.
+   - Per-module state: none beyond the existing `m_moduleFlowData`
+     (`FlowData.flow/enterFlow/exitFlow` are exactly $P, Q^{in}, Q^{out}$).
+   - `calculateCodelengthTerms`/`FromCodelengthTerms`: index term becomes
+     $\sum_i -Q_i^{in} \log_2 P_i$; drop `enterFlow_log_enterFlow`.
+   - `getDeltaCodelengthOnMovingNode(+Hoisted)`: four evaluations of $g$;
+     the old-side pair is hoistable per node exactly like the base class's
+     `hoistOldSide`. Reuses `DeltaFlow` and `addTeleportationFlow` verbatim.
+   - `updateCodelengthOnMovingNode`: two-module aggregate update only — the
+     method stops writing any shared scalar, which is the hook the parallel
+     commit needs.
+   - `calcCodelength(parent)`: per-module reporting; for the hierarchical
+     variant choose atlas-root or nested charts (§5).
+2. **Factory**: one branch in `InfomapBase::initOptimizer()`
+   (`src/core/InfomapBase.cpp`, next to the `--lossy` branch).
+3. **Option surface**: a flag (e.g. `--atlas`) in
+   `src/io/ParameterCatalog.cpp`, then `make build-binding-options` and the
+   freshness check, per the documented generator workflow.
+4. **Parallel sweeps**: phase 1, reuse the existing inner parallelization
+   unchanged (correct for any objective). Phase 2, add the two-lock commit
+   path for objectives that declare no global state — a natural trait to
+   express in the optimizer template (e.g. a `constexpr bool
+   hasGlobalCodelengthState` on the objective).
+
+Until then, everything here runs standalone; nothing in `src/` is touched by
+this note.
+
+## 9. Relation to prior work
+
+- **Map equation** (Rosvall & Bergstrom 2008): the parent framework; the
+  atlas equation changes only the index codebook, from adaptive to static.
+- **RelaxMap** (Bae, Halperin, West, Rosvall, Howe 2017) and **GossipMap**
+  (Bae & Howe 2015): parallel/distributed map-equation search that *relaxes
+  consistency* of the shared state. The atlas equation is the complementary
+  move: change the objective so no shared state exists, keeping exactness.
+- **Markov stability** (Delvenne, Yaliraki, Barahona 2010) and **CPM/Leiden**
+  (Traag, Waltman, van Eck 2019): additively separable objectives — which is
+  why parallel Louvain-family algorithms thrive on them — but not
+  description-length-based. The atlas equation is an MDL-semantics member of
+  the separable family.
+- **Smart teleportation** (Lambiotte & Rosvall 2012): changes the *process*
+  to tame directed flows; the atlas equation changes the *code*, and its
+  static addresses are the coding twin of stationary relocation at borders
+  (§2).
+- **Regularized/Bayesian map equation** (Smiljanić, Edler, Rosvall 2020) and
+  the in-repo **lossy map equation** (rate-distortion): orthogonal
+  variations (priors; lossy node identity) that keep the adaptive index
+  codebook; in principle composable with static addresses.
+- **MapSim** (Blöcker, Smiljanić, Scholtes, Rosvall 2024): uses
+  map-equation coding rates as inter-node similarities — kindred
+  address-based reading of the coding hierarchy.
+
+To our knowledge the specific construction — cross-entropy index coding
+against the module-mass distribution, chosen to make the objective
+additively separable — has not been proposed; a proper literature check
+should precede any publication claim.
+
+## 10. Open questions
+
+1. **Systematic bias characterization.** The KL term penalizes
+   entry-rate/size disproportion. On which real network families does that
+   change partitions materially (e.g. hub-and-spoke, strongly heterogeneous
+   module sizes, flow bottlenecks), and is the change ever preferable?
+2. **Hierarchical formalization** (§5): exit-word treatment for nested
+   charts; whether the telescoping property yields a cheaper multilevel
+   search than recursive two-level.
+3. **Alternative static references.** Addresses from node counts
+   ($-\log_2(n_i/n)$) give a structure-only variant; addresses from
+   teleportation weights connect to smart teleportation. Same separability,
+   different biases.
+4. **Deterministic parallel commits** via module-pair coloring (§4, design
+   2): is the coloring overhead worth bit-reproducibility?
+5. **Combination with Bayesian regularization**: the static address book has
+   no usage parameters to estimate, which may simplify the prior story for
+   sparse data.
+
+## Reproducing
+
+```bash
+# Math validation + quality experiments (pure stdlib, ~4 min; add --quick for ~40 s)
+python3 research/atlas-equation/prototype/atlas_prototype.py
+
+# Parallel benchmark (standalone, needs OpenMP)
+make -C research/atlas-equation/bench run
+```
+
+The prototype validates its map-equation baseline against the built
+`./Infomap` binary when present (skips that section otherwise).

--- a/research/atlas-equation/README.md
+++ b/research/atlas-equation/README.md
@@ -37,20 +37,21 @@ mass, $\ell_i = -\log_2 P_i$. The consequences:
 
 In the prototype benchmark (undirected planted partition, 200k nodes, 4
 physical cores, every mode driven to a verified single-move local optimum),
-the fused parallel sweep under the atlas equation cuts the top-level phase
-from 6.6 s to 1.0 s going from 1 to 4 threads **with sequential-grade
-bookkeeping consistency at every thread count**
-($|L - \sum\delta| \lesssim 10^{-12}$) — and with no serial section, so
-nothing in the design bounds it as cores grow. The map equation's
-propose-parallel/commit-serial scheme (implemented with Infomap's
-fast-accept path, and here exactly rather than on a stale snapshot) reaches
-2.1× over its sequential baseline while its commit pass stays flat at
-~0.35 s regardless of thread count. Under the atlas equation's own two-lock
-scheme the map equation scales but loses consistency (drift $\sim 10^{-8}$,
-i.e. it stops optimizing its own objective) — which isolates the objective,
-not the machinery, as the obstacle. Thread ratios here are end-to-end phase
-times, not parallel speedup: concurrency also changes the search trajectory
-(§7.3). Partition quality tracks the map equation
+the fused two-lock sweep keeps $|L - \sum\delta|$ at the sequential
+floating-point level ($\lesssim 10^{-12}$) **at every thread count**, and
+converges in 32 sweeps against 53 for propose-parallel/commit-serial, which
+has a sweep-start snapshot to go stale. Running the *same* two-lock scheme
+under the map equation scales just as well but drifts by $\sim 10^{-8}$ —
+it stops optimizing its own objective — which isolates the objective rather
+than the machinery as the obstacle.
+
+Be careful about the throughput half of the argument, though: measured
+properly (identical state, one sweep, best of 15), per-sweep scaling on 4
+cores is **indistinguishable between the two designs**, 3.7–4.4× for both.
+The map equation's serial commit is only ~1.4% of a sweep, which caps its
+speedup near $70\times$ asymptotically — real, but far beyond 4 cores. The
+claim this note can support on this hardware is exactness and sweep count,
+not wall-clock throughput (§7.4). Partition quality tracks the map equation
 closely on every test used here — karate club: identical partition; ring of
 cliques: identical resolution behavior up to 256 cliques; planted partitions:
 recovery differences within seed-to-seed spread — though these are small
@@ -482,16 +483,16 @@ rather than on a stale snapshot — strictly stronger than Infomap's. It also
 takes no per-sweep snapshot copies: the proposal pass precedes all commits, so
 it reads live state directly, as Infomap does.
 
-Timings are from one run with nothing else on the machine; run-to-run spread
-is roughly ±10%, so treat smaller differences as noise. **Read the thread
-ratios as end-to-end phase times, not as parallel speedup.** Concurrency
-changes the search trajectory: at higher thread counts proposals see fresher
-state, more moves land per sweep, the dirty set drains faster, and the level
-converges in fewer sweeps (par-atlas: 32 sweeps at 1 thread, 27 at 4). The
-resulting ratio can exceed the core count — par-atlas is 7.0× from 1 to 4
-threads on 4 physical cores, so at least 40% of that is trajectory, not
-parallelism. The defensible claim here is about the *shape* of the two designs
-(no serial floor vs. a serial floor), not a speedup number.
+**Read the thread columns as end-to-end phase times, not as parallel
+speedup.** Two things make them unsuitable as speedup measurements. First,
+concurrency changes the search trajectory: at higher thread counts proposals
+see fresher state and the level converges in a different number of sweeps
+(par-atlas: 32 sweeps at 1 thread, 27 at 4). Second, this machine is noisy —
+repeating a *bit-identical deterministic* run (par-atlas at 1 thread, same
+seed, same 32 sweeps, same final codelength) gave 6.63 s and 5.37 s on two
+consecutive runs, a 24% spread. Ratios computed from these columns can and do
+exceed the core count, which is by itself proof that they are not speedups.
+§7.4 measures scaling properly instead.
 
 | mode | threads | L0 time | L0 commit | fast | sweeps | final $L_M$ | modules | consistency |
 |:--|--:|--:|--:|--:|--:|--:|--:|--:|
@@ -509,25 +510,63 @@ parallelism. The defensible claim here is about the *shape* of the two designs
 
 Readings:
 
-- **par-atlas**: 6.63 s → 0.95 s from 1 to 4 threads, with consistency at
-  the sequential level for *every* thread count and final quality matching
-  seq-atlas. The 1-thread run reproduces seq-atlas exactly — the locking
-  discipline is free when uncontended. The whole sweep — proposal, commit,
-  and the verification sweeps — parallelizes; there is no serial section to
-  bound it. (See the caveat above on reading the ratio as speedup.)
+- **par-atlas**: consistency stays at the sequential floating-point level at
+  *every* thread count, and final quality matches seq-atlas. The 1-thread run
+  reproduces seq-atlas exactly — the locking discipline is free when
+  uncontended. It converges in 32 sweeps versus par-map's 53: the fused sweep
+  has no snapshot to go stale, so a proposal accepted late in a sweep already
+  accounts for everything committed earlier in it.
 - **par-map (serial commit)**: the commit pass does not shrink with threads —
-  0.36 / 0.34 / 0.35 s at 1 / 2 / 4 — so it is a floor that grows as a share
-  of the sweep (15% at 4 threads here, and it would dominate at 16+ cores).
-  Snapshot staleness costs sweeps as well: 53 to converge versus 32 for
-  par-atlas. At 4 threads it comes to 2.1× over seq-map. (The final-quality
-  gap of this mode is an artifact of this benchmark's plain Louvain pipeline
-  lacking Infomap's tuning iterations, not a claim about Infomap.)
-- **par-map-twolock**: scales like par-atlas but is unsound — the committed
-  deltas drift from the true codelength change by $10^{-8}$, four orders of
-  magnitude above everyone else's floating-point floor, and growing with
-  contention. This isolates the cause: the same commit machinery is exact
-  for the atlas equation and inexact for the map equation, so the obstacle
-  is the objective's global term, nothing else.
+  0.36 / 0.34 / 0.35 s at 1 / 2 / 4 — and snapshot staleness costs it 53
+  sweeps to par-atlas's 32. (The final-quality gap of this mode is an
+  artifact of this benchmark's plain Louvain pipeline lacking Infomap's tuning
+  iterations, not a claim about Infomap.)
+- **par-map-twolock**: the negative control. It runs at par-atlas speed but is
+  unsound — the committed deltas drift from the true codelength change by
+  $10^{-8}$, four orders of magnitude above everyone else's floating-point
+  floor, and growing with contention. This isolates the cause: the same commit
+  machinery is exact for the atlas equation and inexact for the map equation,
+  so the obstacle is the objective's global term, nothing else. (RelaxMap's
+  authors report the same outcome from the same experiment — see §9.)
+
+### 7.4 Controlled strong scaling, and what it does *not* show
+
+To separate sweep throughput from trajectory, `--sweep-scaling` advances to a
+fixed state (2 sequential sweeps from singletons), snapshots it, then runs one
+sweep from that identical state at each thread count, keeping the best of 15
+repetitions. Work is then identical across rows. Two invocations:
+
+| mode | threads | sweep | vs 1 thread | serial part | share |
+|:--|--:|--:|--:|--:|--:|
+| par-atlas   | 1 | 0.187 / 0.184 s | 1.00× | — | — |
+| par-atlas   | 2 | 0.112 / 0.092 s | 1.67× / 2.00× | — | — |
+| par-atlas   | 4 | 0.051 / 0.042 s | 3.70× / 4.42× | — | — |
+| par-map     | 1 | 0.164 / 0.198 s | 1.00× | 0.0027 / 0.0024 s | 1.6% / 1.2% |
+| par-map     | 2 | 0.082 / 0.095 s | 1.99× / 2.09× | 0.0025 / 0.0027 s | 3.0% / 2.8% |
+| par-map     | 4 | 0.039 / 0.047 s | 4.16× / 4.23× | 0.0023 / 0.0025 s | 5.8% / 5.4% |
+
+**This is the honest result, and it is narrower than a throughput claim.** On
+4 cores the two designs' per-sweep scaling is indistinguishable — both land
+between 3.7× and 4.4×, inside the measurement spread. The serial commit is
+only about 1.4% of a 1-thread sweep here, so by Amdahl it caps speedup at
+roughly $70\times$ asymptotically: ~13× of a possible 16 at 16 threads, ~34×
+of 64 at 64 threads. Real but distant. **A 4-core machine cannot demonstrate
+the throughput half of this note's motivation**, and the earlier framing of
+the serial commit as a near-term bottleneck overstated it.
+
+What the benchmark does establish, and what does not depend on core count:
+
+1. **Exactness under concurrent commits.** par-atlas keeps
+   $|L - \sum \delta|$ at the sequential floating-point level at every thread
+   count; the identical scheme under the map equation drifts by $10^{-8}$.
+   Every accepted move provably improves the objective (Theorem 3) — the
+   search cannot silently optimize something other than what it reports.
+2. **Fewer sweeps to converge**: 32 versus 53, because there is no
+   sweep-start snapshot to go stale.
+3. **No barrier and no shared scalar**, so the design's scaling ceiling is
+   set by lock contention on individual module pairs rather than by a fixed
+   serial section — which is the property that would matter at high core
+   counts, on hardware not available here.
 
 ## 8. Integration path into Infomap
 
@@ -694,9 +733,14 @@ python3 research/atlas-equation/prototype/atlas_prototype.py
 # Vectorized batch search (needs numpy + scipy; add --quick for ~45 s)
 python3 research/atlas-equation/prototype/atlas_numpy.py
 
-# Parallel benchmark (standalone, needs OpenMP)
+# Parallel benchmark, end-to-end phase times (standalone, needs OpenMP)
 make -C research/atlas-equation/bench run
+
+# Controlled strong scaling from an identical state (§7.4)
+research/atlas-equation/bench/parallel_bench --blocks 200 --block-size 1000 \
+    --threads 1,2,4 --sweep-scaling --reps 15
 ```
 
 The prototype validates its map-equation baseline against the built
-`./Infomap` binary when present (skips that section otherwise).
+`./Infomap` binary when present; pass `--require-binary` to make a missing
+binary an error rather than a skip.

--- a/research/atlas-equation/README.md
+++ b/research/atlas-equation/README.md
@@ -20,32 +20,41 @@ mass, $\ell_i = -\log_2 P_i$. The consequences:
    where $L_M$ is the two-level map equation, $q$ is the total boundary
    flow, $\hat Q$ the distribution of module entries and $\hat P$ the
    distribution of module flow masses. The two objectives coincide exactly
-   when module usage is proportional to module mass, and the gap is at most
-   $q \log_2(1/\min_i P_i)$ — vanishing with the boundary flow on any
-   family of partitions whose module masses stay bounded below (not
-   uniformly over all partitions; see §3).
-3. **Additive separability.** $L_A = \sum_i g(P_i, Q_i^{in}, Q_i^{out})$ with
-   no global term. A node move touches exactly two module terms. This is the
-   property the map equation lacks (its single coupling term
-   $\operatorname{plogp}(q)$ is repriced by *every* move), and it is what
-   makes the top-level search parallelize with per-module locks instead of a
-   serial commit pass: commits become **linearizable** — every committed move
-   improves the true objective, at any thread count.
+   when module usage is proportional to module mass, and because
+   stationarity forces $Q_i^{in} \le P_i$, the gap is at most
+   $q \log_2(1/q)$ — vanishing with the boundary flow uniformly over all
+   partitions (§3).
+3. **Additive separability.** Up to a move-invariant constant,
+   $L_A = \sum_i g(P_i, Q_i^{in}, Q_i^{out})$ — a sum of per-module terms
+   with no term coupling different modules. A node move touches exactly two
+   of them. The map equation instead carries the coupling term
+   $\operatorname{plogp}(q)$, which *every* move reprices, so an individual
+   move's exact delta is never a function of local state alone. That is what
+   lets the atlas equation commit under per-module locks instead of a serial
+   pass: commits become **linearizable** — every committed move improves the
+   true objective, at any thread count (§4 draws the precise line, which is
+   about per-move exactness, not about batching).
 
 In the prototype benchmark (undirected planted partition, 200k nodes, 4
-cores, every mode driven to a verified single-move local optimum), the
-fused parallel sweep under the atlas equation cuts the top-level phase from
-7.4 s to 1.4 s on 4 threads **with sequential-grade bookkeeping
-consistency at every thread count** ($|L - \sum\delta| \lesssim 10^{-12}$),
-while the map equation with the faithful propose-parallel/commit-serial
-scheme reaches 2.3× against the sequential baseline (its commit pass stays
-a serial floor as cores grow, and snapshot staleness doubles its sweep
-count), and the map equation under the same two-lock scheme as the atlas
-equation loses consistency (drift $\sim 10^{-8}$, i.e. it no longer
-optimizes its own objective). Partition quality between the two objectives is statistically
-indistinguishable on the test suites (karate club: identical partition;
-ring of cliques: identical resolution behavior up to 256 cliques; planted
-partitions: equal recovery within noise).
+physical cores, every mode driven to a verified single-move local optimum),
+the fused parallel sweep under the atlas equation cuts the top-level phase
+from 6.6 s to 1.0 s going from 1 to 4 threads **with sequential-grade
+bookkeeping consistency at every thread count**
+($|L - \sum\delta| \lesssim 10^{-12}$) — and with no serial section, so
+nothing in the design bounds it as cores grow. The map equation's
+propose-parallel/commit-serial scheme (implemented with Infomap's
+fast-accept path, and here exactly rather than on a stale snapshot) reaches
+2.1× over its sequential baseline while its commit pass stays flat at
+~0.35 s regardless of thread count. Under the atlas equation's own two-lock
+scheme the map equation scales but loses consistency (drift $\sim 10^{-8}$,
+i.e. it stops optimizing its own objective) — which isolates the objective,
+not the machinery, as the obstacle. Thread ratios here are end-to-end phase
+times, not parallel speedup: concurrency also changes the search trajectory
+(§7.3). Partition quality tracks the map equation
+closely on every test used here — karate club: identical partition; ring of
+cliques: identical resolution behavior up to 256 cliques; planted partitions:
+recovery differences within seed-to-seed spread — though these are small
+suites, not a systematic quality study.
 
 The name: a *map* has one global legend that must be kept in sync with how
 often every region is visited; an *atlas* is a book of self-contained charts,
@@ -72,7 +81,11 @@ $\operatorname{plogp}(q)$. In the implementation this is explicit:
 assembles the codelength from per-module sums plus the single global
 `enterFlow_log_enterFlow = plogp(enterFlow)`, and
 `updateCodelengthOnMovingNode()` ends by recomputing exactly that scalar
-after *every* accepted move.
+after *every* accepted move. (The default objective is actually
+`BiasedMapEquation`, which keeps a second global — `currentNumModules` — but
+it is inert unless `--preferred-number-of-modules` or `--entropy-corrected`
+is set, and with default options its codelength and deltas reduce exactly to
+the base map equation. The argument below concerns the unbiased objective.)
 
 That one nonlinear global term is the entire reason the move loop resists
 parallelization:
@@ -83,11 +96,18 @@ parallelization:
 - Infomap's inner parallelization
   (`InfomapOptimizer::tryMoveEachNodeIntoBestModuleInParallel`) therefore
   splits each sweep into a **parallel, read-only proposal pass** against a
-  sweep-start snapshot and a **strictly serial commit pass** that rechecks
-  each proposal against the live state. The serial pass is Amdahl's-law
-  overhead that grows precisely when the sweep is productive (early sweeps
-  from singletons, i.e. the expensive top-level phase), and proposals go
-  stale across the barrier, costing extra sweeps.
+  sweep-start snapshot and a **strictly serial commit pass**. That pass
+  re-gathers edge sums and recomputes the delta for any proposal whose old or
+  new module was already touched earlier in the same pass, and *fast-accepts*
+  the rest on their snapshot deltas
+  (`src/core/InfomapOptimizer.h:887-909`). Codelength bookkeeping stays exact
+  either way, because `updateCodelengthOnMovingNode` reprices the global term
+  from the live `enterFlow` at commit; what the fast path gives up is the
+  guarantee that the accepted move is still an improvement, since $q$ may
+  have moved under it. The serial pass is Amdahl's-law overhead that grows
+  precisely when the sweep is productive (early sweeps from singletons, i.e.
+  the expensive top-level phase), and proposals go stale across the barrier,
+  costing extra sweeps.
 
 Conceptually the coupling is no accident: the index codebook is the
 *adaptive* (Shannon-optimal) code for module entries, and optimal adaptive
@@ -144,14 +164,18 @@ from the map equation — they were already module-local, both statistically
 and algorithmically. Only cross-module navigation is made static.
 
 **Interpretation.** $-\log_2 P_i$ is the Shannon codeword length for the
-event "the walker is in module $i$" under the stationary distribution.
-Equivalently: the static code is the optimal entry code for a walker that,
-whenever it crosses a border, relocates according to the stationary
-distribution ("border teleportation"). The atlas equation is the codelength
-paid by a reader who models within-module dynamics exactly but treats
-cross-module transitions as memoryless relocation. What it deliberately
-forgoes is the information in *where* the walk crosses borders — and Theorem
-1 shows that is exactly the KL gap.
+event "the walker is in module $i$" under the stationary distribution. The
+static address book is thus the code that would be *optimal* for a walker
+which, on crossing any border, relocates according to the stationary
+distribution ("border teleportation"); applied to the real walk it is a
+mismatched code, and the index cost is the cross-entropy
+$q\,H(\hat Q, \hat P)$ rather than that reference process's own entropy
+$q\,H(\hat P)$. Theorem 1 identifies the excess as exactly the KL
+divergence: what the atlas equation forgoes is the information in *which*
+module the walk enters, over and above how large that module is. As in the
+map equation, "models the module interior" means an i.i.d. code over the
+module's own usage distribution, not a model of its internal dynamics; the
+change here is confined to cross-module navigation.
 
 ## 3. Properties
 
@@ -176,13 +200,26 @@ Corollaries:
   to module flow mass ($\hat Q = \hat P$). On the symmetric two-triangle
   example the gap is exactly $0$; on `ninetriangles.net` it is $0.0025$
   bits.
-- Since $\hat Q_i \le 1$, the gap obeys $q\,D_{KL}(\hat Q \| \hat P) \le
-  q \log_2(1/\min_i P_i)$. On any family of partitions whose smallest module
-  flow mass is bounded below, the disagreement therefore vanishes linearly
-  in the boundary flow $q$. This is a *conditional* guarantee: it is not
-  uniform over arbitrary partitions, because the mass of some module can
-  shrink as $q$ does — with $P_{min} \sim 2^{-1/q}$ the product stays
-  $\Theta(1)$ — so small boundary flow alone does not bound the gap.
+- **The gap vanishes with the boundary flow, uniformly over all
+  partitions.** Stationarity forces $Q_i^{in} \le P_i$ for every module:
+  $Q_i^{in} = \Pr[X_t \notin i,\, X_{t+1} \in i] \le \Pr[X_{t+1} \in i] =
+  P_i$ (for the unrecorded-teleportation directed model the link flows omit
+  teleportation steps, so the inequality only gains slack). Hence
+  $\hat Q_i / P_i \le 1/q$ for every $i$, and since $\sum_i \hat Q_i = 1$,
+  $$0 \;\le\; L_A - L_M \;=\; q\,D_{KL}(\hat Q \| \hat P) \;\le\; q \log_2(1/q)
+  \;\xrightarrow[q \to 0]{}\; 0 .$$
+  No assumption on module masses is needed. The complementary bound
+  $q \log_2(1/\min_i P_i)$ also holds, so the gap is at most
+  $q \min\{\log_2(1/q),\, \log_2(1/\min_i P_i)\}$. Both are tight enough to
+  matter: over 720 random partitions the largest observed
+  $\max_i Q_i^{in}/P_i$ is exactly $1$, and the largest observed
+  $\text{gap} / (q \log_2(1/q))$ is $0.96$.
+
+  So the objectives agree increasingly well as the partition improves by
+  either one's standards, and they can only disagree materially when the
+  boundary flow is substantial. (Note what this does *not* say: a large
+  gap requires large $q$, but large $q$ does not by itself make a partition
+  bad — the full codelength has other terms.)
 - The bias is interpretable and arguably useful: partitions in which a
   module's entry rate is disproportionate to its size (small, heavily
   trafficked pass-through modules) pay a surcharge of
@@ -202,20 +239,30 @@ where the map equation instead has the shared $\operatorname{plogp}(q)$).
 $\blacksquare$
 
 **Theorem 3 (lock-local, linearizable parallel search).** Run the local
-moving sweep concurrently; to commit a move $v: a \to b$, acquire the two
-module locks in id order, recheck the delta, apply, release. Then every
-committed move improves $L_A$ by more than the threshold $\varepsilon$, at
-any thread count, so the parallel search is monotone and terminates.
+moving sweep concurrently, with each node assigned to exactly one thread per
+sweep. To commit a move $v: a \to b$, acquire the two module locks in id
+order, re-read $v$'s current module and its link sums to $a$ and $b$,
+recheck the delta, apply, release — abandoning the move if $v$ is no longer
+in $a$. Then every committed move improves $L_A$ by more than the threshold
+$\varepsilon$, at any thread count, so the parallel search is monotone and
+terminates.
 
 *Proof sketch.* While holding both locks, membership of $a$ and $b$ cannot
-change (any move with an endpoint in $\{a,b\}$ needs one of the held locks).
-A concurrent move $u: c \to d$ with $c, d \notin \{a, b\}$ changes neither
-the aggregates of $a, b$ nor the classification of any of $v$'s neighbours
-as "in $a$", "in $b$", or "elsewhere" — a neighbour flipping between two
-"elsewhere" modules leaves the delta unchanged. Hence the recheck under the
-two locks is exact, the committed schedule is equivalent to some sequential
-order of strictly improving moves, and $L_A$ is bounded below.
-$\blacksquare$
+change (any move with an endpoint in $\{a,b\}$ needs one of the held locks),
+so the re-read of $v$'s module and of $v$'s link sums to $a$ and $b$ is
+stable for the duration. A concurrent move $u: c \to d$ with
+$c, d \notin \{a, b\}$ changes neither the aggregates of $a, b$ nor the
+classification of any of $v$'s neighbours as "in $a$", "in $b$", or
+"elsewhere" — a neighbour flipping between two "elsewhere" modules leaves
+the delta unchanged. Hence the recheck under the two locks is exact, the
+committed schedule is equivalent to some sequential order of strictly
+improving moves, and $L_A$ is bounded below. $\blacksquare$
+
+The membership re-read is not redundant bookkeeping: without the
+one-thread-per-node assignment (or an equivalent claim on $v$), a thread
+could hold the $\{a,b\}$ locks while $v$ has already been moved to some
+third module, and "recheck the delta" would be evaluating a move that no
+longer starts where it thinks. The benchmark implements both guards.
 
 For the map equation the same argument fails at one point: the delta
 contains $\operatorname{plogp}(q_{after}) - \operatorname{plogp}(q)$, and
@@ -255,14 +302,15 @@ available, in increasing order of throughput:
    propose-parallel/commit-serial pass works unchanged, but every recheck
    loses its global dependency (per candidate: two evaluations of $g$ after
    hoisting the old-module side, versus a 7-wide plogp batch *plus* the live
-   `enterFlow` read) and the "fast accept" condition (neither module touched
-   this sweep) can be tracked per module pair instead of per sweep. Fully
-   deterministic given the seed, independent of thread count.
+   `enterFlow` read), and the existing fast-accept condition — neither
+   endpoint module touched yet in this commit pass — becomes sufficient for
+   *exactness*, not just for cheapness: with no global term there is nothing
+   left that a third module's commit could have staled. Fully deterministic
+   given the seed, independent of thread count.
 2. **Colored parallel commit.** Since a commit touches two modules only,
    accepted proposals form a conflict graph over module pairs; color it and
    apply colors in parallel batches. Deterministic *and* parallel commits,
-   at the cost of a coloring pass. Impossible for the map equation (every
-   pair of commits conflicts through $q$).
+   at the cost of a coloring pass.
 3. **Fused two-lock sweep (maximum throughput).** Each thread proposes and
    commits immediately under ordered per-module spinlocks with an exact
    recheck (Theorem 3). No barriers, no proposal staleness across a commit
@@ -270,18 +318,37 @@ available, in increasing order of throughput:
    thread interleaving, so runs are not bit-reproducible across thread
    counts — the same trade the current inner parallelization already makes
    for proposals, but with the guarantee that every commit improves the true
-   objective.
+   objective. Note what this does *not* fix: contention is per module pair,
+   so a network with a few very heavy modules (early sweeps from singletons
+   are the opposite — many tiny modules) will serialize on those locks. The
+   design trades a guaranteed serial fraction for a data-dependent one.
 
-Design 2 has a second life as **vectorization**: a batch of accepted moves
-with pairwise-disjoint module pairs is exactly a "color", and applying it is
-a handful of numpy scatter-assignments — the after-aggregates of the touched
-modules are already known from the proposal step, so commit is `P[old] =
-old_p; P[new] = new_p; ...`. `prototype/atlas_numpy.py` implements the full
-search this way (sparse-matmul proposals over dirty nodes, greedy-maximal
-disjoint batches): the accepted deltas of every batch sum to the true
-codelength change to machine precision, while the identical batch scheme
-under the map equation drifts by $\sim 10^{-3}$ bits per sweep — the
-vectorized twin of the two-lock-vs-global-term result in the C++ benchmark.
+**Where the objectives actually part company.** Design 2 is *not* the
+dividing line: the map equation can be batched exactly too. Over a set of
+moves with pairwise-disjoint module pairs, its exact change is the
+per-module part plus a single global correction,
+$$\Delta L_M = \sum_{j} \Delta g_M(\text{pair } j) \; + \;
+\operatorname{plogp}\Big(q + \sum_j \delta q_j\Big) - \operatorname{plogp}(q),$$
+i.e. one reduction and one $\operatorname{plogp}$ per batch, no
+approximation (verified numerically to $2.5 \times 10^{-15}$ over 60 random
+batches). Closed-form bulk operations of this kind are what InfoFlow already
+does for the map equation. What the map equation cannot have is **design 3's
+property**: an individual move's delta that is exact *at commit time* from
+locally held state, with no global read-modify-write and no batch barrier.
+There, $q$ is a genuine serialization point.
+
+Design 2 also has a second life as **vectorization**: a batch of accepted
+moves with pairwise-disjoint module pairs is exactly a "color", and applying
+it is a handful of numpy scatter-assignments — the after-aggregates of the
+touched modules are already known from the proposal step, so commit is
+`P[old] = old_p; P[new] = new_p; ...`. `prototype/atlas_numpy.py` implements
+the full search this way (sparse-matmul proposals over dirty nodes,
+greedy-maximal disjoint batches). Its `demo_map_batch_drift` measures what
+happens when *per-move* deltas priced against the pre-batch $q$ are summed
+over a batch: exact for the atlas equation, off by $\sim 10^{-3}$ bits for
+the map equation. Read that as the cost of per-move attribution under a
+global term — not as a claim that exact batch bookkeeping is unavailable to
+the map equation, which the formula above provides.
 
 A convergence caveat that applies to every design (and to dirty-node
 tracking in general, including the neighbour marking used by Infomap's move
@@ -330,10 +397,19 @@ Nothing in §2 assumed undirectedness: enter and exit flows are tracked
 separately ($Q^{in}$ prices addresses, $Q^{out}$ prices exit words), and
 $p_\alpha$ comes from the usual teleportation-smoothed stationary flows. The
 `DeltaFlow` bookkeeping and `addTeleportationFlow` hooks in the optimizer
-apply verbatim — the delta corrections that Infomap applies symmetrically to
-module enter and exit flows carry over unchanged (validated numerically for
-directed flows in the prototype). Kraft-validity of the static addresses
-only needs $\sum_i P_i = 1$.
+apply verbatim, since the atlas equation consumes exactly the same
+per-module enter/exit aggregates the map equation does. The prototype's
+directed experiments confirm the algebra (deltas exact, KL identity exact)
+on a *simplified* directed flow model — raw PageRank node flow with
+link-following link flows — which matches neither of Infomap's teleportation
+models exactly: the default unrecorded model re-derives node flow as the
+in-aggregate of one teleportation-free link step
+(`src/utils/FlowCalculator.cpp:508-525`), and the recorded model books
+teleportation mass separately into enter/exit flow. That difference is
+orthogonal to the objective (both objectives read whatever flows the flow
+calculator produces), but it does mean the directed results here are not
+binary-validated — only the undirected examples in §7.1 are. Validity of the
+static addresses only needs $\sum_i P_i = 1$.
 
 ## 7. Empirical validation
 
@@ -342,6 +418,14 @@ All numbers below are reproducible with the two programs in this directory
 throughout; `plogp` uses log2 as in `src/utils/infomath.h`.
 
 ### 7.1 Correctness of the math (`prototype/atlas_prototype.py`)
+
+The residuals quoted below are *measured* values; the assertions that gate the
+script's exit code use a looser $10^{-10}$ so it stays stable across platforms
+and BLAS-free stdlib arithmetic. Reference codelengths in the delta checks are
+rebuilt from the network by the `Partition` constructor rather than read off the
+incrementally-updated object, so a wrong incremental formula cannot cancel out
+of both sides of the comparison (verified: a 37% error injected into
+`_module_terms_after` fails 6 checks).
 
 - **Move deltas exact** for both objectives, undirected and directed random
   networks, random partitions, 8 trials × 40 moves: max error $1.4 \times
@@ -380,41 +464,63 @@ throughout; `plogp` uses log2 as in `src/utils/infomath.h`.
 
 Planted partition, 200 blocks × 1000 nodes ($n = 2 \times 10^5$, ~1.2M
 edges, $k_{in} = 8$, nominal $k_{out} = 2$; the generator's two cross-block
-draws per node land closer to 4), Louvain from singletons, 4 cores. Every
-level converges only when a full verification sweep over all nodes accepts
-nothing (§4), so all modes end at single-move local optima. "L0 time" is
-the wall time of the top-level (leaf) local-moving phase — the phase that
-dominates large runs — including the verification sweeps; consistency is
-$|L_{after} - (L_{before} + \sum \delta_{committed})|$ at the top level.
+draws per node land closer to 4), Louvain from singletons, 4 physical cores
+(no SMT). Every level converges only when a full verification sweep over all
+nodes accepts nothing (§4), so all modes end at single-move local optima.
+"L0 time" is the wall time of the top-level (leaf) local-moving phase — the
+phase that dominates large runs — including the verification sweeps;
+consistency is $|L_{after} - (L_{before} + \sum \delta_{committed})|$ at the
+top level.
 
-| mode | threads | L0 time | L0 commit | final $L_M$ | modules | consistency |
-|:--|--:|--:|--:|--:|--:|--:|
-| seq-map                  | 1 | 6.43 s | — | 14.745 | 278 | $2 \times 10^{-12}$ |
-| seq-atlas                | 1 | 7.42 s | — | 14.743 | 250 | $3 \times 10^{-13}$ |
-| par-map (serial commit)  | 1 | 14.31 s | 0.34 s | 15.337 | 289 | $1 \times 10^{-12}$ |
-| par-map (serial commit)  | 2 | 6.55 s | 0.37 s | 15.337 | 289 | $1 \times 10^{-12}$ |
-| par-map (serial commit)  | 4 | 2.80 s | 0.32 s | 15.337 | 289 | $1 \times 10^{-12}$ |
-| par-atlas (two-lock)     | 1 | 7.43 s | — | 14.743 | 250 | $3 \times 10^{-13}$ |
-| par-atlas (two-lock)     | 2 | 2.42 s | — | 14.748 | 251 | $8 \times 10^{-13}$ |
-| par-atlas (two-lock)     | 4 | 1.36 s | — | 14.752 | 252 | $8 \times 10^{-13}$ |
-| par-map-twolock (unsound)| 2 | 2.88 s | — | 14.749 | 285 | $5 \times 10^{-9}$ |
-| par-map-twolock (unsound)| 4 | 1.42 s | — | 14.743 | 291 | $2 \times 10^{-8}$ |
+Two fairness notes on the `par-map` baseline, so its serial floor is not an
+artifact of a weak implementation. It carries Infomap's fast-accept path:
+proposals whose two endpoint modules are both still untouched in the commit
+pass are taken in $O(1)$ without re-walking the node's edges (43% of commits
+here), and because the map equation's delta splits into a per-module part and
+one $\operatorname{plogp}(q)$ term, that fast path is implemented *exactly*
+rather than on a stale snapshot — strictly stronger than Infomap's. It also
+takes no per-sweep snapshot copies: the proposal pass precedes all commits, so
+it reads live state directly, as Infomap does.
+
+Timings are from one run with nothing else on the machine; run-to-run spread
+is roughly ±10%, so treat smaller differences as noise. **Read the thread
+ratios as end-to-end phase times, not as parallel speedup.** Concurrency
+changes the search trajectory: at higher thread counts proposals see fresher
+state, more moves land per sweep, the dirty set drains faster, and the level
+converges in fewer sweeps (par-atlas: 32 sweeps at 1 thread, 27 at 4). The
+resulting ratio can exceed the core count — par-atlas is 7.0× from 1 to 4
+threads on 4 physical cores, so at least 40% of that is trajectory, not
+parallelism. The defensible claim here is about the *shape* of the two designs
+(no serial floor vs. a serial floor), not a speedup number.
+
+| mode | threads | L0 time | L0 commit | fast | sweeps | final $L_M$ | modules | consistency |
+|:--|--:|--:|--:|--:|--:|--:|--:|--:|
+| seq-map                  | 1 | 4.98 s | — | — | 28 | 14.746 | 279 | $4 \times 10^{-12}$ |
+| seq-atlas                | 1 | 6.19 s | — | — | 32 | 14.743 | 250 | $3 \times 10^{-13}$ |
+| par-map (serial commit)  | 1 | 10.54 s | 0.36 s | 43% | 53 | 15.317 | 268 | $6 \times 10^{-12}$ |
+| par-map (serial commit)  | 2 | 4.60 s | 0.34 s | 43% | 53 | 15.317 | 268 | $6 \times 10^{-12}$ |
+| par-map (serial commit)  | 4 | 2.37 s | 0.35 s | 43% | 53 | 15.317 | 268 | $6 \times 10^{-12}$ |
+| par-atlas (two-lock)     | 1 | 6.63 s | — | — | 32 | 14.743 | 250 | $3 \times 10^{-13}$ |
+| par-atlas (two-lock)     | 2 | 2.36 s | — | — | 26 | 14.746 | 258 | $8 \times 10^{-13}$ |
+| par-atlas (two-lock)     | 4 | 0.95 s | — | — | 27 | 14.742 | 251 | $8 \times 10^{-13}$ |
+| par-map-twolock (unsound)| 1 | 5.36 s | — | — | 28 | 14.748 | 275 | $4 \times 10^{-12}$ |
+| par-map-twolock (unsound)| 2 | 2.99 s | — | — | 32 | 14.746 | 273 | $5 \times 10^{-9}$ |
+| par-map-twolock (unsound)| 4 | 0.99 s | — | — | 27 | 14.750 | 277 | $1 \times 10^{-8}$ |
 
 Readings:
 
-- **par-atlas**: 7.43 s → 1.36 s from 1 to 4 threads (the 1-thread run
-  matches seq-atlas — the locking discipline is free when uncontended),
-  with consistency at the sequential level for every thread count and
-  equal final quality. The whole sweep — proposal, commit, and the
-  verification sweeps — parallelizes; there is no serial floor. Wall-clock
-  ratios above ~4× fold in trajectory effects: the asynchronous schedule
-  changes which moves are proposed, so thread count alters the search path,
-  not just its speed.
-- **par-map (serial commit)**: the faithful scheme scales its proposal pass
-  but keeps a ~0.33 s serial commit pass as a hard Amdahl floor, and
-  snapshot staleness roughly doubles the sweeps to convergence (68 vs 32).
-  Net effect at 4 threads: 2.3× over seq-map. (The final-quality gap of
-  this mode is an artifact of this benchmark's plain Louvain pipeline
+- **par-atlas**: 6.63 s → 0.95 s from 1 to 4 threads, with consistency at
+  the sequential level for *every* thread count and final quality matching
+  seq-atlas. The 1-thread run reproduces seq-atlas exactly — the locking
+  discipline is free when uncontended. The whole sweep — proposal, commit,
+  and the verification sweeps — parallelizes; there is no serial section to
+  bound it. (See the caveat above on reading the ratio as speedup.)
+- **par-map (serial commit)**: the commit pass does not shrink with threads —
+  0.36 / 0.34 / 0.35 s at 1 / 2 / 4 — so it is a floor that grows as a share
+  of the sweep (15% at 4 threads here, and it would dominate at 16+ cores).
+  Snapshot staleness costs sweeps as well: 53 to converge versus 32 for
+  par-atlas. At 4 threads it comes to 2.1× over seq-map. (The final-quality
+  gap of this mode is an artifact of this benchmark's plain Louvain pipeline
   lacking Infomap's tuning iterations, not a claim about Infomap.)
 - **par-map-twolock**: scales like par-atlas but is unsound — the committed
   deltas drift from the true codelength change by $10^{-8}$, four orders of
@@ -460,33 +566,97 @@ this note.
 
 ## 9. Relation to prior work
 
-- **Map equation** (Rosvall & Bergstrom 2008): the parent framework; the
-  atlas equation changes only the index codebook, from adaptive to static.
-- **RelaxMap** (Bae, Halperin, West, Rosvall, Howe 2017) and **GossipMap**
-  (Bae & Howe 2015): parallel/distributed map-equation search that *relaxes
-  consistency* of the shared state. The atlas equation is the complementary
-  move: change the objective so no shared state exists, keeping exactness.
-- **Markov stability** (Delvenne, Yaliraki, Barahona 2010) and **CPM/Leiden**
-  (Traag, Waltman, van Eck 2019): additively separable objectives — which is
-  why parallel Louvain-family algorithms thrive on them — but not
-  description-length-based. The atlas equation is an MDL-semantics member of
-  the separable family.
-- **Smart teleportation** (Lambiotte & Rosvall 2012): changes the *process*
-  to tame directed flows; the atlas equation changes the *code*, and its
-  static addresses are the coding twin of stationary relocation at borders
-  (§2).
-- **Regularized/Bayesian map equation** (Smiljanić, Edler, Rosvall 2020) and
-  the in-repo **lossy map equation** (rate-distortion): orthogonal
-  variations (priors; lossy node identity) that keep the adaptive index
-  codebook; in principle composable with static addresses.
-- **MapSim** (Blöcker, Smiljanić, Scholtes, Rosvall 2024): uses
-  map-equation coding rates as inter-node similarities — kindred
-  address-based reading of the coding hierarchy.
+**The map equation itself.** Rosvall & Bergstrom, *PNAS* 105(4):1118–1123
+(2008). The atlas equation changes only the index codebook, from adaptive to
+static. Its predecessor is worth noting too: the two-part MDL formulation in
+Rosvall & Bergstrom, *PNAS* 104(18):7327–7331 (2007) *does* pay for the
+module assignment explicitly, so charging for the partition has precedent
+inside this lineage.
 
-To our knowledge the specific construction — cross-entropy index coding
-against the module-mass distribution, chosen to make the objective
-additively separable — has not been proposed; a proper literature check
-should precede any publication claim.
+**Parallel and distributed map-equation search.** This is the literature the
+note's payoff claim lands in, and it is substantial:
+
+- **RelaxMap** — Bae, Halperin, West, Rosvall, Howe, "Scalable and Efficient
+  Flow-Based Community Detection for Large-Scale Graph Analysis," *ACM TKDD*
+  11(3):32 (2017); originally "Scalable Flow-Based Community Detection for
+  Large-Scale Network Analysis," *ICDMW* 2013, pp. 303–310. Its abstract's
+  "relaxes concurrency assumptions to avoid lock overhead" is easy to
+  misread: RelaxMap keeps the codelength and the per-module statistics
+  **exactly consistent** under a *global* lock around the update step. What
+  it relaxes is the strict sequential order — proposals are evaluated
+  concurrently against possibly stale module state, justified by a rarity
+  argument (collision probability $\approx p/N$ per pass). Most relevant
+  here: the authors report **testing the lock-free variant and finding it
+  unworkable** — convergence slower than the sequential algorithm in some
+  cases, plus incorrect active-module counts causing race conditions and
+  memory faults. That is the same experiment as this note's
+  `par-map-twolock` negative control, and it points the same way. The atlas
+  equation's contribution is complementary: rather than relax consistency or
+  pay for a lock that serializes, remove the shared quantity from the
+  objective so per-module locks suffice.
+- **GossipMap** — Bae & Howe, *SC '15*, Article 27: distributed-memory
+  extension of RelaxMap on PowerGraph, billion-edge graphs.
+- **Distributed Infomap** — Zeng & Yu, *ICPP '18*, Article 4: synchronized
+  exchange of community state, explicitly targeting RelaxMap's shared-memory
+  limits.
+- **InfoFlow** — Fung, *Big Data Cogn. Comput.* 3(3):42 (2019): Spark
+  implementation whose closed-form multi-module merge formulas let it commit
+  a *bulk* merge per iteration, giving logarithmic rather than linear
+  iteration count. This is direct evidence that batching is available to the
+  map equation (§4) — with the nuance that InfoFlow's closed form is exact
+  for the batch it commits while the *selection* is greedy pairwise.
+- **HyPC-Map** — Faysal, Arifuzzaman, Chan, Bremer, Popovici, Shalf, *IEEE
+  HPEC* 2021: hybrid MPI+OpenMP with cache-optimized structures, reporting
+  ~25× over prior map-equation implementations at 41M-node scale. Also
+  Faysal & Arifuzzaman, *IEEE BigData* 2019, pp. 4773–4782, and Faysal,
+  Bremer, Arifuzzaman, Popovici, Shalf, Chan, *IPDPSW* 2023, pp. 601–610
+  (sparse-accumulation acceleration).
+- **Distributed map equation and modularity** — Hamann, Strasser, Wagner,
+  Zeitz, *Euro-Par 2018*, LNCS 11014.
+
+Read together, this body of work attacks the same bottleneck from the
+algorithm side: locking, relaxation, synchronization schedules, and bulk
+operations. None of it changes the objective, which is what this note
+proposes.
+
+**Separable objectives.** Markov stability (Delvenne, Yaliraki, Barahona
+2010) and the Constant Potts Model (Traag, Van Dooren, Nesterov, *Phys. Rev.
+E* 84:016114, 2011 — the CPM *objective*; the 2019 *Sci. Rep.* Leiden paper
+is the *algorithm*) are additively separable, which is exactly why
+Louvain-family parallelizations thrive on them — but they are not
+description-length-based. The atlas equation is an MDL-semantics member of
+that family.
+
+**Map-equation variants.** Smart teleportation (Lambiotte & Rosvall 2012)
+changes the *process* to tame directed flows; the atlas equation changes the
+*code*, and its static addresses are the coding counterpart of stationary
+relocation at borders (§2). The regularized/Bayesian map equation
+(Smiljanić, Blöcker, Edler, Rosvall, *J. Complex Netw.* 9(6):cnab044, 2021)
+and the in-repo lossy map equation (rate–distortion) are orthogonal
+variations that keep the adaptive index codebook; in principle both compose
+with static addresses. For the broader landscape see the map-equation survey
+by Smiljanić, Blöcker, Holmgren, Edler, Neuman & Rosvall (*ACM Computing
+Surveys*, online-first; arXiv:2311.04036).
+
+**Cross-entropy readings of map-equation codes.** The "score a walk with a
+codebook it was not built for" move is already published: *flow divergence*
+(Blöcker & Scholtes, arXiv:2401.09052) measures the excess bits from
+describing a network's flow with **another partition's** codebooks, framed
+as relative entropy; *MapSim* (Blöcker, Smiljanić, Scholtes, Rosvall,
+*Proc. First Learning on Graphs Conference*, PMLR 198:52, 2022) uses
+map-equation coding rates as node similarities; *map equation centrality*
+(Blöcker, Nieves, Rosvall, *Appl. Netw. Sci.* 7:56, 2022) reads compression
+changes as a centrality.
+
+**Novelty caveat.** What appears not to have been proposed is the specific
+combination: pricing module *entries* by the module-mass distribution
+$-\log_2 P_i$, chosen so that the objective becomes additively separable,
+together with the identity $L_A = L_M + q\,D_{KL}(\hat Q \| \hat P)$. The
+ingredients are all in the literature, though — mismatched-codebook
+cross-entropy in the three papers just cited, and partition-cost terms in
+the 2007 two-part MDL and in the SBM/MDL line (below). Any publication claim
+needs a careful check against those; the citations here were assembled from
+search metadata rather than from reading every paper end to end.
 
 ## 10. Open questions
 
@@ -497,10 +667,18 @@ should precede any publication claim.
 2. **Hierarchical formalization** (§5): exit-word treatment for nested
    charts; whether the telescoping property yields a cheaper multilevel
    search than recursive two-level.
-3. **Alternative static references.** Addresses from node counts
-   ($-\log_2(n_i/n)$) give a structure-only variant; addresses from
-   teleportation weights connect to smart teleportation. Same separability,
-   different biases.
+3. **Alternative static references.** Addresses from teleportation weights
+   would connect to smart teleportation; same separability, different bias.
+   Note that the obvious other candidate — addresses from node counts,
+   $-\log_2(n_i/n)$ — is *not* unexplored: summed over nodes it is
+   $\sum_i n_i \log_2(n/n_i)$, which is (via Stirling) exactly the
+   group-label term $-\log P(b \mid n) = \log(N! / \prod_r n_r!)$ of the
+   nonparametric SBM description length (Peixoto, *Phys. Rev. X* 4:011047,
+   2014; *Phys. Rev. E* 95:012317, 2017). A node-count variant of the atlas
+   equation would therefore be closer to inferential SBM/MDL community
+   detection than to the map equation — interesting, but it should be
+   developed against that literature, and it omits the SBM's further terms
+   for $\{n_r\}$ and the number of groups.
 4. **Deterministic parallel commits** via module-pair coloring (§4, design
    2): is the coloring overhead worth bit-reproducibility?
 5. **Combination with Bayesian regularization**: the static address book has

--- a/research/atlas-equation/bench/.gitignore
+++ b/research/atlas-equation/bench/.gitignore
@@ -1,0 +1,2 @@
+# Build output of the standalone benchmark (see Makefile).
+parallel_bench

--- a/research/atlas-equation/bench/Makefile
+++ b/research/atlas-equation/bench/Makefile
@@ -1,11 +1,26 @@
 # Standalone benchmark for the atlas equation's parallel top-level search.
 # Not wired into the repository build; see ../README.md.
 
-CXX ?= g++
+# `?=` cannot express "unless the user set it": make predefines CXX, so its
+# builtin value would always win. Test the origin instead.
+ifeq ($(origin CXX),default)
+CXX = g++
+endif
+
 CXXFLAGS ?= -O3 -march=native -std=c++17 -Wall -Wextra
-OPENMP ?= -fopenmp
+
+# Apple clang ships without -fopenmp; Homebrew libomp supplies it out of tree.
+# Probe the compiler and fall back to a serial build rather than failing, so
+# `make` works on a stock macOS checkout. Override with OPENMP= to force.
+ifeq ($(origin OPENMP),undefined)
+OPENMP := $(shell printf 'int main(){}' > /tmp/.atlas_omp_probe.cpp 2>/dev/null && \
+	  ($(CXX) -fopenmp -x c++ /tmp/.atlas_omp_probe.cpp -o /dev/null >/dev/null 2>&1 && echo -fopenmp) || \
+	  ($(CXX) -Xpreprocessor -fopenmp -lomp -x c++ /tmp/.atlas_omp_probe.cpp -o /dev/null >/dev/null 2>&1 && \
+	   echo "-Xpreprocessor -fopenmp -lomp"))
+endif
 
 parallel_bench: parallel_bench.cpp
+	@test -n "$(OPENMP)" || echo "note: no OpenMP support detected; building single-threaded"
 	$(CXX) $(CXXFLAGS) $(OPENMP) -o $@ $<
 
 .PHONY: run clean

--- a/research/atlas-equation/bench/Makefile
+++ b/research/atlas-equation/bench/Makefile
@@ -1,0 +1,16 @@
+# Standalone benchmark for the atlas equation's parallel top-level search.
+# Not wired into the repository build; see ../README.md.
+
+CXX ?= g++
+CXXFLAGS ?= -O3 -march=native -std=c++17 -Wall -Wextra
+OPENMP ?= -fopenmp
+
+parallel_bench: parallel_bench.cpp
+	$(CXX) $(CXXFLAGS) $(OPENMP) -o $@ $<
+
+.PHONY: run clean
+run: parallel_bench
+	./parallel_bench --blocks 200 --block-size 1000 --threads 1,2,4
+
+clean:
+	rm -f parallel_bench

--- a/research/atlas-equation/bench/parallel_bench.cpp
+++ b/research/atlas-equation/bench/parallel_bench.cpp
@@ -851,6 +851,7 @@ RunResult run(const Graph& leafGraph, Mode mode, unsigned int seed, unsigned int
     double levelSeconds = 0.0;
     double commitSeconds = 0.0;
     LinkSums seqSums(current->n);
+    bool verified = false;
     for (; sweeps < maxSweeps; ++sweeps) {
       std::shuffle(order.begin(), order.end(), rng);
       SweepStats stats;
@@ -871,8 +872,20 @@ RunResult run(const Graph& leafGraph, Mode mode, unsigned int seed, unsigned int
       }
       levelSeconds += stats.seconds;
       committed += stats.committedDelta;
-      if (stats.moved == 0)
-        break;
+      if (stats.moved == 0) {
+        // Neighbour-of-mover dirty marking alone is not sufficient for
+        // convergence: a move changes the aggregates of both endpoint
+        // modules, which stales the deltas of non-adjacent nodes bordering
+        // them. Re-dirty everything and confirm with a full sweep; only a
+        // clean full sweep is a single-move local optimum.
+        if (verified)
+          break;
+        for (unsigned int u = 0; u < current->n; ++u)
+          level.dirty[u].store(1, std::memory_order_relaxed);
+        verified = true;
+      } else {
+        verified = false;
+      }
     }
     const double afterL = level.currentCodelength(obj, 0.0);
 

--- a/research/atlas-equation/bench/parallel_bench.cpp
+++ b/research/atlas-equation/bench/parallel_bench.cpp
@@ -32,8 +32,14 @@
  * committed deltas)| for the level-0 sweeps.
  *
  * Build:  g++ -O3 -march=native -fopenmp -std=c++17 -o parallel_bench parallel_bench.cpp
+ *         (or `make`, which probes for OpenMP support)
  * Run:    ./parallel_bench [--blocks 200] [--block-size 1000] [--kin 8] [--kout 2]
- *                          [--threads 1,2,4] [--seed 1]
+ *                          [--threads 1,2,4] [--seed 1] [--verbose]
+ *
+ * A given seed reproduces bit-for-bit within one toolchain, but not across
+ * standard libraries: geometric_distribution and uniform_real_distribution are
+ * implementation-defined, so libstdc++ and libc++ generate different graphs
+ * from the same seed. Compare numbers only within a single build.
  */
 
 #include <algorithm>
@@ -81,22 +87,30 @@ struct Graph {
 Graph plantedPartition(unsigned int numBlocks, unsigned int blockSize, double kIn, double kOut, unsigned int seed)
 {
   const unsigned int n = numBlocks * blockSize;
+  // Guard the degenerate shapes: a single block leaves no cross-block pairs
+  // (n == blockSize) and a block of one leaves no within-block pairs, so the
+  // probabilities would divide by zero and the NaN edge counts below would be
+  // cast to unsigned (undefined behavior).
+  const double pIn = blockSize > 1 ? kIn / static_cast<double>(blockSize - 1) : 0.0;
+  const double pOut = n > blockSize ? kOut / static_cast<double>(n - blockSize) : 0.0;
   std::mt19937 rng(seed);
   std::uniform_real_distribution<double> unif(0.0, 1.0);
-  const double pIn = kIn / static_cast<double>(blockSize - 1);
-  const double pOut = kOut / static_cast<double>(n - blockSize);
 
   std::vector<std::pair<unsigned int, unsigned int>> edges;
   edges.reserve(static_cast<size_t>(n) * static_cast<size_t>(kIn + kOut) / 2);
-  std::geometric_distribution<unsigned int> gapIn(pIn);
+  // geometric_distribution requires p in (0, 1); pIn == 0 means there are no
+  // within-block pairs to draw at all.
+  std::geometric_distribution<unsigned int> gapIn(pIn > 0.0 ? std::min(pIn, 1.0) : 0.5);
   for (unsigned int u = 0; u < n; ++u) {
     const unsigned int block = u / blockSize;
     const unsigned int blockEnd = (block + 1) * blockSize;
     // within-block partners v > u via geometric gap skipping
-    unsigned int v = u + 1 + gapIn(rng);
-    while (v < blockEnd) {
-      edges.emplace_back(u, v);
-      v += 1 + gapIn(rng);
+    if (pIn > 0.0) {
+      unsigned int v = u + 1 + gapIn(rng);
+      while (v < blockEnd) {
+        edges.emplace_back(u, v);
+        v += 1 + gapIn(rng);
+      }
     }
     // cross-block partners: expected count, uniform targets outside the block
     const double expected = pOut * static_cast<double>(n - blockSize);
@@ -208,6 +222,7 @@ double codelength(Objective obj, const std::vector<double>& P, const std::vector
 
 struct SweepStats {
   unsigned int moved = 0;
+  unsigned int fastAccepts = 0; // serial-commit mode: proposals taken in O(1)
   double seconds = 0.0;
   double committedDelta = 0.0; // sum of the deltas believed at commit time
 };
@@ -261,12 +276,33 @@ double deltaAtlas(double POld, double QOld, double PNew, double QNew, double pNo
   return gAtlas(a.pOld, a.qOld) + gAtlas(a.pNew, a.qNew) - gAtlas(POld, QOld) - gAtlas(PNew, QNew);
 }
 
-double deltaMap(double POld, double QOld, double PNew, double QNew, double pNode, double wNode, double kOld, double kNew, double qTotal)
+// The map equation delta splits cleanly into a part that depends only on the
+// two endpoint modules and a single global repricing of plogp(q). Keeping the
+// two apart is what lets the serial commit pass below fast-accept a proposal
+// in O(1) and still be exact: if neither endpoint module has been touched,
+// `perModule` is unchanged from the proposal snapshot and only the global part
+// needs the live q.
+struct MapDeltaParts {
+  double perModule;
+  double dq;
+};
+
+MapDeltaParts deltaMapParts(double POld, double QOld, double PNew, double QNew, double pNode, double wNode, double kOld, double kNew)
 {
   const auto a = after(POld, QOld, PNew, QNew, pNode, wNode, kOld, kNew);
   auto g = [](double P, double Q) { return -plogp(Q) + plogp(P + Q) - plogp(Q); };
-  const double qAfter = qTotal - QOld - QNew + a.qOld + a.qNew;
-  return plogp(qAfter) - plogp(qTotal) + g(a.pOld, a.qOld) + g(a.pNew, a.qNew) - g(POld, QOld) - g(PNew, QNew);
+  return { g(a.pOld, a.qOld) + g(a.pNew, a.qNew) - g(POld, QOld) - g(PNew, QNew),
+           -QOld - QNew + a.qOld + a.qNew };
+}
+
+double deltaMapFromParts(const MapDeltaParts& parts, double qTotal)
+{
+  return parts.perModule + plogp(qTotal + parts.dq) - plogp(qTotal);
+}
+
+double deltaMap(double POld, double QOld, double PNew, double QNew, double pNode, double wNode, double kOld, double kNew, double qTotal)
+{
+  return deltaMapFromParts(deltaMapParts(POld, QOld, PNew, QNew, pNode, wNode, kOld, kNew), qTotal);
 }
 
 struct Level {
@@ -274,8 +310,11 @@ struct Level {
   std::vector<std::atomic<unsigned int>> module;
   std::vector<std::atomic<char>> dirty;
   ModuleState state;
+  // Serial-commit fast-accept stamps (see sweepParallelMapSerialCommit).
+  std::vector<unsigned int> touchedStamp;
+  unsigned int commitStamp = 0;
 
-  explicit Level(const Graph& g) : graph(&g), module(g.n), dirty(g.n), state(g.n)
+  explicit Level(const Graph& g) : graph(&g), module(g.n), dirty(g.n), state(g.n), touchedStamp(g.n, 0)
   {
     for (unsigned int u = 0; u < g.n; ++u)
       dirty[u].store(1, std::memory_order_relaxed);
@@ -505,6 +544,10 @@ struct Proposal {
   unsigned int oldModule = 0;
   unsigned int newModule = 0;
   bool valid = false;
+  double wNode = 0.0;
+  double kOld = 0.0;
+  double kNew = 0.0;
+  MapDeltaParts parts {};
 };
 
 SweepStats sweepParallelMapSerialCommit(Level& level, const std::vector<unsigned int>& order, double* commitSeconds)
@@ -513,13 +556,15 @@ SweepStats sweepParallelMapSerialCommit(Level& level, const std::vector<unsigned
   SweepStats stats;
   auto t0 = Clock::now();
 
-  // Sweep-start snapshot (like Infomap, proposals are read-only)
-  std::vector<double> P, Q;
-  level.snapshot(P, Q);
+  // No snapshot copies: the proposal pass runs entirely before the commit
+  // pass, so reading the live state here yields the sweep-start values anyway
+  // (this is also what Infomap does -- it proposes against live
+  // m_moduleFlowData). Copying 3 arrays per sweep would be pure overhead
+  // charged to this mode.
   const double qTotal = level.state.qTotal.load(std::memory_order_relaxed);
-  std::vector<unsigned int> moduleOf(g.n);
-  for (unsigned int u = 0; u < g.n; ++u)
-    moduleOf[u] = level.module[u].load(std::memory_order_relaxed);
+  auto moduleOf = [&level](unsigned int x) { return level.module[x].load(std::memory_order_relaxed); };
+  auto Pof = [&level](unsigned int m) { return level.state.P[m].load(std::memory_order_relaxed); };
+  auto Qof = [&level](unsigned int m) { return level.state.Q[m].load(std::memory_order_relaxed); };
 
   std::vector<Proposal> proposals(order.size());
 
@@ -537,8 +582,8 @@ SweepStats sweepParallelMapSerialCommit(Level& level, const std::vector<unsigned
         continue;
       sums.clear();
       for (unsigned int k = g.offset[u]; k < g.offset[u + 1]; ++k)
-        sums.add(moduleOf[g.target[k]], g.flow[k]);
-      const unsigned int oldModule = moduleOf[u];
+        sums.add(moduleOf(g.target[k]), g.flow[k]);
+      const unsigned int oldModule = moduleOf(u);
       const double pNode = g.p[u];
       const double kOld = sums.sum[oldModule];
       unsigned int best = oldModule;
@@ -546,14 +591,17 @@ SweepStats sweepParallelMapSerialCommit(Level& level, const std::vector<unsigned
       for (unsigned int cand : sums.touched) {
         if (cand == oldModule)
           continue;
-        const double d = deltaMap(P[oldModule], Q[oldModule], P[cand], Q[cand], pNode, sums.total, kOld, sums.sum[cand], qTotal);
+        const double d = deltaMap(Pof(oldModule), Qof(oldModule), Pof(cand), Qof(cand), pNode, sums.total, kOld, sums.sum[cand], qTotal);
         if (d < bestDelta) {
           bestDelta = d;
           best = cand;
         }
       }
       if (best != oldModule) {
-        proposals[static_cast<size_t>(idx)] = Proposal { u, oldModule, best, true };
+        // Carry the link sums and the module-local part of the delta so the
+        // commit pass can fast-accept without re-walking the node's edges.
+        const auto parts = deltaMapParts(Pof(oldModule), Qof(oldModule), Pof(best), Qof(best), pNode, sums.total, kOld, sums.sum[best]);
+        proposals[static_cast<size_t>(idx)] = Proposal { u, oldModule, best, true, sums.total, kOld, sums.sum[best], parts };
       } else {
         // Proposal phase is a barrier-separated snapshot: no concurrent
         // commits can re-dirty u here, so clearing is race-free.
@@ -563,7 +611,14 @@ SweepStats sweepParallelMapSerialCommit(Level& level, const std::vector<unsigned
   }
 
   auto tCommit = Clock::now();
-  // Serial commit pass with exact recheck against live state.
+  // Serial commit pass. Mirrors Infomap's structure
+  // (src/core/InfomapOptimizer.h:887-909): proposals whose two endpoint
+  // modules are both still untouched in this pass are fast-accepted from the
+  // snapshot; the rest re-walk the node's edges and recompute the delta.
+  ++level.commitStamp;
+  const unsigned int commitStamp = level.commitStamp;
+  if (level.touchedStamp.size() < g.n)
+    level.touchedStamp.assign(g.n, 0);
   for (const Proposal& prop : proposals) {
     if (!prop.valid)
       continue;
@@ -572,6 +627,40 @@ SweepStats sweepParallelMapSerialCommit(Level& level, const std::vector<unsigned
     if (oldModule != prop.oldModule)
       continue;
     const unsigned int best = prop.newModule;
+
+    if (level.touchedStamp[oldModule] != commitStamp && level.touchedStamp[best] != commitStamp) {
+      // Neither module has changed, so the module-local part of the delta is
+      // still exact and only the global term needs the live q -- O(1), and no
+      // edge walk. (Infomap fast-accepts on the snapshot delta outright; the
+      // O(1) exact repricing here keeps this benchmark's consistency metric
+      // meaningful and only makes the map equation look better, never worse.)
+      const double qLive = level.state.qTotal.load(std::memory_order_relaxed);
+      const double d = deltaMapFromParts(prop.parts, qLive);
+      if (d >= -kMinImprovement)
+        continue;
+      const double POldF = level.state.P[oldModule].load(std::memory_order_relaxed);
+      const double QOldF = level.state.Q[oldModule].load(std::memory_order_relaxed);
+      const double PNewF = level.state.P[best].load(std::memory_order_relaxed);
+      const double QNewF = level.state.Q[best].load(std::memory_order_relaxed);
+      const auto a = after(POldF, QOldF, PNewF, QNewF, g.p[u], prop.wNode, prop.kOld, prop.kNew);
+      level.state.P[oldModule].store(a.pOld, std::memory_order_relaxed);
+      level.state.Q[oldModule].store(a.qOld, std::memory_order_relaxed);
+      level.state.P[best].store(a.pNew, std::memory_order_relaxed);
+      level.state.Q[best].store(a.qNew, std::memory_order_relaxed);
+      level.state.members[oldModule].fetch_sub(1, std::memory_order_relaxed);
+      level.state.members[best].fetch_add(1, std::memory_order_relaxed);
+      level.state.qTotal.store(qLive - QOldF - QNewF + a.qOld + a.qNew, std::memory_order_relaxed);
+      level.module[u].store(best, std::memory_order_relaxed);
+      level.touchedStamp[oldModule] = commitStamp;
+      level.touchedStamp[best] = commitStamp;
+      for (unsigned int k = g.offset[u]; k < g.offset[u + 1]; ++k)
+        level.dirty[g.target[k]].store(1, std::memory_order_relaxed);
+      stats.committedDelta += d;
+      ++stats.moved;
+      ++stats.fastAccepts;
+      continue;
+    }
+
     double kOld = 0.0;
     double kNew = 0.0;
     double wNode = 0.0;
@@ -601,6 +690,8 @@ SweepStats sweepParallelMapSerialCommit(Level& level, const std::vector<unsigned
     level.state.members[best].fetch_add(1, std::memory_order_relaxed);
     level.state.qTotal.store(qLive - QOld - QNew + a.qOld + a.qNew, std::memory_order_relaxed);
     level.module[u].store(best, std::memory_order_relaxed);
+    level.touchedStamp[oldModule] = commitStamp;
+    level.touchedStamp[best] = commitStamp;
     for (unsigned int k = g.offset[u]; k < g.offset[u + 1]; ++k)
       level.dirty[g.target[k]].store(1, std::memory_order_relaxed);
     stats.committedDelta += d;
@@ -820,6 +911,8 @@ struct RunResult {
   double consistency = 0.0; // |L_after - (L_before + sum committed deltas)| at level 0
   unsigned int level0Sweeps = 0;
   unsigned int modules = 0;
+  unsigned int level0Moves = 0;
+  unsigned int level0FastAccepts = 0;
 };
 
 RunResult run(const Graph& leafGraph, Mode mode, unsigned int seed, unsigned int maxSweeps)
@@ -850,6 +943,8 @@ RunResult run(const Graph& leafGraph, Mode mode, unsigned int seed, unsigned int
     unsigned int sweeps = 0;
     double levelSeconds = 0.0;
     double commitSeconds = 0.0;
+    unsigned int levelMoves = 0;
+    unsigned int levelFastAccepts = 0;
     LinkSums seqSums(current->n);
     bool verified = false;
     for (; sweeps < maxSweeps; ++sweeps) {
@@ -872,6 +967,8 @@ RunResult run(const Graph& leafGraph, Mode mode, unsigned int seed, unsigned int
       }
       levelSeconds += stats.seconds;
       committed += stats.committedDelta;
+      levelMoves += stats.moved;
+      levelFastAccepts += stats.fastAccepts;
       if (stats.moved == 0) {
         // Neighbour-of-mover dirty marking alone is not sufficient for
         // convergence: a move changes the aggregates of both endpoint
@@ -892,6 +989,8 @@ RunResult run(const Graph& leafGraph, Mode mode, unsigned int seed, unsigned int
     if (topLevel) {
       result.level0Seconds = levelSeconds;
       result.level0CommitSeconds = commitSeconds;
+      result.level0Moves = levelMoves;
+      result.level0FastAccepts = levelFastAccepts;
       result.level0Sweeps = sweeps + 1;
       result.consistency = std::abs(afterL - (before + committed));
       topLevel = false;
@@ -991,16 +1090,16 @@ int main(int argc, char** argv)
   std::printf("planted partition: %u nodes, %zu edges, %u blocks of %u (k_in=%.1f, k_out=%.1f)\n",
               g.n, g.target.size() / 2, numBlocks, blockSize, kIn, kOut);
   std::printf("one-level codelength: %.6f bits\n\n", g.nodeEntropy());
-  std::printf("%-27s %8s | %10s %10s %9s | %12s %12s %8s | %10s\n",
-              "mode", "threads", "L0 time", "L0 commit", "L0 sweeps", "final L_map", "final L_atlas", "modules", "|L-sumdelta|");
+  std::printf("%-27s %8s | %10s %10s %8s %9s | %12s %12s %8s | %10s\n",
+              "mode", "threads", "L0 time", "L0 commit", "L0 fast", "L0 sweeps", "final L_map", "final L_atlas", "modules", "|L-sumdelta|");
 
   for (Mode mode : { Mode::SeqMap, Mode::SeqAtlas }) {
 #ifdef _OPENMP
     omp_set_num_threads(1);
 #endif
     RunResult r = run(g, mode, seed + 100, maxSweeps);
-    std::printf("%-27s %8d | %9.3fs %9.3fs %9u | %12.6f %12.6f %8u | %10.2e\n",
-                modeName(mode), 1, r.level0Seconds, r.level0CommitSeconds, r.level0Sweeps,
+    std::printf("%-27s %8d | %9.3fs %9.3fs %8s %9u | %12.6f %12.6f %8u | %10.2e\n",
+                modeName(mode), 1, r.level0Seconds, r.level0CommitSeconds, "-", r.level0Sweeps,
                 r.finalMap, r.finalAtlas, r.modules, r.consistency);
   }
   for (Mode mode : { Mode::ParMapSerialCommit, Mode::ParAtlas, Mode::ParMapTwoLock }) {
@@ -1009,8 +1108,13 @@ int main(int argc, char** argv)
       omp_set_num_threads(t);
 #endif
       RunResult r = run(g, mode, seed + 100, maxSweeps);
-      std::printf("%-27s %8d | %9.3fs %9.3fs %9u | %12.6f %12.6f %8u | %10.2e\n",
-                  modeName(mode), t, r.level0Seconds, r.level0CommitSeconds, r.level0Sweeps,
+      char fastCol[16];
+      if (r.level0Moves > 0 && r.level0FastAccepts > 0)
+        std::snprintf(fastCol, sizeof fastCol, "%.0f%%", 100.0 * r.level0FastAccepts / r.level0Moves);
+      else
+        std::snprintf(fastCol, sizeof fastCol, "%s", "-");
+      std::printf("%-27s %8d | %9.3fs %9.3fs %8s %9u | %12.6f %12.6f %8u | %10.2e\n",
+                  modeName(mode), t, r.level0Seconds, r.level0CommitSeconds, fastCol, r.level0Sweeps,
                   r.finalMap, r.finalAtlas, r.modules, r.consistency);
     }
   }

--- a/research/atlas-equation/bench/parallel_bench.cpp
+++ b/research/atlas-equation/bench/parallel_bench.cpp
@@ -975,7 +975,7 @@ int main(int argc, char** argv)
   }
 
   Graph g = plantedPartition(numBlocks, blockSize, kIn, kOut, seed);
-  std::printf("planted partition: %u nodes, %zu half-edges, %u blocks of %u (k_in=%.1f, k_out=%.1f)\n",
+  std::printf("planted partition: %u nodes, %zu edges, %u blocks of %u (k_in=%.1f, k_out=%.1f)\n",
               g.n, g.target.size() / 2, numBlocks, blockSize, kIn, kOut);
   std::printf("one-level codelength: %.6f bits\n\n", g.nodeEntropy());
   std::printf("%-27s %8s | %10s %10s %9s | %12s %12s %8s | %10s\n",

--- a/research/atlas-equation/bench/parallel_bench.cpp
+++ b/research/atlas-equation/bench/parallel_bench.cpp
@@ -1,0 +1,1005 @@
+/*
+ * Parallel top-level search benchmark for the atlas equation.
+ *
+ * Demonstrates the algorithmic consequence of making the index codebook
+ * static (see research/atlas-equation/README.md): the objective becomes a sum
+ * of per-module terms, so a node move touches exactly two modules and a
+ * two-lock commit makes each move's delta exact at commit time. The whole
+ * local-moving sweep -- proposal and commit -- then runs in parallel with no
+ * global synchronization point.
+ *
+ * The map equation cannot do this: its index codebook reprices with the total
+ * boundary flow q (a plogp(q) term), so every commit writes one global scalar
+ * and commits must serialize (Infomap's inner parallelization does exactly
+ * that: parallel proposal pass, serial commit pass).
+ *
+ * Modes benchmarked on a planted-partition graph, Louvain from singletons:
+ *   seq-map          sequential local moving, map equation
+ *   seq-atlas        sequential local moving, atlas equation
+ *   par-map          parallel proposal pass + serial commit pass with exact
+ *                    recheck (faithful to Infomap's inner parallelization)
+ *   par-atlas        fused parallel sweep: propose and commit under two
+ *                    per-module spinlocks, exact delta recheck under lock
+ *   par-map-twolock  negative control: the atlas commit strategy applied to
+ *                    the map equation (global q read/updated atomically but
+ *                    not repriced consistently) -- shows the consistency
+ *                    violation as drift between the summed committed deltas
+ *                    and the true codelength change
+ *
+ * Every mode reports: wall time of the top-level sweep phase, total time to
+ * convergence (all levels), final two-level codelength recomputed from
+ * scratch, and the linearizability check |L_final - (L_init + sum of
+ * committed deltas)| for the level-0 sweeps.
+ *
+ * Build:  g++ -O3 -march=native -fopenmp -std=c++17 -o parallel_bench parallel_bench.cpp
+ * Run:    ./parallel_bench [--blocks 200] [--block-size 1000] [--kin 8] [--kout 2]
+ *                          [--threads 1,2,4] [--seed 1]
+ */
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <random>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace {
+
+bool verboseLevels = false;
+
+double plogp(double x) { return x > 1e-300 ? x * std::log2(x) : 0.0; }
+
+// ---------------------------------------------------------------------------
+// Graph (undirected, CSR with both directions stored)
+// ---------------------------------------------------------------------------
+
+struct Graph {
+  unsigned int n = 0;
+  std::vector<unsigned int> offset; // n + 1
+  std::vector<unsigned int> target;
+  std::vector<double> flow; // per directed half-edge: w / (2W)
+  std::vector<double> p; // node visit rate = strength / (2W)
+
+  double nodeEntropy() const
+  {
+    double h = 0.0;
+    for (double x : p)
+      h -= plogp(x);
+    return h;
+  }
+};
+
+Graph plantedPartition(unsigned int numBlocks, unsigned int blockSize, double kIn, double kOut, unsigned int seed)
+{
+  const unsigned int n = numBlocks * blockSize;
+  std::mt19937 rng(seed);
+  std::uniform_real_distribution<double> unif(0.0, 1.0);
+  const double pIn = kIn / static_cast<double>(blockSize - 1);
+  const double pOut = kOut / static_cast<double>(n - blockSize);
+
+  std::vector<std::pair<unsigned int, unsigned int>> edges;
+  edges.reserve(static_cast<size_t>(n) * static_cast<size_t>(kIn + kOut) / 2);
+  std::geometric_distribution<unsigned int> gapIn(pIn);
+  for (unsigned int u = 0; u < n; ++u) {
+    const unsigned int block = u / blockSize;
+    const unsigned int blockEnd = (block + 1) * blockSize;
+    // within-block partners v > u via geometric gap skipping
+    unsigned int v = u + 1 + gapIn(rng);
+    while (v < blockEnd) {
+      edges.emplace_back(u, v);
+      v += 1 + gapIn(rng);
+    }
+    // cross-block partners: expected count, uniform targets outside the block
+    const double expected = pOut * static_cast<double>(n - blockSize);
+    auto count = static_cast<unsigned int>(expected);
+    if (unif(rng) < expected - count)
+      ++count;
+    for (unsigned int t = 0; t < count; ++t) {
+      unsigned int w = rng() % n;
+      if (w / blockSize != block) {
+        edges.emplace_back(std::min(u, w), std::max(u, w));
+      }
+    }
+  }
+  std::sort(edges.begin(), edges.end());
+  edges.erase(std::unique(edges.begin(), edges.end()), edges.end());
+
+  Graph g;
+  g.n = n;
+  std::vector<unsigned int> degree(n, 0);
+  for (auto& e : edges) {
+    ++degree[e.first];
+    ++degree[e.second];
+  }
+  g.offset.assign(n + 1, 0);
+  for (unsigned int u = 0; u < n; ++u)
+    g.offset[u + 1] = g.offset[u] + degree[u];
+  g.target.resize(g.offset[n]);
+  g.flow.resize(g.offset[n]);
+  const double totalWeight = static_cast<double>(edges.size());
+  const double linkFlow = 1.0 / (2.0 * totalWeight);
+  std::vector<unsigned int> cursor(g.offset.begin(), g.offset.end() - 1);
+  for (auto& e : edges) {
+    g.target[cursor[e.first]] = e.second;
+    g.flow[cursor[e.first]++] = linkFlow;
+    g.target[cursor[e.second]] = e.first;
+    g.flow[cursor[e.second]++] = linkFlow;
+  }
+  g.p.assign(n, 0.0);
+  for (unsigned int u = 0; u < n; ++u) {
+    double s = 0.0;
+    for (unsigned int k = g.offset[u]; k < g.offset[u + 1]; ++k)
+      s += g.flow[k];
+    g.p[u] = s;
+  }
+  return g;
+}
+
+// ---------------------------------------------------------------------------
+// Objectives on per-module aggregates (undirected: Qin == Qout == Q)
+// ---------------------------------------------------------------------------
+
+enum class Objective { MapEq, Atlas };
+
+// Module term of the atlas equation: static address cost + module codebook.
+double gAtlas(double P, double Q)
+{
+  const double idx = (Q > 1e-300 && P > 1e-300) ? -Q * std::log2(P) : 0.0;
+  return idx + plogp(P + Q) - plogp(Q);
+}
+
+struct ModuleState {
+  std::vector<std::atomic<double>> P;
+  std::vector<std::atomic<double>> Q;
+  std::vector<std::atomic<unsigned int>> members;
+  std::vector<std::atomic_flag> lock;
+  std::atomic<double> qTotal { 0.0 }; // used by the map equation only
+
+  explicit ModuleState(unsigned int m) : P(m), Q(m), members(m), lock(m)
+  {
+    for (unsigned int i = 0; i < m; ++i) {
+      P[i].store(0.0, std::memory_order_relaxed);
+      Q[i].store(0.0, std::memory_order_relaxed);
+      members[i].store(0, std::memory_order_relaxed);
+      lock[i].clear();
+    }
+  }
+
+  void acquire(unsigned int i)
+  {
+    while (lock[i].test_and_set(std::memory_order_acquire)) {
+    }
+  }
+  void release(unsigned int i) { lock[i].clear(std::memory_order_release); }
+};
+
+double codelength(Objective obj, const std::vector<double>& P, const std::vector<double>& Q, double nodeEntropy)
+{
+  double L = nodeEntropy;
+  double q = 0.0;
+  for (size_t i = 0; i < P.size(); ++i) {
+    if (P[i] <= 0.0 && Q[i] <= 0.0)
+      continue;
+    L += plogp(P[i] + Q[i]) - plogp(Q[i]);
+    if (obj == Objective::Atlas) {
+      L += (Q[i] > 1e-300 && P[i] > 1e-300) ? -Q[i] * std::log2(P[i]) : 0.0;
+    } else {
+      L -= plogp(Q[i]);
+      q += Q[i];
+    }
+  }
+  if (obj == Objective::MapEq)
+    L += plogp(q);
+  return L;
+}
+
+// ---------------------------------------------------------------------------
+// Local moving sweeps
+// ---------------------------------------------------------------------------
+
+struct SweepStats {
+  unsigned int moved = 0;
+  double seconds = 0.0;
+  double committedDelta = 0.0; // sum of the deltas believed at commit time
+};
+
+using Clock = std::chrono::steady_clock;
+
+double seconds(Clock::time_point a, Clock::time_point b)
+{
+  return std::chrono::duration<double>(b - a).count();
+}
+
+struct LinkSums {
+  // flow between the node and each adjacent module, gathered per node visit
+  std::vector<double> sum;
+  std::vector<unsigned int> touched;
+  double total = 0.0; // the node's total incident link flow (wNode)
+  explicit LinkSums(unsigned int m) : sum(m, 0.0) { touched.reserve(64); }
+  void clear()
+  {
+    for (unsigned int t : touched)
+      sum[t] = 0.0;
+    touched.clear();
+    total = 0.0;
+  }
+  void add(unsigned int module, double f)
+  {
+    if (sum[module] == 0.0)
+      touched.push_back(module);
+    sum[module] += f;
+    total += f;
+  }
+};
+
+// Aggregates of the two touched modules after moving a node with visit rate
+// pNode, total incident link flow wNode, and boundary sums kOld/kNew
+// (undirected). At the leaf level wNode == pNode, but a coarse supernode
+// carries intra-supernode flow in pNode that never appears on links, so the
+// boundary update must use wNode.
+struct TwoModulesAfter {
+  double pOld, qOld, pNew, qNew;
+};
+
+TwoModulesAfter after(double POld, double QOld, double PNew, double QNew, double pNode, double wNode, double kOld, double kNew)
+{
+  return { POld - pNode, QOld - wNode + 2.0 * kOld, PNew + pNode, QNew + wNode - 2.0 * kNew };
+}
+
+double deltaAtlas(double POld, double QOld, double PNew, double QNew, double pNode, double wNode, double kOld, double kNew)
+{
+  const auto a = after(POld, QOld, PNew, QNew, pNode, wNode, kOld, kNew);
+  return gAtlas(a.pOld, a.qOld) + gAtlas(a.pNew, a.qNew) - gAtlas(POld, QOld) - gAtlas(PNew, QNew);
+}
+
+double deltaMap(double POld, double QOld, double PNew, double QNew, double pNode, double wNode, double kOld, double kNew, double qTotal)
+{
+  const auto a = after(POld, QOld, PNew, QNew, pNode, wNode, kOld, kNew);
+  auto g = [](double P, double Q) { return -plogp(Q) + plogp(P + Q) - plogp(Q); };
+  const double qAfter = qTotal - QOld - QNew + a.qOld + a.qNew;
+  return plogp(qAfter) - plogp(qTotal) + g(a.pOld, a.qOld) + g(a.pNew, a.qNew) - g(POld, QOld) - g(PNew, QNew);
+}
+
+struct Level {
+  const Graph* graph;
+  std::vector<std::atomic<unsigned int>> module;
+  std::vector<std::atomic<char>> dirty;
+  ModuleState state;
+
+  explicit Level(const Graph& g) : graph(&g), module(g.n), dirty(g.n), state(g.n)
+  {
+    for (unsigned int u = 0; u < g.n; ++u)
+      dirty[u].store(1, std::memory_order_relaxed);
+    double q = 0.0;
+    for (unsigned int u = 0; u < g.n; ++u) {
+      module[u].store(u, std::memory_order_relaxed);
+      state.P[u].store(g.p[u], std::memory_order_relaxed);
+      state.members[u].store(1, std::memory_order_relaxed);
+      double boundary = 0.0;
+      for (unsigned int k = g.offset[u]; k < g.offset[u + 1]; ++k)
+        boundary += g.flow[k];
+      state.Q[u].store(boundary, std::memory_order_relaxed);
+      q += boundary;
+    }
+    state.qTotal.store(q, std::memory_order_relaxed);
+  }
+
+  void snapshot(std::vector<double>& P, std::vector<double>& Q) const
+  {
+    P.resize(graph->n);
+    Q.resize(graph->n);
+    for (unsigned int i = 0; i < graph->n; ++i) {
+      P[i] = state.P[i].load(std::memory_order_relaxed);
+      Q[i] = state.Q[i].load(std::memory_order_relaxed);
+    }
+  }
+
+  double currentCodelength(Objective obj, double nodeEntropy) const
+  {
+    std::vector<double> P, Q;
+    snapshot(P, Q);
+    return codelength(obj, P, Q, nodeEntropy);
+  }
+};
+
+constexpr double kMinImprovement = 1e-10;
+
+// --- sequential sweep -------------------------------------------------------
+
+SweepStats sweepSequential(Level& level, Objective obj, std::vector<unsigned int>& order, LinkSums& sums)
+{
+  const Graph& g = *level.graph;
+  SweepStats stats;
+  auto t0 = Clock::now();
+  for (unsigned int u : order) {
+    if (!level.dirty[u].load(std::memory_order_relaxed))
+      continue;
+    sums.clear();
+    for (unsigned int k = g.offset[u]; k < g.offset[u + 1]; ++k)
+      sums.add(level.module[g.target[k]].load(std::memory_order_relaxed), g.flow[k]);
+    const unsigned int oldModule = level.module[u].load(std::memory_order_relaxed);
+    const double pNode = g.p[u];
+    const double POld = level.state.P[oldModule].load(std::memory_order_relaxed);
+    const double QOld = level.state.Q[oldModule].load(std::memory_order_relaxed);
+    const double kOld = sums.sum[oldModule];
+    const double qTotal = level.state.qTotal.load(std::memory_order_relaxed);
+
+    unsigned int best = oldModule;
+    double bestDelta = -kMinImprovement;
+    double bestK = 0.0;
+    for (unsigned int cand : sums.touched) {
+      if (cand == oldModule)
+        continue;
+      const double PNew = level.state.P[cand].load(std::memory_order_relaxed);
+      const double QNew = level.state.Q[cand].load(std::memory_order_relaxed);
+      const double kNew = sums.sum[cand];
+      const double d = obj == Objective::Atlas
+          ? deltaAtlas(POld, QOld, PNew, QNew, pNode, sums.total, kOld, kNew)
+          : deltaMap(POld, QOld, PNew, QNew, pNode, sums.total, kOld, kNew, qTotal);
+      if (d < bestDelta) {
+        bestDelta = d;
+        best = cand;
+        bestK = kNew;
+      }
+    }
+    if (best != oldModule) {
+      const double PNew = level.state.P[best].load(std::memory_order_relaxed);
+      const double QNew = level.state.Q[best].load(std::memory_order_relaxed);
+      const auto a = after(POld, QOld, PNew, QNew, pNode, sums.total, kOld, bestK);
+      level.state.P[oldModule].store(a.pOld, std::memory_order_relaxed);
+      level.state.Q[oldModule].store(a.qOld, std::memory_order_relaxed);
+      level.state.P[best].store(a.pNew, std::memory_order_relaxed);
+      level.state.Q[best].store(a.qNew, std::memory_order_relaxed);
+      level.state.members[oldModule].fetch_sub(1, std::memory_order_relaxed);
+      level.state.members[best].fetch_add(1, std::memory_order_relaxed);
+      level.state.qTotal.store(qTotal - QOld - QNew + a.qOld + a.qNew, std::memory_order_relaxed);
+      level.module[u].store(best, std::memory_order_relaxed);
+      for (unsigned int k = g.offset[u]; k < g.offset[u + 1]; ++k)
+        level.dirty[g.target[k]].store(1, std::memory_order_relaxed);
+      stats.committedDelta += bestDelta;
+      ++stats.moved;
+    } else {
+      level.dirty[u].store(0, std::memory_order_relaxed);
+    }
+  }
+  stats.seconds = seconds(t0, Clock::now());
+  return stats;
+}
+
+// --- fused parallel sweep for the atlas equation (two-lock commits) ---------
+
+SweepStats sweepParallelAtlas(Level& level, const std::vector<unsigned int>& order)
+{
+  const Graph& g = *level.graph;
+  SweepStats stats;
+  std::atomic<unsigned int> moved { 0 };
+  double committed = 0.0;
+  auto t0 = Clock::now();
+
+#ifdef _OPENMP
+#pragma omp parallel reduction(+ : committed)
+#endif
+  {
+    LinkSums sums(g.n);
+#ifdef _OPENMP
+#pragma omp for schedule(dynamic, 256)
+#endif
+    for (long long idx = 0; idx < static_cast<long long>(order.size()); ++idx) {
+      const unsigned int u = order[static_cast<size_t>(idx)];
+      if (!level.dirty[u].load(std::memory_order_relaxed))
+        continue;
+      // Claim before scanning: a concurrent commit that re-dirties u after
+      // this store is not lost, it just schedules a revisit next sweep.
+      level.dirty[u].store(0, std::memory_order_relaxed);
+      sums.clear();
+      for (unsigned int k = g.offset[u]; k < g.offset[u + 1]; ++k)
+        sums.add(level.module[g.target[k]].load(std::memory_order_relaxed), g.flow[k]);
+      const unsigned int oldModule = level.module[u].load(std::memory_order_relaxed);
+      const double pNode = g.p[u];
+      const double kOld = sums.sum[oldModule];
+
+      // Unlocked scan: aggregates may be stale; used only to pick a candidate.
+      unsigned int best = oldModule;
+      double bestDelta = -kMinImprovement;
+      {
+        const double POld = level.state.P[oldModule].load(std::memory_order_relaxed);
+        const double QOld = level.state.Q[oldModule].load(std::memory_order_relaxed);
+        for (unsigned int cand : sums.touched) {
+          if (cand == oldModule)
+            continue;
+          const double d = deltaAtlas(POld, QOld,
+                                      level.state.P[cand].load(std::memory_order_relaxed),
+                                      level.state.Q[cand].load(std::memory_order_relaxed),
+                                      pNode, sums.total, kOld, sums.sum[cand]);
+          if (d < bestDelta) {
+            bestDelta = d;
+            best = cand;
+          }
+        }
+      }
+      if (best == oldModule)
+        continue;
+
+      // Ordered two-lock commit with exact recheck. Membership of the two
+      // locked modules cannot change while we hold both locks, and moves
+      // among other modules cannot affect this delta (locality theorem), so
+      // the recheck below is exact -- this is what the map equation lacks.
+      const unsigned int lockA = std::min(oldModule, best);
+      const unsigned int lockB = std::max(oldModule, best);
+      level.state.acquire(lockA);
+      level.state.acquire(lockB);
+
+      const unsigned int curModule = level.module[u].load(std::memory_order_relaxed);
+      if (curModule != oldModule) { // someone moved us? (only this thread owns u; defensive)
+        level.state.release(lockB);
+        level.state.release(lockA);
+        continue;
+      }
+      // Re-gather link sums to the two locked modules (neighbor module ids of
+      // third modules may be stale, but any value != oldModule/best classifies
+      // identically for this delta).
+      double kOldExact = 0.0;
+      double kNewExact = 0.0;
+      double wNode = 0.0;
+      for (unsigned int k = g.offset[u]; k < g.offset[u + 1]; ++k) {
+        const unsigned int m = level.module[g.target[k]].load(std::memory_order_relaxed);
+        wNode += g.flow[k];
+        if (m == oldModule)
+          kOldExact += g.flow[k];
+        else if (m == best)
+          kNewExact += g.flow[k];
+      }
+      const double POld = level.state.P[oldModule].load(std::memory_order_relaxed);
+      const double QOld = level.state.Q[oldModule].load(std::memory_order_relaxed);
+      const double PNew = level.state.P[best].load(std::memory_order_relaxed);
+      const double QNew = level.state.Q[best].load(std::memory_order_relaxed);
+      const double d = deltaAtlas(POld, QOld, PNew, QNew, pNode, wNode, kOldExact, kNewExact);
+      bool didMove = false;
+      if (d < -kMinImprovement) {
+        const auto a = after(POld, QOld, PNew, QNew, pNode, wNode, kOldExact, kNewExact);
+        level.state.P[oldModule].store(a.pOld, std::memory_order_relaxed);
+        level.state.Q[oldModule].store(a.qOld, std::memory_order_relaxed);
+        level.state.P[best].store(a.pNew, std::memory_order_relaxed);
+        level.state.Q[best].store(a.qNew, std::memory_order_relaxed);
+        level.state.members[oldModule].fetch_sub(1, std::memory_order_relaxed);
+        level.state.members[best].fetch_add(1, std::memory_order_relaxed);
+        level.module[u].store(best, std::memory_order_relaxed);
+        committed += d;
+        moved.fetch_add(1, std::memory_order_relaxed);
+        didMove = true;
+      }
+      level.state.release(lockB);
+      level.state.release(lockA);
+      if (didMove) {
+        level.dirty[u].store(1, std::memory_order_relaxed); // mover stays dirty
+        for (unsigned int k = g.offset[u]; k < g.offset[u + 1]; ++k)
+          level.dirty[g.target[k]].store(1, std::memory_order_relaxed);
+      } else if (best != oldModule) {
+        level.dirty[u].store(1, std::memory_order_relaxed); // recheck rejected: retry
+      }
+    }
+  }
+  stats.moved = moved.load();
+  stats.committedDelta = committed;
+  stats.seconds = seconds(t0, Clock::now());
+  return stats;
+}
+
+// --- parallel proposal + serial commit for the map equation -----------------
+// Faithful to InfomapOptimizer::tryMoveEachNodeIntoBestModuleInParallel:
+// proposals against a sweep-start snapshot, then a serial commit pass that
+// rechecks against the live state (the global q makes parallel commits
+// unsound, so the commit pass cannot be parallelized).
+
+struct Proposal {
+  unsigned int node = 0;
+  unsigned int oldModule = 0;
+  unsigned int newModule = 0;
+  bool valid = false;
+};
+
+SweepStats sweepParallelMapSerialCommit(Level& level, const std::vector<unsigned int>& order, double* commitSeconds)
+{
+  const Graph& g = *level.graph;
+  SweepStats stats;
+  auto t0 = Clock::now();
+
+  // Sweep-start snapshot (like Infomap, proposals are read-only)
+  std::vector<double> P, Q;
+  level.snapshot(P, Q);
+  const double qTotal = level.state.qTotal.load(std::memory_order_relaxed);
+  std::vector<unsigned int> moduleOf(g.n);
+  for (unsigned int u = 0; u < g.n; ++u)
+    moduleOf[u] = level.module[u].load(std::memory_order_relaxed);
+
+  std::vector<Proposal> proposals(order.size());
+
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+  {
+    LinkSums sums(g.n);
+#ifdef _OPENMP
+#pragma omp for schedule(dynamic, 256)
+#endif
+    for (long long idx = 0; idx < static_cast<long long>(order.size()); ++idx) {
+      const unsigned int u = order[static_cast<size_t>(idx)];
+      if (!level.dirty[u].load(std::memory_order_relaxed))
+        continue;
+      sums.clear();
+      for (unsigned int k = g.offset[u]; k < g.offset[u + 1]; ++k)
+        sums.add(moduleOf[g.target[k]], g.flow[k]);
+      const unsigned int oldModule = moduleOf[u];
+      const double pNode = g.p[u];
+      const double kOld = sums.sum[oldModule];
+      unsigned int best = oldModule;
+      double bestDelta = -kMinImprovement;
+      for (unsigned int cand : sums.touched) {
+        if (cand == oldModule)
+          continue;
+        const double d = deltaMap(P[oldModule], Q[oldModule], P[cand], Q[cand], pNode, sums.total, kOld, sums.sum[cand], qTotal);
+        if (d < bestDelta) {
+          bestDelta = d;
+          best = cand;
+        }
+      }
+      if (best != oldModule) {
+        proposals[static_cast<size_t>(idx)] = Proposal { u, oldModule, best, true };
+      } else {
+        // Proposal phase is a barrier-separated snapshot: no concurrent
+        // commits can re-dirty u here, so clearing is race-free.
+        level.dirty[u].store(0, std::memory_order_relaxed);
+      }
+    }
+  }
+
+  auto tCommit = Clock::now();
+  // Serial commit pass with exact recheck against live state.
+  for (const Proposal& prop : proposals) {
+    if (!prop.valid)
+      continue;
+    const unsigned int u = prop.node;
+    const unsigned int oldModule = level.module[u].load(std::memory_order_relaxed);
+    if (oldModule != prop.oldModule)
+      continue;
+    const unsigned int best = prop.newModule;
+    double kOld = 0.0;
+    double kNew = 0.0;
+    double wNode = 0.0;
+    for (unsigned int k = g.offset[u]; k < g.offset[u + 1]; ++k) {
+      const unsigned int m = level.module[g.target[k]].load(std::memory_order_relaxed);
+      wNode += g.flow[k];
+      if (m == oldModule)
+        kOld += g.flow[k];
+      else if (m == best)
+        kNew += g.flow[k];
+    }
+    const double pNode = g.p[u];
+    const double POld = level.state.P[oldModule].load(std::memory_order_relaxed);
+    const double QOld = level.state.Q[oldModule].load(std::memory_order_relaxed);
+    const double PNew = level.state.P[best].load(std::memory_order_relaxed);
+    const double QNew = level.state.Q[best].load(std::memory_order_relaxed);
+    const double qLive = level.state.qTotal.load(std::memory_order_relaxed);
+    const double d = deltaMap(POld, QOld, PNew, QNew, pNode, wNode, kOld, kNew, qLive);
+    if (d >= -kMinImprovement)
+      continue;
+    const auto a = after(POld, QOld, PNew, QNew, pNode, wNode, kOld, kNew);
+    level.state.P[oldModule].store(a.pOld, std::memory_order_relaxed);
+    level.state.Q[oldModule].store(a.qOld, std::memory_order_relaxed);
+    level.state.P[best].store(a.pNew, std::memory_order_relaxed);
+    level.state.Q[best].store(a.qNew, std::memory_order_relaxed);
+    level.state.members[oldModule].fetch_sub(1, std::memory_order_relaxed);
+    level.state.members[best].fetch_add(1, std::memory_order_relaxed);
+    level.state.qTotal.store(qLive - QOld - QNew + a.qOld + a.qNew, std::memory_order_relaxed);
+    level.module[u].store(best, std::memory_order_relaxed);
+    for (unsigned int k = g.offset[u]; k < g.offset[u + 1]; ++k)
+      level.dirty[g.target[k]].store(1, std::memory_order_relaxed);
+    stats.committedDelta += d;
+    ++stats.moved;
+  }
+  auto t1 = Clock::now();
+  if (commitSeconds != nullptr)
+    *commitSeconds += seconds(tCommit, t1);
+  stats.seconds = seconds(t0, t1);
+  return stats;
+}
+
+// --- negative control: two-lock commits under the map equation --------------
+// Identical locking discipline to sweepParallelAtlas, but the delta depends on
+// the global q, which other threads mutate concurrently. The committed deltas
+// are therefore not the true codelength changes; the run reports the drift.
+
+SweepStats sweepParallelMapTwoLock(Level& level, const std::vector<unsigned int>& order)
+{
+  const Graph& g = *level.graph;
+  SweepStats stats;
+  std::atomic<unsigned int> moved { 0 };
+  double committed = 0.0;
+  auto t0 = Clock::now();
+
+#ifdef _OPENMP
+#pragma omp parallel reduction(+ : committed)
+#endif
+  {
+    LinkSums sums(g.n);
+#ifdef _OPENMP
+#pragma omp for schedule(dynamic, 256)
+#endif
+    for (long long idx = 0; idx < static_cast<long long>(order.size()); ++idx) {
+      const unsigned int u = order[static_cast<size_t>(idx)];
+      if (!level.dirty[u].load(std::memory_order_relaxed))
+        continue;
+      level.dirty[u].store(0, std::memory_order_relaxed);
+      sums.clear();
+      for (unsigned int k = g.offset[u]; k < g.offset[u + 1]; ++k)
+        sums.add(level.module[g.target[k]].load(std::memory_order_relaxed), g.flow[k]);
+      const unsigned int oldModule = level.module[u].load(std::memory_order_relaxed);
+      const double pNode = g.p[u];
+      const double kOld = sums.sum[oldModule];
+      unsigned int best = oldModule;
+      double bestDelta = -kMinImprovement;
+      {
+        const double POld = level.state.P[oldModule].load(std::memory_order_relaxed);
+        const double QOld = level.state.Q[oldModule].load(std::memory_order_relaxed);
+        const double qTotal = level.state.qTotal.load(std::memory_order_relaxed);
+        for (unsigned int cand : sums.touched) {
+          if (cand == oldModule)
+            continue;
+          const double d = deltaMap(POld, QOld,
+                                    level.state.P[cand].load(std::memory_order_relaxed),
+                                    level.state.Q[cand].load(std::memory_order_relaxed),
+                                    pNode, sums.total, kOld, sums.sum[cand], qTotal);
+          if (d < bestDelta) {
+            bestDelta = d;
+            best = cand;
+          }
+        }
+      }
+      if (best == oldModule)
+        continue;
+
+      const unsigned int lockA = std::min(oldModule, best);
+      const unsigned int lockB = std::max(oldModule, best);
+      level.state.acquire(lockA);
+      level.state.acquire(lockB);
+      double kOldExact = 0.0;
+      double kNewExact = 0.0;
+      double wNode = 0.0;
+      for (unsigned int k = g.offset[u]; k < g.offset[u + 1]; ++k) {
+        const unsigned int m = level.module[g.target[k]].load(std::memory_order_relaxed);
+        wNode += g.flow[k];
+        if (m == oldModule)
+          kOldExact += g.flow[k];
+        else if (m == best)
+          kNewExact += g.flow[k];
+      }
+      const double POld = level.state.P[oldModule].load(std::memory_order_relaxed);
+      const double QOld = level.state.Q[oldModule].load(std::memory_order_relaxed);
+      const double PNew = level.state.P[best].load(std::memory_order_relaxed);
+      const double QNew = level.state.Q[best].load(std::memory_order_relaxed);
+      // q is read without any lock that protects it: this is the unsound step.
+      const double qStale = level.state.qTotal.load(std::memory_order_relaxed);
+      const double d = deltaMap(POld, QOld, PNew, QNew, pNode, wNode, kOldExact, kNewExact, qStale);
+      bool didMove = false;
+      if (d < -kMinImprovement) {
+        const auto a = after(POld, QOld, PNew, QNew, pNode, wNode, kOldExact, kNewExact);
+        level.state.P[oldModule].store(a.pOld, std::memory_order_relaxed);
+        level.state.Q[oldModule].store(a.qOld, std::memory_order_relaxed);
+        level.state.P[best].store(a.pNew, std::memory_order_relaxed);
+        level.state.Q[best].store(a.qNew, std::memory_order_relaxed);
+        level.state.members[oldModule].fetch_sub(1, std::memory_order_relaxed);
+        level.state.members[best].fetch_add(1, std::memory_order_relaxed);
+        // atomic read-modify-write of the global (fetch_add on atomic<double>)
+        double expected = level.state.qTotal.load(std::memory_order_relaxed);
+        const double dq = -QOld - QNew + a.qOld + a.qNew;
+        while (!level.state.qTotal.compare_exchange_weak(expected, expected + dq, std::memory_order_relaxed)) {
+        }
+        level.module[u].store(best, std::memory_order_relaxed);
+        committed += d;
+        moved.fetch_add(1, std::memory_order_relaxed);
+        didMove = true;
+      }
+      level.state.release(lockB);
+      level.state.release(lockA);
+      if (didMove) {
+        level.dirty[u].store(1, std::memory_order_relaxed);
+        for (unsigned int k = g.offset[u]; k < g.offset[u + 1]; ++k)
+          level.dirty[g.target[k]].store(1, std::memory_order_relaxed);
+      } else if (best != oldModule) {
+        level.dirty[u].store(1, std::memory_order_relaxed);
+      }
+    }
+  }
+  stats.moved = moved.load();
+  stats.committedDelta = committed;
+  stats.seconds = seconds(t0, Clock::now());
+  return stats;
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation (module graph) for full Louvain
+// ---------------------------------------------------------------------------
+
+Graph aggregate(const Level& level, std::vector<unsigned int>& leafToCoarse)
+{
+  const Graph& g = *level.graph;
+  std::vector<unsigned int> remap(g.n, 0);
+  unsigned int numModules = 0;
+  std::vector<unsigned int> moduleOf(g.n);
+  for (unsigned int u = 0; u < g.n; ++u)
+    moduleOf[u] = level.module[u].load(std::memory_order_relaxed);
+  {
+    std::vector<char> seen(g.n, 0);
+    for (unsigned int u = 0; u < g.n; ++u) {
+      if (!seen[moduleOf[u]]) {
+        seen[moduleOf[u]] = 1;
+        remap[moduleOf[u]] = numModules++;
+      }
+    }
+  }
+  for (unsigned int u = 0; u < g.n; ++u)
+    leafToCoarse[u] = remap[moduleOf[u]];
+
+  Graph coarse;
+  coarse.n = numModules;
+  coarse.p.assign(numModules, 0.0);
+  for (unsigned int u = 0; u < g.n; ++u)
+    coarse.p[remap[moduleOf[u]]] += g.p[u];
+
+  std::unordered_map<uint64_t, double> flows;
+  flows.reserve(g.target.size() / 4);
+  for (unsigned int u = 0; u < g.n; ++u) {
+    const unsigned int mu = remap[moduleOf[u]];
+    for (unsigned int k = g.offset[u]; k < g.offset[u + 1]; ++k) {
+      const unsigned int mv = remap[moduleOf[g.target[k]]];
+      if (mu != mv)
+        flows[(static_cast<uint64_t>(mu) << 32) | mv] += g.flow[k];
+    }
+  }
+  std::vector<unsigned int> degree(numModules, 0);
+  for (auto& kv : flows)
+    ++degree[kv.first >> 32];
+  coarse.offset.assign(numModules + 1, 0);
+  for (unsigned int m = 0; m < numModules; ++m)
+    coarse.offset[m + 1] = coarse.offset[m] + degree[m];
+  coarse.target.resize(coarse.offset[numModules]);
+  coarse.flow.resize(coarse.offset[numModules]);
+  std::vector<unsigned int> cursor(coarse.offset.begin(), coarse.offset.end() - 1);
+  for (auto& kv : flows) {
+    const auto mu = static_cast<unsigned int>(kv.first >> 32);
+    const auto mv = static_cast<unsigned int>(kv.first & 0xffffffffu);
+    coarse.target[cursor[mu]] = mv;
+    coarse.flow[cursor[mu]++] = kv.second;
+  }
+  return coarse;
+}
+
+// ---------------------------------------------------------------------------
+// Full runs
+// ---------------------------------------------------------------------------
+
+enum class Mode { SeqMap, SeqAtlas, ParMapSerialCommit, ParAtlas, ParMapTwoLock };
+
+const char* modeName(Mode m)
+{
+  switch (m) {
+  case Mode::SeqMap:
+    return "seq-map";
+  case Mode::SeqAtlas:
+    return "seq-atlas";
+  case Mode::ParMapSerialCommit:
+    return "par-map (serial commit)";
+  case Mode::ParAtlas:
+    return "par-atlas (two-lock)";
+  case Mode::ParMapTwoLock:
+    return "par-map-twolock (unsound)";
+  }
+  return "?";
+}
+
+Objective objectiveOf(Mode m)
+{
+  return (m == Mode::SeqAtlas || m == Mode::ParAtlas) ? Objective::Atlas : Objective::MapEq;
+}
+
+struct RunResult {
+  double level0Seconds = 0.0;
+  double level0CommitSeconds = 0.0;
+  double totalSeconds = 0.0;
+  double finalMap = 0.0;
+  double finalAtlas = 0.0;
+  double consistency = 0.0; // |L_after - (L_before + sum committed deltas)| at level 0
+  unsigned int level0Sweeps = 0;
+  unsigned int modules = 0;
+};
+
+RunResult run(const Graph& leafGraph, Mode mode, unsigned int seed, unsigned int maxSweeps)
+{
+  const Objective obj = objectiveOf(mode);
+  const double leafEntropy = leafGraph.nodeEntropy();
+  RunResult result;
+  auto tRun = Clock::now();
+
+  std::vector<unsigned int> leafAssignment(leafGraph.n);
+  for (unsigned int u = 0; u < leafGraph.n; ++u)
+    leafAssignment[u] = u;
+
+  const Graph* current = &leafGraph;
+  Graph owned; // only the current coarse level is kept
+  std::mt19937 rng(seed);
+  bool topLevel = true;
+  unsigned int levelIndex = 0;
+
+  while (true) {
+    Level level(*current);
+    std::vector<unsigned int> order(current->n);
+    for (unsigned int u = 0; u < current->n; ++u)
+      order[u] = u;
+
+    const double before = level.currentCodelength(obj, 0.0);
+    double committed = 0.0;
+    unsigned int sweeps = 0;
+    double levelSeconds = 0.0;
+    double commitSeconds = 0.0;
+    LinkSums seqSums(current->n);
+    for (; sweeps < maxSweeps; ++sweeps) {
+      std::shuffle(order.begin(), order.end(), rng);
+      SweepStats stats;
+      switch (mode) {
+      case Mode::SeqMap:
+      case Mode::SeqAtlas:
+        stats = sweepSequential(level, obj, order, seqSums);
+        break;
+      case Mode::ParAtlas:
+        stats = sweepParallelAtlas(level, order);
+        break;
+      case Mode::ParMapSerialCommit:
+        stats = sweepParallelMapSerialCommit(level, order, &commitSeconds);
+        break;
+      case Mode::ParMapTwoLock:
+        stats = sweepParallelMapTwoLock(level, order);
+        break;
+      }
+      levelSeconds += stats.seconds;
+      committed += stats.committedDelta;
+      if (stats.moved == 0)
+        break;
+    }
+    const double afterL = level.currentCodelength(obj, 0.0);
+
+    if (topLevel) {
+      result.level0Seconds = levelSeconds;
+      result.level0CommitSeconds = commitSeconds;
+      result.level0Sweeps = sweeps + 1;
+      result.consistency = std::abs(afterL - (before + committed));
+      topLevel = false;
+    }
+
+    // Aggregate; stop when (almost) nothing merged
+    std::vector<unsigned int> leafToCoarse(current->n);
+    Graph coarse = aggregate(level, leafToCoarse);
+    if (verboseLevels) {
+      std::fprintf(stderr, "    level %u: %u -> %u nodes, %u sweeps, %.3fs, L %.6f -> %.6f\n",
+                   levelIndex, current->n, coarse.n, sweeps + 1, levelSeconds, before, afterL);
+    }
+    const bool progress = coarse.n < current->n - std::max(1u, current->n / 1000);
+    for (unsigned int u = 0; u < leafGraph.n; ++u)
+      leafAssignment[u] = leafToCoarse[leafAssignment[u]];
+    if (!progress || coarse.n <= 1)
+      break;
+    owned = std::move(coarse);
+    current = &owned;
+    ++levelIndex;
+  }
+
+  result.totalSeconds = seconds(tRun, Clock::now());
+
+  // Final two-level codelengths from the leaf assignment, computed exactly.
+  unsigned int numModules = 0;
+  for (unsigned int u = 0; u < leafGraph.n; ++u)
+    numModules = std::max(numModules, leafAssignment[u] + 1);
+  std::vector<double> P(numModules, 0.0);
+  std::vector<double> Q(numModules, 0.0);
+  for (unsigned int u = 0; u < leafGraph.n; ++u)
+    P[leafAssignment[u]] += leafGraph.p[u];
+  for (unsigned int u = 0; u < leafGraph.n; ++u) {
+    for (unsigned int k = leafGraph.offset[u]; k < leafGraph.offset[u + 1]; ++k) {
+      if (leafAssignment[u] != leafAssignment[leafGraph.target[k]])
+        Q[leafAssignment[u]] += leafGraph.flow[k];
+    }
+  }
+  unsigned int nonEmpty = 0;
+  for (unsigned int m = 0; m < numModules; ++m)
+    if (P[m] > 0.0)
+      ++nonEmpty;
+  result.modules = nonEmpty;
+  result.finalMap = codelength(Objective::MapEq, P, Q, leafEntropy);
+  result.finalAtlas = codelength(Objective::Atlas, P, Q, leafEntropy);
+  return result;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+  unsigned int numBlocks = 200;
+  unsigned int blockSize = 1000;
+  double kIn = 8.0;
+  double kOut = 2.0;
+  unsigned int seed = 1;
+  unsigned int maxSweeps = 200;
+  std::string threadList = "1,2,4";
+
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    auto next = [&]() { return std::string(argv[++i]); };
+    if (arg == "--blocks")
+      numBlocks = static_cast<unsigned int>(std::stoul(next()));
+    else if (arg == "--block-size")
+      blockSize = static_cast<unsigned int>(std::stoul(next()));
+    else if (arg == "--kin")
+      kIn = std::stod(next());
+    else if (arg == "--kout")
+      kOut = std::stod(next());
+    else if (arg == "--seed")
+      seed = static_cast<unsigned int>(std::stoul(next()));
+    else if (arg == "--threads")
+      threadList = next();
+    else if (arg == "--verbose")
+      verboseLevels = true;
+    else {
+      std::fprintf(stderr, "unknown argument: %s\n", arg.c_str());
+      return 1;
+    }
+  }
+
+  std::vector<int> threads;
+  {
+    size_t pos = 0;
+    while (pos < threadList.size()) {
+      size_t comma = threadList.find(',', pos);
+      if (comma == std::string::npos)
+        comma = threadList.size();
+      threads.push_back(std::stoi(threadList.substr(pos, comma - pos)));
+      pos = comma + 1;
+    }
+  }
+
+  Graph g = plantedPartition(numBlocks, blockSize, kIn, kOut, seed);
+  std::printf("planted partition: %u nodes, %zu half-edges, %u blocks of %u (k_in=%.1f, k_out=%.1f)\n",
+              g.n, g.target.size() / 2, numBlocks, blockSize, kIn, kOut);
+  std::printf("one-level codelength: %.6f bits\n\n", g.nodeEntropy());
+  std::printf("%-27s %8s | %10s %10s %9s | %12s %12s %8s | %10s\n",
+              "mode", "threads", "L0 time", "L0 commit", "L0 sweeps", "final L_map", "final L_atlas", "modules", "|L-sumdelta|");
+
+  for (Mode mode : { Mode::SeqMap, Mode::SeqAtlas }) {
+#ifdef _OPENMP
+    omp_set_num_threads(1);
+#endif
+    RunResult r = run(g, mode, seed + 100, maxSweeps);
+    std::printf("%-27s %8d | %9.3fs %9.3fs %9u | %12.6f %12.6f %8u | %10.2e\n",
+                modeName(mode), 1, r.level0Seconds, r.level0CommitSeconds, r.level0Sweeps,
+                r.finalMap, r.finalAtlas, r.modules, r.consistency);
+  }
+  for (Mode mode : { Mode::ParMapSerialCommit, Mode::ParAtlas, Mode::ParMapTwoLock }) {
+    for (int t : threads) {
+#ifdef _OPENMP
+      omp_set_num_threads(t);
+#endif
+      RunResult r = run(g, mode, seed + 100, maxSweeps);
+      std::printf("%-27s %8d | %9.3fs %9.3fs %9u | %12.6f %12.6f %8u | %10.2e\n",
+                  modeName(mode), t, r.level0Seconds, r.level0CommitSeconds, r.level0Sweeps,
+                  r.finalMap, r.finalAtlas, r.modules, r.consistency);
+    }
+  }
+  return 0;
+}

--- a/research/atlas-equation/bench/parallel_bench.cpp
+++ b/research/atlas-equation/bench/parallel_bench.cpp
@@ -35,6 +35,7 @@
  *         (or `make`, which probes for OpenMP support)
  * Run:    ./parallel_bench [--blocks 200] [--block-size 1000] [--kin 8] [--kout 2]
  *                          [--threads 1,2,4] [--seed 1] [--verbose]
+ *         [--sweep-scaling [--warmup-sweeps 2] [--reps 15]]
  *
  * A given seed reproduces bit-for-bit within one toolchain, but not across
  * standard libraries: geometric_distribution and uniform_real_distribution are
@@ -902,6 +903,112 @@ Objective objectiveOf(Mode m)
   return (m == Mode::SeqAtlas || m == Mode::ParAtlas) ? Objective::Atlas : Objective::MapEq;
 }
 
+// ---------------------------------------------------------------------------
+// Controlled strong-scaling measurement
+// ---------------------------------------------------------------------------
+//
+// End-to-end phase times conflate two things: how fast a sweep runs, and how
+// many sweeps the search needs (concurrency changes the trajectory, so thread
+// count alters both). This measures only the first: advance to a fixed state,
+// snapshot it, then run ONE sweep from that identical state at each thread
+// count, repeated, keeping the minimum. The minimum is the right estimator
+// here because timing noise on a shared machine is one-sided -- interruptions
+// only ever add time.
+
+struct LevelSnapshot {
+  std::vector<unsigned int> module;
+  std::vector<char> dirty;
+  std::vector<double> P, Q;
+  std::vector<unsigned int> members;
+  std::vector<unsigned int> touchedStamp;
+  double qTotal = 0.0;
+};
+
+LevelSnapshot saveLevel(const Level& level)
+{
+  const unsigned int n = level.graph->n;
+  LevelSnapshot s;
+  s.module.resize(n);
+  s.dirty.resize(n);
+  s.P.resize(n);
+  s.Q.resize(n);
+  s.members.resize(n);
+  for (unsigned int i = 0; i < n; ++i) {
+    s.module[i] = level.module[i].load(std::memory_order_relaxed);
+    s.dirty[i] = level.dirty[i].load(std::memory_order_relaxed);
+    s.P[i] = level.state.P[i].load(std::memory_order_relaxed);
+    s.Q[i] = level.state.Q[i].load(std::memory_order_relaxed);
+    s.members[i] = level.state.members[i].load(std::memory_order_relaxed);
+  }
+  s.touchedStamp = level.touchedStamp;
+  s.qTotal = level.state.qTotal.load(std::memory_order_relaxed);
+  return s;
+}
+
+void restoreLevel(Level& level, const LevelSnapshot& s)
+{
+  const unsigned int n = level.graph->n;
+  for (unsigned int i = 0; i < n; ++i) {
+    level.module[i].store(s.module[i], std::memory_order_relaxed);
+    level.dirty[i].store(s.dirty[i], std::memory_order_relaxed);
+    level.state.P[i].store(s.P[i], std::memory_order_relaxed);
+    level.state.Q[i].store(s.Q[i], std::memory_order_relaxed);
+    level.state.members[i].store(s.members[i], std::memory_order_relaxed);
+  }
+  level.touchedStamp = s.touchedStamp;
+  level.state.qTotal.store(s.qTotal, std::memory_order_relaxed);
+}
+
+void sweepScaling(const Graph& g, const std::vector<int>& threads, unsigned int warmupSweeps, unsigned int reps, unsigned int seed)
+{
+  std::printf("\nControlled strong scaling: one sweep from an identical state, best of %u\n", reps);
+  std::printf("(state = %u sequential sweeps from singletons; work is identical across rows)\n\n", warmupSweeps);
+  std::printf("%-27s %8s | %10s %10s | %9s %6s | %8s\n",
+              "mode", "threads", "sweep", "vs 1 thread", "serial", "share", "moves");
+
+  for (Mode mode : { Mode::ParAtlas, Mode::ParMapSerialCommit }) {
+    const Objective obj = objectiveOf(mode);
+    Level level(g);
+    std::vector<unsigned int> order(g.n);
+    for (unsigned int u = 0; u < g.n; ++u)
+      order[u] = u;
+    std::mt19937 rng(seed);
+    std::shuffle(order.begin(), order.end(), rng);
+    {
+      LinkSums warmSums(g.n);
+      for (unsigned int k = 0; k < warmupSweeps; ++k)
+        sweepSequential(level, obj, order, warmSums);
+    }
+    const LevelSnapshot snap = saveLevel(level);
+
+    double baseline = 0.0;
+    for (int t : threads) {
+#ifdef _OPENMP
+      omp_set_num_threads(t);
+#endif
+      double best = 1e300;
+      double bestCommit = 0.0;
+      unsigned int moves = 0;
+      for (unsigned int r = 0; r < reps; ++r) {
+        restoreLevel(level, snap);
+        double commit = 0.0;
+        const SweepStats st = mode == Mode::ParAtlas
+            ? sweepParallelAtlas(level, order)
+            : sweepParallelMapSerialCommit(level, order, &commit);
+        if (st.seconds < best) {
+          best = st.seconds;
+          bestCommit = commit;
+          moves = st.moved;
+        }
+      }
+      if (baseline == 0.0)
+        baseline = best;
+      std::printf("%-27s %8d | %9.4fs %10.2fx | %8.4fs %6.1f%% | %8u\n",
+                  modeName(mode), t, best, baseline / best, bestCommit, 100.0 * bestCommit / best, moves);
+    }
+  }
+}
+
 struct RunResult {
   double level0Seconds = 0.0;
   double level0CommitSeconds = 0.0;
@@ -1049,6 +1156,9 @@ int main(int argc, char** argv)
   double kOut = 2.0;
   unsigned int seed = 1;
   unsigned int maxSweeps = 200;
+  unsigned int warmupSweeps = 2;
+  unsigned int reps = 5;
+  bool sweepScalingOnly = false;
   std::string threadList = "1,2,4";
 
   for (int i = 1; i < argc; ++i) {
@@ -1068,6 +1178,12 @@ int main(int argc, char** argv)
       threadList = next();
     else if (arg == "--verbose")
       verboseLevels = true;
+    else if (arg == "--sweep-scaling")
+      sweepScalingOnly = true;
+    else if (arg == "--warmup-sweeps")
+      warmupSweeps = static_cast<unsigned int>(std::stoul(next()));
+    else if (arg == "--reps")
+      reps = static_cast<unsigned int>(std::stoul(next()));
     else {
       std::fprintf(stderr, "unknown argument: %s\n", arg.c_str());
       return 1;
@@ -1092,6 +1208,11 @@ int main(int argc, char** argv)
   std::printf("one-level codelength: %.6f bits\n\n", g.nodeEntropy());
   std::printf("%-27s %8s | %10s %10s %8s %9s | %12s %12s %8s | %10s\n",
               "mode", "threads", "L0 time", "L0 commit", "L0 fast", "L0 sweeps", "final L_map", "final L_atlas", "modules", "|L-sumdelta|");
+
+  if (sweepScalingOnly) {
+    sweepScaling(g, threads, warmupSweeps, reps, seed + 100);
+    return 0;
+  }
 
   for (Mode mode : { Mode::SeqMap, Mode::SeqAtlas }) {
 #ifdef _OPENMP

--- a/research/atlas-equation/prototype/atlas_numpy.py
+++ b/research/atlas-equation/prototype/atlas_numpy.py
@@ -42,10 +42,19 @@ def plogp(x: np.ndarray) -> np.ndarray:
 
 
 def undirected_flow(n: int, u, v, w) -> tuple[sparse.csr_array, np.ndarray]:
-    """Edge lists -> symmetric flow matrix with entries w/(2W), p = strength/2W."""
+    """Edge lists -> symmetric flow matrix with entries w/(2W), p = strength/2W.
+
+    Self-links are dropped, matching the pure-python prototype. They must not
+    survive: `propose()` classifies each incident link as going to the old
+    module, the new module, or elsewhere, and a self-link would be counted on
+    both sides of a move without the compensating -F[x, x] term, silently
+    corrupting the boundary-after values.
+    """
     u = np.asarray(u)
     v = np.asarray(v)
     w = np.asarray(w, dtype=float)
+    keep = u != v
+    u, v, w = u[keep], v[keep], w[keep]
     total = w.sum()
     rows = np.concatenate([u, v])
     cols = np.concatenate([v, u])

--- a/research/atlas-equation/prototype/atlas_numpy.py
+++ b/research/atlas-equation/prototype/atlas_numpy.py
@@ -284,17 +284,27 @@ def batch_local_moving(f, ft, p, module, objective: str, rng, max_sweeps=1000):
     l_fn = l_atlas if objective == "atlas" else l_map
     l_tracked = l_fn(big_p, q_in, q_out, 0.0)
     dirty_idx = np.arange(n)
+    verified = False
     for _ in range(max_sweeps):
-        if len(dirty_idx) == 0:
-            break
-        prop = propose(
-            f, ft, dirty_idx, p, w_out, w_in, module, big_p, q_in, q_out, objective
+        prop = (
+            propose(
+                f, ft, dirty_idx, p, w_out, w_in, module, big_p, q_in, q_out, objective
+            )
+            if len(dirty_idx) > 0
+            else None
         )
         if prop is None:
-            break
+            # Neighbour-of-mover dirty marking alone is not sufficient for
+            # convergence: a move changes the aggregates of both modules, so
+            # non-adjacent nodes bordering them get stale deltas too. Confirm
+            # the local optimum with a full sweep before stopping.
+            if verified:
+                break
+            dirty_idx = np.arange(n)
+            verified = True
+            continue
+        verified = False
         sel = disjoint_batch(prop, m, rng)
-        if len(sel) == 0:
-            break
         nodes = prop["node"][sel]
         module[nodes] = prop["new"][sel]
         # Disjointness makes the update a plain assignment of after-values.

--- a/research/atlas-equation/prototype/atlas_numpy.py
+++ b/research/atlas-equation/prototype/atlas_numpy.py
@@ -454,6 +454,9 @@ def demo_map_batch_drift(quick: bool):
         prop = propose(
             f, ft, np.arange(n), p, w_out, w_in, module, big_p, q_in, q_out, objective
         )
+        if prop is None:
+            print(f"  {objective:<5}: no improving moves from singletons")
+            continue
         sel = disjoint_batch(prop, n, rng)
         module[prop["node"][sel]] = prop["new"][sel]
         big_p, q_in, q_out = module_aggregates(f, p, module, n)

--- a/research/atlas-equation/prototype/atlas_numpy.py
+++ b/research/atlas-equation/prototype/atlas_numpy.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""Vectorized (numpy/scipy) implementation of the atlas equation search.
+
+Why this exists: the atlas equation's additive separability makes a fully
+vectorized batch search *sound*, not just possible. Each sweep proposes the
+best move for every dirty node against the current per-module aggregates
+(two sparse matmuls over the dirty rows), then accepts a maximal set of
+proposals whose module pairs are pairwise disjoint. By the locality theorem
+(README.md, Theorems 2-3), every delta in such a batch stays exact when the
+whole batch is applied at once, so the accepted deltas sum to the true
+codelength change and the per-module aggregates of the touched modules can
+simply be *assigned* their precomputed after-values -- the vectorized twin of
+the two-lock commit in bench/parallel_bench.cpp. The same batch scheme under
+the map equation is inexact, because applying any move reprices the global
+plogp(q) term for every other move in the batch; `demo_map_batch_drift`
+measures that drift.
+
+Everything is in bits (log2). Directed and undirected flows supported;
+undirected networks are represented as symmetric flow matrices.
+
+Usage:  python3 atlas_numpy.py [--quick]
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import numpy as np
+from scipy import sparse
+
+RNG = np.random.default_rng
+
+
+def plogp(x: np.ndarray) -> np.ndarray:
+    return np.where(x > 1e-300, x * np.log2(np.maximum(x, 1e-300)), 0.0)
+
+
+# ---------------------------------------------------------------------------
+# Flow networks: sparse flow matrix F (F[u, v] = walk flow u -> v) + p
+# ---------------------------------------------------------------------------
+
+
+def undirected_flow(n: int, u, v, w) -> tuple[sparse.csr_array, np.ndarray]:
+    """Edge lists -> symmetric flow matrix with entries w/(2W), p = strength/2W."""
+    u = np.asarray(u)
+    v = np.asarray(v)
+    w = np.asarray(w, dtype=float)
+    total = w.sum()
+    rows = np.concatenate([u, v])
+    cols = np.concatenate([v, u])
+    data = np.concatenate([w, w]) / (2.0 * total)
+    f = sparse.csr_array((data, (rows, cols)), shape=(n, n))
+    f.sum_duplicates()
+    p = np.asarray(f.sum(axis=1)).ravel()
+    return f, p
+
+
+def planted_partition(
+    num_blocks: int, block_size: int, k_in: float, k_out: float, seed: int
+):
+    """Sparse planted partition, vectorized generation."""
+    rng = RNG(seed)
+    n = num_blocks * block_size
+    # within-block edges: sample once per block from the upper triangle
+    m_in = rng.poisson(k_in * block_size / 2.0, size=num_blocks)
+    us, vs = [], []
+    for b in range(num_blocks):
+        cnt = m_in[b]
+        a = rng.integers(0, block_size, size=2 * cnt).reshape(2, -1)
+        keep = a[0] != a[1]
+        us.append(b * block_size + np.minimum(a[0][keep], a[1][keep]))
+        vs.append(b * block_size + np.maximum(a[0][keep], a[1][keep]))
+    # cross-block edges: uniform pairs, keep those crossing blocks
+    m_out = rng.poisson(k_out * n / 2.0)
+    a = rng.integers(0, n, size=2 * m_out).reshape(2, -1)
+    keep = a[0] // block_size != a[1] // block_size
+    us.append(np.minimum(a[0][keep], a[1][keep]))
+    vs.append(np.maximum(a[0][keep], a[1][keep]))
+    u = np.concatenate(us)
+    v = np.concatenate(vs)
+    pairs = np.unique(u.astype(np.int64) * n + v)
+    u, v = pairs // n, pairs % n
+    truth = np.arange(n) // block_size
+    f, p = undirected_flow(n, u, v, np.ones(len(u)))
+    return f, p, truth
+
+
+# ---------------------------------------------------------------------------
+# Objectives from per-module aggregates (vectorized)
+# ---------------------------------------------------------------------------
+
+
+def module_aggregates(f: sparse.csr_array, p: np.ndarray, module: np.ndarray, m: int):
+    """P, Qin, Qout per module id in [0, m)."""
+    coo = f.tocoo()
+    cross = module[coo.row] != module[coo.col]
+    big_p = np.bincount(module, weights=p, minlength=m)
+    q_out = np.bincount(module[coo.row[cross]], weights=coo.data[cross], minlength=m)
+    q_in = np.bincount(module[coo.col[cross]], weights=coo.data[cross], minlength=m)
+    return big_p, q_in, q_out
+
+
+def l_map(big_p, q_in, q_out, node_entropy: float) -> float:
+    q = q_in.sum()
+    index = plogp(np.array([q]))[0] - plogp(q_in).sum()
+    modules = (plogp(big_p + q_out) - plogp(q_out)).sum()
+    return float(index + modules + node_entropy)
+
+
+def l_atlas(big_p, q_in, q_out, node_entropy: float) -> float:
+    mask = (q_in > 0.0) & (big_p > 0.0)
+    index = -(q_in[mask] * np.log2(big_p[mask])).sum()
+    modules = (plogp(big_p + q_out) - plogp(q_out)).sum()
+    return float(index + modules + node_entropy)
+
+
+def g_atlas(big_p, q_in, q_out):
+    """Per-module functional of the atlas equation, elementwise."""
+    idx = np.where(
+        (q_in > 1e-300) & (big_p > 1e-300),
+        -q_in * np.log2(np.maximum(big_p, 1e-300)),
+        0.0,
+    )
+    return idx + plogp(big_p + q_out) - plogp(q_out)
+
+
+def kl_gap(big_p, q_in) -> float:
+    q = q_in.sum()
+    if q <= 0.0:
+        return 0.0
+    mask = q_in > 0.0
+    return float((q_in[mask] * np.log2((q_in[mask] / q) / big_p[mask])).sum())
+
+
+# ---------------------------------------------------------------------------
+# One vectorized sweep: propose for dirty nodes, accept a disjoint batch
+# ---------------------------------------------------------------------------
+
+
+def candidate_link_sums(f, ft, rows_idx, module, m):
+    """For every (dirty node, adjacent module) pair: flow node->module (k_out)
+    and module->node (k_in), aligned over the union sparsity. Row indices in
+    the returned arrays are local to `rows_idx`."""
+    n = f.shape[0]
+    h = sparse.csr_array((np.ones(n), (np.arange(n), module)), shape=(n, m))
+    k_out = (f[rows_idx] @ h).tocoo()
+    k_in = (ft[rows_idx] @ h).tocoo()
+    stride = np.int64(m)
+    keys = np.concatenate(
+        [
+            k_out.row.astype(np.int64) * stride + k_out.col,
+            k_in.row.astype(np.int64) * stride + k_in.col,
+        ]
+    )
+    uniq, inverse = np.unique(keys, return_inverse=True)
+    out_aligned = np.zeros(len(uniq))
+    in_aligned = np.zeros(len(uniq))
+    np.add.at(out_aligned, inverse[: len(k_out.data)], k_out.data)
+    np.add.at(in_aligned, inverse[len(k_out.data) :], k_in.data)
+    return (
+        (uniq // stride).astype(np.int64),
+        (uniq % stride).astype(np.int64),
+        out_aligned,
+        in_aligned,
+    )
+
+
+def propose(f, ft, dirty_idx, p, w_out, w_in, module, big_p, q_in, q_out, objective):
+    """Best improving move per dirty node. Returns a dict of aligned arrays:
+    node, old, new, delta, and the exact after-aggregates of both modules."""
+    m = len(big_p)
+    local_row, col, k_out, k_in = candidate_link_sums(f, ft, dirty_idx, module, m)
+    row = dirty_idx[local_row]
+
+    own = module[row]
+    k_own_out = np.zeros(len(dirty_idx))
+    k_own_in = np.zeros(len(dirty_idx))
+    own_mask = col == own
+    k_own_out[local_row[own_mask]] = k_out[own_mask]
+    k_own_in[local_row[own_mask]] = k_in[own_mask]
+
+    cand = ~own_mask
+    local_row, row, col = local_row[cand], row[cand], col[cand]
+    k_out, k_in = k_out[cand], k_in[cand]
+    own = module[row]
+
+    pv, wo, wi = p[row], w_out[row], w_in[row]
+    koa, kia = k_own_out[local_row], k_own_in[local_row]
+
+    old_p = big_p[own] - pv
+    old_qi = q_in[own] - (wi - kia) + koa
+    old_qo = q_out[own] - (wo - koa) + kia
+    new_p = big_p[col] + pv
+    new_qi = q_in[col] + (wi - k_in) - k_out
+    new_qo = q_out[col] + (wo - k_out) - k_in
+
+    if objective == "atlas":
+        delta = (
+            g_atlas(old_p, old_qi, old_qo)
+            - g_atlas(big_p[own], q_in[own], q_out[own])
+            + g_atlas(new_p, new_qi, new_qo)
+            - g_atlas(big_p[col], q_in[col], q_out[col])
+        )
+    else:  # map equation: per-module part + global plogp(q) repricing
+
+        def g_map(bp, qi, qo):
+            return -plogp(qi) + plogp(bp + qo) - plogp(qo)
+
+        q_tot = q_in.sum()
+        q_after = q_tot - q_in[own] - q_in[col] + old_qi + new_qi
+        delta = (
+            plogp(q_after)
+            - plogp(np.array([q_tot]))[0]
+            + g_map(old_p, old_qi, old_qo)
+            - g_map(big_p[own], q_in[own], q_out[own])
+            + g_map(new_p, new_qi, new_qo)
+            - g_map(big_p[col], q_in[col], q_out[col])
+        )
+
+    improving = delta < -1e-12
+    if not improving.any():
+        return None
+    idx = np.flatnonzero(improving)
+    row_f, delta_f = row[idx], delta[idx]
+    # best candidate per node: sort by (node, delta), take first per node
+    order = np.lexsort((delta_f, row_f))
+    first = np.unique(row_f[order], return_index=True)[1]
+    best_local = order[first]
+    best = idx[best_local]
+    return {
+        "node": row[best],
+        "old": own[best],
+        "new": col[best],
+        "delta": delta_f[best_local],
+        "old_p": old_p[best],
+        "old_qi": old_qi[best],
+        "old_qo": old_qo[best],
+        "new_p": new_p[best],
+        "new_qi": new_qi[best],
+        "new_qo": new_qo[best],
+    }
+
+
+def disjoint_batch(prop, m, rng):
+    """Greedy-maximal set of proposals with pairwise-disjoint module pairs:
+    repeat the vectorized first-occurrence filter, dropping proposals that
+    share a module with anything accepted so far. Sound: within the batch
+    every delta stays exact (locality theorem)."""
+    delta = prop["delta"]
+    order = np.lexsort((rng.random(len(delta)), delta))
+    used = np.zeros(m, dtype=bool)
+    selected = []
+    remaining = order
+    while len(remaining) > 0:
+        old, new = prop["old"][remaining], prop["new"][remaining]
+        flat = np.stack([old, new], axis=1).ravel()
+        first_pos = np.zeros(m, dtype=np.int64)
+        uniq, first = np.unique(flat, return_index=True)
+        first_pos[uniq] = first
+        is_first = first_pos[flat] == np.arange(len(flat))
+        accept = is_first.reshape(-1, 2).all(axis=1)
+        acc = remaining[accept]
+        if len(acc) == 0:
+            break
+        selected.append(acc)
+        used[prop["old"][acc]] = True
+        used[prop["new"][acc]] = True
+        rem = remaining[~accept]
+        keep = ~(used[prop["old"][rem]] | used[prop["new"][rem]])
+        remaining = rem[keep]
+    return np.concatenate(selected) if selected else np.array([], dtype=np.int64)
+
+
+def batch_local_moving(f, ft, p, module, objective: str, rng, max_sweeps=1000):
+    """Vectorized local moving with dirty-node tracking and incremental
+    aggregate assignment. Returns (module, level_consistency) where the
+    consistency is |L_recomputed - (L_init + sum of all accepted deltas)|."""
+    n = f.shape[0]
+    m = n
+    w_out = np.asarray(f.sum(axis=1)).ravel()
+    w_in = np.asarray(f.sum(axis=0)).ravel()
+    big_p, q_in, q_out = module_aggregates(f, p, module, m)
+    l_fn = l_atlas if objective == "atlas" else l_map
+    l_tracked = l_fn(big_p, q_in, q_out, 0.0)
+    dirty_idx = np.arange(n)
+    for _ in range(max_sweeps):
+        if len(dirty_idx) == 0:
+            break
+        prop = propose(
+            f, ft, dirty_idx, p, w_out, w_in, module, big_p, q_in, q_out, objective
+        )
+        if prop is None:
+            break
+        sel = disjoint_batch(prop, m, rng)
+        if len(sel) == 0:
+            break
+        nodes = prop["node"][sel]
+        module[nodes] = prop["new"][sel]
+        # Disjointness makes the update a plain assignment of after-values.
+        big_p[prop["old"][sel]] = prop["old_p"][sel]
+        q_in[prop["old"][sel]] = prop["old_qi"][sel]
+        q_out[prop["old"][sel]] = prop["old_qo"][sel]
+        big_p[prop["new"][sel]] = prop["new_p"][sel]
+        q_in[prop["new"][sel]] = prop["new_qi"][sel]
+        q_out[prop["new"][sel]] = prop["new_qo"][sel]
+        l_tracked += prop["delta"][sel].sum()
+        # movers and their neighbourhoods become dirty
+        dirty_idx = np.unique(
+            np.concatenate([nodes, f[nodes].indices, ft[nodes].indices])
+        )
+    big_p2, q_in2, q_out2 = module_aggregates(f, p, module, m)
+    consistency = abs(l_fn(big_p2, q_in2, q_out2, 0.0) - l_tracked)
+    return module, consistency
+
+
+def louvain(f, p, objective: str, seed=1):
+    """Batch local moving + aggregation until no shrink. Returns the leaf
+    assignment and the worst per-level tracking consistency."""
+    rng = RNG(seed)
+    leaf = np.arange(f.shape[0])
+    worst = 0.0
+    while True:
+        ft = f.T.tocsr()
+        module = np.arange(f.shape[0])
+        module, consistency = batch_local_moving(f, ft, p, module, objective, rng)
+        worst = max(worst, consistency)
+        ids, compact = np.unique(module, return_inverse=True)
+        leaf = compact[leaf]
+        if len(ids) == f.shape[0] or len(ids) <= 1:
+            break
+        # aggregate: F <- H^T F H with the diagonal (intra flow) dropped
+        m = len(ids)
+        h = sparse.csr_array(
+            (np.ones(f.shape[0]), (np.arange(f.shape[0]), compact)),
+            shape=(f.shape[0], m),
+        )
+        coarse = (h.T @ f @ h).tocoo()
+        off = coarse.row != coarse.col
+        f = sparse.csr_array(
+            (coarse.data[off], (coarse.row[off], coarse.col[off])), shape=(m, m)
+        )
+        p = np.bincount(compact, weights=p, minlength=m)
+    return leaf, worst
+
+
+# ---------------------------------------------------------------------------
+# Experiments
+# ---------------------------------------------------------------------------
+
+
+def check(label, ok, detail=""):
+    status = "PASS" if ok else "FAIL"
+    print(f"  [{status}] {label}{'  (' + detail + ')' if detail else ''}")
+    return ok
+
+
+def experiment_equivalence():
+    """Numpy codelengths == pure-python prototype codelengths."""
+    import atlas_prototype as pp
+
+    print("== 1. Agreement with the pure-python prototype ==")
+    rng = RNG(3)
+    ok = True
+    for trial in range(5):
+        n = int(rng.integers(20, 60))
+        m_edges = int(rng.integers(2 * n, 4 * n))
+        u = rng.integers(0, n, size=m_edges)
+        v = rng.integers(0, n, size=m_edges)
+        keep = u != v
+        u, v = u[keep], v[keep]
+        w = rng.uniform(0.5, 3.0, size=len(u))
+        net = pp.FlowNetwork.from_undirected(
+            n, list(zip(u.tolist(), v.tolist(), w.tolist(), strict=True))
+        )
+        f, p = undirected_flow(n, u, v, w)
+        assignment = rng.integers(0, max(2, n // 5), size=n)
+        part = pp.Partition(net, assignment.tolist())
+        big_p, q_in, q_out = module_aggregates(
+            f, p, assignment, int(assignment.max()) + 1
+        )
+        node_entropy = -plogp(p).sum()
+        d_map = abs(l_map(big_p, q_in, q_out, node_entropy) - part.L_map())
+        d_atlas = abs(l_atlas(big_p, q_in, q_out, node_entropy) - part.L_atlas())
+        identity = abs(
+            l_atlas(big_p, q_in, q_out, 0.0)
+            - l_map(big_p, q_in, q_out, 0.0)
+            - kl_gap(big_p, q_in)
+        )
+        ok &= check(
+            f"trial {trial}: L_map, L_atlas, KL identity",
+            d_map < 1e-10 and d_atlas < 1e-10 and identity < 1e-10,
+            f"diffs {d_map:.1e} {d_atlas:.1e} {identity:.1e}",
+        )
+    return ok
+
+
+def experiment_karate():
+    import atlas_prototype as pp
+
+    print("\n== 2. Karate club, batch search (20 restarts) ==")
+    edges = [(u, v, 1.0) for u, v in pp.KARATE_EDGES]
+    u, v, w = (np.array(x) for x in zip(*edges, strict=True))
+    f, p = undirected_flow(34, u, v, w)
+    node_entropy = -plogp(p).sum()
+    for objective in ("map", "atlas"):
+        best_l, best_modules = np.inf, 0
+        for seed in range(1, 21):
+            leaf, _ = louvain(f, p, objective, seed=seed)
+            big_p, q_in, q_out = module_aggregates(f, p, leaf, int(leaf.max()) + 1)
+            fn = l_atlas if objective == "atlas" else l_map
+            val = fn(big_p, q_in, q_out, node_entropy)
+            if val < best_l:
+                best_l, best_modules = val, int(leaf.max()) + 1
+        print(f"  {objective:<5}: best L = {best_l:.4f} bits, {best_modules} modules")
+
+
+def experiment_scale(quick: bool):
+    blocks, size = (50, 400) if quick else (200, 1000)
+    print(f"\n== 3. Scale + batch soundness: planted partition {blocks}x{size} ==")
+    f, p, _truth = planted_partition(blocks, size, 8.0, 2.0, seed=1)
+    node_entropy = -plogp(p).sum()
+    print(f"  {f.shape[0]} nodes, {f.nnz // 2} edges, one-level L = {node_entropy:.4f}")
+    for objective in ("atlas", "map"):
+        t0 = time.perf_counter()
+        leaf, worst = louvain(f, p, objective, seed=1)
+        dt = time.perf_counter() - t0
+        big_p, q_in, q_out = module_aggregates(f, p, leaf, int(leaf.max()) + 1)
+        print(
+            f"  {objective:<5}: {dt:6.1f} s, {int(leaf.max()) + 1:>4} modules, "
+            f"L_map = {l_map(big_p, q_in, q_out, node_entropy):.6f}, "
+            f"L_atlas = {l_atlas(big_p, q_in, q_out, node_entropy):.6f}, "
+            f"level consistency = {worst:.2e}"
+        )
+    print("  (atlas batches are exact by construction; map batches drift, see 4.)")
+
+
+def demo_map_batch_drift(quick: bool):
+    """One batch sweep from singletons under both objectives: the accepted
+    deltas sum to the true codelength change for the atlas equation only."""
+    blocks, size = (50, 400) if quick else (100, 1000)
+    print(f"\n== 4. Batch exactness, single sweep from singletons ({blocks}x{size}) ==")
+    f, p, _truth = planted_partition(blocks, size, 8.0, 2.0, seed=2)
+    ft = f.T.tocsr()
+    n = f.shape[0]
+    w_out = np.asarray(f.sum(axis=1)).ravel()
+    w_in = np.asarray(f.sum(axis=0)).ravel()
+    for objective in ("atlas", "map"):
+        rng = RNG(7)
+        module = np.arange(n)
+        big_p, q_in, q_out = module_aggregates(f, p, module, n)
+        l_fn = l_atlas if objective == "atlas" else l_map
+        l0 = l_fn(big_p, q_in, q_out, 0.0)
+        prop = propose(
+            f, ft, np.arange(n), p, w_out, w_in, module, big_p, q_in, q_out, objective
+        )
+        sel = disjoint_batch(prop, n, rng)
+        module[prop["node"][sel]] = prop["new"][sel]
+        big_p, q_in, q_out = module_aggregates(f, p, module, n)
+        l1 = l_fn(big_p, q_in, q_out, 0.0)
+        drift = abs(l1 - (l0 + prop["delta"][sel].sum()))
+        print(
+            f"  {objective:<5}: {len(sel):>6} moves in one batch, "
+            f"|dL - sum(deltas)| = {drift:.2e}"
+        )
+
+
+def main():
+    import sys
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--quick", action="store_true")
+    args = ap.parse_args()
+
+    ok = experiment_equivalence()
+    experiment_karate()
+    experiment_scale(args.quick)
+    demo_map_batch_drift(args.quick)
+    if not ok:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/research/atlas-equation/prototype/atlas_prototype.py
+++ b/research/atlas-equation/prototype/atlas_prototype.py
@@ -1,0 +1,788 @@
+#!/usr/bin/env python3
+"""Numerical validation of the atlas equation prototype.
+
+The atlas equation is a block-autonomous variant of the map equation: the
+adaptive index codebook (Shannon-optimal for the module entry rates, hence
+coupled across all modules through the total boundary flow) is replaced by
+static module addresses of length -log2(P_i), where P_i is the stationary
+flow mass of module i. See research/atlas-equation/README.md for the theory.
+
+This script validates, with no dependencies beyond the standard library:
+
+  1. Exactness of the local move deltas for both objectives
+     (delta == recomputed-from-scratch difference).
+  2. The identity  L_atlas = L_map + q * KL(entry rates || module masses).
+  3. Search behavior: Louvain-style two-level search under both objectives
+     on small reference networks (karate club, ring of cliques, planted
+     partitions, and the repository's example networks).
+  4. Agreement with the Infomap binary on undirected example networks
+     (validates the map equation implementation used as the baseline here).
+
+Everything is measured in bits (log base 2), matching Infomap.
+
+Usage:  python3 atlas_prototype.py [--quick] [--infomap-binary PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import os
+import random
+import subprocess
+import sys
+import tempfile
+from collections import defaultdict
+
+
+def plogp(x: float) -> float:
+    return x * math.log2(x) if x > 1e-300 else 0.0
+
+
+def entropy(dist) -> float:
+    return -sum(plogp(x) for x in dist)
+
+
+# ---------------------------------------------------------------------------
+# Flow networks: stationary node visit rates + directed link flows
+# ---------------------------------------------------------------------------
+
+
+class FlowNetwork:
+    """Node visit rates p (summing to 1) and directed link flows.
+
+    For undirected input each edge (u, v, w) carries flow w / (2W) in each
+    direction, and p is proportional to node strength, matching Infomap's
+    undirected flow model. For directed input, p is the PageRank vector with
+    unrecorded uniform teleportation and link flows are the smoothed walk
+    flows p_u * w_uv / s_u (teleportation steps are not encoded), matching
+    Infomap's default directed flow model up to the teleportation target
+    distribution.
+    """
+
+    def __init__(self, n, p, links):
+        self.n = n
+        self.p = p
+        self.links = links  # list of (u, v, flow), u != v
+        self.out_links = [[] for _ in range(n)]
+        self.in_links = [[] for _ in range(n)]
+        for u, v, f in links:
+            self.out_links[u].append((v, f))
+            self.in_links[v].append((u, f))
+
+    @staticmethod
+    def from_undirected(n, edges):
+        strength = [0.0] * n
+        total = 0.0
+        for u, v, w in edges:
+            if u == v:
+                continue
+            strength[u] += w
+            strength[v] += w
+            total += w
+        p = [s / (2.0 * total) for s in strength]
+        links = []
+        for u, v, w in edges:
+            if u == v:
+                continue
+            f = w / (2.0 * total)
+            links.append((u, v, f))
+            links.append((v, u, f))
+        return FlowNetwork(n, p, links)
+
+    @staticmethod
+    def from_directed(n, edges, tau=0.15, tol=1e-14, max_iter=10_000):
+        out_strength = [0.0] * n
+        for u, v, w in edges:
+            if u == v:
+                continue
+            out_strength[u] += w
+        out_norm = [[] for _ in range(n)]
+        for u, v, w in edges:
+            if u == v:
+                continue
+            out_norm[u].append((v, w / out_strength[u]))
+        p = [1.0 / n] * n
+        for _ in range(max_iter):
+            nxt = [0.0] * n
+            dangling = 0.0
+            for u in range(n):
+                if out_norm[u]:
+                    share = (1.0 - tau) * p[u]
+                    for v, w in out_norm[u]:
+                        nxt[v] += share * w
+                else:
+                    dangling += p[u]
+            base = (tau * (1.0 - dangling) + dangling) / n
+            nxt = [x + base for x in nxt]
+            # dangling mass and teleportation are spread uniformly
+            err = sum(abs(a - b) for a, b in zip(nxt, p, strict=True))
+            p = nxt
+            if err < tol:
+                break
+        links = []
+        for u in range(n):
+            for v, w in out_norm[u]:
+                links.append((u, v, (1.0 - tau) * p[u] * w))
+        return FlowNetwork(n, p, links)
+
+    def aggregate(self, module_of):
+        """Aggregate to the module-level flow network (self-flows dropped from
+        links; they can never contribute to a coarser boundary)."""
+        modules = sorted(set(module_of))
+        remap = {m: i for i, m in enumerate(modules)}
+        np_ = [0.0] * len(modules)
+        for node, m in enumerate(module_of):
+            np_[remap[m]] += self.p[node]
+        flow = defaultdict(float)
+        for u, v, f in self.links:
+            mu, mv = remap[module_of[u]], remap[module_of[v]]
+            if mu != mv:
+                flow[(mu, mv)] += f
+        links = [(u, v, f) for (u, v), f in flow.items()]
+        return FlowNetwork(len(modules), np_, links), remap
+
+
+# ---------------------------------------------------------------------------
+# Two-level objectives over a partition
+# ---------------------------------------------------------------------------
+
+
+class Partition:
+    """Module assignment plus the per-module aggregates both objectives need:
+    P (flow mass), Qin (enter flow), Qout (exit flow)."""
+
+    def __init__(self, net: FlowNetwork, assignment):
+        self.net = net
+        self.module = list(assignment)
+        m = max(self.module) + 1
+        self.P = [0.0] * m
+        self.Qin = [0.0] * m
+        self.Qout = [0.0] * m
+        for node, mod in enumerate(self.module):
+            self.P[mod] += net.p[node]
+        for u, v, f in net.links:
+            if self.module[u] != self.module[v]:
+                self.Qout[self.module[u]] += f
+                self.Qin[self.module[v]] += f
+        self.node_entropy = -sum(plogp(x) for x in net.p)
+
+    # -- codelengths ---------------------------------------------------------
+
+    def L_map(self) -> float:
+        q = sum(self.Qin)
+        index = plogp(q) - sum(plogp(x) for x in self.Qin)
+        modules = sum(
+            plogp(self.P[i] + self.Qout[i]) - plogp(self.Qout[i])
+            for i in range(len(self.P))
+        )
+        return index + modules + self.node_entropy
+
+    def L_atlas(self) -> float:
+        index = -sum(
+            self.Qin[i] * math.log2(self.P[i]) if self.Qin[i] > 0.0 else 0.0
+            for i in range(len(self.P))
+        )
+        modules = sum(
+            plogp(self.P[i] + self.Qout[i]) - plogp(self.Qout[i])
+            for i in range(len(self.P))
+        )
+        return index + modules + self.node_entropy
+
+    def kl_gap(self) -> float:
+        """q * KL(entry distribution || module mass distribution)."""
+        q = sum(self.Qin)
+        if q <= 0.0:
+            return 0.0
+        return sum(
+            qi * math.log2((qi / q) / self.P[i])
+            for i, qi in enumerate(self.Qin)
+            if qi > 0.0
+        )
+
+    # -- local moves ---------------------------------------------------------
+
+    def _link_sums(self, node):
+        """Flow between `node` and each adjacent module: (to_mod, from_mod)."""
+        to_mod = defaultdict(float)
+        from_mod = defaultdict(float)
+        for v, f in self.net.out_links[node]:
+            to_mod[self.module[v]] += f
+        for u, f in self.net.in_links[node]:
+            from_mod[self.module[u]] += f
+        return to_mod, from_mod
+
+    def _module_terms_after(self, node, old, new, to_mod, from_mod):
+        """Aggregates of the two touched modules before/after moving node."""
+        p = self.net.p[node]
+        node_out = sum(f for _, f in self.net.out_links[node])
+        node_in = sum(f for _, f in self.net.in_links[node])
+        # Old module after removal: links node<->old become boundary,
+        # links node<->elsewhere stop counting against old.
+        old_after = (
+            self.P[old] - p,
+            self.Qin[old] - (node_in - from_mod[old]) + to_mod[old],
+            self.Qout[old] - (node_out - to_mod[old]) + from_mod[old],
+        )
+        new_after = (
+            self.P[new] + p,
+            self.Qin[new] + (node_in - from_mod[new]) - to_mod[new],
+            self.Qout[new] + (node_out - to_mod[new]) - from_mod[new],
+        )
+        return old_after, new_after
+
+    @staticmethod
+    def _g_atlas(P, Qin, Qout):
+        idx = -Qin * math.log2(P) if (Qin > 1e-300 and P > 1e-300) else 0.0
+        return idx + plogp(P + Qout) - plogp(Qout)
+
+    def delta_atlas(self, node, new):
+        """Exact codelength change of moving node to module `new`.
+        Touches only the two module aggregates -- no global quantity."""
+        old = self.module[node]
+        if old == new:
+            return 0.0
+        to_mod, from_mod = self._link_sums(node)
+        (oP, oQi, oQo), (nP, nQi, nQo) = self._module_terms_after(
+            node, old, new, to_mod, from_mod
+        )
+        before = self._g_atlas(
+            self.P[old], self.Qin[old], self.Qout[old]
+        ) + self._g_atlas(self.P[new], self.Qin[new], self.Qout[new])
+        after = self._g_atlas(oP, oQi, oQo) + self._g_atlas(nP, nQi, nQo)
+        return after - before
+
+    def delta_map(self, node, new):
+        """Exact codelength change under the map equation. Note the extra
+        global term through q = sum(Qin): every move reprices it."""
+        old = self.module[node]
+        if old == new:
+            return 0.0
+        to_mod, from_mod = self._link_sums(node)
+        (oP, oQi, oQo), (nP, nQi, nQo) = self._module_terms_after(
+            node, old, new, to_mod, from_mod
+        )
+        q_before = sum(self.Qin)
+        q_after = q_before - self.Qin[old] - self.Qin[new] + oQi + nQi
+
+        def g(P, Qin, Qout):
+            return -plogp(Qin) + plogp(P + Qout) - plogp(Qout)
+
+        before = (
+            plogp(q_before)
+            + g(self.P[old], self.Qin[old], self.Qout[old])
+            + g(self.P[new], self.Qin[new], self.Qout[new])
+        )
+        after = plogp(q_after) + g(oP, oQi, oQo) + g(nP, nQi, nQo)
+        return after - before
+
+    def move(self, node, new):
+        old = self.module[node]
+        if old == new:
+            return
+        to_mod, from_mod = self._link_sums(node)
+        (
+            (self.P[old], self.Qin[old], self.Qout[old]),
+            (
+                self.P[new],
+                self.Qin[new],
+                self.Qout[new],
+            ),
+        ) = self._module_terms_after(node, old, new, to_mod, from_mod)
+        self.module[node] = new
+
+
+# ---------------------------------------------------------------------------
+# Louvain-style two-level search (objective-agnostic)
+# ---------------------------------------------------------------------------
+
+
+def local_moving(net, objective, rng, max_sweeps=100):
+    part = Partition(net, list(range(net.n)))
+    delta = part.delta_atlas if objective == "atlas" else part.delta_map
+    order = list(range(net.n))
+    moved_any = False
+    for _ in range(max_sweeps):
+        rng.shuffle(order)
+        moved = 0
+        for node in order:
+            candidates = set()
+            for v, _ in net.out_links[node]:
+                candidates.add(part.module[v])
+            for u, _ in net.in_links[node]:
+                candidates.add(part.module[u])
+            candidates.discard(part.module[node])
+            best, best_delta = part.module[node], -1e-12
+            for cand in candidates:
+                d = delta(node, cand)
+                if d < best_delta:
+                    best, best_delta = cand, d
+            if best != part.module[node]:
+                part.move(node, best)
+                moved += 1
+        if moved == 0:
+            break
+        moved_any = True
+    return part, moved_any
+
+
+def louvain(net, objective, seed=1):
+    """Local moving + aggregation until no further improvement.
+    Returns the induced leaf-level partition."""
+    rng = random.Random(seed)
+    leaf_assignment = list(range(net.n))
+    current = net
+    while True:
+        part, moved = local_moving(current, objective, rng)
+        modules = sorted(set(part.module))
+        if len(modules) == current.n or not moved:
+            break
+        agg, remap = current.aggregate(part.module)
+        leaf_assignment = [remap[part.module[m]] for m in leaf_assignment]
+        current = agg
+    # Normalize module ids
+    ids = {m: i for i, m in enumerate(sorted(set(leaf_assignment)))}
+    return [ids[m] for m in leaf_assignment]
+
+
+def best_of(net, objective, seeds):
+    best_part, best_L = None, float("inf")
+    for seed in seeds:
+        assignment = louvain(net, objective, seed)
+        part = Partition(net, assignment)
+        L = part.L_atlas() if objective == "atlas" else part.L_map()
+        if L < best_L:
+            best_part, best_L = part, L
+    return best_part
+
+
+# ---------------------------------------------------------------------------
+# Partition similarity (normalized mutual information)
+# ---------------------------------------------------------------------------
+
+
+def nmi(a, b):
+    n = len(a)
+    ca, cb, joint = defaultdict(int), defaultdict(int), defaultdict(int)
+    for x, y in zip(a, b, strict=True):
+        ca[x] += 1
+        cb[y] += 1
+        joint[(x, y)] += 1
+    hx = entropy(c / n for c in ca.values())
+    hy = entropy(c / n for c in cb.values())
+    mi = sum(
+        (c / n) * math.log2((c / n) / ((ca[x] / n) * (cb[y] / n)))
+        for (x, y), c in joint.items()
+    )
+    if hx == 0.0 and hy == 0.0:
+        return 1.0
+    denom = math.sqrt(hx * hy)
+    return mi / denom if denom > 0 else 0.0
+
+
+# ---------------------------------------------------------------------------
+# Test networks
+# ---------------------------------------------------------------------------
+
+KARATE_EDGES = [
+    (0, 1),
+    (0, 2),
+    (0, 3),
+    (0, 4),
+    (0, 5),
+    (0, 6),
+    (0, 7),
+    (0, 8),
+    (0, 10),
+    (0, 11),
+    (0, 12),
+    (0, 13),
+    (0, 17),
+    (0, 19),
+    (0, 21),
+    (0, 31),
+    (1, 2),
+    (1, 3),
+    (1, 7),
+    (1, 13),
+    (1, 17),
+    (1, 19),
+    (1, 21),
+    (1, 30),
+    (2, 3),
+    (2, 7),
+    (2, 8),
+    (2, 9),
+    (2, 13),
+    (2, 27),
+    (2, 28),
+    (2, 32),
+    (3, 7),
+    (3, 12),
+    (3, 13),
+    (4, 6),
+    (4, 10),
+    (5, 6),
+    (5, 10),
+    (5, 16),
+    (6, 16),
+    (8, 30),
+    (8, 32),
+    (8, 33),
+    (9, 33),
+    (13, 33),
+    (14, 32),
+    (14, 33),
+    (15, 32),
+    (15, 33),
+    (18, 32),
+    (18, 33),
+    (19, 33),
+    (20, 32),
+    (20, 33),
+    (22, 32),
+    (22, 33),
+    (23, 25),
+    (23, 27),
+    (23, 29),
+    (23, 32),
+    (23, 33),
+    (24, 25),
+    (24, 27),
+    (24, 31),
+    (25, 31),
+    (26, 29),
+    (26, 33),
+    (27, 33),
+    (28, 31),
+    (28, 33),
+    (29, 32),
+    (29, 33),
+    (30, 32),
+    (30, 33),
+    (31, 32),
+    (31, 33),
+    (32, 33),
+]
+
+
+def karate():
+    return FlowNetwork.from_undirected(34, [(u, v, 1.0) for u, v in KARATE_EDGES])
+
+
+def ring_of_cliques(num_cliques, clique_size=5, ring_weight=1.0):
+    edges = []
+    for c in range(num_cliques):
+        base = c * clique_size
+        for i in range(clique_size):
+            for j in range(i + 1, clique_size):
+                edges.append((base + i, base + j, 1.0))
+        nxt = ((c + 1) % num_cliques) * clique_size
+        edges.append((base, nxt + 1 if num_cliques > 1 else nxt, ring_weight))
+    n = num_cliques * clique_size
+    return FlowNetwork.from_undirected(n, edges), n
+
+
+def ring_partition_codelengths(num_cliques, clique_size=5):
+    """Codelength of 'b consecutive cliques per module' for each divisor b."""
+    net, n = ring_of_cliques(num_cliques, clique_size)
+    rows = []
+    for b in [d for d in range(1, num_cliques + 1) if num_cliques % d == 0]:
+        assignment = [(node // clique_size) // b for node in range(n)]
+        part = Partition(net, assignment)
+        rows.append((b, part.L_map(), part.L_atlas()))
+    return rows
+
+
+def planted_partition(n_blocks, block_size, k_in, k_out, rng, directed=False):
+    """Sparse planted-partition graph via expected-degree sampling."""
+    n = n_blocks * block_size
+    p_in = k_in / (block_size - 1)
+    p_out = k_out / (n - block_size)
+    edges = set()
+    for u in range(n):
+        bu = u // block_size
+        # within-block
+        for v in range(bu * block_size, (bu + 1) * block_size):
+            if v <= u:
+                continue
+            if rng.random() < p_in:
+                edges.add((u, v))
+        # between-block: sample number of partners
+        expected = p_out * (n - block_size)
+        count = int(expected) + (1 if rng.random() < expected - int(expected) else 0)
+        for _ in range(count):
+            v = rng.randrange(n)
+            if v // block_size != bu:
+                edges.add((min(u, v), max(u, v)))
+    edge_list = [(u, v, 1.0) for u, v in edges]
+    if directed:
+        directed_edges = []
+        for u, v, w in edge_list:
+            if rng.random() < 0.5:
+                directed_edges.append((u, v, w))
+            else:
+                directed_edges.append((v, u, w))
+        net = FlowNetwork.from_directed(n, directed_edges)
+    else:
+        net = FlowNetwork.from_undirected(n, edge_list)
+    truth = [u // block_size for u in range(n)]
+    return net, truth
+
+
+def parse_net_file(path):
+    """Minimal Pajek/link-list parser for the repository's undirected
+    examples: `*Vertices` may lack a count, and a bare link list (no section
+    headers at all) is valid input."""
+    edges = []
+    mode = "edges"  # a headerless file is a plain link list
+    max_id = 0
+    with open(path) as fh:
+        for line in fh:
+            line = line.split("#")[0].strip()
+            if not line:
+                continue
+            low = line.lower()
+            if low.startswith("*vertices"):
+                mode = "vertices"
+                continue
+            if low.startswith("*edges") or low.startswith("*links"):
+                mode = "edges"
+                continue
+            if low.startswith("*"):
+                mode = None
+                continue
+            if mode == "vertices":
+                max_id = max(max_id, int(line.split()[0]))
+            elif mode == "edges":
+                parts = line.split()
+                u, v = int(parts[0]) - 1, int(parts[1]) - 1
+                w = float(parts[2]) if len(parts) > 2 else 1.0
+                max_id = max(max_id, u + 1, v + 1)
+                edges.append((u, v, w))
+    return FlowNetwork.from_undirected(max_id, edges)
+
+
+# ---------------------------------------------------------------------------
+# Validation experiments
+# ---------------------------------------------------------------------------
+
+
+def check(label, ok, detail=""):
+    status = "PASS" if ok else "FAIL"
+    print(f"  [{status}] {label}{'  (' + detail + ')' if detail else ''}")
+    return ok
+
+
+def experiment_deltas_and_identity(quick):
+    print("\n== 1. Move deltas are exact; L_atlas = L_map + q*KL identity ==")
+    rng = random.Random(42)
+    all_ok = True
+    trials = 3 if quick else 8
+    for trial in range(trials):
+        n = rng.randint(20, 60)
+        m = rng.randint(int(1.5 * n), 3 * n)
+        edges = set()
+        while len(edges) < m:
+            u, v = rng.randrange(n), rng.randrange(n)
+            if u != v:
+                edges.add((min(u, v), max(u, v)))
+        if trial % 2 == 0:
+            net = FlowNetwork.from_undirected(
+                n, [(u, v, rng.uniform(0.5, 3.0)) for u, v in edges]
+            )
+        else:
+            net = FlowNetwork.from_directed(
+                n, [(u, v, rng.uniform(0.5, 3.0)) for u, v in edges]
+            )
+        assignment = [rng.randrange(max(2, n // 6)) for _ in range(n)]
+        # densify ids
+        ids = {mm: i for i, mm in enumerate(sorted(set(assignment)))}
+        part = Partition(net, [ids[x] for x in assignment])
+
+        gap = part.L_atlas() - part.L_map() - part.kl_gap()
+        all_ok &= check(
+            f"identity, trial {trial} ({'undirected' if trial % 2 == 0 else 'directed'})",
+            abs(gap) < 1e-10,
+            f"residual {gap:.2e}",
+        )
+
+        max_err = 0.0
+        for _ in range(40):
+            node = rng.randrange(n)
+            new = rng.randrange(len(part.P))
+            for _name, delta_fn, L_fn in (
+                ("atlas", part.delta_atlas, Partition.L_atlas),
+                ("map", part.delta_map, Partition.L_map),
+            ):
+                d = delta_fn(node, new)
+                before = L_fn(part)
+                saved = part.module[node]
+                part.move(node, new)
+                after = L_fn(part)
+                part.move(node, saved)
+                max_err = max(max_err, abs((after - before) - d))
+        all_ok &= check(
+            f"move deltas exact, trial {trial}",
+            max_err < 1e-10,
+            f"max err {max_err:.2e}",
+        )
+    return all_ok
+
+
+def experiment_karate():
+    print("\n== 2. Karate club: search under each objective ==")
+    net = karate()
+    seeds = range(1, 21)
+    p_map = best_of(net, "map", seeds)
+    p_atlas = best_of(net, "atlas", seeds)
+    print(
+        f"  map-equation optimum : {max(p_map.module) + 1} modules, "
+        f"L_map={p_map.L_map():.4f}, L_atlas={p_map.L_atlas():.4f}"
+    )
+    print(
+        f"  atlas optimum        : {max(p_atlas.module) + 1} modules, "
+        f"L_map={p_atlas.L_map():.4f}, L_atlas={p_atlas.L_atlas():.4f}"
+    )
+    print(f"  NMI(map, atlas) = {nmi(p_map.module, p_atlas.module):.4f}")
+    print(f"  one-level reference L = {p_map.node_entropy:.4f} bits")
+
+
+def experiment_ring(quick):
+    print("\n== 3. Ring of 5-cliques: optimal block size (resolution behavior) ==")
+    print("  r (cliques) | argmin_b L_map | argmin_b L_atlas   (b = cliques/module)")
+    sizes = [4, 8, 16, 32] if quick else [4, 8, 16, 32, 64, 128, 256]
+    for r in sizes:
+        rows = ring_partition_codelengths(r)
+        best_map = min(rows, key=lambda t: t[1])[0]
+        best_atlas = min(rows, key=lambda t: t[2])[0]
+        print(f"  {r:>11} | {best_map:>14} | {best_atlas:>16}")
+
+
+def experiment_planted(quick):
+    print("\n== 4. Planted partition (10 blocks x 100): recovery vs mixing ==")
+    print("  k_out/k_in | NMI map | NMI atlas | modules map/atlas | NMI(map,atlas)")
+    rng = random.Random(7)
+    mixes = (
+        [(8.0, 1.0), (8.0, 2.0), (8.0, 3.0)]
+        if quick
+        else [
+            (8.0, 0.5),
+            (8.0, 1.0),
+            (8.0, 2.0),
+            (8.0, 3.0),
+            (8.0, 4.0),
+        ]
+    )
+    for k_in, k_out in mixes:
+        net, truth = planted_partition(10, 100, k_in, k_out, rng)
+        seeds = range(1, 4)
+        p_map = best_of(net, "map", seeds)
+        p_atlas = best_of(net, "atlas", seeds)
+        print(
+            f"  {k_out / k_in:>10.3f} | {nmi(truth, p_map.module):>7.3f} |"
+            f" {nmi(truth, p_atlas.module):>9.3f} |"
+            f" {max(p_map.module) + 1:>5} / {max(p_atlas.module) + 1:<5} |"
+            f" {nmi(p_map.module, p_atlas.module):>8.3f}"
+        )
+
+
+def experiment_directed(quick):
+    print("\n== 5. Directed planted partition: recovery vs mixing ==")
+    print("  k_out/k_in | NMI map | NMI atlas | q*KL gap at atlas optimum")
+    rng = random.Random(11)
+    mixes = [(8.0, 1.0), (8.0, 2.0)] if quick else [(8.0, 1.0), (8.0, 2.0), (8.0, 3.0)]
+    for k_in, k_out in mixes:
+        net, truth = planted_partition(10, 100, k_in, k_out, rng, directed=True)
+        seeds = range(1, 4)
+        p_map = best_of(net, "map", seeds)
+        p_atlas = best_of(net, "atlas", seeds)
+        print(
+            f"  {k_out / k_in:>10.3f} | {nmi(truth, p_map.module):>7.3f} |"
+            f" {nmi(truth, p_atlas.module):>9.3f} | {p_atlas.kl_gap():.5f} bits"
+        )
+
+
+def experiment_examples(binary, repo_root):
+    print("\n== 6. Repository examples: agreement with the Infomap binary ==")
+    if not binary or not os.path.exists(binary):
+        print("  (Infomap binary not found; skipping)")
+        return
+    for name in ("twotriangles.net", "ninetriangles.net"):
+        path = os.path.join(repo_root, "examples", "networks", name)
+        if not os.path.exists(path):
+            print(f"  ({name} not found; skipping)")
+            continue
+        net = parse_net_file(path)
+        with tempfile.TemporaryDirectory() as tmp:
+            subprocess.run(
+                [binary, path, tmp, "--two-level", "--silent", "--seed", "123"],
+                check=True,
+                capture_output=True,
+            )
+            tree_file = os.path.join(tmp, name.replace(".net", ".tree"))
+            codelength_reported = None
+            assignment = [0] * net.n
+            with open(tree_file) as fh:
+                for line in fh:
+                    low = line.lower()
+                    if (
+                        line.startswith("#")
+                        and low.startswith("# codelength")
+                        and codelength_reported is None
+                    ):
+                        for token in line.replace(",", " ").split():
+                            try:
+                                codelength_reported = float(token)
+                                break
+                            except ValueError:
+                                continue
+                    if line.startswith("#") or not line.strip():
+                        continue
+                    parts = line.split()
+                    module = int(parts[0].split(":")[0]) - 1
+                    node_id = int(parts[-1]) - 1
+                    assignment[node_id] = module
+            part = Partition(net, assignment)
+            ours = part.L_map()
+            print(
+                f"  {name:<18} Infomap L = {codelength_reported} bits, "
+                f"prototype L_map on same partition = {ours:.9f} bits"
+            )
+            if codelength_reported is not None:
+                # The .tree header rounds to 6 significant digits.
+                ok = abs(ours - codelength_reported) < 1e-4
+                check(
+                    f"{name} codelength match",
+                    ok,
+                    f"|diff| = {abs(ours - codelength_reported):.2e}",
+                )
+            print(
+                f"  {name:<18} atlas on same partition: L_atlas = {part.L_atlas():.9f} "
+                f"(gap = {part.kl_gap():.9f} bits)"
+            )
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--quick", action="store_true")
+    ap.add_argument("--infomap-binary", default=None)
+    args = ap.parse_args()
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    repo_root = os.path.abspath(os.path.join(here, "..", "..", ".."))
+    binary = args.infomap_binary or os.path.join(repo_root, "Infomap")
+
+    ok = experiment_deltas_and_identity(args.quick)
+    experiment_karate()
+    experiment_ring(args.quick)
+    experiment_planted(args.quick)
+    experiment_directed(args.quick)
+    experiment_examples(binary, repo_root)
+    print()
+    if not ok:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/research/atlas-equation/prototype/atlas_prototype.py
+++ b/research/atlas-equation/prototype/atlas_prototype.py
@@ -545,6 +545,11 @@ def parse_net_file(path):
             low = line.lower()
             if low.startswith("*vertices"):
                 mode = "vertices"
+                # honor a declared count so isolated vertices are kept even
+                # when the explicit vertex list is omitted
+                parts = line.split()
+                if len(parts) > 1 and parts[1].isdigit():
+                    max_id = max(max_id, int(parts[1]))
                 continue
             if low.startswith("*edges") or low.startswith("*links"):
                 mode = "edges"

--- a/research/atlas-equation/prototype/atlas_prototype.py
+++ b/research/atlas-equation/prototype/atlas_prototype.py
@@ -53,11 +53,22 @@ class FlowNetwork:
 
     For undirected input each edge (u, v, w) carries flow w / (2W) in each
     direction, and p is proportional to node strength, matching Infomap's
-    undirected flow model. For directed input, p is the PageRank vector with
-    unrecorded uniform teleportation and link flows are the smoothed walk
-    flows p_u * w_uv / s_u (teleportation steps are not encoded), matching
-    Infomap's default directed flow model up to the teleportation target
-    distribution.
+    undirected flow model (this is the model the §7.1 binary-agreement check
+    exercises).
+
+    The directed model here is a deliberately simplified one: p is the raw
+    PageRank vector under uniform teleportation and link flows are the
+    link-following share (1 - tau) * p_u * w_uv / s_u, with teleportation
+    steps left unencoded. It matches NEITHER of Infomap's two teleportation
+    models exactly. Infomap's default (unrecorded) model re-derives the node
+    flow after convergence as the in-aggregate of one teleportation-free link
+    step, divided by the link-following mass 1 - danglingRank, so its node
+    flow is not the raw PageRank vector (src/utils/FlowCalculator.cpp:508-525);
+    its recorded model keeps raw PageRank as node flow but books the
+    teleportation mass separately into module enter/exit flow. The directed
+    experiments below are therefore internally consistent -- both objectives
+    see identical flows, which is what the comparison needs -- but are not
+    validated against the binary.
     """
 
     def __init__(self, n, p, links):
@@ -612,25 +623,47 @@ def experiment_deltas_and_identity(quick):
             f"residual {gap:.2e}",
         )
 
+        # Reference codelengths are recomputed from the network by the
+        # Partition constructor, which aggregates over net.links. That is an
+        # independent path from the incremental _module_terms_after that both
+        # the deltas and move() use: comparing a delta against before/after
+        # readings of the *same* incrementally-updated object would cancel any
+        # error common to both and pass even for a badly wrong formula.
         max_err = 0.0
+        max_commit_err = 0.0
         for _ in range(40):
             node = rng.randrange(n)
             new = rng.randrange(len(part.P))
+            saved = part.module[node]
+            before_scratch = Partition(net, part.module)
+            moved_assignment = list(part.module)
+            moved_assignment[node] = new
+            after_scratch = Partition(net, moved_assignment)
             for _name, delta_fn, L_fn in (
                 ("atlas", part.delta_atlas, Partition.L_atlas),
                 ("map", part.delta_map, Partition.L_map),
             ):
                 d = delta_fn(node, new)
-                before = L_fn(part)
-                saved = part.module[node]
-                part.move(node, new)
-                after = L_fn(part)
-                part.move(node, saved)
-                max_err = max(max_err, abs((after - before) - d))
+                truth = L_fn(after_scratch) - L_fn(before_scratch)
+                max_err = max(max_err, abs(truth - d))
+            # The commit path deserves the same independent check: after
+            # move(), the incrementally maintained aggregates must still agree
+            # with a from-scratch rebuild.
+            part.move(node, new)
+            for L_fn in (Partition.L_atlas, Partition.L_map):
+                max_commit_err = max(
+                    max_commit_err, abs(L_fn(part) - L_fn(after_scratch))
+                )
+            part.move(node, saved)
         all_ok &= check(
-            f"move deltas exact, trial {trial}",
+            f"move deltas exact vs from-scratch, trial {trial}",
             max_err < 1e-10,
             f"max err {max_err:.2e}",
+        )
+        all_ok &= check(
+            f"commit matches from-scratch, trial {trial}",
+            max_commit_err < 1e-10,
+            f"max err {max_commit_err:.2e}",
         )
     return all_ok
 
@@ -709,10 +742,15 @@ def experiment_directed(quick):
 
 
 def experiment_examples(binary, repo_root):
+    """Returns (ok, ran): `ok` is False only on a real mismatch, `ran` says
+    whether any comparison happened, so a silent skip cannot masquerade as a
+    passing validation."""
     print("\n== 6. Repository examples: agreement with the Infomap binary ==")
     if not binary or not os.path.exists(binary):
-        print("  (Infomap binary not found; skipping)")
-        return
+        print("  (Infomap binary not found; build it with `make build-native`)")
+        return True, False
+    all_ok = True
+    ran = False
     for name in ("twotriangles.net", "ninetriangles.net"):
         path = os.path.join(repo_root, "examples", "networks", name)
         if not os.path.exists(path):
@@ -756,22 +794,31 @@ def experiment_examples(binary, repo_root):
             )
             if codelength_reported is not None:
                 # The .tree header rounds to 6 significant digits.
-                ok = abs(ours - codelength_reported) < 1e-4
-                check(
+                ran = True
+                all_ok &= check(
                     f"{name} codelength match",
-                    ok,
+                    abs(ours - codelength_reported) < 1e-4,
                     f"|diff| = {abs(ours - codelength_reported):.2e}",
                 )
+            else:
+                all_ok = False
+                print(f"  [FAIL] {name}: no codelength found in the .tree header")
             print(
                 f"  {name:<18} atlas on same partition: L_atlas = {part.L_atlas():.9f} "
                 f"(gap = {part.kl_gap():.9f} bits)"
             )
+    return all_ok, ran
 
 
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--quick", action="store_true")
     ap.add_argument("--infomap-binary", default=None)
+    ap.add_argument(
+        "--require-binary",
+        action="store_true",
+        help="fail instead of skipping when the Infomap binary is unavailable",
+    )
     args = ap.parse_args()
 
     here = os.path.dirname(os.path.abspath(__file__))
@@ -783,7 +830,11 @@ def main():
     experiment_ring(args.quick)
     experiment_planted(args.quick)
     experiment_directed(args.quick)
-    experiment_examples(binary, repo_root)
+    examples_ok, examples_ran = experiment_examples(binary, repo_root)
+    ok &= examples_ok
+    if args.require_binary and not examples_ran:
+        print("  [FAIL] --require-binary given but no comparison ran")
+        ok = False
     print()
     if not ok:
         sys.exit(1)


### PR DESCRIPTION
## Summary

Research note proposing the **atlas equation**: a flow-based MDL objective with the map equation's coding philosophy, but with the adaptive index codebook replaced by static module addresses of idealized length `-log2(P_i)` (module flow mass).

- The map equation's only non-separable term is `plogp(enterFlow)` (`src/core/MapEquation.h`). The static address book removes it, making the objective a sum of per-module terms.
- Exact relation: `L_atlas = L_map + q * KL(entry rates || module masses)`. Because stationarity forces `Q_i^in <= P_i`, the gap is at most `q * log2(1/q)` — vanishing with the boundary flow **unconditionally**, over all partitions.
- With no shared scalar, a node move touches exactly two modules, so commits are linearizable under ordered per-module locks: every committed move provably improves the objective at any thread count, with no barrier and no serial commit pass.

Everything is self-contained under `research/atlas-equation/` (theory in `README.md`, pure-python validation, vectorized numpy search, standalone C++/OpenMP benchmark). Nothing in `src/` is touched.

## Verification

All searches converge to verified single-move local optima: dirty-node tracking is an accelerator only, and a level terminates only when a full sweep over all nodes accepts nothing (neighbour-of-mover marking alone is insufficient — a move stales the deltas of non-adjacent nodes bordering the two changed modules).

- `python3 research/atlas-equation/prototype/atlas_prototype.py` — 26 checks pass. Move deltas exact to 1e-15 against codelengths **rebuilt from the network**, not read off the incrementally-updated object (an injected 37% error in the incremental formula fails 6 checks); KL identity to 1e-15; map-equation baseline matches the built `./Infomap` (v2.15.0) on `twotriangles.net` and `ninetriangles.net`. Karate club: both objectives find the same 3-module partition; ring of 5-cliques: one clique per module up to r = 256 for both.
- `python3 research/atlas-equation/prototype/atlas_numpy.py` — agrees with the pure-python prototype to 1e-15, undirected and directed; 200k nodes / 1M edges full Louvain in 60 s single-core; one batch applies 23 400 simultaneous moves with zero drift, while the identical per-move batch scheme under the map equation drifts ~1e-3 bits per sweep.
- `make -C research/atlas-equation/bench run` — 200k nodes / 1.2M edges, 4 physical cores. The fused two-lock sweep holds `|L - sum(delta)|` at the sequential floating-point level (~1e-13) at every thread count and converges in 32 sweeps against 53 for propose-parallel/commit-serial; the same two-lock scheme under the map equation drifts ~2e-8 (negative control).
- `parallel_bench --sweep-scaling` — controlled strong scaling from an identical state. **Per-sweep scaling on 4 cores is indistinguishable between the two designs (3.7–4.4x for both)**; the map equation's serial commit is ~1.4% of a sweep, an Amdahl ceiling near 70x. The throughput half of the motivation is therefore a projection beyond 4 cores, not a measurement, and the note says so.
- `ruff check` / `ruff format --check` clean on `research/`; benchmark compiles with `-Wall -Wextra` (not wired into the repository build).

## Notes

Status: proposal. Open questions are listed in the note (bias characterization on heterogeneous real networks, hierarchical formalization, deterministic colored commits).

Review findings addressed, including three where the review was right and the note was wrong:

- **Dirty-set convergence bug** — fixed with terminal verification sweeps; all measurements re-run at local convergence.
- **The uniform-gap caveat was wrong in the conservative direction.** Entering module `i` is a subset of being in `i` at the next step, so `Q_i^in <= P_i` and the gap bound `q*log2(1/q)` needs no assumption on module masses (verified over 720 random partitions: max ratio exactly 1). The note now states the stronger result.
- **"Impossible for the map equation" (batching) was wrong.** Over disjoint module pairs its exact change is the per-module part plus one `plogp(q)` correction (verified to 2.5e-15); InfoFlow already exploits this. The line is redrawn at per-move exactness without global synchronization.
- **RelaxMap was mischaracterized.** It keeps codelength and module statistics exactly consistent under a *global* lock and relaxes the sequential order; its authors report the lock-free variant converged slower than sequential and faulted — the same experiment as this note's negative control. §9 now also covers GossipMap, Zeng & Yu, InfoFlow, HyPC-Map, Faysal et al. and Hamann et al., and fixes MapSim (2022), CPM (Traag/Van Dooren/Nesterov 2011, not the Leiden paper) and map equation centrality (Nieves).
- **Benchmark fairness** — the map-equation baseline now carries Infomap's fast-accept path, implemented *exactly* since only the global term needs repricing, and drops snapshot copies it does not need.
- Kraft/prefix-code wording corrected to idealized per-event lengths achievable as a rate; Theorem 3's one-thread-per-node hypothesis stated; `BiasedMapEquation`'s second global noted; the claim that the serial commit rechecks every proposal corrected.

One open question for a maintainer: `research/` is a new top-level directory not listed in `AGENTS.md`'s repo map. Keeping the note in-repo needs that entry; otherwise it should live outside the repository.