### PR TITLE
fix: report a clu file whose node ids repeat

### DIFF
--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -279,6 +279,7 @@ public:
     m_runParallelTrials = selectParallelTrialMode();
     m_threadsUsed = m_runParallelTrials ? parallelTrialWorkers() : 1;
     releaseInputLinksIfCli();
+    reportClusterDataIssues();
     logRunPartitionStart();
     Result result;
     {
@@ -626,6 +627,76 @@ private:
         || m_infomap.haveMemory()
         || m_network.higherOrderInputMethodCalled();
     return stateOutput ? HigherOrderInput::Yes : HigherOrderInput::No;
+  }
+
+  // Report what is wrong with the --cluster-data file, once per run and on the
+  // main instance, where nothing is muted. Doing this from initPartition instead
+  // put it inside the trial loop: ten warnings on a serial -N10, and none at all
+  // under --parallel-trials, because every worker's initTrialPartition is wrapped
+  // in Log::ScopedMute. The cost is one extra parse of the cluster file, which is
+  // a validation pass and not the partition the trials build.
+  void reportClusterDataIssues()
+  {
+    if (!m_infomap.isMainInfomap() || m_infomap.clusterDataFile.empty()) {
+      return;
+    }
+
+    ClusterMap clusterMap;
+    if (m_network.isMultilayerNetwork()) {
+      const auto& map = m_network.layerNodeToStateId();
+      clusterMap.readClusterData(m_infomap.clusterDataFile, false, &map);
+    } else {
+      clusterMap.readClusterData(m_infomap.clusterDataFile);
+    }
+
+    if (clusterMap.extension() != "clu") {
+      // A tree carries a path per row, so a repeated id there is a different
+      // situation with its own report in normalizeTreePaths (#908).
+      return;
+    }
+
+    const auto& duplicates = clusterMap.duplicateClusterIds();
+    if (!duplicates.any()) {
+      return;
+    }
+
+    const auto idPhrase = duplicates.ids == 1 ? "id appears" : "ids appear";
+
+    if (!duplicates.anyConflicting()) {
+      // Every repeat agrees on the module, so nothing was replaced and the reader
+      // ends up with exactly the partition the file describes. Still worth saying:
+      // a clu file is meant to have one row per node.
+      Console::warn(0,
+                    "{} node {} more than once in '{}', {} repeated {} in all, but every repeat gives the same module. "
+                    "The partition is unaffected.",
+                    duplicates.ids,
+                    idPhrase,
+                    m_infomap.clusterDataFile,
+                    duplicates.rows,
+                    duplicates.rows == 1 ? "row" : "rows");
+      return;
+    }
+
+    // haveMemory() describes the network, not the file, so the higher-order advice
+    // says what repeats by construction without asserting that this is that file:
+    // a malformed state clu reaches this branch too.
+    const auto* advice = m_infomap.haveMemory()
+        ? "On a higher-order network the physical clu repeats ids by construction -- it has one row per "
+          "(physical node, module) pair, and overlapping modules are not a partition. If that is this file, use "
+          "the state clu (_states.clu) instead; if this already is the state clu, the repeats are in the file."
+        : "A clu file has one row per node, so the last row read wins and the earlier assignments are discarded. "
+          "The codelength below is for the partition that survived, not for the one in the file.";
+
+    Console::warn(0,
+                  "{} node {} more than once in '{}': {} {} an id's module, and node {} alone has {} rows. {}",
+                  duplicates.conflictingIds,
+                  duplicates.conflictingIds == 1 ? "id appears" : "ids appear",
+                  m_infomap.clusterDataFile,
+                  duplicates.conflictingRows,
+                  duplicates.conflictingRows == 1 ? "row changed" : "rows changed",
+                  duplicates.exampleId,
+                  duplicates.maxRowsForOneId,
+                  advice);
   }
 
   void configureNetworkMode()
