### PR TITLE
fix: charge the entropy correction in bits, not nats

### DIFF
--- a/interfaces/python/source/robustness/incomplete-data.md
+++ b/interfaces/python/source/robustness/incomplete-data.md
@@ -100,7 +100,13 @@ evidence does not support any community structure.
 
 A separate option, `entropy_corrected`, corrects the small-sample bias in the
 entropy estimate itself; it is independent of the prior-network regularization
-described here.
+described here. It applies the Miller-Madow correction to every codebook: with
+$N$ nodes, $m$ modules and total degree $D$, an $m$-module partition has
+$m - 1 + N$ free parameters -- $m - 1$ in the index codebook, and, per module,
+its nodes plus an exit codeword less the codebook's own normalisation -- each
+charged $1 / (2 D \ln 2)$ bits. That keeps the description length of a *given*
+partition roughly constant as links go missing, but it is far too small to stop
+the splitting described above, which is what the prior network is for.
 :::
 
 ## A 70%-sparse planted partition

--- a/src/core/BiasedMapEquation.cpp
+++ b/src/core/BiasedMapEquation.cpp
@@ -14,10 +14,34 @@
 
 #include <vector>
 #include <utility>
+#include <algorithm>
+#include <cmath>
 #include <cstdlib>
 #include "StateNetwork.h"
 
 namespace infomap {
+
+namespace {
+
+  // Miller-Madow charges (K - 1) / (2n) *nats* for a codebook with K codewords
+  // estimated from n observations, and the map equation is in bits, hence 1/ln2.
+  const double LOG_2 = std::log(2.0);
+
+  // Can the walker ever leave this module, i.e. does its codebook hold an exit
+  // codeword? Leaving a module means emitting its exit codeword and then entering
+  // a sibling somewhere further up, so a module that is its parent's only child
+  // can only be left if that parent can be left. The root can never be left, so a
+  // chain of only-children below the root has no exit codeword anywhere along it.
+  bool hasExitCodeword(const InfoNode& module)
+  {
+    for (const InfoNode* node = &module; node->parent != nullptr; node = node->parent) {
+      if (node->parent->childDegree() > 1)
+        return true;
+    }
+    return false;
+  }
+
+} // namespace
 
 void BiasedMapEquation::setNetworkProperties(const StateNetwork& network)
 {
@@ -107,19 +131,50 @@ double BiasedMapEquation::calcNumModuleCost(unsigned int numModules) const
   return 1 * std::abs(deltaNumModules);
 }
 
-double BiasedMapEquation::calcIndexEntropyBiasCorrection(unsigned int numModules) const
+// The network is the sample: an undirected link of weight w is w walk steps in
+// each direction, so the sample size is the total degree D, and every codebook is
+// a multinomial count vector over those steps. Codebook c is used u_c * D times
+// and the map equation weights it by that same u_c, so the usage cancels and each
+// codebook costs the same per free parameter:
+//
+//   sum_c u_c * (K_c - 1) / (2 u_c D ln2) = sum_c (K_c - 1) / (2 D ln2)
+//
+// Equivalently: L is the entropy rate of the Markov chain over codebooks, whose
+// ML estimate is biased by -(free parameters)/(2D) nats.
+double BiasedMapEquation::bitsPerFreeParameter() const
 {
-  return useEntropyBiasCorrection ? entropyBiasCorrectionMultiplier * (numModules - 1) / (2 * m_totalDegree) : 0;
+  return entropyBiasCorrectionMultiplier / (2 * m_totalDegree * LOG_2);
 }
 
-double BiasedMapEquation::calcModuleEntropyBiasCorrection() const
+double BiasedMapEquation::calcIndexEntropyBiasCorrection(unsigned int numModules) const
 {
-  return useEntropyBiasCorrection ? entropyBiasCorrectionMultiplier * m_numNodes / (2 * m_totalDegree) : 0;
+  // One codeword per module, so numModules - 1 free parameters -- and none at all
+  // for a single module, whose index codebook is never used.
+  if (!useEntropyBiasCorrection)
+    return 0;
+  const double numCodewords = static_cast<double>(numModules);
+  return bitsPerFreeParameter() * std::max(numCodewords - 1, 0.0);
+}
+
+double BiasedMapEquation::calcModuleEntropyBiasCorrection(unsigned int numModules) const
+{
+  // Each module codebook holds a codeword per node plus an exit codeword, i.e.
+  // (n_i + 1) - 1 = n_i free parameters, summing to numNodes over the partition.
+  // The alphabet is the one the partition declares, not the one this sample
+  // happens to exercise: a node or a boundary link that no walk step touched is
+  // unobserved, not impossible, which is the premise the correction exists to
+  // serve. The single exception is impossible by construction rather than
+  // unobserved -- one module holding the whole network can never be exited, so
+  // that codeword does not exist and the partition has one parameter less.
+  if (!useEntropyBiasCorrection)
+    return 0;
+  const double numParameters = numModules == 1 ? std::max(m_numNodes - 1.0, 0.0) : m_numNodes;
+  return bitsPerFreeParameter() * numParameters;
 }
 
 double BiasedMapEquation::calcEntropyBiasCorrection(unsigned int numModules) const
 {
-  return useEntropyBiasCorrection ? entropyBiasCorrectionMultiplier * (numModules - 1 + m_numNodes) / (2 * m_totalDegree) : 0;
+  return calcIndexEntropyBiasCorrection(numModules) + calcModuleEntropyBiasCorrection(numModules);
 }
 
 void BiasedMapEquation::calculateCodelength(std::vector<InfoNode*>& nodes)
@@ -133,7 +188,7 @@ void BiasedMapEquation::calculateCodelength(std::vector<InfoNode*>& nodes)
   biasedCost = calcNumModuleCost(currentNumModules);
 
   indexEntropyBiasCorrection = calcIndexEntropyBiasCorrection(currentNumModules);
-  moduleEntropyBiasCorrection = calcModuleEntropyBiasCorrection();
+  moduleEntropyBiasCorrection = calcModuleEntropyBiasCorrection(currentNumModules);
 }
 
 double BiasedMapEquation::calcCodelength(const InfoNode& parent) const
