### PR TITLE
ci: keep a third-party apt repo's 403 from failing toolchain installs

### DIFF
--- a/.github/actions/setup-ccache/action.yml
+++ b/.github/actions/setup-ccache/action.yml
@@ -24,7 +24,11 @@ runs:
           if [ "$RUNNER_OS" = "macOS" ]; then
             brew install ccache
           else
-            sudo apt-get update && sudo apt-get install -y ccache
+            # A third-party repo in the runner image (azure-cli, chrome, ...) can
+            # 403, which fails `apt-get update` even when the Ubuntu archive we
+            # install from downloaded fine. The install is the real gate.
+            sudo apt-get update || echo "::warning::apt-get update reported errors; continuing to the install"
+            sudo apt-get install -y ccache
           fi
         fi
         ccache --version

--- a/.github/actions/setup-swig/action.yml
+++ b/.github/actions/setup-swig/action.yml
@@ -20,7 +20,10 @@ runs:
       shell: bash
       run: |
         swig_prefix="$RUNNER_TOOL_CACHE/swig/${{ inputs.swig-version }}/$RUNNER_ARCH"
-        sudo apt-get update
+        # A third-party repo in the runner image (azure-cli, chrome, ...) can 403,
+        # which fails `apt-get update` even when the Ubuntu archive we install
+        # from downloaded fine. The install is the real gate.
+        sudo apt-get update || echo "::warning::apt-get update reported errors; continuing to the install"
         sudo apt-get install -y ca-certificates curl build-essential libpcre2-dev
         curl -L --retry 3 --output /tmp/swig.tar.gz \
           https://downloads.sourceforge.net/project/swig/swig/swig-${{ inputs.swig-version }}/swig-${{ inputs.swig-version }}.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,10 @@ jobs:
 
       - name: Install sanitizer toolchain
         run: |
-          sudo apt-get update
+          # A third-party repo in the runner image (azure-cli, chrome, ...) can
+          # 403, which fails `apt-get update` even when the Ubuntu archive we
+          # install from downloaded fine. The install is the real gate.
+          sudo apt-get update || echo "::warning::apt-get update reported errors; continuing to the install"
           sudo apt-get install -y clang lld ninja-build
         shell: bash
 
@@ -163,7 +166,10 @@ jobs:
 
       - name: Install clang-tidy toolchain
         run: |
-          sudo apt-get update
+          # A third-party repo in the runner image (azure-cli, chrome, ...) can
+          # 403, which fails `apt-get update` even when the Ubuntu archive we
+          # install from downloaded fine. The install is the real gate.
+          sudo apt-get update || echo "::warning::apt-get update reported errors; continuing to the install"
           sudo apt-get install -y clang-tidy ninja-build
         shell: bash
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -33,7 +33,10 @@ jobs:
         # Recommends today, but that is not a contract, so name it explicitly.
         # The unversioned metapackage tracks the image's default clang.
         run: |
-          sudo apt-get update
+          # A third-party repo in the runner image (azure-cli, chrome, ...) can
+          # 403, which fails `apt-get update` even when the Ubuntu archive we
+          # install from downloaded fine. The install is the real gate.
+          sudo apt-get update || echo "::warning::apt-get update reported errors; continuing to the install"
           sudo apt-get install -y clang libclang-rt-dev
 
       # The evolved corpus compounds across the weekly runs instead of


### PR DESCRIPTION
The runner images carry apt sources we never install from (`azure-cli`,
`chrome`, `microsoft-prod`). When one of them 403s, `apt-get update` exits
nonzero even though the Ubuntu archive lists downloaded fine, and every
toolchain install that ran it first went down with it.

That is what blocked 2.15.1. In [CI run 30892303762](https://github.com/mapequation/infomap/actions/runs/30892303762), `packages.microsoft.com`'s
`azure-cli` repo returned `403 Forbidden`, so:

```
E: Failed to fetch https://packages.microsoft.com/repos/azure-cli/dists/noble/InRelease  403  Forbidden
/home/runner/work/_temp/....sh: line 8: ccache: command not found
##[error]Process completed with exit code 127
```

`apt-get update && apt-get install -y ccache` short-circuited on the failed
update, ccache was never installed, and the trailing `ccache --version` left
`python / Python ubuntu-24.04 / 3.12` at exit 127.

The knock-on cost was the real problem. The failing step is `Install ccache`
rather than `"Set up job"`, so `ci-auto-rerun` correctly read it as a genuine
regression by its own rule and left master red. The release gate keys off the
same classifier, so it refused to publish — and v2.15.1 landed as a published
GitHub release with **zero assets**, with PyPI, npm, Docker and all three
downstream notifications skipped, even though every build job in the release
run had succeeded.

## The change

Let the install be the gate instead. A nonzero `apt-get update` is tolerated
with a warning; the `apt-get install` that follows is what decides the step,
since that is the command that actually needs a package. A truly unreachable
Ubuntu archive still fails loudly there.

Applied at all five `apt-get update` sites so no one site is left brittle:

- `.github/actions/setup-ccache/action.yml` (the one that bit us)
- `.github/actions/setup-swig/action.yml`
- `.github/workflows/ci.yml` — sanitizer and clang-tidy toolchains
- `.github/workflows/fuzz.yml`

Deliberately not `-o Dir::Etc::sourceparts=-` (ignore `sources.list.d`): that
depends on the Ubuntu archive staying in `/etc/apt/sources.list`, and would
silently update nothing if a future runner image moves to deb822
`sources.list.d/ubuntu.sources`. Tolerating the update degrades gracefully
under any image layout.

## Verification

- `actionlint` clean (exit 0) — it also shellchecks the `run:` blocks; pre-commit's `actionlint` and `check yaml` hooks pass
- All four files parse as YAML
- Confirmed under the exact shell GitHub uses (`bash --noprofile --norc -e -o pipefail`) that a tolerated `update` does **not** mask a failing install:

```
$ bash --noprofile --norc -e -o pipefail -c '
    false || echo "::warning::apt-get update reported errors; continuing to the install"
    false   # stands in for a genuinely failing apt-get install
    echo "REACHED-AFTER-FAILED-INSTALL"'
::warning::apt-get update reported errors; continuing to the install
exit=1
```

`REACHED-AFTER-FAILED-INSTALL` is never printed — `-e` still fails the step on the install.