### PR TITLE
fix: report an index codelength in the super consolidation log

### DIFF
--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -2968,7 +2968,13 @@ unsigned int InfomapBase::findHierarchicalSuperModules(unsigned int superLevelLi
     // Consolidate the dynamic modules without replacing any existing ones.
     consolidateModules(false);
 
-    Console::detail(1, "super: consolidated {} modules, index codelength {:g} {} {}", numTopModules(), oldIndexLength, Console::arrow(), io::stringify(*this));
+    // The arrow has to land on an index codelength, since that is what the sentence
+    // says and what oldIndexLength is updated to just below. It used to print
+    // io::stringify(*this): a correctly computed but different quantity -- the whole
+    // objective over the module network after the flat initPartition above -- so the
+    // line compared an index codelength against a full one and reported a value
+    // larger than the codelength the very next line announces (#837).
+    Console::detail(1, "super: consolidated {} modules, index codelength {:g} {} {:g}", numTopModules(), oldIndexLength, Console::arrow(), superIndexCodelength);
 
     hierarchicalCodelength = workingHierarchicalCodelength;
     oldIndexLength = superIndexCodelength;

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -13,6 +13,7 @@
 #include <set>
 #include <iostream>
 #include <fstream>
+#include <regex>
 #include <sstream>
 #include <tuple>
 #include <vector>
@@ -428,6 +429,46 @@ TEST_CASE("The duplicate-clu report survives the trial loop and parallel trials 
   CHECK(warningCount("--num-trials 10 --parallel-trials") == 1);
 
   std::remove(duplicateClu.c_str());
+}
+
+TEST_CASE("The super consolidation log reports an index codelength [fast][core][partition]")
+{
+  // #837: the line said "index codelength X -> Y" but Y was io::stringify(*this) --
+  // the whole objective over the module network after the flat initPartition just
+  // above it. A correctly computed but different quantity, so the arrow compared an
+  // index codelength against a full one and landed on a value larger than the
+  // codelength the next line announces. On examples/networks/ninetriangles.net it
+  // read `0.93613 -> 0.0990602 + 3.74245 = 3.84151` against a result of 3.8415.
+  //
+  // Asserted as the invariant rather than on the numbers: the value the arrow lands
+  // on has to be the super index codelength, which the "found N super modules" line
+  // prints as its own first term.
+  std::ostringstream captured;
+  {
+    infomap::test::ScopedLogCapture capture(captured);
+    InfomapWrapper im("--seed 123 --num-trials 1 --no-file-output --verbose --verbose");
+    im.readInputData(infomap::test::repoPath("examples/networks/ninetriangles.net"));
+    im.run();
+  }
+
+  const std::string haystack = captured.str();
+
+  std::smatch found;
+  REQUIRE(std::regex_search(haystack, found, std::regex(R"(found \d+ super modules, codelength ([0-9.e+-]+) \+)")));
+  const auto superIndexCodelength = found[1].str();
+
+  // The whole line, so the assertion can see what follows the arrow as well as the
+  // value it lands on. The old format's stringify(*this) *began* with the same index
+  // codelength and then continued " + <module> = <total>", so matching only the
+  // first number after the arrow passes on both formats and proves nothing.
+  std::smatch consolidated;
+  REQUIRE(std::regex_search(haystack, consolidated, std::regex(R"(super: consolidated \d+ modules, index codelength [^\n]*)")));
+  const auto line = consolidated[0].str();
+
+  INFO("super index=" << superIndexCodelength << " line: " << line);
+  CHECK(line.find(superIndexCodelength) != std::string::npos);
+  // An index codelength is one number. A sum is the other quantity.
+  CHECK(line.find(" = ") == std::string::npos);
 }
 
 TEST_CASE("Mixed-depth cluster data is rejected instead of crashing [fast][core][partition][parser]")


### PR DESCRIPTION
## Summary

Refs #837 — its **second half**, the wrong super-index consolidation value. The first half (the recursive step landing worse than its two-level base) is untouched; see Notes.

The line said `index codelength X -> Y`, but `Y` was `io::stringify(*this)`: the whole objective over the module network after the flat `initPartition` just above it. A correctly computed quantity, but a different one — so the arrow compared an index codelength against a full one and landed on a value *larger* than the codelength the very next line announces.

On `examples/networks/ninetriangles.net`, `--seed 123 -N1 -vv`:

```
super iter 1: found 3 super modules, codelength 0.0990602 + ... = 3.84151
super: consolidated 3 modules, index codelength 0.93613 -> 0.0990602 + 3.74245 = 3.84151   <- before
super: consolidated 3 modules, index codelength 0.93613 -> 0.0990602                        <- after
```

It now prints `superIndexCodelength`, which is what the sentence claims and what `oldIndexLength` is assigned two lines below, so the log narrates the state change it is describing.

## Two corrections to the issue's reading

- **There is no flow-versus-enter-flow bug to chase here.** The issue guesses the 6.19 came from the super-index consolidation using `flow` where it should use `enter`-flow. The value was never a miscomputed index codelength at all — it is the objective over the module network, computed correctly, printed under the wrong name. So this half does not point into the enter-flow area.
- **It is not memory-specific.** The issue reproduces it on `air30k`, a state network, and frames the whole issue as memory/state. The log defect reproduces on the plain first-order `ninetriangles` fixture, which is what the test uses.

## Verification

- `make test-native`: 26/26.
- New case in `test_partition.cpp` capturing the log and asserting the consolidation line carries the super index codelength and **nothing summed after it**. **It fails on unfixed code.**
- My first version of that test passed on unfixed code and I tightened it: the old `stringify(*this)` output *began* with the same index codelength before continuing `" + <module> = <total>"`, so matching only the first number after the arrow could not tell the two formats apart. The assertion is now on the absence of `" = "` on that line.
- Pre-commit hooks on the changed files: clean.

## Notes

**The other half of #837 is deliberately untouched.** The recursive step ending worse than the two-level base it started from is a search-quality question, and the issue's own priority note puts it behind the memory codelength drift — with best-of-10 on `air30k` already not losing to two-level once that is fixed. Not something to change from the outside on a single-trial regression.