@@ -143,29 +198,31 @@ double BiasedMapEquation::calcCodelength(const InfoNode& parent) const
       : calcCodelengthOnModuleOfModules(parent);
 }
 
+// Free parameters of the codebook this tree node owns: one codeword per child
+// plus an exit codeword, minus one for the codebook's own normalisation. The root
+// owns the index codebook, which has no exit codeword, and neither does any module
+// that cannot be left (see hasExitCodeword).
+double BiasedMapEquation::calcCodebookFreeParameters(const InfoNode& parent) const
+{
+  const double numCodewords = static_cast<double>(parent.childDegree()) + (hasExitCodeword(parent) ? 1.0 : 0.0);
+  return std::max(numCodewords - 1, 0.0);
+}
+
 double BiasedMapEquation::calcCodelengthOnModuleOfModules(const InfoNode& parent) const
 {
   double L = Base::calcCodelengthOnModuleOfModules(parent);
   if (!useEntropyBiasCorrection)
     return L;
 
-  // NOTE (#830): this recompute and the tracked value disagree, by a now fully
-  // measured amount. The tracked side uses (numModules - 1 + numNodes) / (2D),
-  // i.e. one term for the root index codebook and one for the leaf codewords.
-  // This recompute instead sums childDegree over every internal node, which
-  // differs in exactly two places:
-  //   * the root is charged childDegree here but childDegree - 1 there, and the
-  //     latter is right: the root index codebook has no exit codeword;
-  //   * every non-root module-of-modules contributes childDegree here and
-  //     nothing at all there.
-  // Measured with the root term corrected: the residual drift is exactly
-  // (number of non-root module-of-modules) / (2 * totalDegree) -- 0 on two-level
-  // trees (lossy_benchmark, ninetriangles: exact match) and 1/514 on
-  // unbalanced_hierarchy, which has one. Both sides are left alone here so the
-  // root term and the missing intermediate term land together; fixing only the
-  // root would make two-level runs exact while leaving hierarchical runs off by
-  // a tree-shape-dependent amount.
-  return L + entropyBiasCorrectionMultiplier * parent.childDegree() / (2 * m_totalDegree);
+  // NOTE (#830): this recompute and the tracked value now agree on two-level
+  // trees -- the root term above was the whole of the disagreement there -- but
+  // not on deeper ones. The tracked side charges (numModules - 1) + numNodes,
+  // which is every codebook a two-level partition has; this recompute walks the
+  // whole tree, so it also charges the intermediate module-of-modules codebooks,
+  // one free parameter per non-root module-of-modules more. This side is the
+  // correct one. The tracked side is left alone here because making it tree-aware
+  // changes what the search minimises, not what it reports.
+  return L + bitsPerFreeParameter() * calcCodebookFreeParameters(parent);
 }
 
 double BiasedMapEquation::calcCodelengthOnModuleOfLeafNodes(const InfoNode& parent) const
