### PR TITLE
perf: validate cluster-data tree shape where input enters, not on every materialization

### DIFF
--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -970,6 +970,7 @@ private:
       const auto normalizedTree = infomap.normalizeTreePaths(m_network.initialPartitionPaths(), numNodesNotInNetwork);
       if (numNodesNotInNetwork > 0)
         Console::note(1, "{} nodes in embedded initial-partition paths not found in network.", numNodesNotInNetwork);
+      InfomapBase::validateClusterDataTreeShape(normalizedTree);
       infomap.initTree(normalizedTree);
     }
   }
@@ -1381,6 +1382,7 @@ InfomapBase& InfomapBase::initPartition(const std::string& clusterDataFile, bool
     if (numTreeNodesNotInNetwork > 0) {
       Console::note(1, "{} physical nodes in tree not found in network.", numTreeNodesNotInNetwork);
     }
+    validateClusterDataTreeShape(normalizedTree);
     initTree(normalizedTree);
   } else if (ext == "clu") {
     initPartition(clusterMap.clusterIds(), hard);
@@ -1479,33 +1481,18 @@ NodePaths InfomapBase::normalizeTreePaths(const TreePaths& tree, unsigned int& n
   return normalized;
 }
 
-InfomapBase& InfomapBase::initTree(const NodePaths& tree)
+// Refuse cluster data that gives a module both a leaf and a sub-module as children.
+//
+// Called where a tree is *parsed from input*, not from initTree itself. initTree also
+// materializes trees the engine generated -- the best-result restore, the deep-repair
+// reseed, and on the columnar engine every trial's own partition -- which cannot mix
+// depths by construction. Running the check there cost O(leaves x depth) std::map
+// insertions per call to reject a condition that can never hold: ~1.6M insertions per
+// trial on a 325k-node network. Validating where input enters keeps initTree a pure
+// materialization step, and keeps ExitCode::InputError on a path that is actually
+// handling input (#990).
+void InfomapBase::validateClusterDataTreeShape(const NodePaths& tree)
 {
-  Log(4) << "Init tree... ";
-  int maxDepth = 2;
-  // If only two-level partition, we can directly use initPartition
-  for (const auto& nodePath : tree) {
-    if (nodePath.second.size() > 2) {
-      maxDepth = std::max(maxDepth, static_cast<int>(nodePath.second.size()));
-    }
-  }
-  // A deeper tree under --two-level takes the same route, keeping each leaf's top-level
-  // module and dropping the sub-module structure below it. That is the collapse the
-  // hierarchical path performs with removeSubModules, and doing it here means the
-  // objective is initialised by the branch that works: building the full tree and then
-  // running a two-level search over it left the search with the deeper tree's
-  // index/module codelengths, which it reported as 0 -- or, with the tuning loop
-  // enabled, aborted on "fineTune() called but numLevels != 2" (#898).
-  if (maxDepth == 2 || twoLevel) {
-    std::map<unsigned int, unsigned int> clusterIds;
-    for (const auto& nodePath : tree) {
-      const auto nodeId = nodePath.first;
-      const auto clusterId = nodePath.second[0]; // First level module
-      clusterIds[nodeId] = clusterId;
-    }
-    return initPartition(clusterIds, false);
-  }
-
   // Refuse a module that would get both a leaf and a sub-module as children. The
   // search never produces that shape -- checked across 205k leaves at depths 2 to 8 --
   // and the code downstream assumes it cannot happen: the per-level aggregation used to
@@ -1548,6 +1535,34 @@ InfomapBase& InfomapBase::initTree(const NodePaths& tree)
                                               "--two-level to keep only the top-level assignment."),
                                    modulePath,
                                    modulePath));
