### PR TITLE
fix: make numLevels the tree's depth so every channel reports the same number

### DIFF
--- a/interfaces/R/infomap/R/Infomap.R
+++ b/interfaces/R/infomap/R/Infomap.R
@@ -1441,7 +1441,7 @@ InfomapClass <- R6::R6Class(
     },
     #' @field num_levels Depth of the hierarchical tree. Alias of
     #'   `max_tree_depth`.
-    num_levels = function() private$.swig$maxTreeDepth(),
+    num_levels = function() private$.swig$numLevels(),
     #' @field max_tree_depth Maximum depth of the tree.
     max_tree_depth = function() private$.swig$maxTreeDepth(),
     #' @field num_leaf_nodes Number of leaf nodes in the tree.

--- a/interfaces/R/infomap/R/Infomap.R
+++ b/interfaces/R/infomap/R/Infomap.R
@@ -1439,8 +1439,9 @@ InfomapClass <- R6::R6Class(
     num_non_trivial_top_modules = function() {
       private$.swig$numNonTrivialTopModules()
     },
-    #' @field num_levels Number of levels in the tree.
-    num_levels = function() private$.swig$numLevels(),
+    #' @field num_levels Depth of the hierarchical tree. Alias of
+    #'   `max_tree_depth`.
+    num_levels = function() private$.swig$maxTreeDepth(),
     #' @field max_tree_depth Maximum depth of the tree.
     max_tree_depth = function() private$.swig$maxTreeDepth(),
     #' @field num_leaf_nodes Number of leaf nodes in the tree.

--- a/interfaces/R/infomap/man/Infomap.Rd
+++ b/interfaces/R/infomap/man/Infomap.Rd
@@ -75,7 +75,8 @@ wrong values (numNodes 11 for a three-node network) or aborting R (#900).}
 
 \item{\code{num_non_trivial_top_modules}}{Number of non-trivial top modules.}
 
-\item{\code{num_levels}}{Number of levels in the tree.}
+\item{\code{num_levels}}{Depth of the hierarchical tree. Alias of
+\code{max_tree_depth}.}
 
 \item{\code{max_tree_depth}}{Maximum depth of the tree.}
 

--- a/interfaces/R/infomap/tests/testthat/test-modules.R
+++ b/interfaces/R/infomap/tests/testthat/test-modules.R
@@ -67,3 +67,61 @@ test_that("multilayer_node returns a tagged integer pair", {
   expect_equal(unname(m), c(1L, 2L))
   expect_named(m, c("layer_id", "node_id"))
 })
+
+test_that("num_levels is the tree depth, not the first-child branch's (#1036)", {
+  # numLevels() in the C++ core walks only the first-child chain, so on a ragged
+  # tree it reports one arbitrary branch's depth. num_levels used it, which also
+  # made get_multilevel_modules() truncate the deeper branches.
+  net <- tempfile(fileext = ".net")
+  writeLines(
+    c(
+      "*Vertices",
+      "1 \"A\"",
+      "2 \"B\"",
+      "3 \"C\"",
+      "4 \"D\"",
+      "5 \"E\"",
+      "6 \"F\"",
+      "*Edges",
+      "1 2",
+      "1 3",
+      "2 3",
+      "3 4",
+      "4 5",
+      "4 6",
+      "5 6"
+    ),
+    net
+  )
+
+  # Ragged, with the shallow branch first: module 1 ends at depth 2, module 2 at
+  # depth 3. --no-infomap keeps that shape instead of re-partitioning it.
+  tree <- tempfile(fileext = ".tree")
+  writeLines(
+    c(
+      "# path flow name state_id",
+      "1:1 0.1 \"A\" 1",
+      "1:2 0.1 \"B\" 2",
+      "1:3 0.1 \"C\" 3",
+      "2:1:1 0.1 \"D\" 4",
+      "2:1:2 0.1 \"E\" 5",
+      "2:2:1 0.1 \"F\" 6"
+    ),
+    tree
+  )
+
+  im <- Infomap(
+    args = paste("--no-infomap --cluster-data", tree),
+    silent = TRUE
+  )
+  im$read_file(net)
+  im$run()
+
+  # Precondition: the tree really is three deep, so this is not vacuous.
+  expect_equal(im$max_tree_depth, 3L)
+  expect_equal(im$num_levels, im$max_tree_depth)
+
+  ml <- im$get_multilevel_modules()
+  expect_length(ml, 6L)
+  expect_true(all(vapply(ml, length, integer(1L)) == 3L))
+})

--- a/interfaces/python/src/infomap/result.py
+++ b/interfaces/python/src/infomap/result.py
@@ -351,7 +351,7 @@ class Result(_ResultWritersMixin):
         object.__setattr__(
             self, "_num_non_trivial_top_modules", core.numNonTrivialTopModules()
         )
-        object.__setattr__(self, "_num_levels", core.maxTreeDepth())
+        object.__setattr__(self, "_num_levels", core.numLevels())
         object.__setattr__(self, "_num_nodes", core.network().numNodes())
         object.__setattr__(
             self, "_num_physical_nodes", core.network().numPhysicalNodes()

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1005,11 +1005,11 @@ private:
     // From trialSeed, not from the live config field: seedTrial has already moved
     // that field to this trial's seed, so recomputing from it would double-count
     // the global index.
-    // maxTreeDepth, not numLevels: numLevels only walks the first-child chain, so on a
-    // ragged tree it records one arbitrary branch's depth and the JSON disagrees with the
-    // .tree file and the summary it describes (#1036). The parallel path below already
-    // records printPerLevelCodelength's level count, which is the same all-leaves depth.
-    m_timing.recordTrial(trialIndex, 0, trialSeed(trialIndex), timer.getElapsedTimeInSec(), m_infomap.m_hierarchicalCodelength, m_infomap.numTopModules(), m_infomap.maxTreeDepth());
+    // numLevels, which counts over every branch. This used to walk the first-child chain
+    // only, so on a ragged tree the JSON recorded one arbitrary branch's depth and
+    // disagreed with the .tree file and the summary it describes (#1036). The parallel
+    // path below records printPerLevelCodelength's level count, which is the same depth.
+    m_timing.recordTrial(trialIndex, 0, trialSeed(trialIndex), timer.getElapsedTimeInSec(), m_infomap.m_hierarchicalCodelength, m_infomap.numTopModules(), m_infomap.numLevels());
 
     if (m_infomap.printAllTrials && m_numTrials > 1) {
       auto outputTimer = m_timing.scope("output_s");
@@ -1226,10 +1226,11 @@ std::ostream& operator<<(std::ostream& out, const InfomapBase& infomap)
 
 unsigned int InfomapBase::numLevels() const
 {
-  // Walks the first-child chain only, so this is the depth of ONE branch, not the tree's.
-  // Valid only where the tree is uniform-depth by construction (the two-level guards, the
-  // super-level bookkeeping). Anything that reports a depth to a user or to a file wants
-  // maxTreeDepth instead -- see #1036, #898.
+  return maxTreeDepth();
+}
+
+unsigned int InfomapBase::depthOfFirstLeaf() const
+{
   unsigned int depth = 0;
   InfoNode* n = m_root.firstChild;
   while (n != nullptr) {
@@ -1395,9 +1396,9 @@ InfomapBase& InfomapBase::initPartition(const std::string& clusterDataFile, bool
     initPartition(clusterMap.clusterIds(), hard);
   }
 
-  // maxTreeDepth, not numLevels (#1036): an initial partition read from a .tree file is
-  // exactly the ragged case, and numLevels would report the first-child branch's depth.
-  const unsigned int initialDepth = maxTreeDepth();
+  // An initial partition read from a .tree file is exactly the ragged case, so this has
+  // to count over every branch -- it used to print the first-child branch's depth (#1036).
+  const unsigned int initialDepth = numLevels();
   Console().status("Initial", fmt::format(FMT_STRING("generated {} levels, codelength {}"), initialDepth, io::toPrecision(m_hierarchicalCodelength)));
   Console::detail(1, "generated {} levels, codelength {:g} + {:g} = {}", initialDepth, getIndexCodelength(), m_hierarchicalCodelength - getIndexCodelength(), io::toPrecision(m_hierarchicalCodelength));
 
@@ -2586,7 +2587,7 @@ void InfomapBase::findTopModulesRepeatedly(unsigned int maxLevels)
   std::vector<std::string> passList; // "<nodes>*<loops>" per aggregation pass, for the -v trace
   Log(3).print("\nIteration {}:\n", m_tuneIterationIndex + 1);
   m_aggregationLevel = 0;
-  unsigned int numLevelsConsolidated = numLevels() - 1;
+  unsigned int numLevelsConsolidated = depthOfFirstLeaf() - 1;
   if (maxLevels == 0)
     maxLevels = std::numeric_limits<unsigned int>::max();
 
@@ -2632,8 +2633,8 @@ void InfomapBase::findTopModulesRepeatedly(unsigned int maxLevels)
 
 unsigned int InfomapBase::fineTune()
 {
-  if (numLevels() != 2)
-    throw std::logic_error("InfomapBase::fineTune() called but numLevels != 2");
+  if (depthOfFirstLeaf() != 2)
+    throw std::logic_error("InfomapBase::fineTune() called but the tree is not two-level");
 
   setActiveNetworkFromLeafs();
   initPartition();
@@ -2670,8 +2671,8 @@ unsigned int InfomapBase::fineTune()
 
 unsigned int InfomapBase::coarseTune()
 {
-  if (numLevels() != 2)
-    throw std::logic_error("InfomapBase::coarseTune() called but numLevels != 2");
+  if (depthOfFirstLeaf() != 2)
+    throw std::logic_error("InfomapBase::coarseTune() called but the tree is not two-level");
 
   Log(4) << "Coarse-tune...\nPartition each module in sub-modules for coarse tune...\n";
 
@@ -2783,7 +2784,7 @@ unsigned int InfomapBase::findHierarchicalSuperModules(unsigned int superLevelLi
   double hierarchicalCodelength = getCodelength();
   double workingHierarchicalCodelength = hierarchicalCodelength;
 
-  const unsigned int prefBaseDepth = numLevels(); // #308: depth before super levels are added
+  const unsigned int prefBaseDepth = depthOfFirstLeaf(); // #308: depth before super levels are added
 
   if (!haveModules())
     throw std::logic_error("Trying to find hierarchical super modules without any modules");
@@ -2984,12 +2985,12 @@ void InfomapBase::resetFlowOnModules()
 
 unsigned int InfomapBase::removeModules()
 {
-  // Flatten until every child of root is a leaf. numLevels() only follows the
-  // firstChild chain (it assumes a uniform-depth tree, see its TODO), so it
-  // under-counts a ragged multilevel tree and would stop early, leaving deeper
-  // module subtrees behind. Loop on "any non-leaf child" instead so ragged trees
-  // (e.g. from materialize-and-free) flatten completely. For the uniform trees
-  // produced elsewhere this does the same number of passes as before.
+  // Flatten until every child of root is a leaf. This used to loop on numLevels(),
+  // which then followed the firstChild chain only (what depthOfFirstLeaf does now), so
+  // it under-counted a ragged multilevel tree and stopped early, leaving deeper module
+  // subtrees behind. Loop on "any non-leaf child" instead so ragged trees (e.g. from
+  // materialize-and-free) flatten completely. For the uniform trees produced elsewhere
+  // this does the same number of passes as before.
   auto rootHasModuleChild = [this]() {
     for (auto& child : m_root)
       if (!child.isLeaf())
@@ -3011,11 +3012,11 @@ unsigned int InfomapBase::removeModules()
 unsigned int InfomapBase::removeSubModules(bool recalculateCodelengthOnTree)
 {
   // Loop on "any top module still has a module child" for the reason removeModules
-  // gives above: numLevels() follows the firstChild chain only, so on a ragged tree it
-  // reports the leftmost branch's depth and this loop stopped while deeper branches
-  // were still nested. What came out was neither the two-level tree the caller asked
-  // for nor a codelength of it -- calcCodelengthOnTree below then scored a tree that
-  // still had sub-modules in it (#898).
+  // gives above: the old numLevels() followed the firstChild chain only, so on a ragged
+  // tree it reported the leftmost branch's depth and this loop stopped while deeper
+  // branches were still nested. What came out was neither the two-level tree the caller
+  // asked for nor a codelength of it -- calcCodelengthOnTree below then scored a tree
+  // that still had sub-modules in it (#898).
   auto anyModuleHasModuleChild = [this]() {
     for (auto& module : m_root)
       for (auto& child : module)
@@ -3069,9 +3070,9 @@ unsigned int InfomapBase::recursivePartition()
   std::string queueSource;
   if (fastHierarchicalSolution > 0) {
     queueLeafModules(partitionQueue);
-    // partitionQueue.level, not numLevels() - 2 (#1036): queueLeafModules already recorded
-    // the depth of the deepest queued module, computed over all branches. numLevels walks
-    // the first-child chain, and its - 2 named the level above the modules it describes.
+    // partitionQueue.level, not a depth recomputed here (#1036): queueLeafModules already
+    // recorded the depth of the deepest queued module. The old `numLevels() - 2` walked the
+    // first-child chain, and its - 2 named the level above the modules it describes.
     queueSource = fmt::format(FMT_STRING("{} sub modules on level {}"), partitionQueue.size(), partitionQueue.level);
   } else {
     queueTopModules(partitionQueue);

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1005,7 +1005,11 @@ private:
     // From trialSeed, not from the live config field: seedTrial has already moved
     // that field to this trial's seed, so recomputing from it would double-count
     // the global index.
-    m_timing.recordTrial(trialIndex, 0, trialSeed(trialIndex), timer.getElapsedTimeInSec(), m_infomap.m_hierarchicalCodelength, m_infomap.numTopModules(), m_infomap.numLevels());
+    // maxTreeDepth, not numLevels: numLevels only walks the first-child chain, so on a
+    // ragged tree it records one arbitrary branch's depth and the JSON disagrees with the
+    // .tree file and the summary it describes (#1036). The parallel path below already
+    // records printPerLevelCodelength's level count, which is the same all-leaves depth.
+    m_timing.recordTrial(trialIndex, 0, trialSeed(trialIndex), timer.getElapsedTimeInSec(), m_infomap.m_hierarchicalCodelength, m_infomap.numTopModules(), m_infomap.maxTreeDepth());
 
     if (m_infomap.printAllTrials && m_numTrials > 1) {
       auto outputTimer = m_timing.scope("output_s");
@@ -1222,7 +1226,10 @@ std::ostream& operator<<(std::ostream& out, const InfomapBase& infomap)
 
 unsigned int InfomapBase::numLevels() const
 {
-  // TODO: Make sure this is not called unless tree is guaranteed to have even depth!
+  // Walks the first-child chain only, so this is the depth of ONE branch, not the tree's.
+  // Valid only where the tree is uniform-depth by construction (the two-level guards, the
+  // super-level bookkeeping). Anything that reports a depth to a user or to a file wants
+  // maxTreeDepth instead -- see #1036, #898.
   unsigned int depth = 0;
   InfoNode* n = m_root.firstChild;
   while (n != nullptr) {
@@ -1388,8 +1395,11 @@ InfomapBase& InfomapBase::initPartition(const std::string& clusterDataFile, bool
     initPartition(clusterMap.clusterIds(), hard);
   }
 
-  Console().status("Initial", fmt::format(FMT_STRING("generated {} levels, codelength {}"), numLevels(), io::toPrecision(m_hierarchicalCodelength)));
-  Console::detail(1, "generated {} levels, codelength {:g} + {:g} = {}", numLevels(), getIndexCodelength(), m_hierarchicalCodelength - getIndexCodelength(), io::toPrecision(m_hierarchicalCodelength));
+  // maxTreeDepth, not numLevels (#1036): an initial partition read from a .tree file is
+  // exactly the ragged case, and numLevels would report the first-child branch's depth.
+  const unsigned int initialDepth = maxTreeDepth();
+  Console().status("Initial", fmt::format(FMT_STRING("generated {} levels, codelength {}"), initialDepth, io::toPrecision(m_hierarchicalCodelength)));
+  Console::detail(1, "generated {} levels, codelength {:g} + {:g} = {}", initialDepth, getIndexCodelength(), m_hierarchicalCodelength - getIndexCodelength(), io::toPrecision(m_hierarchicalCodelength));
 
   return *this;
 }
@@ -3059,7 +3069,10 @@ unsigned int InfomapBase::recursivePartition()
   std::string queueSource;
   if (fastHierarchicalSolution > 0) {
     queueLeafModules(partitionQueue);
-    queueSource = fmt::format(FMT_STRING("{} sub modules on level {}"), partitionQueue.size(), numLevels() - 2);
+    // partitionQueue.level, not numLevels() - 2 (#1036): queueLeafModules already recorded
+    // the depth of the deepest queued module, computed over all branches. numLevels walks
+    // the first-child chain, and its - 2 named the level above the modules it describes.
+    queueSource = fmt::format(FMT_STRING("{} sub modules on level {}"), partitionQueue.size(), partitionQueue.level);
   } else {
     queueTopModules(partitionQueue);
     queueSource = fmt::format(FMT_STRING("{} top modules"), partitionQueue.size());

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -122,7 +122,9 @@ public:
   bool haveNonTrivialModules() const { return numNonTrivialTopModules() > 0; }
 
   /**
-   * Number of node levels below the root in current Infomap instance, 1 if no modules
+   * Depth of the first-child branch below the root, 1 if no modules. This equals the
+   * tree's depth only when the tree is uniform-depth; on a ragged tree it under-counts.
+   * Use maxTreeDepth for anything reported to a user or written to a file (#1036).
    */
   unsigned int numLevels() const;
 

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -122,9 +122,9 @@ public:
   bool haveNonTrivialModules() const { return numNonTrivialTopModules() > 0; }
 
   /**
-   * Depth of the first-child branch below the root, 1 if no modules. This equals the
-   * tree's depth only when the tree is uniform-depth; on a ragged tree it under-counts.
-   * Use maxTreeDepth for anything reported to a user or written to a file (#1036).
+   * Number of node levels below the root, counted over every branch, 1 if no modules.
+   * Alias of maxTreeDepth. This is the depth the summary, the tree writer and the JSON
+   * output report, so it is what any other report of a depth should use (#1036).
    */
   unsigned int numLevels() const;
 
@@ -270,6 +270,18 @@ public:
 
 private:
   class RunSession;
+
+  /**
+   * Depth of the leftmost branch: follows firstChild to the first leaf. O(depth) where
+   * numLevels is O(nodes), which is why the search uses it -- consolidateModules alone
+   * calls it ~270k times per web-NotreDame trial. It equals numLevels only on a
+   * uniform-depth tree, which every one of its call sites has by construction: they run
+   * inside the per-module optimization, below the point where sub-Infomap results are
+   * stitched in and make the tree ragged. Measured over the test suite and the benchmark
+   * networks, the two never disagreed at any of those sites. Never report this value --
+   * that is the bug in #1036.
+   */
+  unsigned int depthOfFirstLeaf() const;
 
   // Allocate a tree node from this instance's pool and stamp its owning pool
   // back-pointer so node-local teardown (deleteChildren / remove /

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -1008,7 +1008,7 @@ inline void InfomapOptimizer<Objective>::consolidateModules(bool replaceExisting
 
   InfoNode& firstActiveNode = *network[0];
   auto level = firstActiveNode.depth();
-  auto leafLevel = m_infomap->numLevels();
+  auto leafLevel = m_infomap->depthOfFirstLeaf(); // cheap: uniform tree here, see its docs
 
   if (leafLevel == 1)
     replaceExistingModules = false;

--- a/src/io/Output.cpp
+++ b/src/io/Output.cpp
@@ -141,7 +141,7 @@ std::string getOutputFileHeader(const InfomapBase& im, const StateNetwork& netwo
                      // interrupt time, when doing work is least reliable.
                      im.codelengths().size(),
                      im.numTrials,
-                     im.maxTreeDepth(),
+                     im.numLevels(),
                      im.numTopModules(),
                      im.codelength(),
                      im.getRelativeCodelengthSavings() * 100,
@@ -301,7 +301,7 @@ void writeJsonTree(InfomapBase& im, const StateNetwork& network, std::ostream& o
   json["startedAt"] = io::stringify(im.getStartDate());
   json["completedIn"] = im.getElapsedTime().getElapsedTimeInSec();
   json["codelength"] = im.codelength();
-  json["numLevels"] = im.maxTreeDepth();
+  json["numLevels"] = im.numLevels();
   json["numTopModules"] = im.numTopModules();
 
   Json numModules = Json::array();

--- a/test/bench/native_benchmark.cpp
+++ b/test/bench/native_benchmark.cpp
@@ -147,7 +147,7 @@ int main(int argc, char* argv[])
           runSec,
           currentPeakRss,
           im.numTopModules(),
-          im.numLevels(),
+          im.maxTreeDepth(), // not numLevels: that is one branch's depth, #1036
           im.codelength(),
       });
     }
@@ -166,7 +166,7 @@ int main(int argc, char* argv[])
     result["num_nodes"] = inputNodeCount;
     result["num_links"] = inputLinkCount;
     result["num_top_modules"] = im.numTopModules();
-    result["num_levels"] = im.numLevels();
+    result["num_levels"] = im.maxTreeDepth(); // matches the Python benchmark's num_levels, #1036
     result["codelength"] = im.codelength();
     result["higher_order_input"] = higherOrderInput;
     result["directed_input"] = directedInput;

--- a/test/bench/native_benchmark.cpp
+++ b/test/bench/native_benchmark.cpp
@@ -147,7 +147,7 @@ int main(int argc, char* argv[])
           runSec,
           currentPeakRss,
           im.numTopModules(),
-          im.maxTreeDepth(), // not numLevels: that is one branch's depth, #1036
+          im.numLevels(),
           im.codelength(),
       });
     }
@@ -166,7 +166,7 @@ int main(int argc, char* argv[])
     result["num_nodes"] = inputNodeCount;
     result["num_links"] = inputLinkCount;
     result["num_top_modules"] = im.numTopModules();
-    result["num_levels"] = im.maxTreeDepth(); // matches the Python benchmark's num_levels, #1036
+    result["num_levels"] = im.numLevels();
     result["codelength"] = im.codelength();
     result["higher_order_input"] = higherOrderInput;
     result["directed_input"] = directedInput;

--- a/test/cpp/test_infomap_wrapper.cpp
+++ b/test/cpp/test_infomap_wrapper.cpp
@@ -713,11 +713,11 @@ TEST_CASE("Run reports write machine-readable JSON with no-file-output [fast][co
 
 TEST_CASE("Per-trial num_levels reports the tree's depth, not the first-child branch's [fast][core][lifecycle][output]")
 {
-  // numLevels() walks the first-child chain only, so on a ragged tree it reported one
-  // arbitrary branch's depth while the console summary, the .tree file and the JSON tree
-  // output all reported maxTreeDepth. --timing-json and --trial-results share the record,
-  // so both carried the shallow branch (#1036). --no-infomap keeps the fixture's ragged
-  // shape through the trial, so the two depths stay observably different here.
+  // numLevels() used to walk the first-child chain only, so on a ragged tree it reported
+  // one arbitrary branch's depth while the console summary, the .tree file and the JSON
+  // tree output all counted over every branch. --timing-json and --trial-results share
+  // the record, so both carried the shallow branch (#1036). --no-infomap keeps the
+  // fixture's ragged shape through the trial, where the difference is observable.
   const std::vector<std::string> paths = {
     "run_report_ragged_timing.json",
     "run_report_ragged_trials.json",
@@ -732,10 +732,16 @@ TEST_CASE("Per-trial num_levels reports the tree's depth, not the first-child br
 
   im.run();
 
-  // Preconditions. Without both of these the checks below would pass on the old value
-  // too: the tree has to be ragged, and the shallow branch has to be the first child.
+  // The fixture's shape, pinned so an edit to it cannot silently stop exercising this:
+  // three deep, with the SHALLOW branch first. Root's leftmost top module ends at depth
+  // 2 while another branch runs to 3, which is what made the leftmost-branch walk report
+  // 2 for a three-level tree.
   REQUIRE(im.maxTreeDepth() == 3);
-  REQUIRE(im.numLevels() == 2);
+  REQUIRE(im.numLevels() == im.maxTreeDepth());
+  const infomap::InfoNode* firstTopModule = im.root().firstChild;
+  REQUIRE(firstTopModule != nullptr);
+  REQUIRE(firstTopModule->firstChild != nullptr);
+  REQUIRE(firstTopModule->firstChild->isLeaf());
 
   CHECK(infomap::test::readTextFile(paths[0]).find("\"num_levels\":3") != std::string::npos);
   CHECK(infomap::test::readTextFile(paths[1]).find("\"num_levels\":3") != std::string::npos);

--- a/test/cpp/test_infomap_wrapper.cpp
+++ b/test/cpp/test_infomap_wrapper.cpp
@@ -711,6 +711,38 @@ TEST_CASE("Run reports write machine-readable JSON with no-file-output [fast][co
   removeFiles(paths);
 }
 
+TEST_CASE("Per-trial num_levels reports the tree's depth, not the first-child branch's [fast][core][lifecycle][output]")
+{
+  // numLevels() walks the first-child chain only, so on a ragged tree it reported one
+  // arbitrary branch's depth while the console summary, the .tree file and the JSON tree
+  // output all reported maxTreeDepth. --timing-json and --trial-results share the record,
+  // so both carried the shallow branch (#1036). --no-infomap keeps the fixture's ragged
+  // shape through the trial, so the two depths stay observably different here.
+  const std::vector<std::string> paths = {
+    "run_report_ragged_timing.json",
+    "run_report_ragged_trials.json",
+  };
+  removeFiles(paths);
+
+  InfomapWrapper im("--silent --seed 1 --num-trials 1 --no-file-output --no-infomap"
+                    " --cluster-data "
+                    + infomap::test::clusterFixturePath("twotriangles_ragged_branches.tree")
+                    + " --timing-json " + paths[0] + " --trial-results " + paths[1]);
+  im.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+
+  im.run();
+
+  // Preconditions. Without both of these the checks below would pass on the old value
+  // too: the tree has to be ragged, and the shallow branch has to be the first child.
+  REQUIRE(im.maxTreeDepth() == 3);
+  REQUIRE(im.numLevels() == 2);
+
+  CHECK(infomap::test::readTextFile(paths[0]).find("\"num_levels\":3") != std::string::npos);
+  CHECK(infomap::test::readTextFile(paths[1]).find("\"num_levels\":3") != std::string::npos);
+
+  removeFiles(paths);
+}
+
 TEST_CASE("Parallel trials report the best trial codelength [fast][core][lifecycle][openmp]")
 {
   InfomapWrapper im("--silent --seed 7 --num-trials 4 --parallel-trials --no-file-output");

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -299,18 +299,26 @@ TEST_CASE("A two-level search from a deeper tree keeps its top level [fast][core
 
 TEST_CASE("removeSubModules flattens a ragged tree whose shallow branch comes first [fast][core][partition][tree]")
 {
-  // numLevels() follows the firstChild chain only, so with the shallow branch first it
-  // reports 2 for a three-level tree and the old `while (numLevels() > 2)` loop did
-  // nothing at all -- leaving sub-modules in place for calcCodelengthOnTree to score as
-  // if they were not there (#898).
+  // The old numLevels() followed the firstChild chain only (that walk is now the private
+  // depthOfFirstLeaf), so with the shallow branch first it reported 2 for a three-level
+  // tree and the old `while (numLevels() > 2)` loop did nothing at all -- leaving
+  // sub-modules in place for calcCodelengthOnTree to score as if they were not there
+  // (#898).
   InfomapWrapper im(infomap::test::defaultFlags());
   im.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
   im.initNetwork(im.network());
   im.initPartition(infomap::test::clusterFixturePath("twotriangles_ragged_branches.tree"), false, &im.network());
 
+  // The fixture's shape, pinned so an edit to it cannot silently stop exercising this:
+  // three deep, with the SHALLOW branch first. Root's leftmost top module ends at depth
+  // 2 while another branch runs to 3, which is what made the leftmost-branch walk report
+  // 2 for a three-level tree.
   REQUIRE(im.maxTreeDepth() == 3);
-  // The shortcut this test exists for, pinned so the fixture keeps exercising it.
-  REQUIRE(im.numLevels() == 2);
+  REQUIRE(im.numLevels() == im.maxTreeDepth());
+  const infomap::InfoNode* firstTopModule = im.root().firstChild;
+  REQUIRE(firstTopModule != nullptr);
+  REQUIRE(firstTopModule->firstChild != nullptr);
+  REQUIRE(firstTopModule->firstChild->isLeaf());
 
   im.removeSubModules(true);
 


### PR DESCRIPTION
Fixes #1036.

`--timing-json`'s `trials[].num_levels` and `--trial-results`' `num_levels` recorded
`InfomapBase::numLevels()`, which walked only the first-child chain. On a ragged tree that is one
arbitrary branch's depth, so the two machine-readable outputs silently disagreed with the console
summary, the `.tree` file and the JSON tree output. On `web-NotreDame -d` they said **5** where every
other channel said **12**.

Only the **serial** trial path was affected — the parallel path already recorded
`printPerLevelCodelength`'s level count — so the same run reported two different depths depending on
`--parallel-trials`.

## The fix: make the name honest

Rather than move the reporting sites off `numLevels()` one by one, `numLevels()` now *is* the tree's
depth (`return maxTreeDepth();`), and the cheap leftmost-branch walk moves to a **private**
`depthOfFirstLeaf()` for the search's own use. Patching call sites would have left the trap in place:
the name says "number of levels in the tree" and every caller had to know it did not mean that.

**Nothing depended on the old meaning.** All five internal call sites were instrumented to compare
the two depths at each call, then run over the whole C++ test suite and the benchmark networks —
including `web-NotreDame -d`, whose final tree is 12 deep and ragged, and a deliberately ragged
`--cluster-data` initial partition:

| internal call site | calls | mismatches |
|---|--:|--:|
| `consolidateModules` | 288,706 | **0** |
| `findTopModulesRepeatedly` | 202,775 | **0** |
| `fineTune` | 21,191 | **0** |
| `coarseTune` | 20,856 | **0** |
| `findHierarchicalSuperModules` | 8,128 | **0** |

All five run inside the per-module optimization, where the tree below the active root is uniform by
construction — the raggedness only appears higher up, once sub-Infomap results are stitched into the
parent tree.

So the reason to keep a second function is **cost, not meaning**: `numLevels()` is now O(nodes) where
the branch walk is O(depth), and `consolidateModules` alone calls it ~270k times per web-NotreDame
trial. `depthOfFirstLeaf()` is private — `InfomapOptimizer` is already a `friend` — so it adds no
binding surface and needs no SWIG regeneration.

With the name honest, every reporting site and both bindings just say `numLevels`: the per-trial
record, the `Initial: generated N levels` line, the `numLevels` field in the JSON output, the run
header, the benchmark harness, Python's `Result.num_levels` and R's `$num_levels`. `maxTreeDepth()`
stays as the implementation and keeps its own bindings (`max_depth`, `max_tree_depth`).

## Before / after

`./Infomap networks/db/web-NotreDame.net out -d --seed 123 -N1 -o json,tree --timing-json -`

| channel | before | after |
|---|--:|--:|
| `timing.json` `trials[0].num_levels` | **5** | **12** |
| `--trial-results` `num_levels` | **5** | **12** |
| `web-NotreDame.json` `numLevels` | 12 | 12 |
| console `Levels` | 12 | 12 |
| `web-NotreDame.tree` deepest path | 12 | 12 |

All four channels now agree on every network in the issue:

| network | before (`--timing-json`) | after (all channels) |
|---|--:|--:|
| ninetriangles | 3 | 3 |
| politicalblogs `-d` | 2 | 3 |
| science2001 `-d` | 3 | 4 |
| web-NotreDame `-d` | 5 | 12 |

## Other reporting uses the issue asked to audit

- **`Initial: generated N levels`** in `initPartition(clusterDataFile)` — an initial partition read
  from a `.tree` file is exactly the ragged case; it printed 2 for a 3-deep fixture.
- **`recursivePartition`'s queue-source line** now uses `partitionQueue.level`, the depth
  `queueLeafModules` already computed over all branches. The old `numLevels() - 2` was also off by
  one against that field, naming the level *above* the modules it describes.
- **`test/bench/native_benchmark.cpp`** — the harness's `num_levels`, so it matches the Python
  benchmark it is compared against.

## R binding

The audit surfaced the same bug one layer out: `Infomap$num_levels` called `numLevels()` while being
documented as "Number of levels in the tree", and `get_multilevel_modules()` used it as its loop
bound — so on a ragged tree it returned length-2 paths for a 3-deep tree, and `cluster_infomap()`
reported the short value. Both are fixed by the core change; the field is now documented as an alias
of `max_tree_depth`, exactly as Python's `num_levels` aliases `max_depth`. `man/Infomap.Rd`
regenerated with the pinned roxygen2 7.3.3.

The JS interface reads `numLevels` from the JSON tree output and was already correct.

## Tests

- `test/cpp/test_infomap_wrapper.cpp` — a ragged tree held in place with `--no-infomap --cluster-data`
  (reusing the `twotriangles_ragged_branches.tree` fixture from #898), asserting both JSON artifacts
  report 3. Against `master`'s core it fails on both `CHECK`s.
- `interfaces/R/infomap/tests/testthat/test-modules.R` — the same tree from `tempfile()`s, asserting
  `num_levels == max_tree_depth` and that `get_multilevel_modules()` returns full-depth paths. Fails
  twice against the old binding.
- The two ragged-fixture tests that pinned the old quirk through `numLevels() == 2` now pin the tree
  shape directly — three deep, leftmost top module ending at depth 2 — which is the property the
  fixture actually has to keep, and does not depend on a private helper.

## Verification

Partitions are **bit-identical** to the pre-refactor head on six configurations — same codelength,
top modules and levels on every one: ninetriangles `-N5`, politicalblogs `-d -N3`, science2001
`-d -N3 --preferred-number-of-levels 3` (exercising the `prefBaseDepth` site), web-NotreDame `-d -N1`,
the ragged `--cluster-data` run, and `-2`.

`make test-native MODE=release` green at `OPENMP=1`, `OPENMP=0` and
`OPENMP=1 FEATURES="lossy-map-equation regularized-multilayer"` — 26/26 each. Python suite 850 passed
/ 2 skipped / 1 xfailed. `make test-r` 0 errors (3 WARNINGs / 2 NOTEs, all pre-existing environment
findings: missing `checkbashisms`, missing `qpdf`, CRAN incoming feasibility, unverifiable clock).
`format-native-check`, `format-r-check` (Air 0.9.0), `test-r-man-freshness`,
`test-python-swig-freshness`, `test-binding-options-freshness` all green.

## Cost

The hot path is unchanged — it kept the O(depth) walk. `web-NotreDame -d --seed 123 -N1`, both
binaries interleaved in one session, 6 reps each, `timing.total_s`:

| | min | median | max |
|---|--:|--:|--:|
| before the refactor | 14.254 s | 14.699 s | 15.173 s |
| after the refactor | 14.363 s | 14.538 s | 15.967 s |

Overlapping; no signal. Against `master` the same measurement (8 reps) was 14.541 s vs 14.476 s min —
the once-per-trial full-tree walk is lost in session noise.