@@ -1418,33 +1489,11 @@ InfomapBase& InfomapBase::initPartition(const std::string& clusterDataFile, bool
     validateClusterDataTreeShape(normalizedTree);
     initTree(normalizedTree);
   } else if (ext == "clu") {
-    // A clu row is (node id, module) and nothing else, so a repeated id is not
-    // recoverable the way a repeated id in a tree is -- there is no path to pair
-    // with a state, and the reader can only keep the row it saw last. Saying so is
-    // still the difference between a one-line diagnosis and a codelength silently
-    // off by bits, which is what #1039 was reported as.
-    const auto& duplicates = clusterMap.duplicateClusterIds();
-    if (duplicates.any()) {
-      // haveMemory() describes the network, not the file, so the higher-order advice
-      // says what repeats by construction without asserting that this is that file:
-      // a malformed state clu reaches this branch too.
-      const auto* advice = haveMemory()
-          ? "On a higher-order network the physical clu repeats ids by construction -- it has one row per "
-            "(physical node, module) pair, and overlapping modules are not a partition. If that is this file, use "
-            "the state clu (_states.clu) instead; if this already is the state clu, the repeats are in the file."
-          : "A clu file has one row per node, so the last row read wins and the earlier assignments are discarded. "
-            "The codelength below is for the partition that survived, not for the one in the file.";
-      Console::warn(0,
-                    "{} node {} more than once in '{}': {} {} an earlier module assignment, and node {} alone has {} rows. {}",
-                    duplicates.ids,
-                    duplicates.ids == 1 ? "id appears" : "ids appear",
-                    clusterDataFile,
-                    duplicates.rows,
-                    duplicates.rows == 1 ? "row replaced" : "rows replaced",
-                    duplicates.exampleId,
-                    duplicates.maxRowsForOneId,
-                    advice);
-    }
+    // Repeated ids in this file are reported once per run by
+    // RunSession::reportClusterDataIssues, not here: this runs per trial, and per
+    // trial it printed the warning ten times on -N10 and not at all under
+    // --parallel-trials, where the worker's initTrialPartition is wrapped in
+    // Log::ScopedMute.
     initPartition(clusterMap.clusterIds(), hard);
   }
 

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1418,6 +1418,30 @@ InfomapBase& InfomapBase::initPartition(const std::string& clusterDataFile, bool
     validateClusterDataTreeShape(normalizedTree);
     initTree(normalizedTree);
   } else if (ext == "clu") {
+    // A clu row is (node id, module) and nothing else, so a repeated id is not
+    // recoverable the way a repeated id in a tree is -- there is no path to pair
+    // with a state, and the reader can only keep the row it saw last. Saying so is
+    // still the difference between a one-line diagnosis and a codelength silently
+    // off by bits, which is what #1039 was reported as.
+    const auto& duplicates = clusterMap.duplicateClusterIds();
+    if (duplicates.any()) {
+      const auto* advice = haveMemory()
+          ? "This is the physical clu of a higher-order network -- one row per (physical node, module) pair -- so its "
+            "overlapping modules cannot be expressed as a partition at all. Use the state clu (_states.clu) for an "
+            "exact round trip."
+          : "A clu file has one row per node, so the last row read wins and the earlier assignments are discarded. "
+            "The codelength below is for the partition that survived, not for the one in the file.";
+      Console::warn(0,
+                    "{} node {} more than once in '{}': {} {} an earlier module assignment, and node {} alone has {} rows. {}",
+                    duplicates.ids,
+                    duplicates.ids == 1 ? "id appears" : "ids appear",
+                    clusterDataFile,
+                    duplicates.rows,
+                    duplicates.rows == 1 ? "row replaced" : "rows replaced",
+                    duplicates.exampleId,
+                    duplicates.maxRowsForOneId,
+                    advice);
+    }
     initPartition(clusterMap.clusterIds(), hard);
   }
 

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -1425,10 +1425,13 @@ InfomapBase& InfomapBase::initPartition(const std::string& clusterDataFile, bool
     // off by bits, which is what #1039 was reported as.
     const auto& duplicates = clusterMap.duplicateClusterIds();
     if (duplicates.any()) {
+      // haveMemory() describes the network, not the file, so the higher-order advice
+      // says what repeats by construction without asserting that this is that file:
+      // a malformed state clu reaches this branch too.
       const auto* advice = haveMemory()
-          ? "This is the physical clu of a higher-order network -- one row per (physical node, module) pair -- so its "
-            "overlapping modules cannot be expressed as a partition at all. Use the state clu (_states.clu) for an "
-            "exact round trip."
+          ? "On a higher-order network the physical clu repeats ids by construction -- it has one row per "
+            "(physical node, module) pair, and overlapping modules are not a partition. If that is this file, use "
+            "the state clu (_states.clu) instead; if this already is the state clu, the repeats are in the file."
           : "A clu file has one row per node, so the last row read wins and the earlier assignments are discarded. "
             "The codelength below is for the partition that survived, not for the one in the file.";
       Console::warn(0,

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -687,13 +687,17 @@ private:
         : "A clu file has one row per node, so the last row read wins and the earlier assignments are discarded. "
           "The codelength below is for the partition that survived, not for the one in the file.";
 
+    // The leading counts are the totals, or a file that mixes a verbatim repeat with
+    // a conflicting one undercounts what the sentence claims to summarize. The
+    // conflicting rows are then named as the subset they are.
     Console::warn(0,
-                  "{} node {} more than once in '{}': {} {} an id's module, and node {} alone has {} rows. {}",
-                  duplicates.conflictingIds,
-                  duplicates.conflictingIds == 1 ? "id appears" : "ids appear",
+                  "{} node {} more than once in '{}': {} repeated {}, {} of which changed an id's module, and node {} alone has {} rows. {}",
+                  duplicates.ids,
+                  duplicates.ids == 1 ? "id appears" : "ids appear",
                   m_infomap.clusterDataFile,
+                  duplicates.rows,
+                  duplicates.rows == 1 ? "row" : "rows",
                   duplicates.conflictingRows,
-                  duplicates.conflictingRows == 1 ? "row changed" : "rows changed",
                   duplicates.exampleId,
                   duplicates.maxRowsForOneId,
                   advice);

--- a/src/io/ClusterMap.cpp
+++ b/src/io/ClusterMap.cpp
@@ -178,11 +178,12 @@ void ClusterMap::readClu(const std::string& filename, bool includeFlow, const st
   SafeInFile input(filename);
   std::string line;
   std::istringstream lineStream;
-  // Rows accepted per node id. A well-formed clu has one row per node, so anything
-  // above one means later rows silently replaced earlier ones (#1039). Counted only
-  // for rows that reach m_clusterIds, so multilayer rows skipped for a layer/node
-  // the network does not have are not mistaken for duplicates.
-  std::map<unsigned int, unsigned int> rowsPerId;
+  // Rows seen per node id, but only for ids that actually repeat: a well-formed clu
+  // has one row per node (#1039), so keying this off the insert result below keeps
+  // the common case at no extra storage and no extra lookup. Populated only from
+  // rows that reach m_clusterIds, so multilayer rows skipped for a layer/node the
+  // network does not have are never mistaken for duplicates.
+  std::map<unsigned int, unsigned int> repeatedRows;
 
   while (!std::getline(input, line).fail()) {
     if (line.empty() || line[0] == '#' || line[0] == '*')
@@ -236,13 +237,18 @@ void ClusterMap::readClu(const std::string& filename, bool includeFlow, const st
       continue;
     }
 
-    m_clusterIds[stateId] = moduleId;
-    ++rowsPerId[stateId];
+    // insert_or_assign keeps the last row, which is the behaviour this reports on,
+    // and its bool tells us the id was already there without a second lookup.
+    const auto isNewId = m_clusterIds.insert_or_assign(stateId, moduleId).second;
+    if (!isNewId) {
+      auto& rows = repeatedRows[stateId];
+      if (rows == 0)
+        rows = 1; // the row already in m_clusterIds
+      ++rows;
+    }
   }
 
-  for (const auto& [nodeId, rows] : rowsPerId) {
-    if (rows < 2)
-      continue;
+  for (const auto& [nodeId, rows] : repeatedRows) {
     m_duplicateClusterIds.rows += rows - 1;
     ++m_duplicateClusterIds.ids;
     if (rows > m_duplicateClusterIds.maxRowsForOneId) {

--- a/src/io/ClusterMap.cpp
+++ b/src/io/ClusterMap.cpp
@@ -178,12 +178,18 @@ void ClusterMap::readClu(const std::string& filename, bool includeFlow, const st
   SafeInFile input(filename);
   std::string line;
   std::istringstream lineStream;
-  // Rows seen per node id, but only for ids that actually repeat: a well-formed clu
+  // Repeat bookkeeping, kept only for ids that actually repeat: a well-formed clu
   // has one row per node (#1039), so keying this off the insert result below keeps
   // the common case at no extra storage and no extra lookup. Populated only from
   // rows that reach m_clusterIds, so multilayer rows skipped for a layer/node the
-  // network does not have are never mistaken for duplicates.
-  std::map<unsigned int, unsigned int> repeatedRows;
+  // network does not have are never mistaken for duplicates. `conflicting` counts
+  // the repeats that changed the module, which is a different thing from a row
+  // repeated verbatim.
+  struct RepeatCount {
+    unsigned int rows = 0;
+    unsigned int conflicting = 0;
+  };
+  std::map<unsigned int, RepeatCount> repeats;
 
   while (!std::getline(input, line).fail()) {
     if (line.empty() || line[0] == '#' || line[0] == '*')
@@ -238,21 +244,31 @@ void ClusterMap::readClu(const std::string& filename, bool includeFlow, const st
     }
 
     // insert_or_assign keeps the last row, which is the behaviour this reports on,
-    // and its bool tells us the id was already there without a second lookup.
-    const auto isNewId = m_clusterIds.insert_or_assign(stateId, moduleId).second;
+    // and its result gives both whether the id was already there and what it held,
+    // without a second lookup.
+    const auto existing = m_clusterIds.find(stateId);
+    const bool isNewId = existing == m_clusterIds.end();
+    const bool changesModule = !isNewId && existing->second != moduleId;
+    m_clusterIds.insert_or_assign(stateId, moduleId);
     if (!isNewId) {
-      auto& rows = repeatedRows[stateId];
-      if (rows == 0)
-        rows = 1; // the row already in m_clusterIds
-      ++rows;
+      auto& repeat = repeats[stateId];
+      if (repeat.rows == 0)
+        repeat.rows = 1; // the row already in m_clusterIds
+      ++repeat.rows;
+      if (changesModule)
+        ++repeat.conflicting;
     }
   }
 
-  for (const auto& [nodeId, rows] : repeatedRows) {
-    m_duplicateClusterIds.rows += rows - 1;
+  for (const auto& [nodeId, repeat] : repeats) {
+    m_duplicateClusterIds.rows += repeat.rows - 1;
     ++m_duplicateClusterIds.ids;
-    if (rows > m_duplicateClusterIds.maxRowsForOneId) {
-      m_duplicateClusterIds.maxRowsForOneId = rows;
+    if (repeat.conflicting > 0) {
+      m_duplicateClusterIds.conflictingRows += repeat.conflicting;
+      ++m_duplicateClusterIds.conflictingIds;
+    }
+    if (repeat.rows > m_duplicateClusterIds.maxRowsForOneId) {
+      m_duplicateClusterIds.maxRowsForOneId = repeat.rows;
       m_duplicateClusterIds.exampleId = nodeId;
     }
   }

--- a/src/io/ClusterMap.cpp
+++ b/src/io/ClusterMap.cpp
@@ -24,6 +24,7 @@ void ClusterMap::readClusterData(const std::string& filename, bool includeFlow, 
   m_flowData.clear();
   m_treePaths.clear();
   m_extension.clear();
+  m_duplicateClusterIds = {};
   m_isHigherOrder = false;
   m_hasTreeLeafIdType = false;
   m_treeLeafIdType = TreeLeafIdType::physical;
@@ -177,7 +178,11 @@ void ClusterMap::readClu(const std::string& filename, bool includeFlow, const st
   SafeInFile input(filename);
   std::string line;
   std::istringstream lineStream;
-  std::map<unsigned int, unsigned int> clusterData;
+  // Rows accepted per node id. A well-formed clu has one row per node, so anything
+  // above one means later rows silently replaced earlier ones (#1039). Counted only
+  // for rows that reach m_clusterIds, so multilayer rows skipped for a layer/node
+  // the network does not have are not mistaken for duplicates.
+  std::map<unsigned int, unsigned int> rowsPerId;
 
   while (!std::getline(input, line).fail()) {
     if (line.empty() || line[0] == '#' || line[0] == '*')
@@ -232,6 +237,18 @@ void ClusterMap::readClu(const std::string& filename, bool includeFlow, const st
     }
 
     m_clusterIds[stateId] = moduleId;
+    ++rowsPerId[stateId];
+  }
+
+  for (const auto& [nodeId, rows] : rowsPerId) {
+    if (rows < 2)
+      continue;
+    m_duplicateClusterIds.rows += rows - 1;
+    ++m_duplicateClusterIds.ids;
+    if (rows > m_duplicateClusterIds.maxRowsForOneId) {
+      m_duplicateClusterIds.maxRowsForOneId = rows;
+      m_duplicateClusterIds.exampleId = nodeId;
+    }
   }
 }
 

--- a/src/io/ClusterMap.cpp
+++ b/src/io/ClusterMap.cpp
@@ -243,14 +243,14 @@ void ClusterMap::readClu(const std::string& filename, bool includeFlow, const st
       continue;
     }
 
-    // insert_or_assign keeps the last row, which is the behaviour this reports on,
-    // and its result gives both whether the id was already there and what it held,
-    // without a second lookup.
-    const auto existing = m_clusterIds.find(stateId);
-    const bool isNewId = existing == m_clusterIds.end();
-    const bool changesModule = !isNewId && existing->second != moduleId;
-    m_clusterIds.insert_or_assign(stateId, moduleId);
-    if (!isNewId) {
+    // try_emplace, not find-then-assign: on a repeat its iterator already points at
+    // what the id held, so the old value, the fact that it is a repeat, and the
+    // overwrite all come out of a single traversal. A well-formed file pays exactly
+    // one lookup per row, which is what a clu reader should cost.
+    const auto [entry, inserted] = m_clusterIds.try_emplace(stateId, moduleId);
+    if (!inserted) {
+      const bool changesModule = entry->second != moduleId;
+      entry->second = moduleId; // the last row wins, which is what this reports on
       auto& repeat = repeats[stateId];
       if (repeat.rows == 0)
         repeat.rows = 1; // the row already in m_clusterIds
@@ -260,16 +260,28 @@ void ClusterMap::readClu(const std::string& filename, bool includeFlow, const st
     }
   }
 
+  // The example id is there to illustrate the problem, so a conflicting id always
+  // beats one that merely repeats a row verbatim, and within a tier the id with the
+  // most rows wins. Without the first rule a file holding both kinds could name the
+  // harmless one while the warning talks about changed modules.
+  bool exampleIsConflicting = false;
   for (const auto& [nodeId, repeat] : repeats) {
     m_duplicateClusterIds.rows += repeat.rows - 1;
     ++m_duplicateClusterIds.ids;
-    if (repeat.conflicting > 0) {
+
+    const bool isConflicting = repeat.conflicting > 0;
+    if (isConflicting) {
       m_duplicateClusterIds.conflictingRows += repeat.conflicting;
       ++m_duplicateClusterIds.conflictingIds;
     }
-    if (repeat.rows > m_duplicateClusterIds.maxRowsForOneId) {
+
+    const bool betterTier = isConflicting && !exampleIsConflicting;
+    const bool sameTierMoreRows = isConflicting == exampleIsConflicting
+        && repeat.rows > m_duplicateClusterIds.maxRowsForOneId;
+    if (betterTier || sameTierMoreRows) {
       m_duplicateClusterIds.maxRowsForOneId = repeat.rows;
       m_duplicateClusterIds.exampleId = nodeId;
+      exampleIsConflicting = isConflicting;
     }
   }
 }

--- a/src/io/ClusterMap.h
+++ b/src/io/ClusterMap.h
@@ -43,12 +43,20 @@ using TreePaths = std::vector<TreePath>;
 // that matters -- it has one row per (physical node, module) pair, so overlapping
 // modules make its ids repeat by construction (#1039).
 struct DuplicateClusterIds {
-  unsigned int rows = 0; // rows that replaced an earlier row
+  unsigned int rows = 0; // repeated rows, whether or not they changed anything
   unsigned int ids = 0; // distinct node ids seen more than once
   unsigned int exampleId = 0; // the worst one, named in the warning
   unsigned int maxRowsForOneId = 0; // how many rows that id had
 
+  // Repeats that actually changed the id's module. A file can repeat a row
+  // verbatim, and then nothing is replaced and the partition it describes is the
+  // one the reader ends up with -- so only these justify saying the result is not
+  // the file's partition.
+  unsigned int conflictingRows = 0;
+  unsigned int conflictingIds = 0;
+
   bool any() const noexcept { return rows > 0; }
+  bool anyConflicting() const noexcept { return conflictingRows > 0; }
 };
 
 class ClusterMap {

--- a/src/io/ClusterMap.h
+++ b/src/io/ClusterMap.h
@@ -36,6 +36,21 @@ struct TreePath {
 
 using TreePaths = std::vector<TreePath>;
 
+// What a clu file's repeated node ids amounted to. A clu file has one row per
+// node, so a repeat means the file is not a partition of the network it is being
+// applied to: the reader keeps whichever row it saw last and the earlier module
+// assignments are gone. The physical clu of a higher-order network is the case
+// that matters -- it has one row per (physical node, module) pair, so overlapping
+// modules make its ids repeat by construction (#1039).
+struct DuplicateClusterIds {
+  unsigned int rows = 0; // rows that replaced an earlier row
+  unsigned int ids = 0; // distinct node ids seen more than once
+  unsigned int exampleId = 0; // the worst one, named in the warning
+  unsigned int maxRowsForOneId = 0; // how many rows that id had
+
+  bool any() const noexcept { return rows > 0; }
+};
+
 class ClusterMap {
 public:
   void readClusterData(const std::string& filename, bool includeFlow = false, const std::map<unsigned int, std::map<unsigned int, unsigned int>>* layerNodeToStateId = nullptr);
@@ -51,6 +66,11 @@ public:
 
   TreeLeafIdType treeLeafIdType() const noexcept { return m_treeLeafIdType; }
 
+  // Only ever non-empty for a clu file. The tree reader has its own report for the
+  // same situation, which it can make more precise because a tree row carries a
+  // path it can pair with a state id -- see normalizeTreePaths.
+  const DuplicateClusterIds& duplicateClusterIds() const noexcept { return m_duplicateClusterIds; }
+
 private:
   void readTree(const std::string& filename, bool includeFlow, const std::map<unsigned int, std::map<unsigned int, unsigned int>>* layerNodeToStateId = nullptr);
   void readClu(const std::string& filename, bool includeFlow, const std::map<unsigned int, std::map<unsigned int, unsigned int>>* layerNodeToStateId = nullptr);
@@ -59,6 +79,7 @@ private:
   std::map<unsigned int, double> m_flowData;
   TreePaths m_treePaths;
   std::string m_extension;
+  DuplicateClusterIds m_duplicateClusterIds;
   bool m_isHigherOrder = false;
   bool m_hasTreeLeafIdType = false;
   TreeLeafIdType m_treeLeafIdType = TreeLeafIdType::physical;

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -326,9 +326,76 @@ TEST_CASE("Duplicate clu ids are reported for a first-order network too [fast][c
 
   const auto output = captured.str();
   CHECK(output.find("1 node id appears more than once") != std::string::npos);
+  CHECK(output.find("1 row changed an id's module") != std::string::npos);
   CHECK(output.find("node 3 alone has 2 rows") != std::string::npos);
   // The higher-order advice would be wrong here; this network has no state clu.
   CHECK(output.find("_states.clu") == std::string::npos);
+
+  std::remove(duplicateClu.c_str());
+}
+
+TEST_CASE("A clu that repeats a row verbatim is not reported as a changed partition [fast][core][partition][parser]")
+{
+  // A repeated id whose module agrees replaces nothing, and the reader ends up with
+  // exactly the partition the file describes -- so the warning must not claim the
+  // codelength is for something else. Worth a line anyway, since a clu file is
+  // meant to have one row per node.
+  const std::string sameModuleClu = "duplicate_same_module.clu";
+  {
+    std::ofstream out(sameModuleClu);
+    out << "# node_id module\n1 1\n2 1\n3 2\n3 2\n4 2\n5 3\n6 3\n";
+  }
+
+  std::ostringstream captured;
+  {
+    infomap::test::ScopedLogCapture capture(captured);
+    InfomapWrapper reader("--seed 123 --num-trials 1 --no-file-output --no-infomap --cluster-data " + sameModuleClu);
+    reader.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+    reader.run();
+  }
+
+  const auto output = captured.str();
+  CHECK(output.find("every repeat gives the same module") != std::string::npos);
+  CHECK(output.find("The partition is unaffected") != std::string::npos);
+  // None of the claims that only hold when a module actually changed.
+  CHECK(output.find("changed an id's module") == std::string::npos);
+  CHECK(output.find("not for the one in the file") == std::string::npos);
+
+  std::remove(sameModuleClu.c_str());
+}
+
+TEST_CASE("The duplicate-clu report survives the trial loop and parallel trials [fast][core][partition][parser][threads]")
+{
+  // The report used to sit in initPartition, which runs per trial: ten warnings on
+  // a serial -N10, and none at all under --parallel-trials, where every worker's
+  // initTrialPartition is wrapped in Log::ScopedMute. It is now emitted once on the
+  // main instance before any trial starts.
+  const std::string duplicateClu = "duplicate_trials.clu";
+  {
+    std::ofstream out(duplicateClu);
+    out << "# node_id module\n1 1\n2 1\n3 2\n3 3\n4 2\n5 3\n6 3\n";
+  }
+
+  const auto warningCount = [&duplicateClu](const std::string& extraFlags) {
+    std::ostringstream captured;
+    {
+      infomap::test::ScopedLogCapture capture(captured);
+      InfomapWrapper reader("--seed 123 --no-file-output --two-level --cluster-data " + duplicateClu + " " + extraFlags);
+      reader.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+      reader.run();
+    }
+    const auto output = captured.str();
+    unsigned int count = 0;
+    for (std::size_t at = output.find("more than once"); at != std::string::npos;
+         at = output.find("more than once", at + 1)) {
+      ++count;
+    }
+    return count;
+  };
+
+  CHECK(warningCount("--num-trials 1") == 1);
+  CHECK(warningCount("--num-trials 10") == 1);
+  CHECK(warningCount("--num-trials 10 --parallel-trials") == 1);
 
   std::remove(duplicateClu.c_str());
 }

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -326,7 +326,7 @@ TEST_CASE("Duplicate clu ids are reported for a first-order network too [fast][c
 
   const auto output = captured.str();
   CHECK(output.find("1 node id appears more than once") != std::string::npos);
-  CHECK(output.find("1 row changed an id's module") != std::string::npos);
+  CHECK(output.find("1 repeated row, 1 of which changed an id's module") != std::string::npos);
   CHECK(output.find("node 3 alone has 2 rows") != std::string::npos);
   // The higher-order advice would be wrong here; this network has no state clu.
   CHECK(output.find("_states.clu") == std::string::npos);
@@ -362,6 +362,36 @@ TEST_CASE("A clu that repeats a row verbatim is not reported as a changed partit
   CHECK(output.find("not for the one in the file") == std::string::npos);
 
   std::remove(sameModuleClu.c_str());
+}
+
+TEST_CASE("A clu mixing a verbatim repeat with a conflicting one counts both [fast][core][partition][parser]")
+{
+  // The leading counts are totals, not the conflicting subset: reporting only the
+  // conflicts undercounts what the sentence claims to summarize. And the example id
+  // has to name a conflicting id, or the warning talks about changed modules while
+  // pointing at the harmless repeat -- node 2 repeats its row verbatim and has as
+  // many rows as node 3, which is the one that changes module.
+  const std::string mixedClu = "duplicate_mixed.clu";
+  {
+    std::ofstream out(mixedClu);
+    out << "# node_id module\n1 1\n2 1\n2 1\n3 2\n3 3\n4 2\n5 3\n6 3\n";
+  }
+
+  std::ostringstream captured;
+  {
+    infomap::test::ScopedLogCapture capture(captured);
+    InfomapWrapper reader("--seed 123 --num-trials 1 --no-file-output --no-infomap --cluster-data " + mixedClu);
+    reader.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+    reader.run();
+  }
+
+  const auto output = captured.str();
+  CHECK(output.find("2 node ids appear more than once") != std::string::npos);
+  CHECK(output.find("2 repeated rows, 1 of which changed an id's module") != std::string::npos);
+  CHECK(output.find("node 3 alone has 2 rows") != std::string::npos);
+  CHECK(output.find("node 2 alone") == std::string::npos);
+
+  std::remove(mixedClu.c_str());
 }
 
 TEST_CASE("The duplicate-clu report survives the trial loop and parallel trials [fast][core][partition][parser][threads]")

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -12,6 +12,7 @@
 #include <map>
 #include <set>
 #include <iostream>
+#include <fstream>
 #include <sstream>
 #include <tuple>
 #include <vector>
@@ -250,6 +251,86 @@ TEST_CASE("A physical tree that cannot express the partition says so [fast][core
 
   std::remove(physicalTree.c_str());
   std::remove(statesTree.c_str());
+}
+
+TEST_CASE("A physical clu whose ids repeat says so [fast][core][partition][parser]")
+{
+  // The clu twin of the physical-tree case above. A physical .clu has one row per
+  // (physical node, module) pair, so overlapping modules make its node ids repeat,
+  // and the reader keeps whichever row it saw last. Unlike a tree row, a clu row
+  // carries no path to pair with a state id, so nothing can be recovered -- but it
+  // used to be silent, and a codelength off by bits reads as a real objective
+  // difference rather than a misread file (#1039).
+  //
+  // A *state* network on purpose, not a multilayer one: the multilayer clu reader
+  // demands node_id and layer_id columns that a physical clu does not carry, so it
+  // already fails loudly ("Couldn't parse node key"). The silent path is this one.
+  const std::string physicalClu = "physical_roundtrip.clu";
+  const std::string statesClu = "physical_roundtrip_states.clu";
+  std::remove(physicalClu.c_str());
+  std::remove(statesClu.c_str());
+
+  {
+    InfomapWrapper writer(infomap::test::defaultFlags("--seed 1"));
+    writer.readInputData(infomap::test::repoPath("examples/networks/states.net"));
+    writer.run();
+    infomap::writeClu(writer, writer.network(), physicalClu, false, 1);
+    infomap::writeClu(writer, writer.network(), statesClu, true, 1);
+  }
+
+  auto warningsWhenReading = [](const std::string& clusterFile) {
+    std::ostringstream captured;
+    {
+      infomap::test::ScopedLogCapture capture(captured);
+      // Not defaultFlags: it carries --silent, which mutes the very warning under test.
+      InfomapWrapper reader("--seed 123 --num-trials 1 --no-file-output --no-infomap --cluster-data " + clusterFile);
+      reader.readInputData(infomap::test::repoPath("examples/networks/states.net"));
+      reader.run();
+    }
+    return captured.str();
+  };
+
+  const auto physicalOutput = warningsWhenReading(physicalClu);
+  CHECK(physicalOutput.find("more than once") != std::string::npos);
+  // Singular, since exactly one physical node repeats here.
+  CHECK(physicalOutput.find("1 node id appears") != std::string::npos);
+  // The message has to name the file to use instead, or it only says "wrong".
+  CHECK(physicalOutput.find("_states.clu") != std::string::npos);
+
+  // The state clu is a partition of the network that was searched, so it must stay quiet.
+  const auto statesOutput = warningsWhenReading(statesClu);
+  CHECK(statesOutput.find("more than once") == std::string::npos);
+
+  std::remove(physicalClu.c_str());
+  std::remove(statesClu.c_str());
+}
+
+TEST_CASE("Duplicate clu ids are reported for a first-order network too [fast][core][partition][parser]")
+{
+  // Nothing higher-order about a repeated id: a hand-written or concatenated clu can
+  // carry one, and the reader discards assignments just the same. The advice differs,
+  // since there is no `_states.clu` to point at.
+  const std::string duplicateClu = "duplicate_ids.clu";
+  {
+    std::ofstream out(duplicateClu);
+    out << "# node_id module\n1 1\n2 1\n3 2\n3 3\n4 2\n5 3\n6 3\n";
+  }
+
+  std::ostringstream captured;
+  {
+    infomap::test::ScopedLogCapture capture(captured);
+    InfomapWrapper reader("--seed 123 --num-trials 1 --no-file-output --no-infomap --cluster-data " + duplicateClu);
+    reader.readInputData(infomap::test::repoPath("examples/networks/twotriangles.net"));
+    reader.run();
+  }
+
+  const auto output = captured.str();
+  CHECK(output.find("1 node id appears more than once") != std::string::npos);
+  CHECK(output.find("node 3 alone has 2 rows") != std::string::npos);
+  // The higher-order advice would be wrong here; this network has no state clu.
+  CHECK(output.find("_states.clu") == std::string::npos);
+
+  std::remove(duplicateClu.c_str());
 }
 
 TEST_CASE("Mixed-depth cluster data is rejected instead of crashing [fast][core][partition][parser]")


### PR DESCRIPTION
## Summary

Closes #1039. Independent of #1049 and #1050 — this branch is off `master` and touches the cluster reader, not the output plan.

A clu file has one row per node, and `readClu` ended each row with `m_clusterIds[stateId] = moduleId`, so a repeated id silently replaced the earlier assignment. The physical clu of a higher-order network hits this by construction: one row per (physical node, module) pair, so overlapping modules make its ids repeat. Feeding it back with `-c` produced a codelength off by bits with no warning at any verbosity, which reads as a real objective difference rather than a misread file — which is how it was first logged.

The tree reader already learned this in #908 and warns clearly. The clu reader had no equivalent. It now counts the repeats, the distinct ids involved, and one example id with its row count, and warns once per run with all of that plus the file name. The advice differs by input: on a higher-order network the message names the state clu to use instead; on a first-order network, where there is no `_states.clu` to point at, it says the codelength is for the partition that survived rather than for the file.

**Two corrections from review, both measured before changing anything:**

- *The report was in the wrong place.* It was emitted from `initPartition`, which runs per trial. A serial `-N10` printed it **ten times**, and `--parallel-trials` printed it **not at all** — every worker wraps `initTrialPartition` in `Log::ScopedMute`, so it was suppressed exactly on the path a user is most likely to take. It now runs once on the main instance before any trial starts. Measured 10 and 0 before, 1 and 1 after. The cost is one extra parse of the cluster file: a validation pass, not the partition the trials build.
- *The message asserted more than it knew.* A repeated id whose module agrees replaces nothing, and the reader ends up with exactly the partition the file describes — so telling that user the codelength is "not for the one in the file" was wrong. Repeats that change an id's module are now counted separately from ones that do not, and only the former get that wording; a file that merely repeats a row verbatim gets a line saying the partition is unaffected.

**One scope correction to the issue.** A *multilayer* network already fails loudly rather than silently: the multilayer clu reader demands `node_id` and `layer_id` columns that a physical clu does not carry, so it throws `Couldn't parse node key`. The silent path is the state-network one, which is where the reported measurements came from. The test uses a state network for that reason, and the comment says why.

## Verification

`examples/networks/states.net`, `-2 --no-infomap -c`:

| fed back | codelength | before | after |
|---|--:|---|---|
| `s_states.clu` | 2.011405238 (exact) | silent | silent |
| `s.clu` (physical) | 3.394087996 | **silent** | warns, names `_states.clu` |
| `s.tree` (physical) | 2.011405238 | warns (#908) | unchanged |
| first-order round trip | — | silent | silent |
| hand-written clu with a duplicate id | — | **silent** | warns, no `_states.clu` advice |

- `make test-native`: 26/26.
- Five cases in `test_partition.cpp`. Two mirror the #908 physical-tree case: one writes both clu variants and asserts the physical one warns while the state one stays quiet, the other covers the first-order message — **5 of their 7 assertions fail with the src changes reverted**, and the 2 that pass are the silence assertions, which must pass on both sides. Three more came from review: the per-run warning counts at `-N1`, `-N10` and `-N10 --parallel-trials`, the verbatim-repeat wording, and the absence of the conflict claims there. **5 of those assertions fail on the revision reviewed.**
- `make format-native-check`, `scripts/check_cpp_stream_policy.py`: clean.
- Pre-commit hooks (ruff lint/format, clang-format, C++ stream policy, and the generic safety nets) and the pre-push `pyright` gate on the core Python surface: clean.
- `make test-fast`: 850 passed, 2 skipped, 1 xfailed.

## Notes

Also drops the unused `clusterData` local in `readClu`. Repeat bookkeeping is keyed off `insert_or_assign`'s own result, so only ids that actually repeat cost anything and a well-formed file pays no extra storage or lookup.

Rebased onto `master` after #1049, #1050, #1052 and #1053 landed; the conflict was positional — this branch and #1049 each add a method just before `configureNetworkMode()`, and both are kept.

**Left for the issue's second suggestion:** a physical clu whose ids happen *not* to repeat, because no physical node's states are split across modules. Its ids are still read as state ids and this change adds no signal for that. Suggestion 3 (a header line on the physical writer marking its own overlap) is also untouched, since it changes an output file's content and is worth deciding separately.
