### PR TITLE
fix: score a re-initialised leaf partition with the leaf network's terms (#831)

### DIFF
--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1836,6 +1836,23 @@ InfomapBase& InfomapBase::initPartition(std::vector<unsigned int>& modules, bool
 {
   removeModules();
   setActiveNetworkFromLeafs();
+  // Re-init the objective for the leaf network before scoring a leaf partition on it.
+  // The objective's network-level terms (the base map equation's nodeFlow_log_nodeFlow,
+  // and each derived objective's equivalent) describe whichever network was active when
+  // they were last initialised -- root's children, not necessarily the leaves. Both the
+  // multi-level branch of initTree and the fast super-level search leave them initialised
+  // for a *module* network, and nothing restored them here, so re-initialising a two-level
+  // partition on a reused instance scored the leaves against the module network's terms.
+  // That is #831: on politicalblogs a preceding multi-level trial left the term at the
+  // two top modules' -1.0 instead of the leaves' -7.6, and the recomputed codelength came
+  // out one whole one-level codelength too low -- negative, and written to the .tree file
+  // while the console reported the correct value.
+  // removeModules() above has just made the leaves root's children again, which is what
+  // initNetwork() reads. Skip it when the terms already describe the leaf network: the
+  // walk is over every leaf through the sibling chain, and paying it per trial costs
+  // web-NotreDame --two-level --columnar ~2.5% for nothing.
+  if (!m_objectiveTermsAreForLeafNetwork)
+    initNetwork();
   initPartition(); // TODO: confusing same name, should be able to init default without arguments here too
   moveActiveNodesToPredefinedModules(modules);
   consolidateModules(false);

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -489,9 +489,21 @@ private:
   // Init terms that is constant for the whole network
   void initTree() { return m_optimizer->initTree(); }
 
-  void initNetwork() { return m_optimizer->initNetwork(); }
+  // The objective's network-level terms describe whichever network was active when they
+  // were last initialised -- root's children, which are the leaves only sometimes. Record
+  // which, so a later leaf-level partition can restore them instead of scoring the leaves
+  // against a module network's terms (#831; see initPartition(std::vector<unsigned int>&)).
+  void initNetwork()
+  {
+    m_optimizer->initNetwork();
+    m_objectiveTermsAreForLeafNetwork = m_root.firstChild != nullptr && m_root.firstChild->isLeaf();
+  }
 
-  void initSuperNetwork() { return m_optimizer->initSuperNetwork(); }
+  void initSuperNetwork()
+  {
+    m_optimizer->initSuperNetwork();
+    m_objectiveTermsAreForLeafNetwork = false;
+  }
 
   double calcCodelength(const InfoNode& parent) const { return m_optimizer->calcCodelength(parent); }
 
@@ -675,6 +687,8 @@ protected:
   unsigned int m_tuneIterationIndex = 0;
   bool m_isCoarseTune = false;
   unsigned int m_aggregationLevel = 0;
+  //! Whether the objective's network-level terms currently describe the leaf network (#831).
+  bool m_objectiveTermsAreForLeafNetwork = false;
 
   double m_hierarchicalCodelength = 0.0;
   std::vector<double> m_codelengths;

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -379,6 +379,42 @@ TEST_CASE("Tree cluster-data reinit and rerun stay stable on the same instance [
   CHECK(im.numLevels() == firstNumLevels);
 }
 
+TEST_CASE("A two-level partition re-initialised after a multi-level one scores the leaves [fast][core][partition][lifecycle]")
+{
+  // #831: the objective's network-level terms (the base map equation's
+  // nodeFlow_log_nodeFlow) describe whichever network was active when they were last
+  // initialised. The multi-level branch of initTree leaves them initialised for the
+  // *module* network, and the two-level route did not restore them, so re-initialising a
+  // two-level partition on the same instance scored the leaves against the module
+  // network's terms -- off by one whole one-level codelength. On politicalblogs that came
+  // out negative and was written to the .tree file while the console reported the correct
+  // value. Pinned as: the same partition must score the same on a reused instance as on a
+  // fresh one.
+  auto twoLevelCodelength = [](InfomapWrapper& im) {
+    im.initPartition(infomap::test::clusterFixturePath("twotriangles_two_modules.clu"), false, &im.network());
+    return im.codelength();
+  };
+  // --no-infomap so the flow is calculated (the codelength is 0 without it) while no
+  // search runs, keeping each instance's only module state the one this test gives it.
+  auto makeInstance = [] {
+    return infomap::test::makeRunningInfomap(
+        [](InfomapWrapper& im) { im.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net")); },
+        "--no-infomap");
+  };
+
+  auto fresh = makeInstance();
+  const auto expected = twoLevelCodelength(*fresh);
+  REQUIRE(expected > 0.0);
+
+  auto reused = makeInstance();
+  // A multi-level partition first -- this is what left the terms behind.
+  reused->initPartition(infomap::test::clusterFixturePath("twotriangles_three_level.tree"), false, &reused->network());
+  REQUIRE(reused->numLevels() == 3);
+
+  CHECK(twoLevelCodelength(*reused) == doctest::Approx(expected));
+  CHECK(reused->getIndexCodelength() == doctest::Approx(fresh->getIndexCodelength()));
+}
+
 TEST_CASE("Pretty per-level codelength renders a structured levels table [fast][core][partition][output]")
 {
   InfomapWrapper im(infomap::test::defaultFlags("--directed -0 --no-file-output --pretty"));


### PR DESCRIPTION
Fixes #831.

## The bug

The objective's network-level terms — the base map equation's `nodeFlow_log_nodeFlow`, and each
derived objective's equivalent — describe **whichever network was active when they were last
initialised**. That is root's children, which are the leaves only sometimes: both the multi-level
branch of `initTree` (`InfomapBase.cpp:1879`) and the fast super-level search (`initSuperNetwork`)
leave them initialised for a *module* network, and nothing restored them when a leaf partition was
re-initialised on the same instance. So `initPartition(std::vector<unsigned int>&)` scored the leaves
against a module network's terms.

The error is exactly one one-level codelength. On the twotriangles fixture a three-level cluster-data
init followed by a two-level one scores **0.764074** where a fresh instance scores **2.320730357** —
`2.320730357 − 0.764074 = 1.556657 = oneLevelCodelength (2.556657) − 1.0`, the leaves' term (−2.556657)
replaced by the two modules' (`2·plogp(0.5) = −1.0`).

**This is reachable from the public API with no columnar engine involved**, which is what the
regression test pins: `initPartition(<3-level tree>)` then `initPartition(<2-level clu>)` on one
instance. It is also how #831 was found — the columnar engine materializes its result through
`initTree` every trial, so a two-level result after a multi-level trial wrote a **negative** codelength
into the `.tree` file while the console reported the correct value:

```
console:  Best codelength 6.739181803 / Relative savings 111.29%
.tree:    # codelength -0.858985 bits
          # relative codelength savings 111.287%
```

## The fix

Restore the terms for the leaf network in `initPartition`, guarded on a flag recording which network
they currently describe (`initNetwork` sets it from `m_root.firstChild->isLeaf()`, `initSuperNetwork`
clears it).

**The guard is not cosmetic.** The re-init walks every leaf through the sibling chain; paying it per
trial when the terms are already correct costs web-NotreDame `--two-level --columnar` a reproducible
**+2.5%** (min-of-5 CPU, disjoint distributions: 19.41–19.68s vs 19.90–20.37s) for no behavior change.
Guarded, the same comparison is −1.2% with fully overlapping distributions.

## Verification

**On this branch (OO only — master has no `-C`), 13 benchmark configs × {hierarchical, `-2`},
`--seed 123 -N10`, baseline vs fix:** 26 of 26 reported codelengths bit-identical, 26 of 26 written
`.tree` codelengths bit-identical. The OO engine is untouched.

`make test-native` passes at `OPENMP=1`, `OPENMP=0`, and
`FEATURES="lossy-map-equation regularized-multilayer"` (26/26 each). The new test fails on the parent
commit with `CHECK( 0.764074 == Approx( 2.32073 ) )` and passes here.

**Additionally verified on the columnar branch** (where the symptom is visible), 13 configs × 5
variants = 65 runs, baseline vs the same patch:

- **0 of 65** reported codelengths changed — the search is untouched.
- **2 written codelengths corrected**, both corrupt at seed 123: science2001
  `--preferred-number-of-modules 25` under `-C` (**−1.39324**) and `-C -F` (**−1.40803**), both now
  8.23559, matching the console.
- politicalblogs `-C -d -N10`: 4 of 7 seeds (345, 42, 99, 2024) wrote a negative codelength before,
  none after; every console value unchanged.

## Note for reviewers

`make build-native` does not track header dependencies — no `.d` file lists `InfomapBase.h`. Since this
change adds a member to that header, an incremental build recompiles only `InfomapBase.cpp` and leaves
every other translation unit on the old object layout, producing a binary that writes garbage
(`# codelength 2.62515e-313`) while printing correct values. Build clean (`rm -rf build/native`) when
measuring this branch. Filed separately as a build-system issue.



---

<!-- `core` is not a sanctioned commit scope. Release Please reads the block below
     in place of the squash-commit message, so the changelog entry stays unscoped. -->

BEGIN_COMMIT_OVERRIDE
fix: score a re-initialised leaf partition with the leaf network's terms (#998)
END_COMMIT_OVERRIDE
