### PR TITLE
fix: charge the module-count preference on a scored partition

### DIFF
--- a/src/core/BiasedMapEquation.cpp
+++ b/src/core/BiasedMapEquation.cpp
@@ -198,6 +198,17 @@ double BiasedMapEquation::calcCodelength(const InfoNode& parent) const
       : calcCodelengthOnModuleOfModules(parent);
 }
 
+// Charged once for the whole tree, not per node. biasedCost is a single scalar in
+// |K - K_pref|, so there is no share of it for calcCodelength to return, which is
+// why the scored value used to lose the term entirely while the search kept it --
+// up to 7 bits on a six-node fixture, unbounded in K_pref (#1021). Read from the
+// tree rather than from currentNumModules so a partition that was materialized
+// rather than searched is charged for the modules it actually has.
+double BiasedMapEquation::calcTreeCodelengthCost(const InfoNode& root) const
+{
+  return calcNumModuleCost(root.childDegree());
+}
+
 // Free parameters of the codebook this tree node owns: one codeword per child
 // plus an exit codeword, minus one for the codebook's own normalisation. The root
 // owns the index codebook, which has no exit codeword, and neither does any module

--- a/src/core/BiasedMapEquation.h
+++ b/src/core/BiasedMapEquation.h
@@ -72,6 +72,9 @@ public:
 
   double calcCodelength(const InfoNode& parent) const;
 
+  // The |K - K_pref| cost, charged once from the tree's own top-module count.
+  double calcTreeCodelengthCost(const InfoNode& root) const;
+
   using Base::addMemoryContributions;
 
   using Base::addTeleportationFlow;

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -2555,7 +2555,10 @@ double InfomapBase::calcCodelengthOnTree(InfoNode& root, bool includeRoot) const
     node.codelength = calcCodelength(node);
     totalCodelength += node.codelength;
   }
-  return totalCodelength;
+  // Added to the total only, never written into a node's codelength: the term
+  // belongs to the partition, and the two callers that pass includeRoot=false do
+  // so for the per-node side effect and discard this return value (#1021).
+  return totalCodelength + calcTreeCodelengthCost(root);
 }
 
 // ===================================================

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -507,6 +507,8 @@ private:
 
   double calcCodelength(const InfoNode& parent) const { return m_optimizer->calcCodelength(parent); }
 
