### PR TITLE
fix: keep the linlog damping interpolation smooth at q = 1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,6 +200,7 @@ if(BUILD_TESTING)
     add_infomap_cpp_test(infomap_cpp_preferred_levels_tests test/cpp/test_preferred_levels.cpp "fast;core;preferred-levels")
     add_infomap_cpp_test(infomap_cpp_random_tests test/cpp/test_random.cpp "fast;core;rng")
     add_infomap_cpp_test(infomap_cpp_map_equation_invariants_tests test/cpp/test_map_equation_invariants.cpp "fast;core;mapeq")
+    add_infomap_cpp_test(infomap_cpp_infomath_tests test/cpp/test_infomath.cpp "fast;core;utils")
 
     add_test(
         NAME print_json_parameters
@@ -322,6 +323,7 @@ if(BUILD_TESTING)
             infomap_cpp_preferred_levels_tests
             infomap_cpp_random_tests
             infomap_cpp_map_equation_invariants_tests
+            infomap_cpp_infomath_tests
             infomap_cli
     )
 endif()

--- a/src/utils/infomath.h
+++ b/src/utils/infomath.h
@@ -207,11 +207,20 @@ namespace infomath {
    * Interpolate from linear (q = 0) to log (q = 1)
    * linlog(k, 0) = k
    * linlog(k, 1) = log2(k)
+   *
+   * The Tsallis entropy of a uniform distribution already interpolates between
+   * (k - 1) / ln2 and log2(k), so two corrections rescale it onto the endpoints
+   * above. Both are written in a shape variable s(q) with s(0) = 0 and s(1) = 1,
+   * and both are held constant for q > 1. Any such s reproduces the endpoints,
+   * but only one with s'(1) = 0 joins the constant branch with a matching
+   * derivative, so s(q) = q(2 - q) keeps linlog continuously differentiable in q
+   * at q = 1 where the linear s(q) = q leaves a kink.
    */
   inline double linlog(double k, double q = 1)
   {
-    double baseCorrection = q <= 1 ? (1 - q) * std::log(2) + q : 1;
-    double offsetCorrection = q <= 1 ? 1 - q : 0;
+    double shape = q <= 1 ? q * (2 - q) : 1;
+    double baseCorrection = (1 - shape) * std::log(2) + shape;
+    double offsetCorrection = 1 - shape;
     return tsallisEntropyUniform(k, q) * baseCorrection + offsetCorrection;
   }
 

--- a/test/cpp/test_infomath.cpp
+++ b/test/cpp/test_infomath.cpp
@@ -1,0 +1,77 @@
+#include "vendor/doctest.h"
+
+#include "utils/infomath.h"
+
+#include <cmath>
+#include <vector>
+
+using infomap::infomath::linlog;
+using infomap::infomath::tsallisEntropyUniform;
+
+namespace {
+
+const std::vector<double> kValues = { 1, 2, 3, 5, 10, 64, 1000, 1e5 };
+
+// Central difference is not usable across q = 1: the corrections are held
+// constant above it, so the two sides are different expressions and a symmetric
+// stencil would average them. One-sided slopes are what the smoothness claim is
+// about.
+double slopeFromLeft(double k, double q, double h = 1e-6)
+{
+  return (linlog(k, q) - linlog(k, q - h)) / h;
+}
+
+double slopeFromRight(double k, double q, double h = 1e-6)
+{
+  return (linlog(k, q + h) - linlog(k, q)) / h;
+}
+
+} // namespace
+
+TEST_CASE("linlog reproduces its endpoints exactly [fast][core][utils]")
+{
+  for (double k : kValues) {
+    CHECK(linlog(k, 0) == doctest::Approx(k).epsilon(1e-12));
+    CHECK(linlog(k, 1) == doctest::Approx(std::log2(k)).epsilon(1e-12));
+  }
+}
+
+TEST_CASE("linlog is smooth in q where the corrections stop varying [fast][core][utils]")
+{
+  // The corrections are frozen for q > 1, so the interpolation joins that branch
+  // smoothly only if the shape variable has zero slope at q = 1. Without it the
+  // derivative jumps and a damping sweep through 1 shows a kink.
+  for (double k : { 2.0, 64.0, 1000.0 }) {
+    CHECK(linlog(k, 1) == doctest::Approx(linlog(k, 1 + 1e-9)).epsilon(1e-9));
+    CHECK(slopeFromLeft(k, 1) == doctest::Approx(slopeFromRight(k, 1)).epsilon(1e-4));
+  }
+}
+
+TEST_CASE("linlog keeps the monotonicity the flow model relies on [fast][core][utils]")
+{
+  // Local Markov time is a ratio of scales, so the scale has to grow with the
+  // local flow and damping has to shrink the spread rather than invert it.
+  for (double q = 0; q <= 1.0001; q += 0.1) {
+    for (std::size_t i = 1; i < kValues.size(); ++i) {
+      CHECK(linlog(kValues[i], q) > linlog(kValues[i - 1], q));
+    }
+  }
+
+  for (double k : { 2.0, 10.0, 1000.0 }) {
+    double previous = linlog(k, 0);
+    for (double q = 0.1; q <= 1.0001; q += 0.1) {
+      const double current = linlog(k, q);
+      CHECK(current <= previous + 1e-12);
+      previous = current;
+    }
+  }
+}
+
+TEST_CASE("linlog leaves the Tsallis entropy uncorrected above q = 1 [fast][core][utils]")
+{
+  for (double k : kValues) {
+    for (double q : { 1.5, 2.0, 4.0 }) {
+      CHECK(linlog(k, q) == doctest::Approx(tsallisEntropyUniform(k, q)).epsilon(1e-12));
+    }
+  }
+}


### PR DESCRIPTION
## What

`infomath::linlog` rescales the Tsallis entropy of a uniform distribution onto the endpoints `linlog(k, 0) = k` and `linlog(k, 1) = log2(k)` with a scale and an offset correction. Both are written in a shape variable `s(q)` with `s(0) = 0` and `s(1) = 1`, and both are frozen above `q = 1`.

Any such `s` reproduces the endpoints, but the interpolation joins the constant branch with a matching derivative only when `s'(1) = 0`. The linear `s(q) = q` does not. At `k = 64` the one-sided slopes of `linlog` in `q` were `-11.64` from the left and `-12.48` from the right, a jump of `0.84`, so a sweep of `--variable-markov-damping` through 1 crossed a corner instead of passing through smoothly.

This switches the shape to `s(q) = q(2 - q)`, which satisfies the same endpoint conditions and has `s'(1) = 0`.

## Scope of the behavior change

- `q = 0` and `q = 1` are unchanged and still exact.
- `q > 1` is unchanged; the corrections were already constant there.
- Only `0 < damping < 1` moves. Over `k` in `[2, 1e6]` the two shapes differ by at most 11 percent in the local scale. On the street, electronic circuit, power grid and transport networks the induced local Markov times move by 9 to 17 percent at intermediate damping, and the partitions agree at an adjusted mutual information between 0.89 and 1.00.
- The default damping is 1, so default behavior does not change.

## Tests

New `test/cpp/test_infomath.cpp` pins:

- both endpoints, exactly
- the one-sided derivatives in `q` at `q = 1` agreeing
- monotonicity in `k`, and non-increasing in `q`
- the uncorrected passthrough to `tsallisEntropyUniform` above `q = 1`

The smoothness case fails against the linear shape and passes with the quadratic one; the other three pass either way, since only the interior path changed. `make test-native`: 27/27 passing.