### PR TITLE
fix: write the pre-flow artifacts after the network is classified

### DIFF
--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -253,12 +253,20 @@ public:
     validateNetwork();
     preflightOutputTargets(m_infomap, higherOrderInput());
     {
-      auto timer = m_timing.scope("pre_run_output_s");
-      writeOutputArtifacts(m_infomap, m_network, OutputPhase::BeforeFlow);
-    }
-    {
       auto timer = m_timing.scope("configure_network_s");
       configureNetworkMode();
+    }
+    // After configureNetworkMode(), not before it. These artifacts describe the
+    // network as read, but the config that names and labels them is only finished
+    // by the classification: state output decides whether the Pajek dump is the
+    // `_states_as_physical` one, and the flow model decides whether it declares
+    // `*Edges` or `*Arcs`. Written earlier, a multilayer run produced a dump named
+    // and labelled as a first-order undirected network while the run itself had
+    // already expanded the links to directed. Still before any flow is computed,
+    // which is what the phase means.
+    {
+      auto timer = m_timing.scope("pre_run_output_s");
+      writeOutputArtifacts(m_infomap, m_network, OutputPhase::BeforeFlow);
     }
     calculateFlowAndInitNetwork();
     {

--- a/src/io/OutputPlan.cpp
+++ b/src/io/OutputPlan.cpp
@@ -353,36 +353,36 @@ std::vector<std::string> planAllOutputPaths(const Config& config, HigherOrderInp
 {
   std::vector<std::string> paths;
 
-  // Config::stateOutput changes value inside the window this function has to
-  // describe: configureNetworkMode() sets it after the BeforeFlow artifacts are
-  // written and before everything else. So the phases are planned on either side
-  // of that call. Getting it wrong in either direction is a live defect: too few
-  // paths lets a run destroy its own input (#1018), too many refuses a run that
-  // would have been fine.
+  // Config::stateOutput is still false when the pre-flight runs -- it is set by
+  // configureNetworkMode() once the network is read -- so the classification is
+  // supplied instead. Every write phase now happens after that call, so one value
+  // covers them all. Getting it wrong in either direction is a live defect: too
+  // few paths lets a run destroy its own input (#1018), too many refuses a run
+  // that would have been fine.
   //
-  // BeforeFlow is planned from the config exactly as given, never forced, because
-  // that is what its writer sees. Config::stateOutput is public and the Python and
-  // R bindings expose a setter, so a caller can enter run() with it already true;
-  // the writer then emits the `_states_as_physical` name and the plan has to agree.
-  Config afterConfigure = config;
+  // The copy preserves a stateOutput the caller set itself -- the field is public
+  // and the Python and R bindings expose a setter -- and the classification only
+  // ever turns it on, never off. So the plan agrees with the writers on that case
+  // too, which is what the forced first-order plan this replaced got wrong.
+  Config planConfig = config;
   if (higherOrder == HigherOrderInput::Yes)
-    afterConfigure.setStateOutput();
+    planConfig.setStateOutput();
 
-  const auto collectPhase = [&](const Config& phaseConfig, OutputPhase phase, int trial) {
-    for (const auto& artifact : planOutputArtifacts(phaseConfig, phase, trial))
+  const auto collectPhase = [&](OutputPhase phase, int trial) {
+    for (const auto& artifact : planOutputArtifacts(planConfig, phase, trial))
       paths.push_back(artifact.filename);
   };
 
   // Network sidecars are written once, independent of trial.
-  collectPhase(config, OutputPhase::BeforeFlow, -1);
-  collectPhase(afterConfigure, OutputPhase::AfterFlow, -1);
+  collectPhase(OutputPhase::BeforeFlow, -1);
+  collectPhase(OutputPhase::AfterFlow, -1);
 
   // The final modular result is written once with the canonical basename, and
   // additionally per trial when --print-all-trials uses separate files.
-  collectPhase(afterConfigure, OutputPhase::AfterPartition, -1);
+  collectPhase(OutputPhase::AfterPartition, -1);
   if (config.printAllTrials && config.numTrials > 1) {
     for (unsigned int trial = 1; trial <= config.numTrials; ++trial)
-      collectPhase(afterConfigure, OutputPhase::AfterPartition, static_cast<int>(trial));
+      collectPhase(OutputPhase::AfterPartition, static_cast<int>(trial));
   }
 
   for (const auto& report : planReportArtifacts(config))

--- a/src/io/OutputPlan.h
+++ b/src/io/OutputPlan.h
@@ -65,11 +65,9 @@ enum class HigherOrderInput : std::uint8_t {
 // (expanded per trial when --print-all-trials writes separate files) plus the
 // report sidecars. Used by the no-overwrite pre-flight.
 //
-// `higherOrder` is applied per phase, not globally, because state output is
-// turned on between two of them: the BeforeFlow artifacts are written before
-// configureNetworkMode() runs, so they keep the first-order names whatever the
-// input turns out to be, while the AfterFlow and AfterPartition artifacts get
-// their `_states` / `_states_as_physical` names.
+// `higherOrder` stands in for Config::stateOutput, which the caller cannot have
+// set yet. It applies to every phase: all three are written after
+// configureNetworkMode() installs the flag.
 std::vector<std::string> planAllOutputPaths(const Config& config, HigherOrderInput higherOrder);
 
 // Throws InfomapError(OutputError) when a planned output path is one of the run's

--- a/test/cpp/test_config.cpp
+++ b/test/cpp/test_config.cpp
@@ -571,8 +571,10 @@ TEST_CASE("Output plan applies trial suffix before format suffix [fast][core][co
 TEST_CASE("Output preflight refuses to write over the run's own input [fast][core][config][output]")
 {
   // `Infomap ml.net . -o network` plans ./ml.net for the Pajek output, which is
-  // the input itself. It used to overwrite it and exit 0, replacing a multilayer
-  // network with its single-layer projection.
+  // the input itself. It used to overwrite it and exit 0, replacing the network
+  // with Infomap's own dump of it. First-order input, which is what this config
+  // describes -- higher-order input takes the `_states_as_physical` name and does
+  // not collide, which the write-phase case below pins down.
   Config config;
   config.networkFile = "ml.net";
   config.outDirectory = "./";
@@ -808,11 +810,12 @@ TEST_CASE("Output preflight protects the input against the _states artifacts [fa
 
 TEST_CASE("Output preflight follows state output across the write phases [fast][core][config][output]")
 {
-  // Config::stateOutput is set by configureNetworkMode(), which runs after the
-  // BeforeFlow artifacts are written and before the rest. So on higher-order input
-  // the Pajek network still lands on the first-order name while the flow network
-  // picks up the `_states_as_physical_flow` suffix, and the preflight has to model
-  // that boundary rather than flip the flag for the whole run.
+  // Config::stateOutput is set by configureNetworkMode(), which now runs before
+  // every write phase, so one classification names every network artifact. It used
+  // to run after the BeforeFlow write: the Pajek dump then kept the first-order
+  // name on higher-order input, where it collided with an input the run had no
+  // business touching, while the flow network one phase later took the
+  // `_states_as_physical_flow` suffix the pre-flight did not know about.
   const auto collides = [](void (*attach)(Config&), const std::string& input, infomap::HigherOrderInput higherOrder) {
     Config config;
     config.networkFile = input;
@@ -830,17 +833,17 @@ TEST_CASE("Output preflight follows state output across the write phases [fast][
   const auto pajek = [](Config& c) { c.printPajekNetwork = true; };
   const auto flow = [](Config& c) { c.printFlowNetwork = true; };
 
-  // BeforeFlow: `ml.net` whatever the input turns out to be, because the write
-  // happens before configureNetworkMode() and so cannot see the classification.
+  // BeforeFlow, the Pajek dump: the suffix follows the classification, so
+  // higher-order input never lands on the bare `ml.net`.
   CHECK(collides(pajek, "ml.net", infomap::HigherOrderInput::No));
-  CHECK(collides(pajek, "ml.net", infomap::HigherOrderInput::Yes));
-  CHECK_FALSE(collides(pajek, "ml_states_as_physical.net", infomap::HigherOrderInput::Yes));
+  CHECK_FALSE(collides(pajek, "ml.net", infomap::HigherOrderInput::Yes));
+  CHECK(collides(pajek, "ml_states_as_physical.net", infomap::HigherOrderInput::Yes));
+  CHECK_FALSE(collides(pajek, "ml_states_as_physical.net", infomap::HigherOrderInput::No));
 
   // A library caller can set stateOutput itself -- it is public, and the Python and
-  // R bindings expose a setter -- and then the BeforeFlow writer does emit the
-  // `_states_as_physical` name before any classification runs. So that phase is
-  // planned from the config as given and never forced to first-order, or this
-  // collision goes unseen.
+  // R bindings expose a setter. The classification only ever turns it on, never off,
+  // so the caller's value survives configureNetworkMode() and reaches the writer.
+  // The plan has to carry it, not force the phase to first-order.
   const auto pajekWithStateOutput = [](Config& c) {
     c.printPajekNetwork = true;
     c.setStateOutput();
@@ -848,7 +851,7 @@ TEST_CASE("Output preflight follows state output across the write phases [fast][
   CHECK(collides(pajekWithStateOutput, "ml_states_as_physical.net", infomap::HigherOrderInput::No));
   CHECK_FALSE(collides(pajekWithStateOutput, "ml.net", infomap::HigherOrderInput::No));
 
-  // AfterFlow: the suffix depends on the classification, in both directions.
+  // AfterFlow, the flow network: same rule, one phase later.
   CHECK(collides(flow, "ml_flow.net", infomap::HigherOrderInput::No));
   CHECK_FALSE(collides(flow, "ml_flow.net", infomap::HigherOrderInput::Yes));
   CHECK(collides(flow, "ml_states_as_physical_flow.net", infomap::HigherOrderInput::Yes));

--- a/test/scripts/check_pretty_output.py
+++ b/test/scripts/check_pretty_output.py
@@ -163,7 +163,6 @@ def main():
             "test.csv",
             "test.ftree",
             "test.json",
-            "test.net",
             "test.nwk",
             "test.tree",
             "test_states.clu",
@@ -173,6 +172,12 @@ def main():
             "test_states.net",
             "test_states.nwk",
             "test_states.tree",
+            # The Pajek dump of a state network is the `_states_as_physical` one,
+            # matching its own "# State network as physical network" header and the
+            # flow variant below it. It was written as a bare `test.net` until the
+            # artifact stopped being written ahead of the higher-order
+            # classification that names it.
+            "test_states_as_physical.net",
             "test_states_as_physical_flow.net",
         ):
             assert Path(tmpdir, filename).is_file()

--- a/test/scripts/check_run_metadata_cli.py
+++ b/test/scripts/check_run_metadata_cli.py
@@ -154,6 +154,79 @@ def test_first_order_run_may_write_beside_a_states_named_input(infomap_bin, work
     assert (work / "net.tree").exists()
 
 
+def make_multilayer_workdir(path: Path) -> Path:
+    # *Intra/*Inter multilayer input. The inter-layer links break the symmetry, so
+    # reading it expands the undirected links to directed pairs and the run's flow
+    # model flips to directed -- which is what the Pajek dump has to declare.
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "ml.net").write_text(
+        '*Vertices 3\n1 "i"\n2 "j"\n3 "k"\n'
+        "*Intra\n1 1 2 1\n1 2 1 1\n2 1 3 1\n2 3 1 1\n"
+        "*Inter\n1 1 2 0.4\n2 1 1 0.4\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_pajek_dump_of_a_higher_order_network_is_named_and_labelled_for_it(
+    infomap_bin, work
+):
+    # The BeforeFlow artifacts used to be written before configureNetworkMode(),
+    # so the Pajek dump of a higher-order network was named `<out-name>.net` --
+    # the `_states_as_physical` variant was unreachable from a run -- and declared
+    # `*Edges` while the run had already expanded the links to directed. Both came
+    # from writing the artifact before the config that describes it was finished.
+    make_multilayer_workdir(work)
+
+    result = run(
+        infomap_bin,
+        "ml.net",
+        "out",
+        "--out-name",
+        "ml",
+        "--silent",
+        "-o",
+        "network",
+        "-N1",
+        cwd=work,
+    )
+
+    assert result.returncode == 0, result.stderr
+    dump = work / "out" / "ml_states_as_physical.net"
+    assert dump.exists()
+    assert not (work / "out" / "ml.net").exists()
+
+    text = dump.read_text(encoding="utf-8")
+    assert "# State network as physical network" in text
+    assert "*Arcs" in text
+    assert "*Edges" not in text
+
+
+def test_pajek_dump_of_a_first_order_network_is_unchanged(infomap_bin, work):
+    # The control: first-order input keeps the bare name and the undirected label.
+    make_workdir(work)
+
+    result = run(
+        infomap_bin,
+        "network.net",
+        "out",
+        "--silent",
+        "-o",
+        "network",
+        "-N1",
+        cwd=work,
+    )
+
+    assert result.returncode == 0, result.stderr
+    dump = work / "out" / "network.net"
+    assert dump.exists()
+    assert not (work / "out" / "network_states_as_physical.net").exists()
+
+    text = dump.read_text(encoding="utf-8")
+    assert "*Edges" in text
+    assert "# State network as physical network" not in text
+
+
 def test_overwrite_flag_is_removed(infomap_bin, work):
     make_workdir(work)
 
@@ -199,6 +272,8 @@ def main(argv):
             test_no_overwrite_preflight_writes_no_files_when_one_target_exists,
             test_state_output_does_not_overwrite_its_own_input,
             test_first_order_run_may_write_beside_a_states_named_input,
+            test_pajek_dump_of_a_higher_order_network_is_named_and_labelled_for_it,
+            test_pajek_dump_of_a_first_order_network_is_unchanged,
             test_overwrite_flag_is_removed,
             test_run_manifest_contains_fingerprints_and_outputs,
         ]:


### PR DESCRIPTION
## Summary

#1049 has landed, so this is now a plain single-commit PR against `master`.

The BeforeFlow artifacts were written before `configureNetworkMode()`, so the config that names and labels them was still unfinished. Two wrong outputs followed from that one ordering, both on higher-order input.

**The Pajek dump took the first-order name.** `printStates()` is what picks `_states_as_physical` over the bare `<out-name>.net`, and it was always false at that point, so the `states_as_physical` artifact was unreachable from any CLI run — even though the file it produced said `# State network as physical network` in its own header, and even though the AfterFlow flow network one phase later kept its `_states_as_physical_flow` name throughout. The two dumps of the same network disagreed about what to call it.

This is long-standing, not a regression from the output-plan refactor in #575: the write sat ahead of the classification before #575 and before #573 too (checked at `b38ddb2a^` and `55d75a85^`). The name is still reachable from a library caller who sets state output before `run()`, which is presumably how the entry in CHANGELOG.md:735 came about.

**The dump also declared `*Edges` for a network the run treats as directed.** A multilayer input with inter-layer links has its undirected links expanded to directed pairs at read time (`Network.cpp:214`), and `configureNetworkMode()` flips the flow model to match. Written before the flip, the file carried both directions of every link under an undirected header, so re-reading it double-counted. Plain `*Arcs` Pajek input is unaffected — `haveDirectedInput()` is only set for the multilayer expansion, which I verified rather than assumed.

Moving the write fixes both, and the phase still means what it says: it runs before any flow is computed. Nothing else the two BeforeFlow writers read from the config changes across the call — `writeStateNetwork()` takes only `parsedString` and the overwrite policy, and its filename was never conditional.

This also simplifies #1049's pre-flight: all three write phases now sit after the classification, so one value covers them, and a higher-order run with `-o network` writing into its own input directory no longer collides at all rather than being refused for a name it never writes.

## Verification

- `make test-native`: 26/26.
- New CLI tests covering the name and the `*Arcs` label, with a first-order control asserting byte-compatible behaviour.
- `check_pretty_output.py` failed first: it encoded the bug, asserting `test.net` for a state network while already asserting `test_states_as_physical_flow.net` for the flow variant. Expectation corrected, with a comment saying why.
- `make format-native-check`, `scripts/check_cpp_stream_policy.py`, `ruff check` / `ruff format`: clean.
- JS output-format metadata unchanged: the format table already carried both keys, so nothing regenerates.
- Pre-commit hooks (ruff lint/format, clang-format, C++ stream policy, and the generic safety nets) and the pre-push `pyright` gate on the core Python surface: clean.
- `make test-fast`: 850 passed, 2 skipped, 1 xfailed.

## Notes

**Breaking, but narrowly.** On higher-order input `-o network` now writes `<out-name>_states_as_physical.net` instead of `<out-name>.net`, and a multilayer dump declares `*Arcs`. Every modular result (`.tree`, `.clu`, `.ftree`, `.json`, `.csv`, `.nwk`), every codelength, and the whole Python/R/JS surface are untouched. `-o` is an `.advanced()` option that does not appear in `--help`, and no doc mentions the filename. No CLI user can be depending on the new name, because the CLI has never written it.

Deliberately **no** `BREAKING CHANGE:` footer: release-please is node-typed with no overrides here, so the footer would bump 2.15.1 → 3.0.0 and collide with the real 3.0 program (#737). Filed for a 2.x minor on that basis.

The commit message on `f0d1087b` contains one sentence I have since verified to be wrong — it credits #575 with moving the write ahead of the classification. The summary above is the corrected version and is what should land as the squash message.