@@ -174,7 +231,7 @@ double BiasedMapEquation::calcCodelengthOnModuleOfLeafNodes(const InfoNode& pare
   if (!useEntropyBiasCorrection)
     return L;
 
-  return L + entropyBiasCorrectionMultiplier * parent.childDegree() / (2 * m_totalDegree);
+  return L + bitsPerFreeParameter() * calcCodebookFreeParameters(parent);
 }
 
 // The post-move module count. deltaNumModules is -1, 0 or +1, and a removal
@@ -279,7 +336,7 @@ void BiasedMapEquation::updateCodelengthOnMovingNode(InfoNode& current,
   if (preferredNumModules != 0)
     biasedCost = calcNumModuleCost(currentNumModules);
   indexEntropyBiasCorrection = calcIndexEntropyBiasCorrection(currentNumModules);
-  moduleEntropyBiasCorrection = calcModuleEntropyBiasCorrection();
+  moduleEntropyBiasCorrection = calcModuleEntropyBiasCorrection(currentNumModules);
 }
 
 void BiasedMapEquation::consolidateModules(std::vector<InfoNode*>& modules)

--- a/src/core/BiasedMapEquation.h
+++ b/src/core/BiasedMapEquation.h
@@ -136,8 +136,10 @@ private:
 
   unsigned int numModulesAfterMove(int deltaNumModules) const;
 
+  double bitsPerFreeParameter() const;
+  double calcCodebookFreeParameters(const InfoNode& parent) const;
   double calcIndexEntropyBiasCorrection(unsigned int numModules) const;
-  double calcModuleEntropyBiasCorrection() const;
+  double calcModuleEntropyBiasCorrection(unsigned int numModules) const;
   double calcEntropyBiasCorrection(unsigned int numModules) const;
 
   // ===================================================

--- a/test/cpp/test_map_equation_invariants.cpp
+++ b/test/cpp/test_map_equation_invariants.cpp
@@ -1,6 +1,7 @@
 #include "TestUtils.h"
 
 #include <cmath>
+#include <memory>
 
 // Invariant tests for the map-equation objective family.
 //
@@ -89,18 +90,71 @@ TEST_CASE("MapEquation invariant: RegularizedMultilayerMapEquation, tracked == r
 }
 #endif
 
