### PR TITLE
fix: guard the _states output artifacts against overwriting the input

### DIFF
--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -246,8 +246,12 @@ public:
     // back on the way out -- including when a run throws.
     const ScopedOpenMpNumThreads scopedThreadBudget(asOpenMpThreadCount(m_threadBudget.threads));
 #endif
-    preflightOutputTargets(m_infomap);
+    // After validateNetwork(), because the pre-flight needs to know whether the
+    // input is higher-order and that is only settled once the network is read and
+    // post-processed -- a multilayer file has no state nodes at all until then.
+    // Still ahead of every writer, which is what the check exists for.
     validateNetwork();
+    preflightOutputTargets(m_infomap, higherOrderInput());
     {
       auto timer = m_timing.scope("pre_run_output_s");
       writeOutputArtifacts(m_infomap, m_network, OutputPhase::BeforeFlow);
@@ -604,12 +608,27 @@ private:
     }
   }
 
+  // Whether configureNetworkMode() will turn state output on, answerable as soon
+  // as the network is read. The output pre-flight has to plan the `_states`
+  // artifacts before the classification runs, and a second, drifting copy of this
+  // condition is exactly how #1018 let a run overwrite its own input.
+  HigherOrderInput higherOrderInput() const
+  {
+    const bool stateOutput = m_network.haveMemoryInput()
+        || m_infomap.haveMemory()
+        || m_network.higherOrderInputMethodCalled();
+    return stateOutput ? HigherOrderInput::Yes : HigherOrderInput::No;
+  }
+
   void configureNetworkMode()
   {
+    // Read before setStateInput() below, which would otherwise make haveMemory()
+    // true and change the predicate's answer mid-function.
+    const bool useStateOutput = higherOrderInput() == HigherOrderInput::Yes;
+
     if (m_network.haveMemoryInput()) {
       Console::detail(1, "found higher-order network input, using the Map Equation for higher-order flows");
       m_infomap.setStateInput();
-      m_infomap.setStateOutput();
 
       if (m_network.isMultilayerNetwork() && !m_infomap.isMultilayerNetwork()) {
         m_infomap.setMultilayerInput();
@@ -617,10 +636,16 @@ private:
     } else {
       if (m_infomap.haveMemory() || m_network.higherOrderInputMethodCalled()) {
         Console::warn(0, "Higher-order network specified but no higher-order input found.");
-        // Use state output anyway for consistency even in the special case when input is first order
-        m_infomap.setStateOutput();
       }
       Console::detail(1, "ordinary network input, using the Map Equation for first-order flows");
+    }
+
+    // Set from the shared predicate rather than inside either branch, so the
+    // pre-flight's view of which artifacts a run writes cannot diverge from the
+    // run's. The first-order branch turns it on too, for consistency, when
+    // higher-order input was asked for but not found.
+    if (useStateOutput) {
+      m_infomap.setStateOutput();
     }
 
     if (m_network.haveDirectedInput() && m_infomap.isUndirectedFlow()) {

--- a/src/io/OutputPlan.cpp
+++ b/src/io/OutputPlan.cpp
@@ -349,25 +349,39 @@ std::vector<std::pair<std::string, std::string>> planReportArtifacts(const Confi
   return reports;
 }
 
-std::vector<std::string> planAllOutputPaths(const Config& config)
+std::vector<std::string> planAllOutputPaths(const Config& config, HigherOrderInput higherOrder)
 {
   std::vector<std::string> paths;
 
-  const auto collectPhase = [&](OutputPhase phase, int trial) {
-    for (const auto& artifact : planOutputArtifacts(config, phase, trial))
+  // Two configs, because Config::stateOutput changes value inside the window
+  // this function has to describe. configureNetworkMode() sets it after the
+  // BeforeFlow artifacts are written and before everything else, so the
+  // BeforeFlow phase is planned as the run will actually write it -- with state
+  // output still off -- and the later phases with the value the classification
+  // will install. Getting this wrong in either direction is a live defect: too
+  // few paths lets a run destroy its own input (#1018), too many refuses a run
+  // that would have been fine.
+  Config beforeConfigure = config;
+  beforeConfigure.stateOutput = false;
+  Config afterConfigure = config;
+  if (higherOrder == HigherOrderInput::Yes)
+    afterConfigure.setStateOutput();
+
+  const auto collectPhase = [&](const Config& phaseConfig, OutputPhase phase, int trial) {
+    for (const auto& artifact : planOutputArtifacts(phaseConfig, phase, trial))
       paths.push_back(artifact.filename);
   };
 
   // Network sidecars are written once, independent of trial.
-  collectPhase(OutputPhase::BeforeFlow, -1);
-  collectPhase(OutputPhase::AfterFlow, -1);
+  collectPhase(beforeConfigure, OutputPhase::BeforeFlow, -1);
+  collectPhase(afterConfigure, OutputPhase::AfterFlow, -1);
 
   // The final modular result is written once with the canonical basename, and
   // additionally per trial when --print-all-trials uses separate files.
-  collectPhase(OutputPhase::AfterPartition, -1);
+  collectPhase(afterConfigure, OutputPhase::AfterPartition, -1);
   if (config.printAllTrials && config.numTrials > 1) {
     for (unsigned int trial = 1; trial <= config.numTrials; ++trial)
-      collectPhase(OutputPhase::AfterPartition, static_cast<int>(trial));
+      collectPhase(afterConfigure, OutputPhase::AfterPartition, static_cast<int>(trial));
   }
 
   for (const auto& report : planReportArtifacts(config))
@@ -376,9 +390,9 @@ std::vector<std::string> planAllOutputPaths(const Config& config)
   return paths;
 }
 
-void preflightOutputTargets(const Config& config)
+void preflightOutputTargets(const Config& config, HigherOrderInput higherOrder)
 {
-  const auto plannedPaths = planAllOutputPaths(config);
+  const auto plannedPaths = planAllOutputPaths(config, higherOrder);
 
   // Checked before the overwrite policy, and deliberately not subject to it:
   // writing a result over the run's own input destroys the input, and

--- a/src/io/OutputPlan.cpp
+++ b/src/io/OutputPlan.cpp
@@ -353,16 +353,17 @@ std::vector<std::string> planAllOutputPaths(const Config& config, HigherOrderInp
 {
   std::vector<std::string> paths;
 
-  // Two configs, because Config::stateOutput changes value inside the window
-  // this function has to describe. configureNetworkMode() sets it after the
-  // BeforeFlow artifacts are written and before everything else, so the
-  // BeforeFlow phase is planned as the run will actually write it -- with state
-  // output still off -- and the later phases with the value the classification
-  // will install. Getting this wrong in either direction is a live defect: too
-  // few paths lets a run destroy its own input (#1018), too many refuses a run
-  // that would have been fine.
-  Config beforeConfigure = config;
-  beforeConfigure.stateOutput = false;
+  // Config::stateOutput changes value inside the window this function has to
+  // describe: configureNetworkMode() sets it after the BeforeFlow artifacts are
+  // written and before everything else. So the phases are planned on either side
+  // of that call. Getting it wrong in either direction is a live defect: too few
+  // paths lets a run destroy its own input (#1018), too many refuses a run that
+  // would have been fine.
+  //
+  // BeforeFlow is planned from the config exactly as given, never forced, because
+  // that is what its writer sees. Config::stateOutput is public and the Python and
+  // R bindings expose a setter, so a caller can enter run() with it already true;
+  // the writer then emits the `_states_as_physical` name and the plan has to agree.
   Config afterConfigure = config;
   if (higherOrder == HigherOrderInput::Yes)
     afterConfigure.setStateOutput();
@@ -373,7 +374,7 @@ std::vector<std::string> planAllOutputPaths(const Config& config, HigherOrderInp
   };
 
   // Network sidecars are written once, independent of trial.
-  collectPhase(beforeConfigure, OutputPhase::BeforeFlow, -1);
+  collectPhase(config, OutputPhase::BeforeFlow, -1);
   collectPhase(afterConfigure, OutputPhase::AfterFlow, -1);
 
   // The final modular result is written once with the canonical basename, and

--- a/src/io/OutputPlan.h
+++ b/src/io/OutputPlan.h
@@ -51,14 +51,32 @@ std::vector<OutputArtifact> planOutputArtifacts(const Config& config, OutputPhas
 // and the no-overwrite pre-flight so the two never drift apart.
 std::vector<std::pair<std::string, std::string>> planReportArtifacts(const Config& config);
 
+// Whether the network the run is about to partition is higher-order, as
+// configureNetworkMode() will classify it once the network is read. The pre-flight
+// runs before that classification but has to plan the paths it produces, so the
+// answer is passed in rather than read off Config::stateOutput, which is still
+// false at that point (#1018).
+enum class HigherOrderInput : std::uint8_t {
+  No,
+  Yes
+};
+
 // Every file path a CLI run would write: modular artifacts across all phases
 // (expanded per trial when --print-all-trials writes separate files) plus the
 // report sidecars. Used by the no-overwrite pre-flight.
-std::vector<std::string> planAllOutputPaths(const Config& config);
+//
+// `higherOrder` is applied per phase, not globally, because state output is
+// turned on between two of them: the BeforeFlow artifacts are written before
+// configureNetworkMode() runs, so they keep the first-order names whatever the
+// input turns out to be, while the AfterFlow and AfterPartition artifacts get
+// their `_states` / `_states_as_physical` names.
+std::vector<std::string> planAllOutputPaths(const Config& config, HigherOrderInput higherOrder);
 
-// Throws InfomapError(OutputError) before any work when --no-overwrite is set and
-// any planned output path already exists. No-op when overwriting is allowed.
-void preflightOutputTargets(const Config& config);
+// Throws InfomapError(OutputError) when a planned output path is one of the run's
+// own input files, and additionally when --no-overwrite is set and any planned
+// output path already exists. No-op when overwriting is allowed and nothing
+// collides with an input.
+void preflightOutputTargets(const Config& config, HigherOrderInput higherOrder);
 
 void writeOutputArtifact(InfomapBase& infomap, Network& network, const OutputArtifact& artifact);
 

--- a/test/cpp/test_config.cpp
+++ b/test/cpp/test_config.cpp
@@ -830,10 +830,23 @@ TEST_CASE("Output preflight follows state output across the write phases [fast][
   const auto pajek = [](Config& c) { c.printPajekNetwork = true; };
   const auto flow = [](Config& c) { c.printFlowNetwork = true; };
 
-  // BeforeFlow: `ml.net` whatever the input turns out to be.
+  // BeforeFlow: `ml.net` whatever the input turns out to be, because the write
+  // happens before configureNetworkMode() and so cannot see the classification.
   CHECK(collides(pajek, "ml.net", infomap::HigherOrderInput::No));
   CHECK(collides(pajek, "ml.net", infomap::HigherOrderInput::Yes));
   CHECK_FALSE(collides(pajek, "ml_states_as_physical.net", infomap::HigherOrderInput::Yes));
+
+  // A library caller can set stateOutput itself -- it is public, and the Python and
+  // R bindings expose a setter -- and then the BeforeFlow writer does emit the
+  // `_states_as_physical` name before any classification runs. So that phase is
+  // planned from the config as given and never forced to first-order, or this
+  // collision goes unseen.
+  const auto pajekWithStateOutput = [](Config& c) {
+    c.printPajekNetwork = true;
+    c.setStateOutput();
+  };
+  CHECK(collides(pajekWithStateOutput, "ml_states_as_physical.net", infomap::HigherOrderInput::No));
+  CHECK_FALSE(collides(pajekWithStateOutput, "ml.net", infomap::HigherOrderInput::No));
 
   // AfterFlow: the suffix depends on the classification, in both directions.
   CHECK(collides(flow, "ml_flow.net", infomap::HigherOrderInput::No));

--- a/test/cpp/test_config.cpp
+++ b/test/cpp/test_config.cpp
@@ -579,10 +579,10 @@ TEST_CASE("Output preflight refuses to write over the run's own input [fast][cor
   config.outName = "ml";
   config.printPajekNetwork = true;
 
-  CHECK_THROWS_AS(infomap::preflightOutputTargets(config), infomap::InfomapError);
+  CHECK_THROWS_AS(infomap::preflightOutputTargets(config, infomap::HigherOrderInput::No), infomap::InfomapError);
 
   try {
-    infomap::preflightOutputTargets(config);
+    infomap::preflightOutputTargets(config, infomap::HigherOrderInput::No);
     FAIL("expected the input collision to be rejected");
   } catch (const infomap::InfomapError& e) {
     CHECK(e.code() == infomap::ExitCode::OutputError);
@@ -603,7 +603,7 @@ TEST_CASE("Output preflight input check ignores the overwrite policy [fast][core
   config.printJson = true;
 
   REQUIRE(config.overwriteOutput());
-  CHECK_THROWS_AS(infomap::preflightOutputTargets(config), infomap::InfomapError);
+  CHECK_THROWS_AS(infomap::preflightOutputTargets(config, infomap::HigherOrderInput::No), infomap::InfomapError);
 }
 
 TEST_CASE("Output preflight protects every input the run reads [fast][core][config][output]")
@@ -616,7 +616,7 @@ TEST_CASE("Output preflight protects every input the run reads [fast][core][conf
     config.printTree = true;
     attach(config);
     try {
-      infomap::preflightOutputTargets(config);
+      infomap::preflightOutputTargets(config, infomap::HigherOrderInput::No);
     } catch (const infomap::InfomapError&) {
       return true;
     }
@@ -641,7 +641,7 @@ TEST_CASE("Output preflight names the option that owns a colliding report path [
   config.summaryJsonPath = "run.json";
 
   try {
-    infomap::preflightOutputTargets(config);
+    infomap::preflightOutputTargets(config, infomap::HigherOrderInput::No);
     FAIL("expected the report-path collision to be rejected");
   } catch (const infomap::InfomapError& e) {
     const std::string message = e.what();
@@ -657,7 +657,7 @@ TEST_CASE("Output preflight names the option that owns a colliding report path [
   artifactCollision.printTree = true;
 
   try {
-    infomap::preflightOutputTargets(artifactCollision);
+    infomap::preflightOutputTargets(artifactCollision, infomap::HigherOrderInput::No);
     FAIL("expected the artifact collision to be rejected");
   } catch (const infomap::InfomapError& e) {
     const std::string message = e.what();
@@ -676,7 +676,7 @@ TEST_CASE("Output preflight compares paths through './' [fast][core][config][out
   config.outName = "net";
   config.printTree = true;
 
-  CHECK_THROWS_AS(infomap::preflightOutputTargets(config), infomap::InfomapError);
+  CHECK_THROWS_AS(infomap::preflightOutputTargets(config, infomap::HigherOrderInput::No), infomap::InfomapError);
 }
 
 TEST_CASE("Output preflight anchors relative paths to the working directory [fast][core][config][output]")
@@ -696,14 +696,14 @@ TEST_CASE("Output preflight anchors relative paths to the working directory [fas
   relativeInput.outDirectory = cwd + "/";
   relativeInput.outName = "ml";
   relativeInput.printPajekNetwork = true;
-  CHECK_THROWS_AS(infomap::preflightOutputTargets(relativeInput), infomap::InfomapError);
+  CHECK_THROWS_AS(infomap::preflightOutputTargets(relativeInput, infomap::HigherOrderInput::No), infomap::InfomapError);
 
   Config absoluteInput;
   absoluteInput.networkFile = cwd + "/ml.net";
   absoluteInput.outDirectory = "./";
   absoluteInput.outName = "ml";
   absoluteInput.printPajekNetwork = true;
-  CHECK_THROWS_AS(infomap::preflightOutputTargets(absoluteInput), infomap::InfomapError);
+  CHECK_THROWS_AS(infomap::preflightOutputTargets(absoluteInput, infomap::HigherOrderInput::No), infomap::InfomapError);
 
   // Report paths are given directly, so they mix forms just as easily.
   Config absoluteReport;
@@ -711,7 +711,7 @@ TEST_CASE("Output preflight anchors relative paths to the working directory [fas
   absoluteReport.outDirectory = "";
   absoluteReport.outName = "run";
   absoluteReport.summaryJsonPath = cwd + "/run.json";
-  CHECK_THROWS_AS(infomap::preflightOutputTargets(absoluteReport), infomap::InfomapError);
+  CHECK_THROWS_AS(infomap::preflightOutputTargets(absoluteReport, infomap::HigherOrderInput::No), infomap::InfomapError);
 
 #ifdef _WIN32
   // A UNC path and a root-relative one with the same tail name different files, and
@@ -723,7 +723,7 @@ TEST_CASE("Output preflight anchors relative paths to the working directory [fas
   uncVersusRootRelative.outName = "net";
   uncVersusRootRelative.printTree = true;
   REQUIRE(uncVersusRootRelative.overwriteOutput());
-  CHECK_NOTHROW(infomap::preflightOutputTargets(uncVersusRootRelative));
+  CHECK_NOTHROW(infomap::preflightOutputTargets(uncVersusRootRelative, infomap::HigherOrderInput::No));
 
   // Two UNC paths that do name the same file must still be caught.
   Config uncCollision;
@@ -731,7 +731,7 @@ TEST_CASE("Output preflight anchors relative paths to the working directory [fas
   uncCollision.outDirectory = "\\\\server\\share\\";
   uncCollision.outName = "net";
   uncCollision.printTree = true;
-  CHECK_THROWS_AS(infomap::preflightOutputTargets(uncCollision), infomap::InfomapError);
+  CHECK_THROWS_AS(infomap::preflightOutputTargets(uncCollision, infomap::HigherOrderInput::No), infomap::InfomapError);
 #endif
 
 #ifndef _WIN32
@@ -742,7 +742,7 @@ TEST_CASE("Output preflight anchors relative paths to the working directory [fas
   driveLetterLookalike.outDirectory = cwd + "/a:/";
   driveLetterLookalike.outName = "net";
   driveLetterLookalike.printTree = true;
-  CHECK_THROWS_AS(infomap::preflightOutputTargets(driveLetterLookalike), infomap::InfomapError);
+  CHECK_THROWS_AS(infomap::preflightOutputTargets(driveLetterLookalike, infomap::HigherOrderInput::No), infomap::InfomapError);
 #endif
 
   // Anchoring must not turn a different directory into a collision.
@@ -752,7 +752,94 @@ TEST_CASE("Output preflight anchors relative paths to the working directory [fas
   elsewhere.outName = "ml";
   elsewhere.printPajekNetwork = true;
   REQUIRE(elsewhere.overwriteOutput());
-  CHECK_NOTHROW(infomap::preflightOutputTargets(elsewhere));
+  CHECK_NOTHROW(infomap::preflightOutputTargets(elsewhere, infomap::HigherOrderInput::No));
+}
+
+TEST_CASE("Output preflight protects the input against the _states artifacts [fast][core][config][output]")
+{
+  // #1018: a higher-order run writes both `<name>.<ext>` and `<name>_states.<ext>`,
+  // and only the physical half used to be checked. An input named after the state
+  // half was destroyed, exit 0, no warning. The `_states` twin exists for every
+  // modular format, so each one is checked.
+  const auto collides = [](void (*attach)(Config&), infomap::HigherOrderInput higherOrder) {
+    Config config;
+    config.networkFile = "net_states.tree";
+    config.outDirectory = "";
+    config.outName = "net";
+    attach(config);
+    try {
+      infomap::preflightOutputTargets(config, higherOrder);
+    } catch (const infomap::InfomapError&) {
+      return true;
+    }
+    return false;
+  };
+
+  CHECK(collides([](Config& c) { c.printTree = true; }, infomap::HigherOrderInput::Yes));
+
+  // First-order input writes no `_states` half, so the same command is fine. The
+  // fix must not buy the refusal above by rejecting runs that would have worked.
+  CHECK_FALSE(collides([](Config& c) { c.printTree = true; }, infomap::HigherOrderInput::No));
+
+  const auto stateArtifactCollides = [](void (*attach)(Config&), const std::string& input) {
+    Config config;
+    config.networkFile = input;
+    config.outDirectory = "";
+    config.outName = "net";
+    attach(config);
+    try {
+      infomap::preflightOutputTargets(config, infomap::HigherOrderInput::Yes);
+    } catch (const infomap::InfomapError&) {
+      return true;
+    }
+    return false;
+  };
+
+  CHECK(stateArtifactCollides([](Config& c) { c.printClu = true; }, "net_states.clu"));
+  CHECK(stateArtifactCollides([](Config& c) { c.printFlowTree = true; }, "net_states.ftree"));
+  CHECK(stateArtifactCollides([](Config& c) { c.printNewick = true; }, "net_states.nwk"));
+  CHECK(stateArtifactCollides([](Config& c) { c.printJson = true; }, "net_states.json"));
+  CHECK(stateArtifactCollides([](Config& c) { c.printCsv = true; }, "net_states.csv"));
+
+  // The physical half is still protected on higher-order input -- the fix adds
+  // paths to the plan, it does not move them.
+  CHECK(stateArtifactCollides([](Config& c) { c.printTree = true; }, "net.tree"));
+}
+
+TEST_CASE("Output preflight follows state output across the write phases [fast][core][config][output]")
+{
+  // Config::stateOutput is set by configureNetworkMode(), which runs after the
+  // BeforeFlow artifacts are written and before the rest. So on higher-order input
+  // the Pajek network still lands on the first-order name while the flow network
+  // picks up the `_states_as_physical_flow` suffix, and the preflight has to model
+  // that boundary rather than flip the flag for the whole run.
+  const auto collides = [](void (*attach)(Config&), const std::string& input, infomap::HigherOrderInput higherOrder) {
+    Config config;
+    config.networkFile = input;
+    config.outDirectory = "";
+    config.outName = "ml";
+    attach(config);
+    try {
+      infomap::preflightOutputTargets(config, higherOrder);
+    } catch (const infomap::InfomapError&) {
+      return true;
+    }
+    return false;
+  };
+
+  const auto pajek = [](Config& c) { c.printPajekNetwork = true; };
+  const auto flow = [](Config& c) { c.printFlowNetwork = true; };
+
+  // BeforeFlow: `ml.net` whatever the input turns out to be.
+  CHECK(collides(pajek, "ml.net", infomap::HigherOrderInput::No));
+  CHECK(collides(pajek, "ml.net", infomap::HigherOrderInput::Yes));
+  CHECK_FALSE(collides(pajek, "ml_states_as_physical.net", infomap::HigherOrderInput::Yes));
+
+  // AfterFlow: the suffix depends on the classification, in both directions.
+  CHECK(collides(flow, "ml_flow.net", infomap::HigherOrderInput::No));
+  CHECK_FALSE(collides(flow, "ml_flow.net", infomap::HigherOrderInput::Yes));
+  CHECK(collides(flow, "ml_states_as_physical_flow.net", infomap::HigherOrderInput::Yes));
+  CHECK_FALSE(collides(flow, "ml_states_as_physical_flow.net", infomap::HigherOrderInput::No));
 }
 
 TEST_CASE("Parameter catalog owns option choices and render policy [fast][core][config][cli]")

--- a/test/scripts/check_run_metadata_cli.py
+++ b/test/scripts/check_run_metadata_cli.py
@@ -93,6 +93,67 @@ def test_no_overwrite_preflight_writes_no_files_when_one_target_exists(
     assert not (out_dir / "network.clu").exists()
 
 
+def make_state_workdir(path: Path) -> Path:
+    # A higher-order input, so the run writes both `<name>.tree` and
+    # `<name>_states.tree`. The file is named after the state half on purpose.
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "net_states.tree").write_text(
+        '*States\n1 1 "a"\n2 2 "b"\n3 1 "a"\n*Links\n1 2 1\n2 3 1\n',
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_state_output_does_not_overwrite_its_own_input(infomap_bin, work):
+    # #1018: the input-overwrite pre-flight saw only the physical artifact, so a
+    # state-network run whose input was named `<out-name>_states.<ext>` destroyed
+    # the input and exited 0. The check needs the higher-order classification,
+    # which is only settled once the network is read -- so this exercises the
+    # ordering inside RunSession::run, not just the plan.
+    make_state_workdir(work)
+    original = (work / "net_states.tree").read_text(encoding="utf-8")
+
+    result = run(
+        infomap_bin,
+        "net_states.tree",
+        ".",
+        "--out-name",
+        "net",
+        "--silent",
+        "-N1",
+        cwd=work,
+    )
+
+    assert result.returncode == 3, result.stderr
+    assert "Refusing to write output" in result.stderr
+    assert (work / "net_states.tree").read_text(encoding="utf-8") == original
+    assert not (work / "net.tree").exists()
+
+
+def test_first_order_run_may_write_beside_a_states_named_input(infomap_bin, work):
+    # The mirror of the case above: first-order input writes no `_states` half, so
+    # the same command must still be allowed. The fix must not buy its refusal by
+    # rejecting runs that would have worked.
+    make_workdir(work)
+    (work / "net_states.tree").write_text(
+        "not an input to this run\n", encoding="utf-8"
+    )
+
+    result = run(
+        infomap_bin,
+        "network.net",
+        ".",
+        "--out-name",
+        "net",
+        "--silent",
+        "-N1",
+        cwd=work,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (work / "net.tree").exists()
+
+
 def test_overwrite_flag_is_removed(infomap_bin, work):
     make_workdir(work)
 
@@ -136,6 +197,8 @@ def main(argv):
             test_missing_input_returns_input_exit_code,
             test_no_overwrite_returns_output_exit_code,
             test_no_overwrite_preflight_writes_no_files_when_one_target_exists,
+            test_state_output_does_not_overwrite_its_own_input,
+            test_first_order_run_may_write_beside_a_states_named_input,
             test_overwrite_flag_is_removed,
             test_run_manifest_contains_fingerprints_and_outputs,
         ]:


### PR DESCRIPTION
## Summary

Closes #1018.

The input-overwrite pre-flight from #907 planned its paths from `Config::stateOutput`, which `configureNetworkMode()` only sets once the network has been read. The pre-flight ran eight lines earlier, so the flag was always false there and the `_states` half of every modular artifact was missing from the plan. A state or multilayer run whose input happened to be named `<out-name>_states.<ext>` destroyed that input, exit code 0, no warning.

Same shape as #1004: a validation reading a field that is only set at network-read time. Here the consequence is data loss rather than dead code.

The pre-flight now runs after `validateNetwork()`, where the higher-order classification is settled, and takes that classification as an argument. The predicate behind it is shared with `configureNetworkMode()` rather than copied — a second, drifting copy of the condition is what let this through in the first place.

Applying the classification per phase rather than globally closes a second hole of the same shape. State output is turned on between two write phases: the BeforeFlow artifacts (`-o network`) are written before `configureNetworkMode()` and keep their first-order names, while the AfterFlow flow network takes the `_states_as_physical_flow` suffix. The old plan named `<out-name>_flow.net` for both, so on higher-order input `-o flow` could destroy an input named after the real target, and refused runs whose input matched the name it never writes.

| Case | Before | After |
|---|---|---|
| `net_states.tree` in, `--out-name net` | input destroyed, exit 0 | refused, exit 3, input intact |
| same with `-o clu` | input destroyed | refused |
| `-o flow`, input `ml_states_as_physical_flow.net` | input destroyed | refused |
| `-o flow`, input `ml_flow.net`, higher-order | refused for a name it never writes | allowed, writes the right file |
| `-o network`, input `ml.net` | refused (#907) | refused, unchanged |
| first-order input named `x_states.tree` | allowed | allowed, input intact |

As a side effect `--no-overwrite` also sees the `_states` targets now.

## Verification

- `make test-native`: 26/26.
- New unit cases over the plan for every modular format and both write phases; the config suite runs 36/36 assertions.
- New CLI regression test in `check_run_metadata_cli.py` exercising the ordering inside `RunSession::run`, not just the plan. **It fails on a binary built without the src changes; its first-order mirror passes there**, so the refusal is not bought by rejecting runs that would have worked.
- `make format-native-check`, `scripts/check_cpp_stream_policy.py`, `ruff check` / `ruff format`: clean.
- Pre-commit hooks (ruff lint/format, clang-format, C++ stream policy, and the generic safety nets) and the pre-push `pyright` gate on the core Python surface: clean.
- `make test-fast`: 850 passed, 2 skipped, 1 xfailed.

## Notes

The `states_as_physical` naming gap this pre-flight has to model is itself a defect, fixed separately in #1050 (stacked on this branch): once that lands, all three write phases sit after the classification and the per-phase split here collapses to a single value.
