### PR TITLE
fix: the winner split repair is on by default, as its results claim

### DIFF
--- a/src/core/ColumnarMapEquation.cpp
+++ b/src/core/ColumnarMapEquation.cpp
@@ -81,10 +81,12 @@ enum HSplitMode : std::uint8_t {
   kHSplitAuto = 5,
   kHSplitWinner = 6
 };
-static int hSplitParseMode(const char* envName)
+static int hSplitParseMode(const char* envName, int whenUnset)
 {
   const char* e = std::getenv(envName);
   if (e == nullptr)
+    return whenUnset;
+  if (std::string(e) == "off")
     return static_cast<int>(kHSplitOff);
   const std::string v(e);
   if (v == "1" || v == "all")
@@ -104,16 +106,23 @@ static int hSplitParseMode(const char* envName)
 // Per-trial variant: run the split interleave inside every trial's coarsening.
 static int hSplitMode()
 {
-  static const int mode = hSplitParseMode("COL_HSPLIT");
+  static const int mode = hSplitParseMode("COL_HSPLIT", static_cast<int>(kHSplitOff));
   return mode;
 }
-// Once-per-run variant (env COL_HSPLIT_WINNER, same vocabulary): run the split
-// interleave ONCE on the winning trial's hierarchy instead of inside every
-// trial — the #889 maybeDeepRepairBest pattern, which today only fires for
-// two-level-shaped winners. Independent of COL_HSPLIT.
+// Once-per-run variant: run the split interleave ONCE on the winning trial's
+// hierarchy instead of inside every trial — the #889 maybeDeepRepairBest
+// pattern, which previously only fired for two-level-shaped winners.
+// Independent of COL_HSPLIT.
+//
+// ON BY DEFAULT: this is the shipped behaviour (malaria -0.371% mean over
+// seeds 123/234/345 for +5..11% CPU on a ~3s run; air30k and regularized
+// microscopic gains at +1.5..3%; every base network bit-identical at zero
+// cost, because the repair is gated on module-move corrections). Set
+// COL_HSPLIT_WINNER=off to disable it, or to any other mode name to override
+// the level policy.
 static int hSplitWinnerMode()
 {
-  static const int mode = hSplitParseMode("COL_HSPLIT_WINNER");
+  static const int mode = hSplitParseMode("COL_HSPLIT_WINNER", static_cast<int>(kHSplitWinner));
   return mode;
 }
 


### PR DESCRIPTION
Follow-up to #987, fixing a defect in it.

## The problem

#987 shipped `splitLevelModules` behind `COL_HSPLIT_WINNER`, and that env var defaulted to **off**. So the merged default produced malaria **7.422254572**, while the performance tables committed in the same PR documented the repaired **7.417149324**. The tables described a configuration no user would get.

That is my error: I benchmarked with `COL_HSPLIT_WINNER=winner`, committed those numbers as the shipped result, and treated an env knob as the delivery mechanism.

## The fix

`hSplitParseMode` now takes an explicit when-unset value:

- **`COL_HSPLIT` (per-trial) stays off** — it was measured and deliberately dropped, since ~85% of its gain lands on trials that cannot win the best-of-N, at +24% on air30k.
- **`COL_HSPLIT_WINNER` (once-per-run) defaults on** — this is the behaviour the approved trade and the committed tables describe.
- **`off` is accepted as an explicit disable**, so the previous behaviour stays reachable.

## Verification (`--seed 123 -N10 -C`, against the committed tables)

| config | default now | table says |
|---|--:|--:|
| malaria | **7.417149324** | 7.417149324 ✓ |
| air30k | **5.393204056** | 5.393204056 ✓ |
| air30k (reg.) | **5.575914886** | 5.575914886 ✓ |
| web-NotreDame | 5.567994170 | unchanged ✓ |
| powergrid | 4.739600284 | unchanged ✓ |
| science2001 | 7.833436601 | unchanged ✓ |

Base networks are bit-identical because the repair is gated on module-move corrections. `COL_HSPLIT_WINNER=off` restores 7.422254572. `-2 -C` unchanged (malaria 7.422254572, air30k 5.392623377); `-N1` unchanged (7.502224007 — the hook is inert at single trial); re-runs bit-identical.

No documentation changes needed: the tables and F27 already describe this behaviour. This makes the code match them.