### PR TITLE
feat: record the effective seed in the default output artifacts

### DIFF
--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -252,6 +252,9 @@ public:
     // Still ahead of every writer, which is what the check exists for.
     validateNetwork();
     preflightOutputTargets(m_infomap, higherOrderInput());
+    // Before the first seedTrial, so this is the seed the run was asked for.
+    m_infomap.m_baseSeed = m_infomap.seedToRandomNumberGenerator;
+    m_infomap.m_haveBaseSeed = true;
     {
       auto timer = m_timing.scope("configure_network_s");
       configureNetworkMode();

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -443,7 +443,14 @@ private:
 #endif
     for (int workerIndex = 0; workerIndex < static_cast<int>(numWorkers); ++workerIndex) {
       auto workerConfig = m_infomap.getConfig();
-      workerConfig.numTrials = 1;
+      // The run's trial count, not the worker's one trial: this field names and
+      // labels the worker's --print-all-trials artifacts. outputPlanBasename only
+      // appends `_trial_N` when numTrials > 1, so at 1 every worker wrote the
+      // aggregate's basename instead -- four trials overwriting one file, and the
+      // per-trial artifacts the output pre-flight had already reserved never
+      // appearing. It does not make the worker run trials: the worker never enters
+      // RunSession::run, and executeTrial is called once per trialIndex from here.
+      workerConfig.numTrials = m_numTrials;
       workerConfig.parallelTrials = false;
       workerConfig.innerParallelization = false;
       workerConfig.seedToRandomNumberGenerator = m_baseSeed + static_cast<unsigned int>(workerIndex);
@@ -463,13 +470,6 @@ private:
           // captured base seed -- and its live seed field is this trial's. Without
           // this, a per-trial artifact written by a worker reports base + offset + i
           // as if it were the run's seed.
-          //
-          // Unreachable today, and deliberately kept: Config::cloneAsNonMain does not
-          // copy printAllTrials, so the worker's per-trial write below never fires and
-          // --print-all-trials is silently ignored under --parallel-trials. Verified
-          // with 4 workers at -N4: only the aggregate reaches disk. That is why no
-          // test covers these two lines -- there is no artifact to inspect. Whoever
-          // closes that gap gets correct seeds instead of a silent regression.
           worker.m_baseSeed = m_infomap.baseSeed();
           worker.m_haveBaseSeed = true;
           worker.reseed(static_cast<unsigned int>(seed));

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -463,6 +463,13 @@ private:
           // captured base seed -- and its live seed field is this trial's. Without
           // this, a per-trial artifact written by a worker reports base + offset + i
           // as if it were the run's seed.
+          //
+          // Unreachable today, and deliberately kept: Config::cloneAsNonMain does not
+          // copy printAllTrials, so the worker's per-trial write below never fires and
+          // --print-all-trials is silently ignored under --parallel-trials. Verified
+          // with 4 workers at -N4: only the aggregate reaches disk. That is why no
+          // test covers these two lines -- there is no artifact to inspect. Whoever
+          // closes that gap gets correct seeds instead of a silent regression.
           worker.m_baseSeed = m_infomap.baseSeed();
           worker.m_haveBaseSeed = true;
           worker.reseed(static_cast<unsigned int>(seed));

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -459,6 +459,12 @@ private:
           Log::ScopedMute muteWorkerLogs;
           const auto seed = trialSeed(trialIndex);
           worker.seedToRandomNumberGenerator = seed;
+          // A worker is its own Infomap, so it does not inherit the main instance's
+          // captured base seed -- and its live seed field is this trial's. Without
+          // this, a per-trial artifact written by a worker reports base + offset + i
+          // as if it were the run's seed.
+          worker.m_baseSeed = m_infomap.baseSeed();
+          worker.m_haveBaseSeed = true;
           worker.reseed(static_cast<unsigned int>(seed));
           int threadNumber = 0;
 #ifdef _OPENMP

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -147,6 +147,15 @@ public:
 
   double getOneLevelCodelength() const { return m_oneLevelCodelength; }
 
+  // The seed the run was configured with, which is not the same as reading
+  // seedToRandomNumberGenerator: the serial loop moves that field to the current
+  // trial's seed (base + trialOffset + index) and only gives it back when the loop
+  // ends, while updateBestResult writes the aggregate artifact from inside the loop.
+  // A header reading the live field therefore recorded the last trial's seed
+  // whenever the best trial was the last one, since restoreBestResult then performs
+  // no rewrite. Falls back to the live value until a run has captured it.
+  unsigned long baseSeed() const { return m_haveBaseSeed ? m_baseSeed : seedToRandomNumberGenerator; }
+
 #ifndef SWIG
   // One-level reference reported to the user. In lossy mode this is the lossless
   // L_1 = H(p_alpha) (a lambda-independent upper bound), not the lambda-dependent
@@ -685,6 +694,8 @@ protected:
   bool m_calculateEnterExitFlow = false;
 
   double m_oneLevelCodelength = 0.0;
+  unsigned long m_baseSeed = 0;
+  bool m_haveBaseSeed = false;
   unsigned int m_numNonTrivialTopModules = 0;
   unsigned int m_tuneIterationIndex = 0;
   bool m_isCoarseTune = false;

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -147,6 +147,7 @@ public:
 
   double getOneLevelCodelength() const { return m_oneLevelCodelength; }
 
+#ifndef SWIG
   // The seed the run was configured with, which is not the same as reading
   // seedToRandomNumberGenerator: the serial loop moves that field to the current
   // trial's seed (base + trialOffset + index) and only gives it back when the loop
@@ -154,7 +155,11 @@ public:
   // A header reading the live field therefore recorded the last trial's seed
   // whenever the best trial was the last one, since restoreBestResult then performs
   // no rewrite. Falls back to the live value until a run has captured it.
+  //
+  // Guarded from SWIG so it is not exposed as a new binding, the same way
+  // getReferenceOneLevelCodelength above is: the output writer is its only caller.
   unsigned long baseSeed() const { return m_haveBaseSeed ? m_baseSeed : seedToRandomNumberGenerator; }
+#endif
 
 #ifndef SWIG
   // One-level reference reported to the user. In lossy mode this is the lossless

--- a/src/io/Output.cpp
+++ b/src/io/Output.cpp
@@ -124,6 +124,7 @@ std::string getOutputFileHeader(const InfomapBase& im, const StateNetwork& netwo
                                 "# started at {}\n"
                                 "# completed in {:g} s\n"
                                 "# trials {} of {}\n"
+                                "# seed {}{}\n"
                                 "# partitioned into {} levels with {} top modules\n"
                                 "# codelength {:g} bits\n"
                                 "# relative codelength savings {:g}%\n"
@@ -141,6 +142,14 @@ std::string getOutputFileHeader(const InfomapBase& im, const StateNetwork& netwo
                      // interrupt time, when doing work is least reliable.
                      im.codelengths().size(),
                      im.numTrials,
+                     // The effective seed, not whatever the user typed: the header
+                     // echoes parsedString, so a run on the default seed published
+                     // artifacts from which the one parameter reproducibility hinges
+                     // on was unrecoverable (#1026). Per-trial seeds derive from
+                     // base + offset + i, so the offset is part of the answer and is
+                     // written when a shard is not the first.
+                     im.seedToRandomNumberGenerator,
+                     im.trialOffset == 0 ? std::string() : fmt::format(FMT_STRING(" offset {}"), im.trialOffset),
                      im.maxTreeDepth(),
                      im.numTopModules(),
                      im.codelength(),
@@ -301,6 +310,14 @@ void writeJsonTree(InfomapBase& im, const StateNetwork& network, std::ostream& o
   json["startedAt"] = io::stringify(im.getStartDate());
   json["completedIn"] = im.getElapsedTime().getElapsedTimeInSec();
   json["codelength"] = im.codelength();
+  // See the text header: the effective seed, and the trial counts the text header
+  // has had since #906 but this output never carried (#1026).
+  json["seed"] = im.seedToRandomNumberGenerator;
+  if (im.trialOffset != 0) {
+    json["trialOffset"] = im.trialOffset;
+  }
+  json["trials"] = im.codelengths().size();
+  json["numTrials"] = im.numTrials;
   json["numLevels"] = im.maxTreeDepth();
   json["numTopModules"] = im.numTopModules();
 

--- a/src/io/Output.cpp
+++ b/src/io/Output.cpp
@@ -148,7 +148,7 @@ std::string getOutputFileHeader(const InfomapBase& im, const StateNetwork& netwo
                      // on was unrecoverable (#1026). Per-trial seeds derive from
                      // base + offset + i, so the offset is part of the answer and is
                      // written when a shard is not the first.
-                     im.seedToRandomNumberGenerator,
+                     im.baseSeed(),
                      im.trialOffset == 0 ? std::string() : fmt::format(FMT_STRING(" offset {}"), im.trialOffset),
                      im.maxTreeDepth(),
                      im.numTopModules(),
@@ -312,7 +312,7 @@ void writeJsonTree(InfomapBase& im, const StateNetwork& network, std::ostream& o
   json["codelength"] = im.codelength();
   // See the text header: the effective seed, and the trial counts the text header
   // has had since #906 but this output never carried (#1026).
-  json["seed"] = im.seedToRandomNumberGenerator;
+  json["seed"] = im.baseSeed();
   if (im.trialOffset != 0) {
     json["trialOffset"] = im.trialOffset;
   }

--- a/test/schemas/json/partition-output.schema.json
+++ b/test/schemas/json/partition-output.schema.json
@@ -15,6 +15,9 @@
     "directed",
     "flowModel",
     "higherOrder",
+    "seed",
+    "trials",
+    "numTrials",
     "nodes",
     "modules"
   ],
@@ -25,6 +28,10 @@
     "startedAt": { "type": "string" },
     "completedIn": { "type": "number" },
     "codelength": { "type": "number" },
+    "seed": { "type": "integer", "minimum": 0 },
+    "trialOffset": { "type": "integer", "minimum": 1 },
+    "trials": { "type": "integer", "minimum": 0 },
+    "numTrials": { "type": "integer", "minimum": 0 },
     "numLevels": { "type": "integer", "minimum": 0 },
     "numTopModules": { "type": "integer", "minimum": 0 },
     "numModules": {

--- a/test/scripts/check_run_metadata_cli.py
+++ b/test/scripts/check_run_metadata_cli.py
@@ -332,11 +332,16 @@ def test_every_artifact_records_the_same_base_seed(infomap_bin, work):
     assert set(seeds.values()) == {"# seed 42"}, seeds
 
 
-def test_parallel_trials_aggregate_records_the_base_seed(infomap_bin, work):
-    # The parallel path takes a different route to the artifact, so it gets its own
-    # assertion. It does not reach the worker's own seed handling: cloneAsNonMain
-    # does not copy printAllTrials, so a worker never writes a per-trial artifact and
-    # there is nothing else to inspect.
+def test_parallel_trials_artifacts_record_the_base_seed(infomap_bin, work):
+    # The parallel path writes through a worker Infomap rather than the main instance,
+    # so it gets its own assertion. A worker does not inherit the main run's captured
+    # base seed and its live seed field is the current trial's, so without the
+    # propagation in runTrialsInParallel the per-trial files here reported 52, 53, 54,
+    # 55 while the aggregate reported 42.
+    #
+    # A build without OpenMP warns and runs the same command serially, which asserts
+    # the same invariant over the serial writer; the worker lines are covered by the
+    # OpenMP build.
     make_workdir(work)
 
     result = run(
@@ -347,14 +352,30 @@ def test_parallel_trials_aggregate_records_the_base_seed(infomap_bin, work):
         "--seed",
         "42",
         "-N4",
+        "--trial-offset",
+        "10",
         "--parallel-trials",
+        "--print-all-trials",
         "-o",
         "tree",
         cwd=work,
     )
 
     assert result.returncode == 0, result.stderr
-    assert "# seed 42" in (work / "out" / "network.tree").read_text(encoding="utf-8")
+
+    # The aggregate plus one file per trial, numbered by offset + trial index.
+    names = sorted(tree.name for tree in (work / "out").glob("*.tree"))
+    assert names == [
+        "network.tree",
+        "network_trial_11.tree",
+        "network_trial_12.tree",
+        "network_trial_13.tree",
+        "network_trial_14.tree",
+    ], names
+
+    for name in names:
+        text = (work / "out" / name).read_text(encoding="utf-8")
+        assert "# seed 42 offset 10" in text, (name, text)
 
 
 def test_overwrite_flag_is_removed(infomap_bin, work):
@@ -407,7 +428,7 @@ def main(argv):
             test_default_headers_record_the_effective_seed,
             test_headers_record_the_trial_offset_of_a_shard,
             test_every_artifact_records_the_same_base_seed,
-            test_parallel_trials_aggregate_records_the_base_seed,
+            test_parallel_trials_artifacts_record_the_base_seed,
             test_overwrite_flag_is_removed,
             test_run_manifest_contains_fingerprints_and_outputs,
         ]:

--- a/test/scripts/check_run_metadata_cli.py
+++ b/test/scripts/check_run_metadata_cli.py
@@ -332,6 +332,31 @@ def test_every_artifact_records_the_same_base_seed(infomap_bin, work):
     assert set(seeds.values()) == {"# seed 42"}, seeds
 
 
+def test_parallel_trials_aggregate_records_the_base_seed(infomap_bin, work):
+    # The parallel path takes a different route to the artifact, so it gets its own
+    # assertion. It does not reach the worker's own seed handling: cloneAsNonMain
+    # does not copy printAllTrials, so a worker never writes a per-trial artifact and
+    # there is nothing else to inspect.
+    make_workdir(work)
+
+    result = run(
+        infomap_bin,
+        "network.net",
+        "out",
+        "--silent",
+        "--seed",
+        "42",
+        "-N4",
+        "--parallel-trials",
+        "-o",
+        "tree",
+        cwd=work,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "# seed 42" in (work / "out" / "network.tree").read_text(encoding="utf-8")
+
+
 def test_overwrite_flag_is_removed(infomap_bin, work):
     make_workdir(work)
 
@@ -382,6 +407,7 @@ def main(argv):
             test_default_headers_record_the_effective_seed,
             test_headers_record_the_trial_offset_of_a_shard,
             test_every_artifact_records_the_same_base_seed,
+            test_parallel_trials_aggregate_records_the_base_seed,
             test_overwrite_flag_is_removed,
             test_run_manifest_contains_fingerprints_and_outputs,
         ]:

--- a/test/scripts/check_run_metadata_cli.py
+++ b/test/scripts/check_run_metadata_cli.py
@@ -289,6 +289,49 @@ def test_headers_record_the_trial_offset_of_a_shard(infomap_bin, work):
     assert data["trialOffset"] == 10
 
 
+def test_every_artifact_records_the_same_base_seed(infomap_bin, work):
+    # The serial loop moves Config::seedToRandomNumberGenerator to the current trial's
+    # seed and only gives it back when the loop ends, while updateBestResult writes the
+    # aggregate artifact from inside the loop. A header reading the live field recorded
+    # 42, 43, 44 across the per-trial files, and the aggregate kept the last trial's
+    # seed whenever the best trial was the last -- restoreBestResult then rewrites
+    # nothing. One stable meaning instead: every artifact carries the run's base seed,
+    # and a trial's own seed is base + offset + (trial - 1), with the trial in the
+    # filename.
+    make_workdir(work)
+
+    result = run(
+        infomap_bin,
+        "network.net",
+        "out",
+        "--silent",
+        "--seed",
+        "42",
+        "-N3",
+        "--print-all-trials",
+        "-o",
+        "tree",
+        cwd=work,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    trees = sorted((work / "out").glob("*.tree"))
+    assert len(trees) >= 4, [t.name for t in trees]
+
+    seeds = {}
+    for tree in trees:
+        lines = [
+            line
+            for line in tree.read_text(encoding="utf-8").splitlines()
+            if line.startswith("# seed ")
+        ]
+        assert len(lines) == 1, (tree.name, lines)
+        seeds[tree.name] = lines[0]
+
+    assert set(seeds.values()) == {"# seed 42"}, seeds
+
+
 def test_overwrite_flag_is_removed(infomap_bin, work):
     make_workdir(work)
 
@@ -338,6 +381,7 @@ def main(argv):
             test_pajek_dump_of_a_first_order_network_is_unchanged,
             test_default_headers_record_the_effective_seed,
             test_headers_record_the_trial_offset_of_a_shard,
+            test_every_artifact_records_the_same_base_seed,
             test_overwrite_flag_is_removed,
             test_run_manifest_contains_fingerprints_and_outputs,
         ]:

--- a/test/scripts/check_run_metadata_cli.py
+++ b/test/scripts/check_run_metadata_cli.py
@@ -227,6 +227,68 @@ def test_pajek_dump_of_a_first_order_network_is_unchanged(infomap_bin, work):
     assert "# State network as physical network" not in text
 
 
+def test_default_headers_record_the_effective_seed(infomap_bin, work):
+    # #1026: the header echoes the as-typed argument string, so a run on the default
+    # seed published artifacts from which the seed was unrecoverable -- the one
+    # parameter reproducibility actually hinges on. No --seed here on purpose.
+    make_workdir(work)
+
+    result = run(
+        infomap_bin,
+        "network.net",
+        "out",
+        "--silent",
+        "-N2",
+        "-o",
+        "tree,json",
+        cwd=work,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    tree = (work / "out" / "network.tree").read_text(encoding="utf-8")
+    assert "# seed 123" in tree
+    # No shard offset in play, so the line carries the seed alone.
+    assert "offset" not in tree.split("# seed")[1].split("\n")[0]
+
+    data = json.loads((work / "out" / "network.json").read_text(encoding="utf-8"))
+    assert data["seed"] == 123
+    assert "trialOffset" not in data
+    # The trial counts the text header has had since #906, which this output lacked.
+    assert data["trials"] == 2
+    assert data["numTrials"] == 2
+
+
+def test_headers_record_the_trial_offset_of_a_shard(infomap_bin, work):
+    # Per-trial seeds derive from base + offset + i, so the offset is part of the
+    # answer and a shard's artifact has to carry it.
+    make_workdir(work)
+
+    result = run(
+        infomap_bin,
+        "network.net",
+        "out",
+        "--silent",
+        "--seed",
+        "42",
+        "-N2",
+        "--trial-offset",
+        "10",
+        "-o",
+        "tree,json",
+        cwd=work,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    tree = (work / "out" / "network.tree").read_text(encoding="utf-8")
+    assert "# seed 42 offset 10" in tree
+
+    data = json.loads((work / "out" / "network.json").read_text(encoding="utf-8"))
+    assert data["seed"] == 42
+    assert data["trialOffset"] == 10
+
+
 def test_overwrite_flag_is_removed(infomap_bin, work):
     make_workdir(work)
 
@@ -274,6 +336,8 @@ def main(argv):
             test_first_order_run_may_write_beside_a_states_named_input,
             test_pajek_dump_of_a_higher_order_network_is_named_and_labelled_for_it,
             test_pajek_dump_of_a_first_order_network_is_unchanged,
+            test_default_headers_record_the_effective_seed,
+            test_headers_record_the_trial_offset_of_a_shard,
             test_overwrite_flag_is_removed,
             test_run_manifest_contains_fingerprints_and_outputs,
         ]:


### PR DESCRIPTION
## Summary

Refs #1026 — its **first checklist item**, and the only one that needs no policy decision. The issue is a seven-item program; this PR does not close it.

The header echoes `parsedString`, the as-typed argument string, so the seed appeared only if the user happened to type `--seed`. A run on the default seed published artifacts from which the one parameter reproducibility hinges on was unrecoverable, and a run driven through the Python API can carry a `parsedString` that names none of the options actually set.

`.tree`/`.ftree`/`.clu` now carry a `# seed N` line, and the JSON tree a `seed` field. Both take the seed the run was **configured with**, captured before the first `seedTrial()`, so the default 123 is written on a run that never mentioned it. Per-trial seeds derive from `base + offset + i`, so the trial offset is part of the answer and is written when a shard is not the first.

```
# trials 3 of 3
# seed 123                     <- new, on a run with no --seed
# partitioned into 3 levels with 3 top modules
```

```
# seed 42 offset 10            <- --seed 42 --trial-offset 10
```

The JSON tree also gains the trial counts the text header has had since #906 — `trials` and `numTrials` — which it omitted, so a pipeline reading JSON could not tell a complete best-of-N from an interrupted one.

The metadata itself is additive: one comment line in the text headers, two to four fields in the JSON. No existing field changes and no value moves.

## One behaviour change beyond the metadata

Getting the seed right on every artifact exposed a pre-existing defect and fixes it, so the scope is wider than metadata alone.

Each parallel-trial worker was constructed with `workerConfig.numTrials = 1`. `outputPlanBasename()` appends the `_trial_N` suffix only when `numTrials > 1`, so under `--parallel-trials --print-all-trials` **every worker wrote the aggregate's basename** — four trials overwriting one file, and none of the per-trial artifacts the output pre-flight had already reserved. The worker now carries the run's trial count, which is what names and labels its artifacts; it does not make the worker run trials, since a worker never enters `RunSession::run()`.

An earlier revision of this description claimed that `--print-all-trials` was silently ignored under `--parallel-trials` because `Config::cloneAsNonMain` does not copy `printAllTrials`, and that the two worker seed lines therefore could not be regression-tested. **Both claims were wrong**, as review pointed out: `workerConfig` is an ordinary full copy of the main config and `InfomapBase(Config)` never calls `cloneAsNonMain`, so `printAllTrials` survived and the write did fire — confirmed with an instrumented build showing four worker writes to the same path. With the naming fixed, those seed lines are reachable and tested.

## Verification

- `ctest`: 26/26. `make test-python-unit`: 850 passed, 2 skipped, 1 xfailed.
- `check_run_metadata_cli.py`, 14 cases, four of them new or rewritten here:
  - the default-seed run records `# seed 123` with no offset clause, plus `trials`/`numTrials` in the JSON;
  - the shard run records `# seed 42 offset 10` and `trialOffset`;
  - every artifact of a serial `-N3 --print-all-trials` run records the one base seed;
  - every artifact of a `--parallel-trials --print-all-trials` run does too, at a nonzero offset, and the per-trial filenames are asserted by name.
- Each of those fails on a binary built without the corresponding src change. Removing the worker seed propagation makes the parallel case report 52, 53, 54, 55 instead of 42; removing the trial-count fix makes the `_trial_N` files disappear entirely.
- `test/schemas/json/partition-output.schema.json` declares the new fields, so the strict-schema validations in `test_output.py` still pass.
- Pre-commit hooks on the changed files: clean.

## Notes

**Left on the issue, and four of these are decisions rather than defects:** the input fingerprint in the headers; whether the fingerprint should become full-content or be renamed to say it is sampled (FNV over size plus first/last 64 KiB is blind to interior edits of files over 128 KiB, which is the edit-and-rerun case it exists to catch); fingerprinting `--cluster-data` and metadata, which change the published partition and have no content identity anywhere; the CSV/Newick position; and the Python `provenance()`-style accessor.

I picked the seed alone because it is the item with no open question attached — the value to write is unambiguous and the change is additive.