-// Regression for #830: under --entropy-corrected the tracked codelength drifts
-// from a fresh recompute (observed tracked 2.9815 vs recompute 2.9911). Marked
-// should_fail so it stays green while the bug is present and turns RED the
-// moment #830 is fixed -- at which point drop the decorator so it becomes a
-// normal passing invariant.
-TEST_CASE("MapEquation invariant: entropy-corrected tracked == recompute (repro #830) [core][mapeq][entropy-corrected]"
-          * doctest::should_fail())
+// Regression for #830: the tracked codelength used to drift from a fresh
+// recompute under --entropy-corrected (before this fix: tracked 2.9815 against
+// recompute 2.9911), because the recompute charged the root index codebook
+// childDegree free parameters where it has childDegree - 1 -- an index codebook
+// has no exit codeword. Deeper trees are not covered: there the recompute also
+// charges the intermediate module-of-modules codebooks that the tracked side
+// never sees, and #830 stays open for that half.
+TEST_CASE("MapEquation invariant: entropy-corrected tracked == recompute (repro #830) [core][mapeq][entropy-corrected]")
 {
   InfomapWrapper im(defaultFlags("--two-level --entropy-corrected"));
   im.readInputData(networkFixturePath("lossy_benchmark.net"));
   im.run();
   checkTrackedMatchesRecompute(im);
+}
+
+// The size of the correction, on a partition pinned from a file so no search
+// enters the comparison. twotriangles has N = 6 nodes and total degree D = 14,
+// and the codebooks of an m-module partition hold m - 1 + N free parameters:
+// m - 1 in the index codebook and, per module, its nodes plus an exit codeword
+// less the codebook's own normalisation. Miller-Madow charges (K - 1) / (2n)
+// nats per codebook and the map equation is in bits, so each parameter costs
+// 1 / (2 D ln2) bits -- the ln2 is what makes the corrected codelength of a
+// fixed partition stay flat as links are removed.
+TEST_CASE("Entropy correction charges m - 1 + N parameters at 1/(2 D ln2) bits [fast][core][mapeq][entropy-corrected]")
+{
+  const auto codelengthOf = [](const std::string& flags) {
+    InfomapWrapper im(defaultFlags("--two-level --no-infomap --cluster-data "
+                                   + clusterFixturePath("twotriangles_two_modules.clu") + " " + flags));
+    im.readInputData(repoPath("examples/networks/twotriangles.net"));
+    im.run();
+    return im.codelength();
+  };
+
+  const double correction = codelengthOf("--entropy-corrected") - codelengthOf("");
+  const double expected = (2 - 1 + 6) / (2 * 14.0 * std::log(2.0));
+  INFO("correction=" << correction << " expected=" << expected);
+  checkApproxCodelength(correction, expected);
+}
+
+// A module holding the whole network cannot be exited, so its codebook has no
+// exit codeword and the partition has one free parameter less: N - 1, not N.
+// Unlike an unobserved node or an unobserved boundary link -- which the declared
+// alphabet keeps charging, since a sample that misses them does not make them
+// impossible -- this codeword cannot occur in any sample. The index codebook of
+// a single module is likewise never used, and both sides of the equality have to
+// agree about that.
+TEST_CASE("A single module covering the network has no exit codeword [fast][core][mapeq][entropy-corrected]")
+{
+  const auto run = [](const std::string& flags) {
+    auto im = std::make_unique<InfomapWrapper>(defaultFlags("--two-level --no-infomap --cluster-data "
+                                                            + clusterFixturePath("twotriangles_single_module.clu") + " " + flags));
+    im->readInputData(repoPath("examples/networks/twotriangles.net"));
+    im->run();
+    return im;
+  };
+
+  const auto plain = run("");
+  const auto corrected = run("--entropy-corrected");
+
+  const double correction = corrected->codelength() - plain->codelength();
+  const double expected = (6 - 1) / (2 * 14.0 * std::log(2.0));
+  INFO("correction=" << correction << " expected=" << expected);
+  checkApproxCodelength(correction, expected);
+
+  checkTrackedMatchesRecompute(*corrected);
 }
 
 // The entropy-bias correction must reach the move loop, not only the reported
@@ -176,3 +230,4 @@ TEST_CASE("Super level never leaves the trial worse than its own two-level solut
 
 } // namespace test
 } // namespace infomap
+


### PR DESCRIPTION
`--entropy-corrected` applies the Miller–Madow correction to every codebook of the map equation. Three things about how it counts were wrong. All three are in `BiasedMapEquation`; none of them costs anything at runtime.

