### PR TITLE
fix: score the flat-shortcut tree, and drop the dead --lossy input guard (#1002, #1004)

### DIFF
--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1562,7 +1562,22 @@ InfomapBase& InfomapBase::initTree(const NodePaths& tree)
       const auto clusterId = nodePath.second[0]; // First level module
       clusterIds[nodeId] = clusterId;
     }
-    return initPartition(clusterIds, false);
+    initPartition(clusterIds, false);
+    // Score the tree for the side effect only. initPartition updates the objective's
+    // aggregate bookkeeping but writes no InfoNode::codelength, so without this the
+    // shortcut leaves every module holding whatever it held before -- 0 on a fresh
+    // instance, or a stale value from an earlier, deeper trial on a reused one. The
+    // deep branch below already ends in this same call, and the fields it writes are
+    // read by the per-level table and by "codelength" per module in the JSON output.
+    // restoreBestResult re-materializes a best-of-N winner through here and rewrites
+    // the output file, so a flat winner used to land zeros in the rewritten JSON.
+    // The return value is deliberately dropped: initPartition has just set
+    // m_hierarchicalCodelength from getCodelength(), which is what restoreBestResult
+    // reports, and for the biased objective the sum over nodes need not agree with the
+    // search bookkeeping to the last digit. Side effect only means no reported number
+    // moves -- verified bit-identical over the benchmark set.
+    calcCodelengthOnTree(root(), true);
+    return *this;
   }
 
   // Tear down the existing partition. Detach the leaves first so that the

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1576,6 +1576,14 @@ InfomapBase& InfomapBase::initTree(const NodePaths& tree)
     // reports, and for the biased objective the sum over nodes need not agree with the
     // search bookkeeping to the last digit. Side effect only means no reported number
     // moves -- verified bit-identical over the benchmark set.
+    //
+    // It does cost one extra pass on --no-infomap with cluster data, where executeTrial
+    // scores the tree again: web-NotreDame with a flat 325k-leaf tree goes 1.45-1.46s ->
+    // 1.47-1.49s, +1.4%, while the same run with a deep tree is unchanged because the
+    // branch below has always ended in this call. Every other caller either runs a search
+    // that dwarfs the pass or scores once, and the alternative -- threading an "already
+    // scored" flag from here into the trial loop -- buys back one pass on a path that
+    // runs no search, at the price of a stateful contract between the two.
     calcCodelengthOnTree(root(), true);
     return *this;
   }
@@ -3539,9 +3547,25 @@ void InfomapBase::initOptimizer(bool forceNoMemory)
   // flow model). Every input-derived constraint is validated here, because the input
   // type is not known at parse time: for memory and multilayer input this is the sole
   // check rather than a second line of defence, and it is also what catches meta-data
