### PR TITLE
fix(columnar): weight the physical-node codebook by the objective's own rate under L*

### DIFF
--- a/columnar_wip/columnar-pr-performance-section.md
+++ b/columnar_wip/columnar-pr-performance-section.md
@@ -4,7 +4,7 @@
 
 Single-threaded (`MODE=release OPENMP=0`), `--seed 123 -N10` — **best of 10 trials**, the way Infomap is normally run. Codelength in bits; `time` = total wall for all 10 trials, minimum of 3 interleaved repetitions; `top`/`lvls` = top modules / levels of the best partition. The network set spans base (undirected + directed), metadata, multilayer and state/memory objectives; see [`columnar_wip/benchmark-networks.md`](columnar_wip/benchmark-networks.md) for paths and full details. Columnar column = the default columnar search (`-C`).
 
-> **This PR is a correctness fix** to the memory objective under L\*: `MemCorrection` substituted the
+> **This PR** ([#1010](https://github.com/mapequation/infomap/pull/1010), fixes [#1009](https://github.com/mapequation/infomap/issues/1009)) **is a correctness fix** to the memory objective under L\*: `MemCorrection` substituted the
 > physical-node `sum plogp(flow)` for the state-node one at coefficient 1, which is the base map
 > equation's coefficient, while L\*'s leaf-module term consumes that quantity at a per-module rate
 > `1 + qEnter*qExit/(flow*(flow+qExit)) >= 1`. `-C --non-redundant` on state / memory / multilayer input
@@ -238,7 +238,7 @@ under both bases, and the `_states.tree` round-trip trap — lives in
 [#1001](https://github.com/mapequation/infomap/pull/1001), whose own copy of this file is the
 measurement that justified it.
 
-### What this PR changes: L\* on higher-order input, and nothing else
+### What this PR changes: L\* on higher-order input, and nothing else ([#1010](https://github.com/mapequation/infomap/pull/1010))
 
 The memory objective's physical-node codebook is a **substitution**, not an additive term: both base
 objectives read a level-1 module's leaf flows only through `F_m = sum_{leaf in m} plogp(flow)`, and

--- a/columnar_wip/columnar-pr-performance-section.md
+++ b/columnar_wip/columnar-pr-performance-section.md
@@ -4,23 +4,39 @@
 
 Single-threaded (`MODE=release OPENMP=0`), `--seed 123 -N10` — **best of 10 trials**, the way Infomap is normally run. Codelength in bits; `time` = total wall for all 10 trials, minimum of 3 interleaved repetitions; `top`/`lvls` = top modules / levels of the best partition. The network set spans base (undirected + directed), metadata, multilayer and state/memory objectives; see [`columnar_wip/benchmark-networks.md`](columnar_wip/benchmark-networks.md) for paths and full details. Columnar column = the default columnar search (`-C`).
 
-> **This PR is a refactor** ([#1003](https://github.com/mapequation/infomap/pull/1003)): it splits
-> `ColumnarMapEquation.cpp` into focused translation units and replaces the mid-function
-> `if (m_nonRedundant)` in the stack scoring with two named objective scorers. **No behaviour change is
-> intended, which makes the numbers the claim rather than context** — see "What this PR changes" at the
-> bottom, measured on this branch's binary (`md5 ab7d77eda448b917d41ad48a8ca832fe`) against the base
-> branch's (`d113e278`).
+> **This PR is a correctness fix** to the memory objective under L\*: `MemCorrection` substituted the
+> physical-node `sum plogp(flow)` for the state-node one at coefficient 1, which is the base map
+> equation's coefficient, while L\*'s leaf-module term consumes that quantity at a per-module rate
+> `1 + qEnter*qExit/(flow*(flow+qExit)) >= 1`. `-C --non-redundant` on state / memory / multilayer input
+> therefore reported L\* **too high**, and the error grew with the number of physical nodes holding
+> several states in one module. **`--non-redundant` on higher-order input changes value and search
+> trajectory. Everything else is bit-identical**, which is the claim the numbers below have to carry.
 >
-> **Nothing in the tables below moved.** All 38 recorded configs (13 networks × {OO, `-C`,
-> `-C --non-redundant`}) reproduce their codelength, top-module count and level count **exactly**, so
-> every table here is carried over rather than restated. The `-C` and OO columns were last re-measured on
-> the #1001 tip, interleaved, minimum of 3 repetitions, and matched the published snapshot on all 26
-> codelengths with the OO/`-C` ratios intact (powergrid 7.45× vs 7.46×, web-NotreDame 7.56× vs 7.39×,
-> science2001 2.56× vs 2.51×).
+> **The base objective did not move — measured, not argued.** 12 `-C` configs run on the pre-fix binary
+> and this one (jazz `-N20` two-level and hierarchical, ninetriangles two-level and hierarchical, the
+> `states.net` / `states_flow.net` / `multilayer.net` fixtures two-level and hierarchical, a
+> `--directed --recorded-teleportation` config, and a 54-state exactly-lumpable duplication of
+> ninetriangles) reproduce their codelength to the **last bit** (`delta == 0.0`, not "within 1e-12").
+> The correction's base branch is untouched down to its summation order, precisely so this holds.
 >
-> **Not re-measured:** the `-F` and `-2` tables. This PR moves code without changing it and the `-C` arm
-> they are compared against reproduced bit-identically, so re-running them would only re-time unchanged
-> code. Stated here rather than left implicit.
+> **STALE — must be re-measured before this PR is reviewed:** the four higher-order rows of the L\*
+> table below (`multilayer (ex.)`, `malaria`, `air30k`, `air30k (reg.)`). Those are pre-fix L\* numbers
+> and this PR changes them by construction. They could not be redone in the session that made the fix:
+> `networks/` (malaria, air30k, and every other real-world benchmark) is not present in that checkout.
+> Every other row of every table is a base-objective or first-order-L\* config that the bit-identity
+> sweep above covers, and is carried over unchanged.
+>
+> Direction of the change, from the configs that *were* available: a 54-state lumpable duplication of
+> ninetriangles under `-C --non-redundant` goes 3.226345721211 → 3.153268798134 (hierarchical, top 3 /
+> 3 levels both ways) and 3.465711933541 → 3.392635010464 (`--two-level`, 9 modules both ways) — the
+> second is now exactly the physical network's L\* for the same partition, which is the invariance the
+> fix restores. The small state fixtures do not move at all: their optima put no physical node's two
+> states in one module, so the correction is zero under either coefficient.
+>
+> **Not re-measured:** the `-F` and `-2` tables, and all timings. Nothing on the base-objective path
+> changed, and the L\* scoring path gained one O(K) pass over level-1 modules on the cold
+> (per-structural-operator) path, only when a `MemCorrection` is attached — so re-running them from the
+> same networks is the check to make, not a different set of numbers.
 
 <table>
 <thead>
@@ -173,10 +189,11 @@ against base L in either direction (see the cross-scored table below, where L\* 
 L for the same partition on 7 of 13 configs). What is comparable is cost and shape, and — through
 cross-scoring — whether the L\*-aware search earns its place.
 
-**All 13 benchmark configs run under L\***, which is the other half of this PR: no input and no
-objective is excluded (see "Every correction composes with L\*" below). Both arms interleaved in one
-session, minimum of 3 repetitions, same binary, `--seed 123 -N10`. Times are comparable within a row,
-not across the three batches (`pr1001-lstar`, `pr1001-lstar-ho`, `pr1001-lstar-meta` in the run log).
+**All 13 benchmark configs run under L\***: no input and no objective is excluded. Both arms
+interleaved in one session, minimum of 3 repetitions, same binary, `--seed 123 -N10`. Times are
+comparable within a row, not across the three batches (`pr1001-lstar`, `pr1001-lstar-ho`,
+`pr1001-lstar-meta` in the run log). The four higher-order L\* codelengths are **stale** — this PR
+changes them and the networks were not available to re-measure; see the note at the top.
 
 <table>
 <thead>
@@ -201,10 +218,10 @@ not across the three batches (`pr1001-lstar`, `pr1001-lstar-ho`, `pr1001-lstar-m
 <tr><td>science2001 (<code>-d</code>)</td><td>base</td><td align="right">7.833436601</td><td align="right">15</td><td align="right">3</td><td align="right">8.009172258</td><td align="right">22</td><td align="right">3</td><td align="right">−9.1%</td></tr>
 <tr><td>web-NotreDame (<code>-d</code>)</td><td>base</td><td align="right">5.568529293</td><td align="right">5</td><td align="right">6</td><td align="right">5.517073626</td><td align="right">5</td><td align="right">6</td><td align="right">+0.6%</td></tr>
 <tr><td>lazega</td><td>metadata</td><td align="right">6.017860269</td><td align="right">7</td><td align="right">2</td><td align="right">5.968624653</td><td align="right">7</td><td align="right">2</td><td align="right">0.015s vs 0.015s</td></tr>
-<tr><td>multilayer (ex.)</td><td>multilayer</td><td align="right">2.011405238</td><td align="right">2</td><td align="right">2</td><td align="right">1.928856578</td><td align="right">2</td><td align="right">2</td><td align="right">0.011s vs 0.012s</td></tr>
-<tr><td>malaria</td><td>multilayer</td><td align="right">7.397501710</td><td align="right">2</td><td align="right">3</td><td align="right">7.432494779</td><td align="right">2</td><td align="right">3</td><td align="right">−0.4%</td></tr>
-<tr><td>air30k</td><td>state/memory</td><td align="right">5.392425413</td><td align="right">22</td><td align="right">3</td><td align="right">5.486124697</td><td align="right">22</td><td align="right">3</td><td align="right">−2.0%</td></tr>
-<tr><td>air30k (reg.)</td><td>state/memory</td><td align="right">5.576242406</td><td align="right">11</td><td align="right">3</td><td align="right">5.691341197</td><td align="right">11</td><td align="right">3</td><td align="right">−3.3%</td></tr>
+<tr><td>multilayer (ex.)</td><td>multilayer</td><td align="right">2.011405238</td><td align="right">2</td><td align="right">2</td><td align="right">1.928856578 (unchanged)</td><td align="right">2</td><td align="right">2</td><td align="right">0.011s vs 0.012s</td></tr>
+<tr><td>malaria</td><td>multilayer</td><td align="right">7.397501710</td><td align="right">2</td><td align="right">3</td><td align="right"><i>7.432494779 — STALE</i></td><td align="right">2</td><td align="right">3</td><td align="right">−0.4%</td></tr>
+<tr><td>air30k</td><td>state/memory</td><td align="right">5.392425413</td><td align="right">22</td><td align="right">3</td><td align="right"><i>5.486124697 — STALE</i></td><td align="right">22</td><td align="right">3</td><td align="right">−2.0%</td></tr>
+<tr><td>air30k (reg.)</td><td>state/memory</td><td align="right">5.576242406</td><td align="right">11</td><td align="right">3</td><td align="right"><i>5.691341197 — STALE</i></td><td align="right">11</td><td align="right">3</td><td align="right">−3.3%</td></tr>
 <tr><td>science2001 (pref-mods)</td><td>base + bias</td><td align="right">8.235585529</td><td align="right">25</td><td align="right">2</td><td align="right">8.447745451</td><td align="right">25</td><td align="right">2</td><td align="right">−1.1%</td></tr>
 </tbody>
 </table>
@@ -221,36 +238,58 @@ under both bases, and the `_states.tree` round-trip trap — lives in
 [#1001](https://github.com/mapequation/infomap/pull/1001), whose own copy of this file is the
 measurement that justified it.
 
-### What this PR changes: the file split, and nothing else
+### What this PR changes: L\* on higher-order input, and nothing else
 
-[#1003](https://github.com/mapequation/infomap/pull/1003) splits `ColumnarMapEquation.cpp` (4284 lines,
-four unrelated concerns) into focused translation units and gives the stack scoring a named seam
-(`StackTerms` + `scoreStackBase` + `scoreStackNonRedundant` in place of an `if (m_nonRedundant)`
-mid-function). No search behaviour is intended to change, so the numbers are the claim:
+The memory objective's physical-node codebook is a **substitution**, not an additive term: both base
+objectives read a level-1 module's leaf flows only through `F_m = sum_{leaf in m} plogp(flow)`, and
+`MemCorrection` is the same objective with the state-node `F_m` replaced by the physical-node one. A
+substitution inherits the coefficient of the term it sits inside — and the two objectives disagree
+about it. The base map equation's `T`-normalized module term collapses to
+`plogp(T) - plogp(qExit) - F_m`, so the coefficient is exactly 1. L\* splits that codebook into an
+enter codebook normalized by `moduleFlow` and a within codebook normalized by `T = moduleFlow + qExit`,
+charging `F_m` against both, so the coefficient is
+`nrLeafCodebookRate = 1 + qEnter*qExit/(flow*(flow+qExit)) >= 1`.
 
-- **38 of 38 recorded configs** (13 networks × {OO, `-C`, `-C --non-redundant`}) reproduce their
-  codelength, top-module count **and** level count exactly. That includes `air30k -d --regularized`,
-  which is the config that exercises the teleport preamble both scorers now share, and the five
-  correction configs, which reach `objectiveCorrection()` through the new seam.
-- **Speed is neutral**, min-of-3 interleaved, base binary `d113e278` against this branch's `ab7d77ed`
-  (they compute identical partitions on all 38 configs, so a wall-time difference is code and nothing
-  else):
+The correction was applied at coefficient 1 under both. Since `plogp` is superadditive under splitting,
+`F^state - F^phys <= 0`, so multiplying it by 1 instead of by `rate >= 1` **under-subtracts**: L\* came
+out too high, always, by `(rate - 1) * (F^phys - F^state)`.
 
-| config | base | split | Δ |
-|---|--:|--:|--:|
-| web-NotreDame `-C` | 19.401s | 19.501s | +0.51% |
-| science2001 `-C` | 3.126s | 3.107s | −0.64% |
-| air30k `-C` | 3.941s | 3.953s | +0.31% |
-| malaria `-C` | 3.251s | 3.278s | +0.85% |
-| powergrid `-C` | 0.247s | 0.248s | +0.22% |
-| science2001 `-C --non-redundant` | 2.879s | 2.872s | −0.25% |
+The observable symptom is a broken invariance. Split every physical node into states the walker cannot
+distinguish and lift the partition so no physical node is split across modules: the process, the
+modules and every describable event are unchanged, so the codelength must be too. `L` always was. `L*`
+was not:
 
-Nothing crosses the 1% reporting threshold and there is no systematic direction. The risk being measured
-is specific: the native build has **no LTO**, so moving the per-candidate arithmetic across a
-translation-unit boundary would cost real time. It is in a header (`ColumnarObjective.h`) for that
-reason, and `moveLoop` keeps `removeModuleTerms`/`addModuleTerms` in its own TU.
+| case | L (before = after) | L\* before | L\* after | error removed |
+|---|--:|--:|--:|--:|
+| two triangles, all 6 nodes ×2 | 2.320730356834 | 2.145875734724 | 2.128018591867 | +0.017857142857 |
+| two triangles, node 3 only ×2 | 2.320730356834 | 2.131845122479 | 2.128018591867 | +0.003826530612 |
+| ninetriangles, all 27 nodes ×2 | 3.572285805615 | 3.465711933541 | 3.392635010464 | +0.073076923077 |
+| two triangles, directed (rawdir), all ×2 | 1.899533374666 | 1.844312916393 | 1.841584741790 | +0.002728174603 |
+| jazz provenance lift, 30 split nodes | 6.861229774904 | 6.841080565212 | 6.836565239276 | +0.004515325936 |
+| jazz provenance lift, 78 split nodes | 6.861229774904 | 6.855445280017 | 6.836565239276 | +0.018880040741 |
 
-An earlier A/B against the pre-#1001 binary put powergrid `-C` at **+1.92%** at min-of-3. At min-of-9 it
-was +0.52%, with the baseline arm's own spread on that config running 0.257–0.348s — the threshold
-crossing was session noise, not the split. Recorded because it crossed 1%.
+Every "after" equals the *physical* network's own L\* for the same partition to `<= 9e-14` (two
+triangles 2.128018591867112, ninetriangles 3.392635010464057, jazz 6.836565239275705), which is the
+invariance stated as an equation rather than as a delta.
+
+**The base objective is bit-identical.** 12 `-C` configs — jazz (`-N20`, two-level and hierarchical),
+ninetriangles (both), the `states.net` / `states_flow.net` / `multilayer.net` fixtures (both), a
+`--directed --recorded-teleportation` config, and a 54-state lumpable duplication of ninetriangles
+(both) — reproduce `delta == 0.0` exactly against the pre-fix binary. `MemCorrection`'s base branch
+keeps its two global sums rather than regrouping per module, so even the floating-point summation
+order is preserved.
+
+**One source of truth for the teleport augmentation.** The correction has to charge its substitution
+against the same enter/exit rates the scorer used, *including* the recorded-teleportation additions —
+re-deriving them from the link-only rates would be silently wrong on exactly the flow models
+(`--regularized`, `--recorded-teleportation`) where it is hardest to notice. So the teleport preamble is
+extracted into `ColumnarTwoLevel::buildStackTerms()`, which both `hierarchicalCodelengthFromStack()` and
+the new `leafCodebookRates()` consume, rather than written twice.
+
+**Cost.** One O(K) pass over level-1 modules per stack scoring — plus, under recorded teleportation
+only, a second run of the teleport preamble's pass over the leaves — on the cold
+(per-candidate-structural-operator) path, and only when a `MemCorrection` is attached under L\*. The
+per-candidate move arithmetic is untouched — the leaf move loop is deliberately base-flavoured under
+L\* (see `--non-redundant-exact`), so `initMoveLoop`/`moveDelta`/`applyMove`/`mergeDelta` keep the
+coefficient-1 form by design.
 

--- a/columnar_wip/columnar-rethink-notes.md
+++ b/columnar_wip/columnar-rethink-notes.md
@@ -2161,3 +2161,65 @@ and level count exactly; min-of-3 interleaved A/B on the two binaries (identical
 code) gives −0.64% to +0.85%; 31/31 tests in all three build configurations. An earlier A/B put powergrid
 at +1.92% at min-of-3, which at min-of-9 was +0.52% against a baseline spread of 0.257–0.348s — the same
 lesson as F28: **a threshold crossing on a 0.25s config is a statement about the session, not the code.**
+
+### F37 — A correction that *substitutes* inherits the objective's coefficient; only an *additive* one composes freely (#1009, 2026-08-15)
+
+`-C --non-redundant` on state / memory / multilayer input reported L\* too high. The size of the error
+was a clean function of the partition: two triangles with all six nodes duplicated into two
+indistinguishable states, partition unchanged, gave exactly **+1/56 bits**; duplicating only node 3 gave
+exactly **+3/784**; ninetriangles all-×2 gave **+0.073076923077**; the jazz provenance lifts gave
+**+0.0045** (30 split nodes) and **+0.0189** (78). Always positive, always growing with the number of
+physical nodes holding several states in one module. `L` was invariant to `1e-15` throughout, so the
+duplication was correct and the defect was in the objective.
+
+**The mechanism.** Both stack scorers read a level-1 module's leaf flows only through
+`F_m = sum_{leaf in m} plogp(flow)`, linearly. `MemCorrection` is not a term added beside them — it is
+the same objective with `F_m^state` replaced by `F_m^phys`, i.e. a **substitution**, and a substitution
+is charged at whatever rate the surrounding term consumes `F_m`. The two objectives do not agree:
+
+- `scoreStackBase`'s level-1 block collapses algebraically to `plogp(T) - plogp(qExit) - F_m` with
+  `T = moduleFlow + qExit`. Coefficient of `F_m`: exactly **1**.
+- `nrEnterWithin` charges `-qEnter*F/moduleFlow` from its enter half and `-(usage/T)*F` from its within
+  half. Coefficient: `qEnter/flow + (flow + qExit - qEnter)/(flow + qExit)`, which is
+  `1 + qEnter*qExit/(flow*(flow+qExit))` — **>= 1**, equal to 1 only when `qEnter == 0` or `qExit == 0`.
+
+`F^state - F^phys <= 0` (plogp is superadditive under splitting), so charging it at 1 instead of at
+`rate >= 1` under-subtracts, and L\* came out high by `(rate - 1) * (F^phys - F^state)`. The sign of the
+observed error was the confirmation before a line was written.
+
+**The rule this generalizes to** — and the reason it shipped. `src/io/Config.cpp` justified composing
+every correction with L\* on the grounds that "they are additive terms that `objectiveCorrection()` sums
+on top of whichever base objective is selected". True, and true of the *value* for Meta / Bias /
+Preferred, whose terms carry their own objective-independent rate: metadata is charged per unit of
+node-visit flow, and L\* changes which codebook names a node, not how often a node is visited. False for
+Mem, which re-encodes a codebook the base objective already priced. **Additive terms compose; substitutions
+inherit.** `MemCorrection` is the only one of the five that substitutes — `LossyCorrection` is the near
+miss, see below.
+
+**The fix, and why the teleport preamble had to move.** `ColumnarTwoLevel::leafCodebookRates()` returns
+the active objective's per-module rate (empty under the base objective, so its arithmetic is untouched
+down to the summation order), and `MemCorrection` returns `sum_m rate_m * (F_m^state - F_m^phys)`. The
+rates must be the *same* enter/exit the scorer used, teleport augmentation included — re-deriving them
+from the link-only crossing flows would be wrong on exactly the flow models (`--regularized`,
+`--recorded-teleportation`) where nothing else would flag it. So the preamble is now
+`buildStackTerms()`, consumed by both `hierarchicalCodelengthFromStack()` and `leafCodebookRates()`,
+rather than duplicated. `StackTerms` moved out of the anonymous namespace into `infomap::columnar` for
+that (the header only forward-declares it).
+
+**Verification.** Every duplicated case now equals its physical L\* to `<= 9e-14`; 12 `-C` configs are
+bit-identical (`delta == 0.0`) against the pre-fix binary; jazz `-C --two-level -N20` 6.861229774903977
+and `-C --non-redundant --two-level -N20` 6.817184613565288 both unmoved; 31/31 tests in all three build
+configurations. The regression test builds the physical and duplicated networks from the same edge list
+in-process, undirected / `--directed` / `--flow-model rawdir`, two-module and multi-module — it fails on
+all six L\* assertions without the fix.
+
+**Deliberately not fixed, recorded here.** (1) The leaf **move loop** stays base-flavoured under L\*
+(`--non-redundant-exact` documents this: L\* drives the structural search, the base objective drives the
+move arithmetic), so `MemCorrection::initMoveLoop`/`moveDelta`/`applyMove`/`mergeDelta` keep coefficient
+1 by design. (2) `LossyCorrection` has the same defect **in kind** — it re-adds `sum plogp(f_i)` at +1 to
+cancel what the base charged at −1, and L\* charges it at `-rate` — but it is not a mechanical
+re-weighting (`l_m` is normalized by `F_m`, not by `T`), it is feature-gated behind
+`INFOMAP_FEATURE_LOSSY_MAP_EQUATION`, and combining a rate-distortion penalty with L\* is a modelling
+question that needs its own derivation. (3) `MetaCorrection` was checked and is **correct** at
+coefficient 1 — see the rule above; the test that asserts it stays green and its comment now says which
+class of correction it speaks for.

--- a/columnar_wip/columnar-rethink-notes.md
+++ b/columnar_wip/columnar-rethink-notes.md
@@ -2167,8 +2167,9 @@ lesson as F28: **a threshold crossing on a 0.25s config is a statement about the
 `-C --non-redundant` on state / memory / multilayer input reported L\* too high. The size of the error
 was a clean function of the partition: two triangles with all six nodes duplicated into two
 indistinguishable states, partition unchanged, gave exactly **+1/56 bits**; duplicating only node 3 gave
-exactly **+3/784**; ninetriangles all-×2 gave **+0.073076923077**; the jazz provenance lifts gave
-**+0.0045** (30 split nodes) and **+0.0189** (78). Always positive, always growing with the number of
+exactly **+3/784**; ninetriangles all-×2 gave **+0.073076923077**; `examples/notebooks/data/jazz.net`
+with a subset of its nodes lifted to two states each gave **+0.0045** (30 split nodes) and **+0.0189**
+(78). Always positive, always growing with the number of
 physical nodes holding several states in one module. `L` was invariant to `1e-15` throughout, so the
 duplication was correct and the defect was in the objective.
 
@@ -2220,6 +2221,6 @@ move arithmetic), so `MemCorrection::initMoveLoop`/`moveDelta`/`applyMove`/`merg
 cancel what the base charged at −1, and L\* charges it at `-rate` — but it is not a mechanical
 re-weighting (`l_m` is normalized by `F_m`, not by `T`), it is feature-gated behind
 `INFOMAP_FEATURE_LOSSY_MAP_EQUATION`, and combining a rate-distortion penalty with L\* is a modelling
-question that needs its own derivation. (3) `MetaCorrection` was checked and is **correct** at
+question that needs its own derivation — filed as #1011. (3) `MetaCorrection` was checked and is **correct** at
 coefficient 1 — see the rule above; the test that asserts it stays green and its comment now says which
 class of correction it speaks for.

--- a/src/core/ColumnarCorrections.cpp
+++ b/src/core/ColumnarCorrections.cpp
@@ -348,16 +348,38 @@ double MemCorrection::hierarchicalCorrection(const ColumnarTwoLevel& core) const
   if (core.hierNumLevels() < 2)
     return 0.0;
   const int nLeaves = core.numLeaves();
+  // Per level-1 module, the rate the active objective charges F_m at. Empty ==
+  // uniformly 1 == the base map equation; see the class comment for why the two
+  // objectives differ here and the header for why empty rather than a vector of ones.
+  const std::vector<double> rates = core.leafCodebookRates();
+  const bool weighted = !rates.empty();
+  std::vector<double> fState;
+  if (weighted)
+    fState.assign(rates.size(), 0.0);
   std::unordered_map<long long, double> physFlowMap; // key = (module<<32)|physical
   for (int i = 0; i < nLeaves; ++i) {
     const int m = core.hierLeafModule(i);
     const long long key = (static_cast<long long>(m) << 32) | static_cast<unsigned int>(m_leafPhysical[i]);
     physFlowMap[key] += m_leafFlow[i];
+    if (weighted)
+      fState[static_cast<std::size_t>(m)] += plogp(m_leafFlow[i]);
   }
-  double sum = 0.0;
+  if (!weighted) {
+    // rate == 1 everywhere, so sum_m (F_m^state - F_m^phys) telescopes and the
+    // per-module split is pure noise — kept as the two global sums it has always
+    // been, since the summation order is part of the reported number.
+    double sum = 0.0;
+    for (const auto& kv : physFlowMap)
+      sum += plogp(kv.second);
+    return m_cState - sum;
+  }
+  std::vector<double> fPhys(rates.size(), 0.0);
   for (const auto& kv : physFlowMap)
-    sum += plogp(kv.second);
-  return m_cState - sum;
+    fPhys[static_cast<std::size_t>(kv.first >> 32)] += plogp(kv.second);
+  double total = 0.0;
+  for (std::size_t m = 0; m < rates.size(); ++m)
+    total += rates[m] * (fState[m] - fPhys[m]);
+  return total;
 }
 
 void MemCorrection::setUnits(const std::vector<int>& leafToUnit, int numUnits)

--- a/src/core/ColumnarMapEquation.h
+++ b/src/core/ColumnarMapEquation.h
@@ -26,6 +26,13 @@ namespace infomap {
 class InfoNode;
 class ColumnarTwoLevel;
 
+// Defined in ColumnarObjectiveScore.cpp, where both the stack scorers and
+// ColumnarTwoLevel::buildStackTerms live. Only ever named as a return type here,
+// so the incomplete declaration is enough and this header stays free of it.
+namespace columnar {
+  struct StackTerms;
+}
+
 /**
  * A composable correction on top of the base columnar map equation.
  *
@@ -213,6 +220,21 @@ public:
   // The leaf's current bottom (level-1) module id.
   int hierLeafModule(int leaf) const { return m_hierAssign[0][leaf]; }
   double leafFlow(int leaf) const { return m_leafFlow[leaf]; }
+
+  // Per level-1 module: the rate at which the ACTIVE base objective's leaf-module
+  // term consumes that module's F_m = sum_{leaf in m} plogp(leafFlow).
+  //
+  // Only corrections that SUBSTITUTE one F for another need this — today just
+  // MemCorrection, which replaces the state-node F by the physical-node F. An
+  // additive correction carrying its own rate (Meta, Bias, Preferred) composes
+  // with either objective unweighted and must not call this.
+  //
+  // Returns EMPTY when the rate is uniformly 1, which is the base map equation's
+  // whole leaf-module level — so the caller keeps its unweighted arithmetic
+  // verbatim rather than multiplying by a vector of ones (the summation order is
+  // part of the reported number). Non-empty only under L*, where the rate is
+  // nrLeafCodebookRate(flow, enter, exit) >= 1 and differs per module.
+  std::vector<double> leafCodebookRates() const;
 
   // Build the leaf level (flow, enter/exit, out+in CSR) from the leaf network.
   void buildFromLeaves(const std::vector<InfoNode*>& leafNodes, bool undirected, unsigned long seed);
@@ -599,6 +621,12 @@ private:
   // codelength (0 for the base objective, i.e. no corrections).
   double objectiveCorrection() const;
 
+  // The levels, assignments and teleport-augmented boundary rates a stack scoring
+  // reads, resolved once. The single source of truth for the recorded-teleportation
+  // augmentation: hierarchicalCodelengthFromStack and leafCodebookRates both go
+  // through it, so no consumer can re-derive a module's enter/exit differently.
+  columnar::StackTerms buildStackTerms() const;
+
   // --- The leaf network and the active level ---
   // Both are read-only for the whole search: nothing writes into a level's
   // columns after it is built (aggregation produces a *new* level). The leaf
@@ -856,14 +884,37 @@ private:
 /**
  * Memory objective (state / higher-order networks): the leaf-module codebook is
  * over PHYSICAL nodes, not state nodes — state nodes of the same physical node
- * in the same module share a codeword (their flows sum). Working the
- * T-normalized module term out, the module-flow*log(T) parts cancel between the
- * state and physical versions, leaving a correction to the base (state-node)
- * codelength of  C_state - sum_{module,phys} plogp(physFlow),  where
- * C_state = sum_leaf plogp(stateFlow) is a constant and physFlow is the summed
- * state flow of a physical node within a module. Leaf-module level only
- * (module-of-modules delegates to base). Same O(1) move-loop hook as Meta with
- * attribute = physical node id — the case the hook is designed for.
+ * in the same module share a codeword (their flows sum).
+ *
+ * This is a SUBSTITUTION, not an additive term, and that distinction is the whole
+ * subtlety. Both base objectives read the leaf flows of a level-1 module only
+ * through F_m = sum_{leaf in m} plogp(leafFlow), linearly; the physical codebook
+ * is the same objective with F_m^state replaced by F_m^phys = sum_phys
+ * plogp(physFlow). So the correction is  sum_m rate_m * (F_m^state - F_m^phys),
+ * where rate_m is the rate at which the ACTIVE objective consumes F_m — and the
+ * two objectives do not agree on it:
+ *
+ *  - Base map equation: the T-normalized module term collapses to
+ *    plogp(T) - plogp(qExit) - F_m (the module-flow*log(T) parts cancel between
+ *    the state and physical versions), so rate_m == 1 for every module and the
+ *    whole correction telescopes into two global sums,
+ *    C_state - sum_{module,phys} plogp(physFlow), with C_state = sum_leaf
+ *    plogp(stateFlow) a constant.
+ *  - L* (--non-redundant): the module codebook is SPLIT into an enter codebook
+ *    normalized by moduleFlow and a within codebook normalized by
+ *    T = moduleFlow + qExit, and F_m is charged against both. rate_m is then
+ *    nrLeafCodebookRate() = 1 + qEnter*qExit/(flow*(flow+qExit)) >= 1, varying per
+ *    module, and the flat coefficient-1 correction under-subtracts a non-positive
+ *    quantity (plogp is superadditive under splitting, so F^state <= F^phys) —
+ *    i.e. it reports L* too HIGH, which broke invariance under exactly lumpable
+ *    state duplication (#1009).
+ *
+ * hierarchicalCorrection therefore asks the core for leafCodebookRates(): empty
+ * under the base objective, where it keeps the two-global-sums form verbatim, and
+ * per-module under L*. Leaf-module level only (module-of-modules delegates to
+ * base; neither objective reads leaf flows above level 1). Same O(1) move-loop
+ * hook as Meta with attribute = physical node id — the case the hook is designed
+ * for; those deltas stay base-flavoured on purpose (see --non-redundant-exact).
  */
 class MemCorrection final : public ColumnarCorrection {
 public:

--- a/src/core/ColumnarObjective.h
+++ b/src/core/ColumnarObjective.h
@@ -172,6 +172,35 @@ namespace columnar {
     return tEnter + tWithin;
   }
 
+  // The rate at which nrEnterWithin consumes F -- i.e. -d(nrEnterWithin)/dF.
+  //
+  // nrEnterWithin is affine in F, so this is exact:
+  //   nrEnterWithin(f, e, x, F2) - nrEnterWithin(f, e, x, F1)
+  //     == -nrLeafCodebookRate(f, e, x) * (F2 - F1).
+  // Closed form: 1 + qEnter*qExit / (moduleFlow * (moduleFlow + qExit)) >= 1, with
+  // equality iff qEnter == 0 or qExit == 0 (both hold for a one-module partition).
+  //
+  // Why this exists: a correction that SUBSTITUTES one F for another inside the
+  // leaf-module codebook -- MemCorrection swaps the state-node F for the
+  // physical-node F -- has to charge the substitution at whatever rate the active
+  // objective consumes F. The base map equation's leaf-module term consumes it at
+  // exactly 1 (see scoreStackBase, where the T-normalized module term collapses to
+  // plogp(T) - plogp(qExit) - F); L* does not, because it splits that codebook into
+  // an enter codebook normalized by moduleFlow and a within codebook normalized by
+  // T = moduleFlow + qExit. Keep this next to nrEnterWithin: the two must move
+  // together, and the 1e-16 guards below mirror it exactly (a module the scorer
+  // skips consumes no F at all, so its rate is 0, not 1).
+  inline double nrLeafCodebookRate(double moduleFlow, double qEnter, double qExit)
+  {
+    if (moduleFlow < 1e-16)
+      return 0.0; // nrEnterWithin returns 0.0 here: F never enters the total
+    double rate = qEnter / moduleFlow; // from tEnter
+    const double T = moduleFlow + qExit;
+    if (T > 1e-16)
+      rate += (moduleFlow + qExit - qEnter) / T; // from tWithin
+    return rate;
+  }
+
   // One module's leave-one-out exit codebook contribution, given the sibling
   // enter-rate total-plus-exit-network sumEnterPlusE = (sum_b qEnter_b) + e and
   // sumEnterLogEnter = sum_b plogp(qEnter_b); e is the exit-to-parent codeword.

--- a/src/core/ColumnarObjectiveScore.cpp
+++ b/src/core/ColumnarObjectiveScore.cpp
@@ -28,7 +28,7 @@ namespace infomap {
 
 using namespace columnar;
 
-namespace {
+namespace columnar {
 
   /**
    * Everything a stack scoring reads, resolved once per call.
@@ -38,6 +38,11 @@ namespace {
    * rather than a branch inside one long function. `enter`/`exit` return the
    * boundary rates with recorded teleportation already folded in, so neither
    * scorer has to know whether the flow model records teleportation.
+   *
+   * Namespace scope rather than this file's anonymous namespace only so that
+   * ColumnarTwoLevel::buildStackTerms can name it as a return type: the struct
+   * and every consumer still live in this translation unit alone, and the header
+   * only forward-declares it.
    */
   struct StackTerms {
     const ColumnarLevel& leaves; // level 0
@@ -56,6 +61,10 @@ namespace {
     double enter(int k, int m) const { return level(k).enter[m] + (tele ? teleEnter[k][m] : 0.0); }
     double exit(int k, int m) const { return level(k).exit[m] + (tele ? teleExit[k][m] : 0.0); }
   };
+
+} // namespace columnar
+
+namespace {
 
   /**
    * The base map equation over the stack: every internal node codes its children.
@@ -199,7 +208,7 @@ namespace {
 
 } // namespace
 
-double ColumnarTwoLevel::hierarchicalCodelengthFromStack() const
+StackTerms ColumnarTwoLevel::buildStackTerms() const
 {
   const int topLevel = static_cast<int>(m_hierLevels.size()) - 1; // >= 1
 
@@ -235,8 +244,37 @@ double ColumnarTwoLevel::hierarchicalCodelengthFromStack() const
     }
   }
 
+  return terms;
+}
+
+double ColumnarTwoLevel::hierarchicalCodelengthFromStack() const
+{
+  const StackTerms terms = buildStackTerms();
   const double base = m_nonRedundant ? scoreStackNonRedundant(terms) : scoreStackBase(terms);
   return base + objectiveCorrection();
+}
+
+std::vector<double> ColumnarTwoLevel::leafCodebookRates() const
+{
+  // Empty = the uniform rate 1 of the base objective (see the header). Reusing
+  // buildStackTerms is the point: the recorded-teleportation augmentation folded
+  // into enter/exit is computed in exactly one place, so a correction cannot charge
+  // its substitution against boundary rates the scorer never used. Re-deriving them
+  // here from the link-only enter/exit would be silently wrong on every flow model
+  // that records teleportation, and right everywhere it is easy to test.
+  //
+  // Cost: O(1) on top of the scoring, except under recorded teleportation, where the
+  // second buildStackTerms repeats the teleport preamble's pass over the leaves. That
+  // is the cold (per-candidate-structural-operator) path; if it ever matters, thread
+  // the already-built terms through objectiveCorrection() instead.
+  if (!m_nonRedundant || m_hierLevels.size() < 2)
+    return {};
+  const StackTerms terms = buildStackTerms();
+  const ColumnarLevel& L1 = terms.level(1);
+  std::vector<double> rates(static_cast<std::size_t>(L1.n));
+  for (int m = 0; m < L1.n; ++m)
+    rates[static_cast<std::size_t>(m)] = nrLeafCodebookRate(L1.flow[m], terms.enter(1, m), terms.exit(1, m));
+  return rates;
 }
 
 double ColumnarTwoLevel::objectiveCorrection() const

--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -210,9 +210,21 @@ namespace {
     // from the one just entered — which is orthogonal to which codebook a step is
     // coded in. Higher-order dynamics (the state/physical codebook) and every
     // composable correction (metadata, entropy bias, preferred module count, lossy)
-    // therefore compose with it: they are additive terms that
-    // ColumnarTwoLevel::objectiveCorrection() sums on top of whichever base
-    // objective is selected, and the L* base is selected the same way as any other.
+    // therefore compose with it, through
+    // ColumnarTwoLevel::objectiveCorrection(), which sums them on top of whichever
+    // base objective is selected.
+    //
+    // "Composes" is not the same as "is objective-independent", and conflating the
+    // two is what let #1009 through. A correction that ADDS a term carrying its own
+    // rate — metadata (charged per unit of node-visit flow), entropy bias (a node
+    // count), preferred module count — contributes the identical number under L and
+    // under L*. A correction that SUBSTITUTES one quantity for another inside a base
+    // codebook term — MemCorrection, which swaps the state-node
+    // sum plogp(leafFlow) for the physical-node one — inherits that term's
+    // coefficient, and L* charges it at a per-module rate >= 1 rather than at 1. Such
+    // a correction must ask the core which objective is active (see
+    // ColumnarTwoLevel::leafCodebookRates); adding it blind is a bug, not a
+    // composition.
     //
     // Earlier cuts of this option rejected memory/multilayer input, meta data,
     // --entropy-corrected and --lossy. Those rejections were wrong in kind, not merely

--- a/test/cpp/test_non_redundant_columnar.cpp
+++ b/test/cpp/test_non_redundant_columnar.cpp
@@ -1,7 +1,11 @@
 #include "TestUtils.h"
+#include "core/ColumnarObjective.h"
 #include "io/Config.h"
 
 #include <cstdio>
+#include <map>
+#include <string>
+#include <vector>
 
 // The non-redundant map equation L* on the columnar (non-recursive) engine. L* is a
 // base-objective variant of ColumnarTwoLevel (not a composable correction): it
@@ -30,6 +34,69 @@ double scoreFixedPartition(const std::string& network, const std::string& cluste
 {
   InfomapWrapper im(defaultFlags(flags + " --no-infomap --cluster-data " + clusterFixturePath(cluster)));
   im.readInputData(networkFixturePath(network));
+  im.run();
+  return im.codelength();
+}
+
+struct RingLink {
+  unsigned int source;
+  unsigned int target;
+  double weight;
+};
+
+// k triangles in a ring: triangle i on nodes 3i+1, 3i+2, 3i+3, its last node
+// linked on to the next triangle's first. k = 2 is the canonical two-module
+// network; larger k gives the multi-module case.
+std::vector<RingLink> ringOfTriangles(unsigned int k)
+{
+  std::vector<RingLink> links;
+  for (unsigned int i = 0; i < k; ++i) {
+    const unsigned int a = 3 * i + 1;
+    links.push_back({ a, a + 1, 1.0 });
+    links.push_back({ a + 1, a + 2, 1.0 });
+    links.push_back({ a + 2, a, 1.0 });
+    links.push_back({ a + 2, 3 * ((i + 1) % k) + 1, 1.0 });
+  }
+  return links;
+}
+
+// Score the one-triangle-per-module partition of ringOfTriangles(k), either on the
+// physical network (copies == 1) or on an exactly lumpable STATE duplication of it:
+// every physical node becomes `copies` state nodes and every link's weight is spread
+// evenly over the copies x copies state pairs.
+//
+// That construction leaves the dynamics alone. Each state of u carries 1/copies of
+// u's flow and u's conditional next-step law, so the state walk projects exactly
+// onto the walk on the physical network, and the lifted partition keeps every
+// physical node's states together in one module. Nothing describable has changed, so
+// the codelength must not change either -- under L* exactly as under L.
+double scoreRingOfTriangles(unsigned int k, unsigned int copies, const std::string& flags)
+{
+  const unsigned int n = 3 * k;
+  const auto links = ringOfTriangles(k);
+  InfomapWrapper im(defaultFlags(flags + " --two-level --no-infomap"));
+  std::map<unsigned int, unsigned int> partition;
+  if (copies == 1) {
+    for (const auto& link : links)
+      im.addLink(link.source, link.target, link.weight);
+    for (unsigned int u = 1; u <= n; ++u)
+      partition[u] = (u - 1) / 3 + 1;
+  } else {
+    for (unsigned int u = 1; u <= n; ++u) {
+      for (unsigned int c = 0; c < copies; ++c) {
+        im.addStateNode(u + c * n, u);
+        partition[u + c * n] = (u - 1) / 3 + 1;
+      }
+    }
+    const double share = 1.0 / static_cast<double>(copies * copies);
+    for (const auto& link : links) {
+      for (unsigned int cs = 0; cs < copies; ++cs) {
+        for (unsigned int ct = 0; ct < copies; ++ct)
+          im.addLink(link.source + cs * n, link.target + ct * n, link.weight * share);
+      }
+    }
+  }
+  im.setInitialPartition(partition);
   im.run();
   return im.codelength();
 }
@@ -86,15 +153,23 @@ TEST_CASE("NonRedundant/columnar: higher-order input runs under L* [fast][core][
   }
 }
 
-TEST_CASE("NonRedundant/columnar: a correction adds the same term under L* as under L [fast][core][non-redundant]")
+TEST_CASE("NonRedundant/columnar: an ADDITIVE correction adds the same term under L* as under L [fast][core][non-redundant]")
 {
-  // This is what "L* supports every correction" actually asserts, and it is a claim
-  // about where corrections enter rather than about L*: they are additive terms that
-  // ColumnarTwoLevel::objectiveCorrection() sums on top of whichever base objective is
-  // selected. On a FIXED partition, therefore, the term a correction contributes must be
-  // identical under both bases — nothing in it can depend on the codebook structure the
-  // base objective chose. Both arms run on the columnar engine so the comparison isolates
-  // the base objective and nothing else.
+  // What "L* supports every correction" asserts for the corrections that ADD a term
+  // carrying their own rate. Metadata is one: its term is metaDataRate * sum_m F_m*H_m,
+  // a separate codebook consulted once per unit of node-visit flow in the module, and L*
+  // changes which codebook names a node, not how often a node is visited. So on a FIXED
+  // partition the metadata term is identical under both bases. Same for the entropy bias
+  // (a node count) and the preferred module count.
+  //
+  // It does NOT generalize to every correction, and reading it as if it did is what let
+  // #1009 through: MemCorrection SUBSTITUTES the physical-node sum plogp(flow) for the
+  // state-node one inside the base objective's own leaf-module term, so it inherits that
+  // term's coefficient — 1 under the base map equation, >= 1 and per-module under L*.
+  // The invariance test below is the one that pins that down.
+  //
+  // Both arms run on the columnar engine so the comparison isolates the base objective
+  // and nothing else.
   const std::string net = "twotriangles_flow.net";
   const std::string clu = "twotriangles_two_modules.clu";
   const std::string meta = " --meta-data " + fixturePath("meta/twotriangles.meta");
@@ -140,6 +215,65 @@ TEST_CASE("NonRedundant/columnar: hierarchical L* on a multilevel fixed partitio
   // level contributes a zero enter codebook and zero-Z exit codebooks.
   const double Lstar3 = scoreFixedPartition("twotriangles_flow.net", "twotriangles_three_level.tree", "--non-redundant");
   CHECK(Lstar3 == doctest::Approx(1.983611049901).epsilon(1e-9));
+}
+
+TEST_CASE("NonRedundant/columnar: L* is invariant under exactly lumpable state duplication [fast][core][non-redundant]")
+{
+  // The regression test for #1009. Splitting a physical node into states that are
+  // indistinguishable to the walker, with the partition lifted so no physical node is
+  // split across modules, describes the same process with the same modules — so both
+  // objectives must report the same codelength. L always did; L* did not, because
+  // MemCorrection substituted the physical-node sum plogp(flow) for the state-node one
+  // at coefficient 1 (right for the base map equation) while L*'s leaf-module term
+  // consumes it at nrLeafCodebookRate() >= 1. The substituted quantity is non-positive,
+  // so the error was always positive and grew with the number of physical nodes holding
+  // several states in one module: +0.050 bits here undirected, +0.026 directed.
+  //
+  // Undirected, PageRank-directed and rawdir all run: the rate is 1 + qEnter*qExit /
+  // (flow*(flow+qExit)), so it is only the undirected case that has qEnter == qExit.
+  for (const std::string& flow : { std::string(""), std::string(" --directed"), std::string(" --flow-model rawdir") }) {
+    for (unsigned int k : { 2u, 5u }) { // two modules, then multi-module
+      CAPTURE(flow);
+      CAPTURE(k);
+      // Control: the base objective was already invariant, so a failure here means the
+      // duplication was built wrong, not that the objective is wrong.
+      const double L = scoreRingOfTriangles(k, 1, "--columnar" + flow);
+      const double Ldup = scoreRingOfTriangles(k, 2, "--columnar" + flow);
+      CHECK(Ldup == doctest::Approx(L).epsilon(1e-12));
+
+      const double Lstar = scoreRingOfTriangles(k, 1, "--non-redundant" + flow);
+      const double LstarDup = scoreRingOfTriangles(k, 2, "--non-redundant" + flow);
+      CHECK(LstarDup == doctest::Approx(Lstar).epsilon(1e-12));
+      CHECK(Lstar < L); // L* is the cheaper description of the same partition
+    }
+  }
+
+  // Goldens on the physical arm, so the pair cannot pass by both sides moving together.
+  CHECK(scoreRingOfTriangles(2, 1, "--non-redundant") == doctest::Approx(2.361270125569452).epsilon(1e-9));
+  CHECK(scoreRingOfTriangles(5, 1, "--non-redundant") == doctest::Approx(2.861270125569453).epsilon(1e-9));
+}
+
+TEST_CASE("NonRedundant/columnar: nrLeafCodebookRate is the rate nrEnterWithin consumes F at [fast][core][non-redundant]")
+{
+  // The two must move together: MemCorrection weights its substitution by
+  // nrLeafCodebookRate while the scorer charges F through nrEnterWithin, and nothing
+  // else ties them. nrEnterWithin is affine in F, so the identity below is exact.
+  using namespace infomap::columnar;
+  const double flow[] = { 0.5, 0.25, 1.0, 1e-17 };
+  const double enter[] = { 0.0, 0.05, 0.3 };
+  const double exit[] = { 0.0, 0.05, 0.4 };
+  for (double f : flow) {
+    for (double e : enter) {
+      for (double x : exit) {
+        const double rate = nrLeafCodebookRate(f, e, x);
+        const double dF = nrEnterWithin(f, e, x, 0.75) - nrEnterWithin(f, e, x, 0.25);
+        CHECK(dF == doctest::Approx(-rate * 0.5).epsilon(1e-12));
+        // >= 1 unless the module is degenerate (no flow) or has no boundary in one
+        // direction, which is what makes the old flat coefficient 1 an under-charge.
+        CHECK(rate >= (f < 1e-16 ? 0.0 : 1.0 - 1e-12));
+      }
+    }
+  }
 }
 
 TEST_CASE("NonRedundant/columnar: hierarchical search produces a sound, self-consistent L* [fast][core][non-redundant]")


### PR DESCRIPTION
Fixes #1009.

`-C --non-redundant` on state / memory / multilayer input reported L\* **too high**, by an amount that grew with the number of physical nodes holding several state nodes inside one module. `L` was unaffected.

## The invariance that broke

Split every physical node into state nodes the walker cannot distinguish, spreading each link's weight over the state pairs, and lift the partition so no physical node is split across modules. Every state of `u` then carries a share of `u`'s flow and `u`'s conditional next-step law, so the state walk projects exactly onto the physical walk. Same process, same modules, no new describable event — the codelength must not move. `L` never did. `L*` did:

| case | L (before = after) | L\* before | L\* after | error removed |
|---|--:|--:|--:|--:|
| two triangles, all 6 nodes ×2 | 2.320730356834 | 2.145875734724 | 2.128018591867 | +0.017857142857 (= 1/56) |
| two triangles, node 3 only ×2 | 2.320730356834 | 2.131845122479 | 2.128018591867 | +0.003826530612 (= 3/784) |
| ninetriangles, all 27 nodes ×2 | 3.572285805615 | 3.465711933541 | 3.392635010464 | +0.073076923077 |
| two triangles, directed (`rawdir`), all ×2 | 1.899533374666 | 1.844312916393 | 1.841584741790 | +0.002728174603 |
| `jazz.net`, 30 of its nodes ×2 | 6.861229774904 | 6.841080565212 | 6.836565239276 | +0.004515325936 |
| `jazz.net`, 78 of its nodes ×2 | 6.861229774904 | 6.855445280017 | 6.836565239276 | +0.018880040741 |

(`jazz.net` is `examples/notebooks/data/jazz.net`; "×2" means those physical nodes lifted to two indistinguishable states each, the rest left alone — i.e. the partial-duplication case.)

Every "after" now equals the **physical** network's own L\* for the same partition to `<= 9e-14` (two triangles 2.128018591867112, ninetriangles 3.392635010464057, jazz 6.836565239275705) — the invariance stated as an equation rather than as a delta.

## Cause: additive terms compose, substitutions inherit

Both stack scorers read a level-1 module's leaf flows only through `F_m = sum_{leaf in m} plogp(flow)`, linearly. `MemCorrection` is not a term added beside them — it is the same objective with `F_m^state` replaced by `F_m^phys`, i.e. a **substitution**, and a substitution is charged at whatever rate the surrounding term consumes `F_m`. The two objectives disagree:

- `scoreStackBase`'s level-1 block collapses algebraically to `plogp(T) - plogp(qExit) - F_m` with `T = moduleFlow + qExit`. Coefficient of `F_m`: exactly **1**.
- `nrEnterWithin` charges `-qEnter*F/moduleFlow` from its enter half and `-(usage/T)*F` from its within half. Coefficient: `1 + qEnter*qExit/(moduleFlow*(moduleFlow+qExit))`, i.e. **>= 1**, equal to 1 only when `qEnter == 0` or `qExit == 0`.

The correction used 1 for both. `plogp` is superadditive under splitting, so `F^state - F^phys <= 0`; charging a non-positive quantity at 1 instead of at `rate >= 1` **under-subtracts**, which is exactly the always-positive error observed. The sign was the confirmation before a line was written.

`src/io/Config.cpp` justified composing every correction with L\* on the grounds that they are additive terms `objectiveCorrection()` sums on top of whichever base objective is selected. True of the *value* for metadata / entropy bias / preferred module count, whose terms carry their own objective-independent rate. False for `MemCorrection` — and that comment is the reasoning that let this through, so it is corrected here too.

## The fix

`ColumnarTwoLevel::leafCodebookRates()` reports the active objective's per-module rate; `MemCorrection::hierarchicalCorrection` returns `sum_m rate_m * (F_m^state - F_m^phys)`. It returns **empty** under the base objective, where the rate is uniformly 1, so that path keeps its two global sums and its exact summation order rather than being multiplied by a vector of ones.

The rates have to be the enter/exit the scorer actually used, **recorded-teleportation augmentation included** — re-deriving them from the link-only rates would be silently wrong on exactly the flow models (`--regularized`, `--recorded-teleportation`) where nothing else would flag it. So the teleport preamble is extracted into `ColumnarTwoLevel::buildStackTerms()`, consumed by both `hierarchicalCodelengthFromStack()` and `leafCodebookRates()` rather than written twice. `StackTerms` moves out of the anonymous namespace into `infomap::columnar`; the header only forward-declares it, so nothing new is included anywhere.

## The base objective is bit-identical

Not "within 1e-12" — `delta == 0.0`. 12 `-C` configs run on the pre-fix binary and this one: jazz `-N20` (two-level and hierarchical), ninetriangles (both), the `states.net` / `states_flow.net` / `multilayer.net` fixtures (both), a `--directed --recorded-teleportation` config, and a 54-state exactly-lumpable duplication of ninetriangles (both). All 12 reproduce exactly.

Also unmoved: jazz `-C --two-level -N20` = 6.861229774903977 and `-C --non-redundant --two-level -N20` = 6.817184613565288 — the physical L\* does not move, only the higher-order one.

## Tests

`test/cpp/test_non_redundant_columnar.cpp` builds the physical and the duplicated network from one edge list in-process — undirected, `--directed` and `--flow-model rawdir`, two-module and multi-module — asserting both `L` (the control that the construction is right) and `L*`, plus goldens on the physical arm so the pair cannot pass by both sides moving together. It fails on all six L\* assertions without the fix. A second case pins the identity `nrEnterWithin(f,e,x,F2) - nrEnterWithin(f,e,x,F1) == -nrLeafCodebookRate(f,e,x) * (F2 - F1)`, the only thing tying the coefficient to the scorer.

31/31 tests pass in all three build configurations (`OPENMP=0`, `OPENMP=1`, `FEATURES="lossy-map-equation regularized-multilayer"`). Clean build under `-Wall -Wextra -pedantic -Wshadow`, no new warnings.

## Randomized sweep beyond the committed tests

The committed tests are six hand-built cases; the claim they stand for was checked much more widely before this was proposed for review. Networks of 10–60 nodes, densities 0.08–0.45, random partitions into 2–8 modules, unequal (Dirichlet) flow splits, 1–4 states per node, partial duplication of 30/60/100% of the nodes, and deliberate zero-flow states.

- **Lumping invariance, 700 cases** across `undirected`, `rawdir`, `directed`, `directed --recorded-teleportation`, `undirdir`, `outdirdir`: max `|L*_phys − L*_state|` = **3.97e-12**, on the recorded-teleportation model whose *base-`L`* control on the same cases is 3.39e-12 — same magnitude, so the residual is the flow solver's power iteration, not the objective. Every non-teleporting model sits at 1e-14 for both objectives. The identical corpus on the pre-fix binary produces **533 failures with errors up to 0.594 bits**, so it discriminates rather than being a tautology.
- **Deeper hierarchies:** 3, 4 and 5 module levels via `-c <tree>`. Invariance ≤ 1.2e-14, and agreement with an independently written multi-level reference implementation of both scorers ≤ 1.3e-14. Pre-fix binary on the same 3-level corpus: 180 failures, max 0.539. This is also the empirical confirmation that leaf flows enter only at level 1, i.e. that the correction is a level-1-only object.
- **Partitions that split a physical node across modules** — where there is no invariance to appeal to, so the *value* is what is being checked: 60 partitions that ignore physical identity, plus a case placing one node's three states in three sibling level-1 modules. Agreement with the reference implementation ≤ 1.3e-14; the pre-fix binary is wrong by up to 0.135 there. The fix does **not** wrongly force equality off the lumpable manifold.
- **Degenerate inputs**, all finite and matching the physical arm or the reference to ≤ 1e-14: one module (`L == L*` exactly), singletons per state and per physical node, zero-flow states, a `rawdir` module of pure source states (`moduleFlow == 0`, `qExit > 0` — the rate-0 guard mirrors `nrEnterWithin` dropping the whole term), disconnected components, non-contiguous cluster ids, a `.clu` missing some states, flow splits as skewed as `1e-13`, and 10 states per node.
- **Regression breadth beyond the 12 bit-identity configs:** 624 base-objective runs (24 networks × 6 configs, plus 80 random networks × 3 configs) and 360 physical-network L\* runs (including `--non-redundant-exact`) compared with `==` on `(codelength, numTopModules, numLevels)`. **Zero differences**, including a 40k-state / 240k-link network.
- **Cost, measured** (the fix's own open question): 40k-state / 240k-link network, `-C --non-redundant -d --recorded-teleportation -N3` — the configuration that actually runs the teleport preamble twice — three repeats each, pre-fix 5.61/5.65/5.58 s vs 5.61/5.63/5.61 s; `-N1` 1.78 vs 1.77 s. No measurable cost.

Caveat on independence: the reference implementation is an independent *implementation* but shares the *definition* with the code it checks, so it cannot test "the physical-node codebook is the wrong model for L\*". What tests the definition is the invariance against the physical arm, which runs with no `MemCorrection` attached at all — that is the check that fails 533 times before the fix.

## Checked and deliberately not changed

- **`MetaCorrection` is correct at coefficient 1.** Its term is a separate codebook charged per unit of node-visit flow; L\* changes which codebook names a node, not how often a node is visited. Its test stays green, and its comment now says which *class* of correction it speaks for instead of implying all of them.
- **The leaf move loop stays base-flavoured** under L\* by design (`--non-redundant-exact` documents it: L\* drives the structural search, the base objective drives the move arithmetic), so `MemCorrection`'s O(1) `initMoveLoop`/`moveDelta`/`applyMove`/`mergeDelta` keep coefficient 1.
- **`LossyCorrection` has the same defect in kind** — it re-adds `sum plogp(f_i)` at +1 to cancel what the base charged at −1 — but it is not a mechanical re-weighting (`l_m` is normalized by `F_m`, not by `T`) and it is feature-gated. Recorded in F37 and filed as #1011 for a separate PR with its own derivation. Not exercised here: this build has no `FEATURES`, so `--lossy` could not be run.

## Pre-existing defects found next to this one, filed not fixed

Both were found while checking the blast radius; both predate this branch and neither is touched here.

- **#1012 — `--meta-data` on a state network silently drops the physical-node codebook.** `addColumnarCorrections` attaches the two as alternatives (`if (haveMetaData()) … else if (haveMemory())`), so the memory objective is not merely mis-weighted in that configuration, it is absent. **This bounds the present PR:** `-C --non-redundant --meta-data` on higher-order input returns the same number before and after this fix, because no `MemCorrection` is attached to re-weight. The object-oriented engine behaves identically, so it is not a columnar regression.
- **#1013 — ragged cluster data reports the base codelength under `--non-redundant`.** `evaluateColumnarPartition` falls back to `calcCodelengthOnTree`, which is the object-oriented base objective, and the two objectives then agree to the last digit. The same flavour applies to the one-level fallback in `runPartition` and to the per-level codelength table in the console and in `-o json`. None of these affect the top-level reported codelength on the ordinary search path.

## Perf snapshot: one gap, flagged rather than hidden

`--non-redundant` on higher-order input **changes value and search trajectory by construction**, so the four higher-order rows of the L\* table (`multilayer (ex.)`, `malaria`, `air30k`, `air30k (reg.)`) must be re-measured. They could not be redone in the session that made the fix: `networks/` is not present in that checkout. Those cells are marked **STALE** in `columnar_wip/columnar-pr-performance-section.md` rather than left looking current. `multilayer (ex.)` *was* re-measured and is unchanged (1.928856578, 2 modules, 2 levels) — its optimum puts no physical node's states in one module, so the correction is zero either way.

Direction of the change, from what was available: a 54-state lumpable duplication of ninetriangles under `-C --non-redundant` goes 3.226345721211 → 3.153268798134 (hierarchical, top 3 / 3 levels both ways) and 3.465711933541 → 3.392635010464 (`--two-level`, 9 modules both ways).

**Whether the changed trajectory finds better partitions.** The two binaries' reported numbers are not comparable — the old scale is the wrong one — so both searches' `.tree` outputs were re-scored with the fixed binary. 60 random state networks × {`--two-level`, hierarchical}, `-N10 --seed 5`: the new search is **better in 27, worse in 2, identical in 91**; best improvement +0.0737 bits, worst regression −0.0088 bits (both regressions hierarchical, i.e. heuristic-trajectory noise at one seed, not a quality claim in either direction). On the lumpable ninetriangles duplication the old partition scores 3.363097097533 under the corrected objective and the new one scores 3.344509477481 — **exactly the physical network's optimum**, 7 modules → 9 modules.

Cost: one O(K) pass over level-1 modules per stack scoring, plus (under recorded teleportation only) a second run of the teleport preamble's pass over the leaves — the cold, per-candidate-structural-operator path, and only when a `MemCorrection` is attached under L\*. The per-candidate move arithmetic is untouched.

Finding recorded as **F37** in `columnar_wip/columnar-rethink-notes.md`.