+  double calcTreeCodelengthCost(const InfoNode& root) const { return m_optimizer->calcTreeCodelengthCost(root); }
+
   /**
    * Calculate and store codelength on all modules in the tree
    * @param includeRoot Also calculate the codelength on the root node

--- a/src/core/InfomapOptimizer.h
+++ b/src/core/InfomapOptimizer.h
@@ -97,6 +97,8 @@ protected:
 
   double calcCodelength(const InfoNode& parent) const override { return m_objective.calcCodelength(parent); }
 
+  double calcTreeCodelengthCost(const InfoNode& root) const override { return m_objective.calcTreeCodelengthCost(root); }
+
   // ===================================================
   // Run: Partition: *
   // ===================================================

--- a/src/core/InfomapOptimizerBase.h
+++ b/src/core/InfomapOptimizerBase.h
@@ -94,6 +94,10 @@ protected:
 
   virtual double calcCodelength(const InfoNode& parent) const = 0;
 
+  // See MapEquation::calcTreeCodelengthCost. Zero for every objective but the
+  // biased one, which owns a partition-level |K - K_pref| cost.
+  virtual double calcTreeCodelengthCost(const InfoNode& root) const = 0;
+
   // ===================================================
   // Run: Partition: *
   // ===================================================

--- a/src/core/LossyMapEquation.h
+++ b/src/core/LossyMapEquation.h
@@ -82,6 +82,9 @@ public:
 
   double calcCodelength(const InfoNode& parent) const;
 
+  // No partition-level term of its own; see MapEquation::calcTreeCodelengthCost.
+  using Base::calcTreeCodelengthCost;
+
   using Base::addMemoryContributions;
 
   using Base::addTeleportationFlow;

--- a/src/core/MapEquation.h
+++ b/src/core/MapEquation.h
@@ -152,6 +152,13 @@ public:
   // Codelength
   // ===================================================
 
+  // A codelength term owned by the partition as a whole rather than by any one
+  // node's codebook, added once by calcCodelengthOnTree instead of being carried
+  // by the per-node sum. Zero here: only the biased objective has one, and a
+  // single global scalar has no per-node share to hand back from calcCodelength
+  // (#1021).
+  double calcTreeCodelengthCost(const InfoNode& /*root*/) const { return 0.0; }
+
   double calcCodelength(const InfoNode& parent) const
   {
     return parent.isLeafModule() ? ME::calcCodelengthOnModuleOfLeafNodes(parent) : ME::calcCodelengthOnModuleOfModules(parent);

--- a/src/core/MemMapEquation.h
+++ b/src/core/MemMapEquation.h
@@ -68,6 +68,9 @@ public:
 
   double calcCodelength(const InfoNode& parent) const;
 
+  // No partition-level term of its own; see MapEquation::calcTreeCodelengthCost.
+  using Base::calcTreeCodelengthCost;
+
   void addMemoryContributions(InfoNode& current, DeltaFlowDataType& oldModuleDelta, VectorMap<DeltaFlowDataType>& moduleDeltaFlow);
 
   using Base::addTeleportationFlow;

--- a/src/core/MetaMapEquation.h
+++ b/src/core/MetaMapEquation.h
@@ -74,6 +74,9 @@ public:
 
   double calcCodelength(const InfoNode& parent) const;
 
+  // No partition-level term of its own; see MapEquation::calcTreeCodelengthCost.
+  using Base::calcTreeCodelengthCost;
+
   using Base::addMemoryContributions;
 
   using Base::addTeleportationFlow;

--- a/src/core/RegularizedMultilayerMapEquation.h
+++ b/src/core/RegularizedMultilayerMapEquation.h
@@ -68,6 +68,9 @@ public:
 
   double calcCodelength(const InfoNode& parent) const;
 
+  // No partition-level term of its own; see MapEquation::calcTreeCodelengthCost.
+  using Base::calcTreeCodelengthCost;
+
   void addMemoryContributions(InfoNode& current, DeltaFlowDataType& oldModuleDelta, VectorMap<DeltaFlowDataType>& moduleDeltaFlow);
 
   void addTeleportationFlow(InfoNode& current, const std::vector<FlowDataType>& moduleFlowData, DeltaFlowDataType& oldModuleDelta, DeltaFlowDataType& newModuleDelta);

--- a/test/cpp/test_map_equation_invariants.cpp
+++ b/test/cpp/test_map_equation_invariants.cpp
@@ -48,6 +48,58 @@ TEST_CASE("MapEquation invariant: BiasedMapEquation (ordinary), tracked == recom
   checkTrackedMatchesRecompute(im);
 }
 
+// The same invariant with a module-count preference in play. The existing biased
+// case above passes at the default --preferred-number-of-modules 0, where the
+// |K - K_pref| term is identically zero, so it never covered the term itself.
+//
+// #1021: biasedCost is one scalar for the whole partition, so calcCodelength has
+// no per-node share to return and calcCodelengthOnTree's sum lost the term
+// completely. The tracked side kept it, so the two disagreed by |K - K_pref| --
+// unbounded in K_pref, and 7 bits on a six-node fixture.
+TEST_CASE("MapEquation invariant: BiasedMapEquation with a module preference, tracked == recompute [fast][core][mapeq][biased]")
+{
+  for (const unsigned int preference : { 1u, 3u, 40u }) {
+    InfomapWrapper im(defaultFlags("--two-level --preferred-number-of-modules " + std::to_string(preference)));
+    im.readInputData(networkFixturePath("lossy_benchmark.net"));
+    im.run();
+    INFO("--preferred-number-of-modules " << preference << ", found " << im.numTopModules());
+    // The invariant is vacuous where the search satisfies the preference exactly,
+    // since |K - K_pref| is then zero and the term under test never appears. At
+    // least one of these has to leave a residual, or the case proves nothing --
+    // 40 exceeds what this fixture can be split into.
+    if (preference == 40u)
+      REQUIRE(im.numTopModules() != preference);
+    checkTrackedMatchesRecompute(im);
+  }
+}
+
+// The user-visible half of #1021, and the shape the issue reported: scoring a
+// tracked partition with --no-infomap never moved, whatever K_pref was, because
+// the reported number on that path is calcCodelengthOnTree's sum. The partition
+// here has two modules, so the term is exactly |2 - K_pref| and the expected
+// values follow from the unbiased run rather than from a hardcoded constant.
+TEST_CASE("A module preference reaches a scored partition, not only the search [fast][core][mapeq][biased]")
+{
+  const auto scoredCodelength = [](const std::string& extraFlags) {
+    InfomapWrapper im(defaultFlags(
+        "--two-level --no-infomap --cluster-data "
+        + clusterFixturePath("twotriangles_two_modules.clu") + " " + extraFlags));
+    im.readInputData(repoPath("test/fixtures/graphs/twotriangles_unweighted.edges"));
+    im.run();
+    REQUIRE(im.numTopModules() == 2);
+    return im.codelength();
+  };
+
+  const double unbiased = scoredCodelength("");
+
+  for (const unsigned int preference : { 1u, 2u, 5u, 9u }) {
+    const double expected = unbiased + std::abs(2.0 - static_cast<double>(preference));
+    const double scored = scoredCodelength("--preferred-number-of-modules " + std::to_string(preference));
+    INFO("K_pref=" << preference << " scored=" << scored << " expected=" << expected);
+    checkApproxCodelength(scored, expected);
+  }
+}
+
 TEST_CASE("MapEquation invariant: MemMapEquation (memory), tracked == recompute [fast][core][mapeq][mem]")
 {
   InfomapWrapper im(defaultFlags("--two-level"));


### PR DESCRIPTION
## Summary

Closes #1021. Independent of #1049, #1050 and #1051 — off `master`, and it touches the biased objective, not the output plan or the cluster reader.

`BiasedMapEquation` carries the `|K - K_pref|` cost in `getCodelength()` and `getModuleCodelength()`, but `calcCodelength()` had no share of it to return: `biasedCost` is one scalar for the whole partition, not a per-node term. Every path that scores an existing tree sums `calcCodelength(node)` through `calcCodelengthOnTree`, so all of them reported the unbiased value — `--no-infomap` with `-c`, the `initTree` materialization, and the best-of-N restore.

Charged once for the tree instead of split across nodes, which is what a partition-level term is. `calcCodelengthOnTree` adds it to the total and never writes it into a node's `codelength` field, so per-module output is untouched; the two callers that pass `includeRoot=false` do so for that side effect and discard the return value. The count comes from the tree's own `childDegree()` rather than from `currentNumModules`, so a partition that was materialized rather than searched is charged for the modules it actually has.

The term reaches the objective through a new `calcTreeCodelengthCost`, zero on `MapEquation` and overridden only by the biased objective. The other objectives inherit `MapEquation` privately and re-expose each member they offer, so they get a using-declaration like the ones they already carry for `calcCodelength`.

**On the modelling choice the issue asks about:** attributing one global scalar across nodes is indeed a choice, so this does not make one. The term is added to the tree total only, leaving every per-node number as it was, which repairs the disagreement without asserting that the cost belongs to any particular codebook. The two alternatives — a per-node share, or making the tracked side tree-aware — both change more than the defect requires; say the word if you want either instead.

## Verification

`test/fixtures/graphs/twotriangles_unweighted.edges` with the tracked two-module partition, scored under `--no-infomap`:

| K_pref | before | after |
|---:|--:|--:|
| absent | 2.320730357 | 2.320730357 |
| 1 | 2.320730357 | **3.320730357** |
| 2 | 2.320730357 | 2.320730357 |
| 5 | 2.320730357 | **5.320730357** |
| 9 | 2.320730357 | **9.320730357** |

Exactly the columnar column the issue quotes as its cross-check.

- **The search is untouched.** `Best codelength` on `ninetriangles -N10` for K_pref 1/3/5/9/27 is bit-identical to the master values in the issue: 4.745545529, 3.385830820, 3.516369448, 3.517754809, 6.745545529.
- **The issue's un-measured question, answered:** the search total does carry the term. At K_pref 7 on the six-node fixture the search lands on 6 modules and reports 5.556656707462823; scoring that same partition gives 5.556656707462822 with the flag and 4.556656707462822 without it. The two reporters now agree to within summation order.
- `make test-native`: 26/26. Two new cases in `test_map_equation_invariants.cpp` — the house `tracked == recompute` invariant with a preference in play, and the scored-partition case with expected values derived from the unbiased run rather than hardcoded. **5 of their 13 assertions fail with the src changes reverted.**
- The first draft of the invariant case passed on unfixed code, because the search satisfied every preference exactly and `|K - K_pref|` was zero; it now includes a preference the fixture cannot be split into, with a `REQUIRE` that the residual is nonzero.
- Pre-commit hooks and `make test-fast`: clean, 850 passed / 2 skipped / 1 xfailed.

## Notes

**Not addressed, and not a module-preference problem.** On a hierarchical winner, search and rescore still differ in the base codelength beyond this term: `ninetriangles -N10 -k 2` reports 3.587025268 against 4.587025268 for its own tree rescored, one bit more than `|3 - 2|` accounts for. That is the aggregate-versus-node-sum axis, the same shape as #1022.