-  // dimensions and a directed flow model that came from the file rather than a flag
-  // (#1004). initOptimizer() is the objective dispatch point, so an embedder calling
-  // initNetwork directly is caught here too.
+  // dimensions read from the file (#1004). initOptimizer() is the objective dispatch
+  // point, so an embedder calling initNetwork directly is caught here too.
+  //
+  // The flow-model clause is narrower than it reads, and a directed edge list is not
+  // what reaches it: *Arcs under an undirected flow model is parsed as undirected and
+  // the model stays undirected. After parsing, flowModel is written by
+  // configureNetworkMode() and by the two config setters setDirected()/setFlowModel().
+  // configureNetworkMode() writes it only when the network was marked as directed input,
+  // which happens solely in multilayer expansion; that normally throws on the clause
+  // above instead, because expansion assigns state ids that differ from the physical
+  // ids, and gets past it only when the expanded map is identity, leaving
+  // haveMemoryInput() false so that neither setStateInput() nor setMultilayerInput()
+  // runs (fixture intra_identity_states.net). The setters reach this guard because
+  // adaptDefaults() runs while a Config is built from flags and never again: on a
+  // constructed instance nothing re-validates, so setDirected(true) and
+  // setFlowModel(directed) land here rather than at parse time. So does an embedder
+  // assigning flowModel on a Config directly, which leaves flowModelIsSet false and is
+  // invisible to adaptDefaults even in the Config-then-adaptDefaults order. All four
+  // routes are pinned in test_lossy.cpp.
   if (lossy) {
     if (haveMetaData() || haveMemory() || isMultilayerNetwork())
       throw std::runtime_error("--lossy does not support memory, multilayer or meta-data input");

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -3534,10 +3534,14 @@ void InfomapBase::initOptimizer(bool forceNoMemory)
   m_root.m_edgePool = &m_edgePool;
 
 #if INFOMAP_FEATURE_LOSSY_MAP_EQUATION
-  // Config::adaptDefaults validates --lossy against the parsed flags, but input
-  // parsing can flip state/multilayer input and auto-switch the flow model to
-  // directed afterwards. Re-validate here so lossy never silently falls through
-  // to another objective.
+  // Config::adaptDefaults validates the constraints decidable from the flags alone
+  // (teleportation, regularization, Markov time, --meta-data, an explicitly directed
+  // flow model). Every input-derived constraint is validated here, because the input
+  // type is not known at parse time: for memory and multilayer input this is the sole
+  // check rather than a second line of defence, and it is also what catches meta-data
+  // dimensions and a directed flow model that came from the file rather than a flag
+  // (#1004). initOptimizer() is the objective dispatch point, so an embedder calling
+  // initNetwork directly is caught here too.
   if (lossy) {
     if (haveMetaData() || haveMemory() || isMultilayerNetwork())
       throw std::runtime_error("--lossy does not support memory, multilayer or meta-data input");

--- a/src/io/Config.cpp
+++ b/src/io/Config.cpp
@@ -183,8 +183,20 @@ namespace {
 
     if (config.directed || (config.flowModelIsSet && config.flowModel != FlowModel::undirected))
       throw std::runtime_error("--lossy requires undirected flow");
-    if (config.stateInput || config.multilayerInput || !config.additionalInput.empty())
-      throw std::runtime_error("--lossy does not support memory or multilayer networks");
+    // No input check here, deliberately. This function runs during flag parsing, before
+    // any file is opened: `stateInput`/`multilayerInput` are set by
+    // configureNetworkMode() when the network is READ, and no CLI option sets them
+    // (`additionalInput` is library-only -- a SWIG property with no CLI binding). An
+    // earlier cut rejected those three fields here and could never fire from the CLI.
+    // The rejection that actually fires is in InfomapBase::initOptimizer(), where the
+    // input type is known; it covers everything this did, plus meta data. Two things it
+    // is worth being precise about rather than calling it a strict superset: a *States
+    // file is rejected there iff its state->physical map is non-identity, since
+    // StateNetwork only sets m_haveMemoryInput when node.id != node.physicalId (an
+    // identity *States file is first-order in substance and runs under --lossy); and
+    // that guard reads haveMemory() without honouring the forceNoMemory argument, unlike
+    // the objective dispatch just below it -- unreachable under --lossy today, because
+    // lossy is rejected before any sub-Infomap is constructed. See #1004.
     if (config.haveMetaData())
       throw std::runtime_error("--lossy does not support meta data");
     if (config.recordedTeleportation || config.regularized)

--- a/test/cpp/test_lossy.cpp
+++ b/test/cpp/test_lossy.cpp
@@ -52,6 +52,54 @@ TEST_CASE("Lossy: rejects unsupported input detected after parsing [fast][core][
   CHECK_THROWS_AS(im.run(), std::runtime_error);
 }
 
+TEST_CASE("Lossy: input constraints are owned by the optimizer dispatch, not by adaptDefaults [fast][core][lossy][config]")
+{
+  // #1004: adaptDefaults used to reject stateInput/multilayerInput/additionalInput, which
+  // no CLI option can set at parse time -- configureNetworkMode() writes the first two
+  // when the network is read, and additionalInput is library-only. The check was
+  // therefore only reachable by a library caller mutating the struct, and even there the
+  // same rejection arrives one stage later from initOptimizer(). The second CHECK of each
+  // pair is what makes the deletion safe rather than merely quiet: it pins that the late
+  // guard still covers every field the parse-time one did. Brace-initialised inside the
+  // macro on purpose: InfomapWrapper(config) risks parsing as a declaration.
+  SUBCASE("state input")
+  {
+    Config config;
+    config.lossy = true;
+    config.setStateInput();
+    CHECK_NOTHROW(config.adaptDefaults());
+    CHECK_THROWS_AS(InfomapWrapper { config }, std::runtime_error);
+  }
+
+  SUBCASE("multilayer input")
+  {
+    Config config;
+    config.lossy = true;
+    config.setMultilayerInput();
+    CHECK_NOTHROW(config.adaptDefaults());
+    CHECK_THROWS_AS(InfomapWrapper { config }, std::runtime_error);
+  }
+
+  SUBCASE("additional input")
+  {
+    Config config;
+    config.lossy = true;
+    config.additionalInput.push_back("extra.net");
+    CHECK_NOTHROW(config.adaptDefaults());
+    CHECK_THROWS_AS(InfomapWrapper { config }, std::runtime_error);
+  }
+
+  SUBCASE("meta data stays a parse-time rejection")
+  {
+    // Unlike the three above, --meta-data is a flag, so this one is decidable before the
+    // input is read and keeps failing early.
+    Config config;
+    config.lossy = true;
+    config.metaDataFile = "foo.txt";
+    CHECK_THROWS_AS(config.adaptDefaults(), std::runtime_error);
+  }
+}
+
 TEST_CASE("Lossy: lambda -> infinity reproduces the standard two-level map equation [fast][core][lossy]")
 {
   InfomapWrapper plain(defaultFlags("--two-level"));

--- a/test/cpp/test_lossy.cpp
+++ b/test/cpp/test_lossy.cpp
@@ -52,6 +52,78 @@ TEST_CASE("Lossy: rejects unsupported input detected after parsing [fast][core][
   CHECK_THROWS_AS(im.run(), std::runtime_error);
 }
 
+TEST_CASE("Lossy: the undirected-flow guard is reachable from the input, not only from a flag [fast][core][lossy][config]")
+{
+  // #1004: adaptDefaults rejects --directed and an explicitly set --flow-model, so the
+  // late guard's flow-model clause only ever sees a model that adaptDefaults did not get
+  // to look at. The four subcases below are the ways that happens: the network read; a
+  // plain assignment on a Config, which leaves flowModelIsSet false; and either config
+  // setter called on a constructed instance, where adaptDefaults no longer runs. A
+  // directed edge list is not one of them: *Arcs under an undirected flow model is parsed
+  // as undirected and the model stays undirected. Every case is checked on the message
+  // rather than on the exception type -- the memory/multilayer clause above throws a
+  // std::runtime_error too, and it is the clause that fires for ordinary multilayer
+  // input.
+  auto messageOf = [](auto&& run) {
+    try {
+      run();
+    } catch (const std::runtime_error& e) {
+      return std::string(e.what());
+    }
+    return std::string("<no exception>");
+  };
+
+  SUBCASE("multilayer expansion whose state map is identity")
+  {
+    // Expansion marks the network as directed input, and configureNetworkMode() then
+    // switches the flow model. Ordinary multilayer input throws one clause earlier,
+    // because expansion gives state ids that differ from the physical ids; this fixture's
+    // coincide, so haveMemoryInput() stays false, neither setStateInput() nor
+    // setMultilayerInput() runs, and the flow-model clause is the only one left.
+    InfomapWrapper im(defaultFlags("--lossy"));
+    im.readInputData(networkFixturePath("intra_identity_states.net"));
+    CHECK(messageOf([&] { im.run(); }) == "--lossy requires undirected flow");
+  }
+
+  SUBCASE("embedder assigning flowModel on a Config before adaptDefaults")
+  {
+    // A plain assignment leaves flowModelIsSet false, so adaptDefaults' clause (which
+    // tests directed || (flowModelIsSet && ...)) does not see it, and it arrives here.
+    Config config;
+    config.lossy = true;
+    config.flowModel = FlowModel::directed;
+    CHECK_NOTHROW(config.adaptDefaults());
+    CHECK(messageOf([&] {
+            InfomapWrapper im { config };
+            (void)im;
+          })
+          == "--lossy requires undirected flow");
+  }
+
+  SUBCASE("embedder calling setDirected on a live instance")
+  {
+    // InfomapConfig::setDirected writes flowModel too, and adaptDefaults ran once while
+    // the flag string was parsed and never runs again, so the parse-time clause cannot
+    // see this. The next initOptimizer() -- here from run() via initNetwork() -- catches
+    // it instead.
+    InfomapWrapper im(defaultFlags("--lossy"));
+    im.readInputData(networkFixturePath("twotriangles_flow.net"));
+    im.setDirected(true);
+    CHECK(messageOf([&] { im.run(); }) == "--lossy requires undirected flow");
+  }
+
+  SUBCASE("embedder calling setFlowModel on a live instance")
+  {
+    // setFlowModel does set flowModelIsSet, but that only matters to adaptDefaults, which
+    // has already run. On a constructed instance it is the same late guard that catches
+    // it.
+    InfomapWrapper im(defaultFlags("--lossy"));
+    im.readInputData(networkFixturePath("twotriangles_flow.net"));
+    im.setFlowModel(FlowModel::directed);
+    CHECK(messageOf([&] { im.run(); }) == "--lossy requires undirected flow");
+  }
+}
+
 TEST_CASE("Lossy: input constraints are owned by the optimizer dispatch, not by adaptDefaults [fast][core][lossy][config]")
 {
   // #1004: adaptDefaults used to reject stateInput/multilayerInput/additionalInput, which

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -74,6 +74,32 @@ std::map<EdgeKey, double> aggregatedModuleFlow(InfoNode& root, bool undirected)
   return flows;
 }
 
+//! Sum InfoNode::codelength over every module including the root, i.e. the quantity
+//! calcCodelengthOnTree(root(), true) returns. Leaves carry no codelength of their own.
+double sumModuleCodelengths(const InfoNode& node)
+{
+  if (node.isLeaf()) {
+    return 0.0;
+  }
+  double sum = node.codelength;
+  for (const auto& child : node.children()) {
+    sum += sumModuleCodelengths(child);
+  }
+  return sum;
+}
+
+unsigned int numScoredModules(const InfoNode& node)
+{
+  if (node.isLeaf()) {
+    return 0;
+  }
+  unsigned int count = node.codelength > 0.0 ? 1 : 0;
+  for (const auto& child : node.children()) {
+    count += numScoredModules(child);
+  }
+  return count;
+}
+
 TEST_CASE("Cluster-data clu fixture initializes a two-level partition [fast][core][partition]")
 {
   InfomapWrapper im(infomap::test::defaultFlags());
@@ -413,6 +439,48 @@ TEST_CASE("A two-level partition re-initialised after a multi-level one scores t
 
   CHECK(twoLevelCodelength(*reused) == doctest::Approx(expected));
   CHECK(reused->getIndexCodelength() == doctest::Approx(fresh->getIndexCodelength()));
+}
+
+TEST_CASE("A flat tree materialization scores its modules [fast][core][partition][lifecycle]")
+{
+  // #1002: initTree's `maxDepth == 2 || twoLevel` shortcut returned straight out of
+  // initPartition, which updates the objective's aggregate bookkeeping but writes no
+  // InfoNode::codelength. Only the deep branch scored the tree, so a flat materialization
+  // left every module holding whatever it held before. Here that is 0 on a fresh
+  // instance; on a reused one it is a stale value from an earlier, deeper partition.
+  // --no-infomap keeps the search out of it: with a search running, partition() rescores
+  // the tree at the end and the gap is invisible.
+  auto im = infomap::test::makeRunningInfomap(
+      [](InfomapWrapper& wrapper) { wrapper.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net")); },
+      "--no-infomap --two-level");
+
+  // A three-level tree under --two-level takes the shortcut through its second
+  // predicate, keeping only each leaf's top-level module.
+  im->initPartition(infomap::test::clusterFixturePath("twotriangles_three_level.tree"), false, &im->network());
+  REQUIRE(im->numLevels() == 2);
+  REQUIRE(im->codelength() > 0.0);
+
+  // Root plus the two modules; the leaves have no codelength of their own.
+  CHECK(numScoredModules(im->root()) == 3);
+  CHECK(sumModuleCodelengths(im->root()) == doctest::Approx(im->codelength()));
+}
+
+TEST_CASE("A restored flat best-of-N winner keeps its module codelengths [fast][core][partition][lifecycle]")
+{
+  // #1002, as users met it: restoreBestResult re-materializes the winning tree through
+  // initTree and immediately rewrites the output file, so when the winner was flat every
+  // modules[].codelength in the JSON output came out 0 -- while the same run at
+  // --num-trials 1 wrote real values, because nothing restored. ninetriangles under
+  // --two-level reaches the same codelength in every trial, so trial 1 stays the best and
+  // the restore always fires.
+  InfomapWrapper im("--seed 123 --num-trials 10 --silent --two-level --no-file-output");
+  im.readInputData(infomap::test::repoPath("examples/networks/ninetriangles.net"));
+  im.run();
+
+  REQUIRE(im.numLevels() == 2);
+  // Root plus nine module nodes.
+  CHECK(numScoredModules(im.root()) == 10);
+  CHECK(sumModuleCodelengths(im.root()) == doctest::Approx(im.codelength()));
 }
 
 TEST_CASE("Pretty per-level codelength renders a structured levels table [fast][core][partition][output]")

--- a/test/fixtures/networks/intra_identity_states.net
+++ b/test/fixtures/networks/intra_identity_states.net
@@ -1,0 +1,11 @@
+# A single-layer multilayer network whose expansion is identity: the state ids are
+# auto-generated from 0 upwards in insertion order, so with physical ids 0,1,2 in that
+# order every state id equals its physical id. StateNetwork only sets m_haveMemoryInput
+# when node.id != node.physicalId, so the expanded network stays first-order in
+# substance -- while the expansion still marks the input as directed, which makes
+# configureNetworkMode() switch the flow model to directed.
+*Intra
+# layer node node weight
+1 0 1 1
+1 1 2 1
+1 2 0 1


### PR DESCRIPTION
Two shared-code defects, both surfaced while working on the columnar engine and both reproducible on `master` with the default object-oriented engine — which is why they belong here rather than on `columnar-hierarchical-core`.

## 1. `initTree`'s flat shortcut never scored the tree (part of #1002)

`InfomapBase::initTree(const NodePaths&)` has two branches. The deep branch ends by calling `calcCodelengthOnTree(root(), true)`, which is the **only** thing that writes `InfoNode::codelength` on every non-leaf node. The flat/two-level shortcut returns early through `initPartition(clusterIds, false)` and never scores the tree, so every module keeps whatever `InfoNode::codelength` held before — `0.0` on a fresh instance, or a **stale value from an earlier, deeper trial** in the same instance.

Reproducible with no `-C` in sight, because `restoreBestResult` re-materializes a flat best-of-N winner through that shortcut and immediately rewrites the output file:

```
$ ./Infomap networks/arenas-jazz.txt out --seed 123 -N10 -o json
  Best codelength               6.863047469
  modules[].codelength = [0.294755, 0.0, 0.0, 0.0, 0.0, 0.0]

$ ./Infomap networks/arenas-jazz.txt out --seed 123 -N1 -o json
  modules[].codelength = [0.30147, 2.88606, 2.34697, 1.32302, 0.00428698, 0.00205053]
```

After the fix the `-N10` run writes `[0.300912, 2.3244, 2.90838, 1.32302, 0.00428698, 0.00205053]`, summing to the reported codelength. `--parallel-trials` was affected more severely — **every** `modules[].codelength` was `0.0`, including the root — and is repaired by the same change.

The scoring call is made **for its side effect only**; the return value is deliberately dropped, because `initPartition` has just set `m_hierarchicalCodelength` from `getCodelength()` and that is what `restoreBestResult` reports. Assigning it would change reported codelengths on the restore path.

**No reported number moves.** Interleaved A/B over 18 configurations — jazz, netscicoauthor2010, powergrid, politicalblogs `-d`, ninetriangles, `modular_wd --directed`, each in `-2`/hierarchical and `-N1`/`-N10` shapes, plus seven `-c` cluster-data configurations and a `--parallel-trials` pair — gives bit-identical `Best codelength` and `One-level codelength` everywhere. The `.tree`, `.ftree`, `.clu` and `.nwk` artifacts are byte-identical; the only JSON field that changes is `modules[].codelength`. Binaries: `31c9ef1fc988af8266cadb3b3a88255d` before, `88d636984b56d502e5532fc993b297c8` after.

## 2. The `--lossy` memory/multilayer guard was dead code (#1004)

```cpp
if (config.stateInput || config.multilayerInput || !config.additionalInput.empty())
  throw std::runtime_error("--lossy does not support memory or multilayer networks");
```

`stateInput`/`multilayerInput` are written only by `configureNetworkMode()`, when the network is **read** — after config validation — and `additionalInput` has no CLI binding at all. So none of the three clauses can fire from the command line.

The rejection that actually fires is the re-validation in `InfomapBase::initOptimizer()`, whose condition is broader. The clause is deleted and replaced by a comment recording why there is no input check at parse time and where the real one lives. Nothing changes behaviourally: `--lossy` on a state or multilayer network exits 7 with the same message before and after.

Three details the comment is careful about, each checked rather than assumed:
- `additionalInput` is library-only — a SWIG property with no CLI binding — not "unwritten".
- A `*States` file is caught by the late guard **iff its state→physical map is non-identity**: `StateNetwork` sets `m_haveMemoryInput` only when `node.id != node.physicalId`, so an identity `*States` file runs under `--lossy`, and is first-order in substance.
- The guard reads `haveMemory()` without honouring `forceNoMemory`, unlike the objective dispatch two lines below, so it is not a strict superset of what it replaced.

The comment above the late guard is reworded too: it read as if the two checks were complementary, when for memory/multilayer input the late one is the only check. Its enumeration of what reaches the `!isUndirectedFlow()` clause is now the measured one — `configureNetworkMode()` on the identity-expansion corner, plus `setDirected()`/`setFlowModel()` on a live instance, which never re-run `adaptDefaults()`. All four routes are pinned by tests.

## Tests

New: two cases asserting a materialized flat tree has non-zero per-module codelengths summing to the reported codelength (one through each predicate of the shortcut); four subcases pinning the `--lossy` input rejections at the point they now fire, asserting on the **message** rather than the exception type, since the deleted clause threw the same type.

Each new test was confirmed non-vacuous by reverting its fix and watching it fail — `CHECK(1 == 3)` and `CHECK(2.55666 == Approx(2.32073))` for the scoring, and the four `--lossy` subcases reporting `<no exception>`.

`make test-native MODE=release` passes 26/26 under `OPENMP=1`, `OPENMP=0`, and `OPENMP=1 FEATURES="lossy-map-equation regularized-multilayer"`.

## Known, not fixed here

`--no-infomap -c <flat tree>` now scores the tree twice (`initTree` and then `executeTrial`), measured at **+1.4%** on a 325k-leaf flat tree with no search running. Removing the second pass needs a scored-flag contract between the two functions, and the `-c <.clu>` path still requires `executeTrial`'s call. The cost and the rejected alternative are recorded in the comment.

Refs #1002, #1004.



---

<!-- `core` is not a sanctioned commit scope. Release Please reads the block below
     in place of the squash-commit message, so the changelog entry stays unscoped. -->

BEGIN_COMMIT_OVERRIDE
fix: score the flat-shortcut tree, and drop the dead --lossy input guard (#1014)
END_COMMIT_OVERRIDE
