### PR TITLE
test(R): stop pinning one runtime's rendering of 1/7

### DIFF
--- a/interfaces/R/infomap/tests/testthat/test-options.R
+++ b/interfaces/R/infomap/tests/testthat/test-options.R
@@ -156,8 +156,14 @@ test_that("whitespace-free values of the same options still render", {
 # different parameter than the one requested and a different codelength than
 # Python reports for the same input.
 test_that("fractional values render with full round-trip precision", {
+  # 1/7 needs all 17 significant digits, and C runtimes disagree on the last
+  # one: glibc, macOS and mingw-gcc render the 1/7 double as
+  # 0.14285714285714285, the clang-aarch64 toolchain behind R on Windows
+  # arm64 as ...284. Both read back as the identical double, so assert the
+  # 16-digit prefix and the round-trip rather than one runtime's digits.
   rendered <- construct_args(NULL, infomap_options(markov_time = 1 / 7))
-  expect_match(rendered, "--markov-time 0.14285714285714285", fixed = TRUE)
+  expect_match(rendered, "--markov-time 0.1428571428571428", fixed = TRUE)
+  expect_identical(as.numeric(sub("^.*--markov-time ", "", rendered)), 1 / 7)
 
   rendered <- construct_args(
     NULL,


### PR DESCRIPTION
## Why

The mapequation r-universe went red on master: the `windows-devel-arm64` config (added to r-universe's build matrix on 2026-07-28, clang-aarch64 Rtools + R-devel) fails a single test:

```
── Failure ('test-options.R:160:3'): fractional values render with full round-trip precision ──
Expected `rendered` to match string "--markov-time 0.14285714285714285".
Actual text:
x | --markov-time 0.14285714285714284
```

No infomap commit caused this — the config simply never existed before. All 13 other r-universe configs are green on the same source.

## Root cause

The 1/7 double needs 17 significant digits, and C runtimes disagree on the last one: glibc, macOS and mingw-gcc render it as `0.14285714285714285`, the clang-aarch64 toolchain as `...284`. Both strings parse back to the identical double (verified in R: `as.numeric("0.14285714285714284") == 1/7` is `TRUE`), so the engine receives the same parameter on every platform. The renderer honours its contract — shortest representation that reads back as the same double — and only the test's expectation was platform-specific.

## Fix

Assert what the contract promises instead of one runtime's digits:

- the stable 16-digit prefix `0.1428571428571428` (every string that round-trips to the 1/7 double shares it), proving full precision reached the argument string, and
- exact read-back equality with `1/7`, the same idiom the neighbouring "rendered numerics read back as the value that was requested" test already uses (that test passes on windows-arm64).

The other two assertions in the test (`1.2345678901234`, `0.2`) pass on windows-arm64 and pin intentional shortest-rendering behaviour, so they stay exact.

## Verification

`make test-r`: `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 332 ]`, R CMD check status: 1 NOTE (the usual "New submission"). The arm64 rendering `0.14285714285714284` satisfies both new assertions.