### PR TITLE
fix: report a regularized multilayer flow imbalance instead of aborting

### DIFF
--- a/src/utils/FlowCalculator.cpp
+++ b/src/utils/FlowCalculator.cpp
@@ -808,7 +808,7 @@ void FlowCalculator::calcDirectedRegularizedFlow(const StateNetwork& network, co
 }
 
 #if INFOMAP_FEATURE_REGULARIZED_MULTILAYER
-void FlowCalculator::calcDirectedRegularizedMultilayerFlow(const StateNetwork& network, const Config& config) noexcept
+void FlowCalculator::calcDirectedRegularizedMultilayerFlow(const StateNetwork& network, const Config& config)
 {
   // Calculate node weights w_i = s_i/k_i, where s_i is the node strength (weighted degree) and k_i the (unweighted) degree
   unsigned int N = network.numNodes();

--- a/src/utils/FlowCalculator.h
+++ b/src/utils/FlowCalculator.h
@@ -41,7 +41,12 @@ private:
   void calcUndirectedRegularizedFlow(const StateNetwork&, const Config&) noexcept;
   void calcUndirectedRegularizedMultilayerFlow(const StateNetwork&, const Config&);
   void calcDirectedRegularizedFlow(const StateNetwork&, const Config&) noexcept;
-  void calcDirectedRegularizedMultilayerFlow(const StateNetwork&, const Config&) noexcept;
+  // Not noexcept: this one throws on a flow imbalance it cannot normalize away,
+  // and a throw escaping a noexcept function calls std::terminate rather than
+  // reaching Infomap's error handler (#1019). The same reason
+  // calcUndirectedRegularizedMultilayerFlow and usePrecomputedFlow are unmarked;
+  // every flow method that cannot throw keeps the marking.
+  void calcDirectedRegularizedMultilayerFlow(const StateNetwork&, const Config&);
   void calcDirectedBipartiteFlow(const StateNetwork&, const Config&) noexcept;
   void calcDirdirFlow(const Config&) noexcept;
   void calcRawdirFlow() noexcept;

--- a/test/cpp/test_flow.cpp
+++ b/test/cpp/test_flow.cpp
@@ -384,6 +384,33 @@ TEST_CASE("Undirected regularization remains stable on the two-triangles fixture
 }
 
 #if INFOMAP_FEATURE_REGULARIZED_MULTILAYER
+// examples/networks/multilayer_intra_inter.net -- a network we ship -- fails its
+// flow-imbalance check under --regularized. The imbalance itself is unresolved
+// (#1019 keeps that separate), but the failure has to arrive as an error the
+// caller can handle: calcDirectedRegularizedMultilayerFlow was noexcept, so the
+// throw called std::terminate and the process died on SIGABRT with a raw
+// libc++abi line instead of Infomap's own message.
+//
+// Note what happens if the noexcept comes back: this test does not fail, it
+// aborts the whole test binary. That is louder than a failed assertion, not
+// quieter, and it is the only way to guard a terminate.
+TEST_CASE("A flow imbalance under regularized multilayer is thrown, not terminated [fast][core][flow]")
+{
+  InfomapWrapper im(infomap::test::defaultFlags("--regularized --two-level"));
+  im.readInputData(infomap::test::repoPath("examples/networks/multilayer_intra_inter.net"));
+
+  CHECK_THROWS_AS(im.run(), std::runtime_error);
+
+  try {
+    im.run();
+    FAIL("expected the flow imbalance to be reported");
+  } catch (const std::runtime_error& e) {
+    // The number is the imbalance and is not asserted -- it belongs to the
+    // unresolved half of the issue and would pin this test to today's value.
+    CHECK(std::string(e.what()).find("Total flow differs from 1") != std::string::npos);
+  }
+}
+
 TEST_CASE("Regularized multilayer flow supports non-dense matchable state ids [fast][core][flow]")
 {
   InfomapWrapper im(infomap::test::defaultFlags(


### PR DESCRIPTION
## Summary

Closes #1019, its reporting half. Independent of #1049, #1050, #1051 and #1052 — off `master`, in the flow calculator.

`examples/networks/multilayer_intra_inter.net` — a network we ship — died on SIGABRT under `--regularized`, printing a raw `libc++abi` line and exit 134. The flow-imbalance check throws, but `calcDirectedRegularizedMultilayerFlow` was marked `noexcept`, so the throw called `std::terminate` instead of reaching Infomap's error handler.

**The repo already answers the issue's "the noexcept is wrong, or the throw is".** Every flow method that cannot throw is marked `noexcept`, and the two that can are not: `usePrecomputedFlow`, and `calcUndirectedRegularizedMultilayerFlow` — the undirected sibling of this very function, unmarked precisely because it throws "not implemented". The directed regularized multilayer one was the only method both marked and throwing. So the marking is the anomaly, not the throw, and it is removed.

| | before | after |
|---|---|---|
| stderr | `libc++abi: terminating due to uncaught exception ...` | `Error: Total flow differs from 1 by -0.06721767791252525 after 0 iterations. Please report the issue.` |
| exit code | 134 (SIGABRT) | 7 |

Exit 7 is `ExitCode::InternalError`, already the right code for an invariant the run cannot satisfy, so no message or exit-code change was needed.

## Verification

- Reproduced on `examples/networks/multilayer_intra_inter.net` with `FEATURES=regularized-multilayer OPENMP=0`, then confirmed the clean failure above.
- `make test-native`: 26/26 in the default build and 26/26 with `FEATURES=regularized-multilayer CMAKE_TEST_BUILD_DIR=build/cmake-features`.
- New case in `test/cpp/test_flow.cpp` under the existing `INFOMAP_FEATURE_REGULARIZED_MULTILAYER` gate. **How it behaves if the `noexcept` ever comes back: it does not fail, it aborts the whole test binary** — verified by restoring the marking, which gives `Subprocess aborted***Exception` and `FATAL ERROR: test case CRASHED: SIGABRT` from the flow suite. Louder than an assertion, and the only way to guard a terminate.
- Pre-commit hooks on the changed files: clean.
- Worth noting for anyone re-running this: the feature-gated cases compile out of the default `build/cmake` test binaries, so a `make test-native FEATURES=...` that reuses that directory proves nothing about them. The feature build needs its own `CMAKE_TEST_BUILD_DIR`, as CI does.

## Notes

**Deliberately not fixed: the imbalance itself.** `-0.0672` undirected and `-0.1148` under `-d` on the first power-iteration step is far too large to be a convergence tail, and diagnosing the regularized multilayer flow model is a separate question from how the failure is reported. #1019 separates the two; this is the reporting half, and the issue stays open for the other unless you want it split out.

One hypothesis ruled out while reading, so nobody else spends time on it: `N` and `numNodes` in that function are both `network.numNodes()`, so the mixed use of the two names is not an off-by-one.

A user on a released build cannot hit either half — `release.yml` passes no `features`, so `--regularized` is not in the shipped binaries. This is maintainer- and CI-facing, which is why I took it after #1021 rather than before.