1. **Units.** Miller–Madow's `(K − 1)/(2n)` is in **nats**, the map equation is in **bits**. The implemented `(K − 1)/(2D)` was a factor `ln2 = 0.693` too small.
2. **A codeword that cannot exist.** A single module covering the whole network can never be exited, so its codebook has no exit codeword: `N − 1` free parameters, not `N`. Its index codebook, with one codeword, has none.
3. **The root term (#830).** The recompute charged the root index codebook `childDegree` parameters where it has `childDegree − 1`. That was the entire tracked-vs-recompute drift on two-level trees.

Everything else keeps the alphabet the *partition declares*, which is a deliberate decision documented below — it is what makes the correction do its job on incomplete data.

## The counting model

The network is the sample. An undirected link of weight `w` is `w` walk steps in each direction, so the sample size is the total degree `D = Σ_α k_α` (`sumDegree`), and every codebook is a multinomial count vector over those steps:

- module *i*: `count(α) = k_α` for α ∈ *i*, plus `count(exit) =` steps leaving *i*
- index: `count(i) =` steps entering *i*

On `twotriangles` split in two, that is module counts `(2,2,3 | 1)` with `n_i = 8`, index counts `(1,1)` with `n = 2`, `D = 14` — and `L = Σ_c (n_c/D)·H(c)` reproduces the engine exactly (2.32073035683379 against 2.320730357 printed).

So codebook *c* is used `n_c = u_c·D` times and the map equation weights it by that same `u_c`. The usage cancels:

```
E[L̂] − L = Σ_c u_c · ( −(K_c − 1) / (2 n_c ln2) ) = − Σ_c (K_c − 1) / (2 D ln2)
```

Equivalently, `L` is the entropy rate of the Markov chain whose states are the codebooks, and the ML entropy-rate bias is −(free parameters)/(2n) with n = D. For an ordinary *m*-module partition the free parameters are `m − 1` in the index codebook and `n_i` per module (its nodes plus an exit codeword, less the codebook's own normalisation), i.e.

```
L^c(M) = L(M) + (N + m − 1) / (2 D ln2)      D = Σ_α k_α = 2W
```

Note `D` is the *total degree*, twice the summed link weight; with `W` read as "sum of link weights" the denominator is `4W ln2`.

### 1. The units, verified

Bias of the plug-in entropy on simulated multinomials, 200 000 draws each:

| K, n | measured bias | −(K−1)/(2n ln2) | −(K−1)/(2n) |
|---|---|---|---|
| 10, 50 | −0.13844 b | **−0.12984** | −0.09000 |
| 10, 200 | −0.03306 b | **−0.03246** | −0.02250 |
| 50, 200 | −0.19010 b | **−0.17673** | −0.12250 |
| 50, 1000 | −0.03589 b | **−0.03535** | −0.02450 |

The default `--entropy-correction-strength 1` now means textbook Miller–Madow.

### 2. Which codewords exist

Miller–Madow is usually stated with `K` = *distinct symbols observed*, because the support is normally unknown. Here the partition declares the support, and the two readings differ exactly on unobserved codewords — a node no walk step touched, a module with no observed boundary link. Under the missing-links premise the option exists to serve, those are **unobserved, not impossible**, and the measurement is decisive. Holding a partition fixed while links are removed at random (128-node planted partition, 1037 links, 4 modules, target = its own codelength on the full network, 6.3749 bits, mean of 12 removals):

| kept links | 1.00 | 0.60 | 0.40 | 0.20 | 0.10 | 0.05 |
|---|---|---|---|---|---|---|
| plug-in | 6.3749 | 6.3517 | 6.3067 | 6.1936 | 5.8581 | 5.4258 |
| **declared alphabet (this PR)** | **6.4204** | **6.4285** | **6.4184** | **6.4233** | **6.3320** | **6.4152** |
| observed-count census | 6.4204 | 6.4285 | 6.4184 | 6.4135 | 6.2323 | 5.9701 |

The observed census stops counting isolated nodes precisely when they are the reason for the bias. The declared alphabet stays flat, and not by luck: under Bernoulli link retention with retention `f` the bias to return is `(1−f)(K−2)/(2fD ln2)`, while the correction supplies `(K−1)/(2fD ln2)` — the difference is `f`-independent to leading order and equals the value at `f = 1`. Predicted against measured offset at `f = 1`: ring of 10 cliques 0.0855 vs 0.0855 bits, scale-free planted 0.1220 vs 0.1221 bits.

The one exception is impossible rather than unobserved: a module holding the whole network cannot be exited in any flow model — including recorded teleportation, where the module-level exit is `α·p_i·(1 − t_i)` and `t_i = 1`. Both that exit codeword and the one-codeword index codebook above it are dropped.

### 3. Worked examples, before and after

`twotriangles` (N = 6, D = 14, so 2D ln2 = 19.408) and two disjoint triangles (N = 6, D = 12):

| partition | master tracked | master reported | this PR (both) | exact |
|---|---|---|---|---|
| one module of 6 | 2.770942422 | 2.806656707 | **2.814280822** | H + 5/(28 ln2) |
| two modules | 2.570730357 | 2.606444643 | **2.681404117** | L + 7/(28 ln2) |
| two disjoint triangles | 1.876629167 | 1.918295834 | **2.005748554** | L + 7/(24 ln2) |

Master prints two different numbers for the same partition (the tracked line and the reported total); after the root fix the two agree, which is the #830 two-level invariant.

### End to end

Same fixed partition and removal sweep, both binaries, `--no-infomap --cluster-data` so no search enters the comparison (mean of 12 removals):

| f | links | plug-in | master `-ec` | this PR `-ec` |
|---|---|---|---|---|
| 1.00 | 1037 | 6.3749 | 6.4067 | 6.4204 |
| 0.60 | 615 | 6.3517 | 6.4053 | 6.4285 |
| 0.40 | 423 | 6.3067 | 6.3847 | 6.4184 |
| 0.20 | 206 | 6.1936 | 6.3540 | 6.4233 |
| 0.10 | 101 | 5.8581 | 6.1891 | 6.3320 |
| 0.05 | 49 | 5.4258 | 6.1169 | 6.4152 |
| **max drift** | | **−0.949 b** | **−0.290 b** | **−0.088 b** |

The correction ratio between the two binaries is a constant 1.4318 = `(N + m − 1)/ln2 ÷ (N + m)`, i.e. `1/ln2` on the parameter count with master's extra root parameter removed.

## Why Miller–Madow and not another estimator

Screened against the two constraints that matter here — a move-loop delta that costs nothing, and flows that are not integer counts:

| estimator | delta cost | non-integer flows | flatness measured |
|---|---|---|---|
| **Miller–Madow** | free, the parameter count is already tracked | yes | **best** |
| Grassberger | digamma per touched codeword | **no** — the `(−1)^{n_i}` term needs integer counts | 2nd, over-corrects at f = 1 |
| Chao–Shen / Chao–Wang–Jost | singleton/doubleton state per codebook | no | rises with removal |
| Shrinkage (James–Stein) | O(1) if Σp̂² is tracked | yes | rises with removal |
| Bayes α=½ / Krichevsky–Trofimov (MDL) | O(1), same plogp structure | yes | rises monotonically |
| NSB | numerical integration per codebook | — | not feasible in a move loop |

That integer-count row is the same wall the regularized map equation hit between `smiljanic2020missing` (Grassberger, unweighted and undirected) and `smiljanic2021incomplete` (Bayesian prior, weighted and directed). Here Grassberger is not buying quality either — measured less flat than Miller–Madow with the right units, and it costs a digamma per codeword.

One caveat worth recording: for a *trajectory* input the plug-in bias carries an extra autocorrelation term, `−(1/N)Σᵢλᵢ/(1−λᵢ)` over the transition-matrix eigenvalues (Weiß 2019; Gregorio et al. 2024, [arXiv:2310.07547](https://arxiv.org/abs/2310.07547)), which grows exactly when the network is strongly modular. That applies to path data, not to a link-sampled network, which is multinomial. Estimator formulas cross-checked against the [infomeasure discrete-entropy reference](https://infomeasure.readthedocs.io/en/0.5.0/guide/entropy/discrete/).

## What this does not fix

**Overpartitioning under link removal.** The correction reduces it but cannot prevent it, at any strength — same benchmark, actual searches, Rand index against the planted partition:

| f | plain | default (s=1) | s=2 | s=4 | s=8 |
|---|---|---|---|---|---|
| 0.30 | 11 mods, .881 | 10, .823 | 8, .841 | 8, .841 | 7, .844 |
| 0.20 | 23 mods, .770 | 15, .781 | 15, .781 | 11, .761 | 10, .765 |
| 0.10 | 49 mods, .766 | 22, .762 | 22, .762 | 21, .759 | 14, .761 |

At f = 0.10 the fragmented partition beats the planted one by ~2.4 bits of plug-in codelength while the whole correction is ~0.06 bits; raising the strength merges fragments without recovering structure. That is what `--regularized` is for, and the docs already say so — the sentence in `interfaces/python/source/robustness/incomplete-data.md` is expanded here to state what the correction does charge and that it is not a substitute for the prior network.

**The hierarchical half of #830.** On deeper trees the recompute also charges the intermediate module-of-modules codebooks, which the tracked side never sees. This side is the correct one; making the tracked side tree-aware changes what the search minimises, not what it reports, so #830 stays open for that.

## Behaviour change

Any run with `--entropy-corrected` reports a larger correction: the parameter count is unchanged for `m ≥ 2` partitions, so reported codelengths move by roughly `+0.44 × (old correction)`, minus one parameter at the root. Partitions can change where the correction was decisive. `--entropy-correction-strength` is unchanged in meaning; strength 0.693 reproduces the old scaling.

## Testing

- `make test-native MODE=release OPENMP=1`, `OPENMP=0`, and `FEATURES="lossy-map-equation regularized-multilayer"` — 26/26 in all three.
- The `should_fail` decorator is dropped from the #830 repro, which is now a passing invariant.
- Two new cases: the correction equals `(m − 1 + N)/(2 D ln2)` on a pinned `twotriangles` partition, and a single module covering the network charges `N − 1` parameters with tracked == recompute.

## Follow-up

The columnar engine carries its own copy of this term (`BiasedEntropyCorrection::hierarchicalCorrection` on `columnar-hierarchical-core`) and will need the same three changes when this lands there through the next master sync, or its parity check against the OO engine will fail.



---

<!-- `core` is not a sanctioned commit scope. Release Please reads the block below
     in place of the squash-commit message, so the changelog entry stays unscoped. -->

BEGIN_COMMIT_OVERRIDE
fix: charge the entropy correction in bits, not nats (#1033)
END_COMMIT_OVERRIDE