+  }
+}
+
+InfomapBase& InfomapBase::initTree(const NodePaths& tree)
+{
+  Log(4) << "Init tree... ";
+  int maxDepth = 2;
+  // If only two-level partition, we can directly use initPartition
+  for (const auto& nodePath : tree) {
+    if (nodePath.second.size() > 2) {
+      maxDepth = std::max(maxDepth, static_cast<int>(nodePath.second.size()));
+    }
+  }
+  // A deeper tree under --two-level takes the same route, keeping each leaf's top-level
+  // module and dropping the sub-module structure below it. That is the collapse the
+  // hierarchical path performs with removeSubModules, and doing it here means the
+  // objective is initialised by the branch that works: building the full tree and then
+  // running a two-level search over it left the search with the deeper tree's
+  // index/module codelengths, which it reported as 0 -- or, with the tuning loop
+  // enabled, aborted on "fineTune() called but numLevels != 2" (#898).
+  if (maxDepth == 2 || twoLevel) {
+    std::map<unsigned int, unsigned int> clusterIds;
+    for (const auto& nodePath : tree) {
+      const auto nodeId = nodePath.first;
+      const auto clusterId = nodePath.second[0]; // First level module
+      clusterIds[nodeId] = clusterId;
+    }
+    return initPartition(clusterIds, false);
   }
 
   // Tear down the existing partition. Detach the leaves first so that the

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -438,6 +438,11 @@ private:
    */
   InfomapBase& initTree(const NodePaths& tree);
 
+  //! Reject cluster data that gives a module both a leaf and a sub-module as children.
+  //! Call this where a tree is parsed from input; initTree does not, because it also
+  //! materializes engine-generated trees, which cannot have that shape (#990).
+  static void validateClusterDataTreeShape(const NodePaths& tree);
+
   /**
    * Normalize tree leaf ids so the leaf id always identifies a state node in
    * m_leafNodes. For higher-order networks, physical-id rows are expanded by


### PR DESCRIPTION
Closes #990.

## What

`InfomapBase::initTree` ran [#948](https://github.com/mapequation/infomap/pull/948)'s mixed-depth
shape check on **every** tree it materialized. That check exists for user-supplied `--cluster-data`
([#898](https://github.com/mapequation/infomap/issues/898)): it rejects a module that would get both a
leaf and a sub-module as children, a shape whose codelength is not defined.

But `initTree` also materializes trees the *engine* generated — the best-result restore, the
deep-repair reseed, and on the columnar engine **every trial's own partition**. Those cannot mix
depths by construction, so the check was building two `std::map<std::vector<unsigned int>, bool>` with
one entry per path prefix per leaf to reject a condition that can never hold. On web-NotreDame
(325 729 leaves) that is roughly **1.6M map insertions per trial**.

## How

Extracted into `validateClusterDataTreeShape` and called from the two places a tree is *parsed from
input*: `--cluster-data`, and the embedded JSON initial-partition paths. `initTree` becomes a pure
materialization step.

This also puts the diagnostic in the right place. `ExitCode::InputError` now only comes from a path
that is handling input; if the engine ever produced a mixed-depth tree that would be an internal bug,
not bad input, and it should not be reported as the latter.

## Measured

web-NotreDame, `trial_optimize_s`, min-of-3, **codelength bit-identical on every row**:

| config | before | after | |
|---|--:|--:|--:|
| `-C` `-N10` | 18.49s | 17.32s | **−6.3%** |
| `-C -F` `-N10` | 13.64s | 12.75s | **−6.5%** |
| `-2 -C` `-N10` | 16.35s | 16.46s | +0.6% (noise) |
| OO, OO `-2` | — | — | −0.2% / +0.3% (noise) |

`-2 -C` is unaffected **by design**: `initTree` routes the two-level case out to `initPartition`
before the check runs, so that path never reached it. The OO engine calls `initTree` once per run
rather than per trial, so it is unchanged too — the win belongs to the columnar engine, but the cost
belongs to this function, which is why the fix lives here.

The cost scales with leaf count × depth: science2001 (7 170 nodes) and air30k are inside noise.

## Not included

#990 also noted that `-2 -C` carries a ~2.5% residual from #948's other two additions
(`removeSubModules`'s loop condition and `aggregatePerLevelCodelength`'s per-child classification).
Both were implemented and measured: **they recover nothing** (`-2 -C` +0.5%, i.e. noise). The original
per-addition attribution was single measurements at small magnitudes and did not hold up. Dropped
rather than shipped, since they modify #898's recently-landed correctness code for no measured payoff.
Recorded on the issue so it is not re-investigated.

## Verification

- `make test-native` green in all three configurations CI runs: `OPENMP=0`, `OPENMP=1`, and the
  `lossy-map-equation regularized-multilayer` feature build. #898's regression tests are among them.
- Mixed-depth cluster data still rejected with the identical message; well-formed cluster data still
  accepted with an unchanged codelength.
