### PR TITLE
docs(python): give every deprecated Options field a versioned directive

### DIFF
--- a/interfaces/python/src/infomap/_options.py
+++ b/interfaces/python/src/infomap/_options.py
@@ -752,8 +752,11 @@ class Options(metaclass=_OptionsMeta):
         Try random moves only for nodes with degree at most this value. Valid range: >=
         0.
     include_self_links : bool, optional
-        Deprecated. Self-links are included by default; use no_self_links=True to
-        exclude them.
+        Self-links are included by default; use no_self_links=True to exclude them.
+
+        .. deprecated:: 2.15
+           Pass no_self_links=True instead. Passing include_self_links explicitly emits
+           a FutureWarning.
     """
 
     # input

--- a/interfaces/python/src/infomap/_options.py
+++ b/interfaces/python/src/infomap/_options.py
@@ -463,58 +463,69 @@ class Options(metaclass=_OptionsMeta):
     out_name : str, optional
         Base name for output files, for example [out_directory]/[out-name].tree.
 
-        Args-only in library mode (see the note above).
+        .. deprecated:: 2.15
+           Args-only in library mode (see the note above).
     no_file_output : bool, optional
         Do not write output files.
 
-        Args-only in library mode (see the note above).
+        .. deprecated:: 2.15
+           Args-only in library mode (see the note above).
     tree : bool, optional
         Write the modular hierarchy to a tree file. Enabled by default when no other
         output format is selected.
 
-        Args-only in library mode (see the note above).
+        .. deprecated:: 2.15
+           Args-only in library mode (see the note above).
     ftree : bool, optional
         Write the modular hierarchy and aggregated links between nested modules to an
         ftree file. Used by Network Navigator.
 
-        Args-only in library mode (see the note above).
+        .. deprecated:: 2.15
+           Args-only in library mode (see the note above).
     clu : bool, optional
         Write top-level module ids for each node to a clu file.
 
-        Args-only in library mode (see the note above).
+        .. deprecated:: 2.15
+           Args-only in library mode (see the note above).
     clu_level : int, optional
         With --clu or --output clu, write module ids at this depth from the root. Use -1
         for bottom-level modules. Valid range: >= -1. Engine default: 1.
 
-        Args-only in library mode (see the note above).
+        .. deprecated:: 2.15
+           Args-only in library mode (see the note above).
     output : sequence of str, optional
         Write selected output formats as a comma-separated list without spaces, e.g. -o
         clu,tree,ftree. Options: clu, tree, ftree, newick, json, csv, network, states,
         flow.
 
-        Args-only in library mode (see the note above).
+        .. deprecated:: 2.15
+           Args-only in library mode (see the note above).
     hide_bipartite_nodes : bool, optional
         Hide bipartite nodes in output by projecting the solution to primary nodes.
 
-        Args-only on the Python library surface. It projects the secondary (type-B)
-        bipartite nodes out of what result.write_tree/write_clu emit, leaving the
-        in-memory result covering both node types. Set it via Options and write from the
-        Result to use it.
+        .. deprecated:: 2.15
+           Args-only on the Python library surface. It projects the secondary (type-B)
+           bipartite nodes out of what result.write_tree/write_clu emit, leaving the
+           in-memory result covering both node types. Set it via Options and write from
+           the Result to use it.
     print_all_trials : bool, optional
         Write each trial to separate output files. Has effect only when --num-trials is
         greater than 1.
 
-        Args-only in library mode (see the note above).
+        .. deprecated:: 2.15
+           Args-only in library mode (see the note above).
     no_overwrite : bool, optional
         Fail with an output error if any target output file already exists. By default
         existing files are replaced.
 
-        Args-only in library mode (see the note above).
+        .. deprecated:: 2.15
+           Args-only in library mode (see the note above).
     print_config_fingerprint : bool, optional
         Print the canonical configuration fingerprint and exit.
 
-        Not a Python library option; it leaves the surface in 3.0. A print-and-exit CLI
-        diagnostic; run the infomap binary.
+        .. deprecated:: 2.15
+           Not a Python library option; it leaves the surface in 3.0. A print-and-exit
+           CLI diagnostic; run the infomap binary.
     timing_json : str or os.PathLike, optional
         Write machine-readable run timing JSON to this path. Use - for stdout.
     summary_json : str or os.PathLike, optional
@@ -539,17 +550,19 @@ class Options(metaclass=_OptionsMeta):
         Verbosity level on the console. 1 keeps the default output level, 2 renders -vv
         and so on.
 
-        Not a Python library option; it leaves the surface in 3.0. A DEBUG-enabled
-        'infomap' logger (infomap.enable_log(logging.DEBUG)) raises engine verbosity;
-        logger levels filter the records.
+        .. deprecated:: 2.15
+           Not a Python library option; it leaves the surface in 3.0. A DEBUG-enabled
+           'infomap' logger (infomap.enable_log(logging.DEBUG)) raises engine verbosity;
+           logger levels filter the records.
     silent : bool, optional
         Suppress console output. The Python API is already quiet by default; to see the
         engine log, use infomap.enable_log() rather than this flag. The command-line
         interface is unaffected.
 
-        Not a Python library option; it leaves the surface in 3.0. The Python API is
-        quiet by default; logging is the control. Attach handlers to
-        logging.getLogger('infomap') (e.g. infomap.enable_log()) for the engine log.
+        .. deprecated:: 2.15
+           Not a Python library option; it leaves the surface in 3.0. The Python API is
+           quiet by default; logging is the control. Attach handlers to
+           logging.getLogger('infomap') (e.g. infomap.enable_log()) for the engine log.
     two_level : bool, optional
         Optimize a two-level partition instead of the default multi-level hierarchy.
     flow_model : str, optional
@@ -679,8 +692,9 @@ class Options(metaclass=_OptionsMeta):
     threads : str or int, optional
         Alias for --num-threads.
 
-        Not a Python library option; it leaves the surface in 3.0. Use num_threads;
-        threads is a redundant alias of the same engine option.
+        .. deprecated:: 2.15
+           Not a Python library option; it leaves the surface in 3.0. Use num_threads;
+           threads is a redundant alias of the same engine option.
     prefer_modular_solution : bool, optional
         Prefer a modular solution even when one module gives a lower codelength.
     num_random_moves : int, optional

--- a/interfaces/python/src/infomap/_options.py
+++ b/interfaces/python/src/infomap/_options.py
@@ -512,42 +512,56 @@ class Options(metaclass=_OptionsMeta):
         Base name for output files, for example [out_directory]/[out-name].tree.
 
         .. deprecated:: 2.15
-           Args-only in library mode (see the note above).
+           Args-only in library mode (see the note above). The guidance above applies
+           through 2.x; in 3.0 the field leaves ``Options`` and is reachable only
+           through the raw ``args`` escape hatch.
     no_file_output : bool, optional
         Do not write output files.
 
         .. deprecated:: 2.15
-           Args-only in library mode (see the note above).
+           Args-only in library mode (see the note above). The guidance above applies
+           through 2.x; in 3.0 the field leaves ``Options`` and is reachable only
+           through the raw ``args`` escape hatch.
     tree : bool, optional
         Write the modular hierarchy to a tree file. Enabled by default when no other
         output format is selected.
 
         .. deprecated:: 2.15
-           Args-only in library mode (see the note above).
+           Args-only in library mode (see the note above). The guidance above applies
+           through 2.x; in 3.0 the field leaves ``Options`` and is reachable only
+           through the raw ``args`` escape hatch.
     ftree : bool, optional
         Write the modular hierarchy and aggregated links between nested modules to an
         ftree file. Used by Network Navigator.
 
         .. deprecated:: 2.15
-           Args-only in library mode (see the note above).
+           Args-only in library mode (see the note above). The guidance above applies
+           through 2.x; in 3.0 the field leaves ``Options`` and is reachable only
+           through the raw ``args`` escape hatch.
     clu : bool, optional
         Write top-level module ids for each node to a clu file.
 
         .. deprecated:: 2.15
-           Args-only in library mode (see the note above).
+           Args-only in library mode (see the note above). The guidance above applies
+           through 2.x; in 3.0 the field leaves ``Options`` and is reachable only
+           through the raw ``args`` escape hatch.
     clu_level : int, optional
         With --clu or --output clu, write module ids at this depth from the root. Use -1
         for bottom-level modules. Valid range: >= -1. Engine default: 1.
 
         .. deprecated:: 2.15
-           Args-only in library mode (see the note above).
+           Args-only in library mode (see the note above). The guidance above applies
+           through 2.x; in 3.0 the field leaves ``Options`` and is reachable only
+           through the raw ``args`` escape hatch.
     output : sequence of str, optional
         Write selected output formats as a comma-separated list without spaces, e.g. -o
         clu,tree,ftree. Options: clu, tree, ftree, newick, json, csv, network, states,
         flow.
 
         .. deprecated:: 2.15
-           Args-only in library mode (see the note above).
+           Args-only in library mode (see the note above). The guidance above applies
+           through 2.x; in 3.0 the field leaves ``Options`` and is reachable only
+           through the raw ``args`` escape hatch.
     hide_bipartite_nodes : bool, optional
         Hide bipartite nodes in output by projecting the solution to primary nodes.
 
@@ -555,19 +569,25 @@ class Options(metaclass=_OptionsMeta):
            Args-only on the Python library surface. It projects the secondary (type-B)
            bipartite nodes out of what result.write_tree/write_clu emit, leaving the
            in-memory result covering both node types. Set it via Options and write from
-           the Result to use it.
+           the Result to use it. The guidance above applies through 2.x; in 3.0 the
+           field leaves ``Options`` and is reachable only through the raw ``args``
+           escape hatch.
     print_all_trials : bool, optional
         Write each trial to separate output files. Has effect only when --num-trials is
         greater than 1.
 
         .. deprecated:: 2.15
-           Args-only in library mode (see the note above).
+           Args-only in library mode (see the note above). The guidance above applies
+           through 2.x; in 3.0 the field leaves ``Options`` and is reachable only
+           through the raw ``args`` escape hatch.
     no_overwrite : bool, optional
         Fail with an output error if any target output file already exists. By default
         existing files are replaced.
 
         .. deprecated:: 2.15
-           Args-only in library mode (see the note above).
+           Args-only in library mode (see the note above). The guidance above applies
+           through 2.x; in 3.0 the field leaves ``Options`` and is reachable only
+           through the raw ``args`` escape hatch.
     print_config_fingerprint : bool, optional
         Print the canonical configuration fingerprint and exit.
 
@@ -752,11 +772,11 @@ class Options(metaclass=_OptionsMeta):
         Try random moves only for nodes with degree at most this value. Valid range: >=
         0.
     include_self_links : bool, optional
-        Self-links are included by default; use no_self_links=True to exclude them.
+        Whether to include self-links.
 
         .. deprecated:: 2.15
-           Pass no_self_links=True instead. Passing include_self_links explicitly emits
-           a FutureWarning.
+           Not a Python library option; it leaves the surface in 3.0. Self-links are
+           included by default; pass no_self_links=True to exclude them.
     """
 
     # input

--- a/scripts/generate_binding_options.py
+++ b/scripts/generate_binding_options.py
@@ -8,7 +8,7 @@ import os
 import subprocess
 from pathlib import Path
 
-from parameter_catalog import GROUPS, ParameterCatalog
+from parameter_catalog import GROUPS, ParameterCatalog, resolve_policy_decision
 from render_parameter_policy import render as render_parameter_policy_md
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -720,8 +720,23 @@ def _options_doc_deprecation_lines(policy: dict, note: str, indent: str) -> list
     if action not in DEPRECATED_POLICY_ACTIONS:
         return []
     lines = [f"{indent}.. deprecated:: {DEPRECATION_WAVE_VERSION}"]
-    if note:
-        lines.extend(wrap_doc(note, indent + "   "))
+    body = note
+    if action == "args-only":
+        # A directive's body reads as migration guidance, and an args-only note
+        # describes how to use the field *today* -- `hide_bipartite_nodes` says to
+        # set it via Options, which is the very surface it leaves. Naming the
+        # post-removal route here keeps the two apart, for every args-only field
+        # rather than depending on how each replacement string happens to be worded
+        # (the policy defines args-only as reachable through the raw args escape
+        # hatch on library surfaces).
+        # Single backticks: wrap_doc promotes them to the RST double form.
+        route = (
+            "The guidance above applies through 2.x; in 3.0 the field leaves "
+            "`Options` and is reachable only through the raw `args` escape hatch."
+        )
+        body = f"{note} {route}".strip() if note else route
+    if body:
+        lines.extend(wrap_doc(body, indent + "   "))
     return lines
 
 
@@ -904,28 +919,26 @@ def generate_python(catalog: ParameterCatalog) -> str:
             elif note:
                 lines.append("")
                 lines.extend(wrap_doc(note, "        "))
+    # The alias is binding-only, so it has no catalog entry and never reaches the
+    # loop above -- but its flag does carry a policy decision, so the note and the
+    # directive are resolved from that same source rather than restated here. A
+    # hand-written copy would go stale the moment the replacement guidance in
+    # overrides.json changes (#915).
     lines.append("    include_self_links : bool, optional")
-    lines.extend(
-        wrap_doc(
-            "Self-links are included by default; use no_self_links=True to exclude them.",
-            "        ",
-        )
+    lines.extend(wrap_doc("Whether to include self-links.", "        "))
+    alias_policy = resolve_policy_decision(
+        catalog.overrides, include_self_links.flag, "python"
     )
-    # Emitted here rather than by the loop above, because this alias is binding-only:
-    # it has no catalog entry, so it never reaches the policy-driven directive. That
-    # makes it the only deprecated field whose directive is written by hand -- the
-    # policy-driven fields above get theirs from _options_doc_deprecation_lines -- and
-    # the one the contract test had no way to cover until it was named explicitly
-    # (#915).
-    lines.append("")
-    lines.append(f"        .. deprecated:: {DEPRECATION_WAVE_VERSION}")
-    lines.extend(
-        wrap_doc(
-            "Pass no_self_links=True instead. Passing include_self_links explicitly "
-            "emits a FutureWarning.",
-            "           ",
-        )
+    alias_note = _options_doc_policy_note(alias_policy)
+    alias_deprecation = _options_doc_deprecation_lines(
+        alias_policy, alias_note, "        "
     )
+    if alias_deprecation:
+        lines.append("")
+        lines.extend(alias_deprecation)
+    elif alias_note:
+        lines.append("")
+        lines.extend(wrap_doc(alias_note, "        "))
     lines.extend(['    """', ""])
     for group in GROUPS:
         lines.append(f"    # {group.lower()}")

--- a/scripts/generate_binding_options.py
+++ b/scripts/generate_binding_options.py
@@ -907,8 +907,21 @@ def generate_python(catalog: ParameterCatalog) -> str:
     lines.append("    include_self_links : bool, optional")
     lines.extend(
         wrap_doc(
-            "Deprecated. Self-links are included by default; use no_self_links=True to exclude them.",
+            "Self-links are included by default; use no_self_links=True to exclude them.",
             "        ",
+        )
+    )
+    # Emitted here rather than by the loop above, because this alias is binding-only:
+    # it has no catalog entry, so it never reaches the policy-driven directive. It is
+    # also the only deprecated field on this surface, so omitting it left the contract
+    # with nothing to enforce (#915).
+    lines.append("")
+    lines.append(f"        .. deprecated:: {DEPRECATION_WAVE_VERSION}")
+    lines.extend(
+        wrap_doc(
+            "Pass no_self_links=True instead. Passing include_self_links explicitly "
+            "emits a FutureWarning.",
+            "           ",
         )
     )
     lines.extend(['    """', ""])

--- a/scripts/generate_binding_options.py
+++ b/scripts/generate_binding_options.py
@@ -645,6 +645,12 @@ def _python_engine_default_doc(param) -> str:
     return f"Engine default: {default}."
 
 
+# The release in which this deprecation wave first shipped. RELEASING.md fixes it at
+# 2.15 -- 2.14.0 shipped the redesign but no versioned markers or runtime warnings --
+# and Sphinx renders an empty version if the directive carries none.
+DEPRECATION_WAVE_VERSION = "2.15"
+
+
 def _options_doc_policy_note(policy: dict) -> str:
     """A short note for the Options docstring flagging fields that are not a
     first-class engine option on the Python library surface.
@@ -675,6 +681,31 @@ def _options_doc_policy_note(policy: dict) -> str:
         "hide": "Not exposed on the Python surface.",
     }.get(action, "")
     return f"{lead} {replacement}".strip()
+
+
+# Actions that make a field deprecated on the Python surface, so it needs the
+# versioned directive RELEASING.md requires. An alias is documented, not deprecated,
+# and `hide` is not on the surface to deprecate in the first place.
+DEPRECATED_POLICY_ACTIONS = {"remove", "args-only", "deprecate"}
+
+
+def _options_doc_deprecation_lines(policy: dict, note: str, indent: str) -> list[str]:
+    """The `.. deprecated::` block for one Options field, or nothing.
+
+    The published Options reference -- which the package docstring points at as the
+    parameter reference -- carried no directive for any field, while RELEASING.md
+    requires one on every deprecated member (#915). The directive goes on its own
+    line with the note indented beneath it: Sphinx reads everything after the
+    directive name as the version, so folding the note onto that line renders the
+    whole sentence as the version string.
+    """
+    action = (policy or {}).get("action", "keep")
+    if action not in DEPRECATED_POLICY_ACTIONS:
+        return []
+    lines = [f"{indent}.. deprecated:: {DEPRECATION_WAVE_VERSION}"]
+    if note:
+        lines.extend(wrap_doc(note, indent + "   "))
+    return lines
 
 
 def generate_python(catalog: ParameterCatalog) -> str:
@@ -809,7 +840,13 @@ def generate_python(catalog: ParameterCatalog) -> str:
             lines.append(f"    {name} : {param.python_doc_type()}")
             lines.extend(wrap_doc(description, "        "))
             note = _options_doc_policy_note(param.policy("python"))
-            if note:
+            deprecation = _options_doc_deprecation_lines(
+                param.policy("python"), note, "        "
+            )
+            if deprecation:
+                lines.append("")
+                lines.extend(deprecation)
+            elif note:
                 lines.append("")
                 lines.extend(wrap_doc(note, "        "))
     lines.append("    include_self_links : bool, optional")

--- a/scripts/generate_binding_options.py
+++ b/scripts/generate_binding_options.py
@@ -912,9 +912,11 @@ def generate_python(catalog: ParameterCatalog) -> str:
         )
     )
     # Emitted here rather than by the loop above, because this alias is binding-only:
-    # it has no catalog entry, so it never reaches the policy-driven directive. It is
-    # also the only deprecated field on this surface, so omitting it left the contract
-    # with nothing to enforce (#915).
+    # it has no catalog entry, so it never reaches the policy-driven directive. That
+    # makes it the only deprecated field whose directive is written by hand -- the
+    # policy-driven fields above get theirs from _options_doc_deprecation_lines -- and
+    # the one the contract test had no way to cover until it was named explicitly
+    # (#915).
     lines.append("")
     lines.append(f"        .. deprecated:: {DEPRECATION_WAVE_VERSION}")
     lines.extend(

--- a/test/python/test_parameter_policy.py
+++ b/test/python/test_parameter_policy.py
@@ -141,6 +141,55 @@ def test_hidden_bindings_are_derived_from_hide_decisions():
     }
 
 
+def test_every_deprecated_option_field_carries_a_versioned_directive():
+    """RELEASING.md requires a ``.. deprecated:: <version>`` note on every deprecated
+    member, and the published ``Options`` reference -- which the package docstring
+    points at as the parameter reference -- carried none for any field (#915).
+
+    Asserted on the rendered docstring rather than on the generator, since that is what
+    a user reads through ``inspect.getdoc``.
+    """
+    import inspect
+    import re as _re
+
+    from infomap import Options
+    from infomap._options import _OPTION_TABLE
+
+    # getdoc dedents, so a field heading sits at column 0 and its body is indented.
+    doc = inspect.getdoc(Options) or ""
+    blocks: dict[str, list[str]] = {}
+    current = None
+    for line in doc.splitlines():
+        heading = _re.match(r"^(\w+) : ", line)
+        if heading:
+            current = heading.group(1)
+            blocks[current] = []
+        elif current is not None:
+            blocks[current].append(line)
+
+    deprecated_actions = {"remove", "args-only", "deprecate"}
+    expected = sorted(
+        name
+        for name, spec in _OPTION_TABLE.items()
+        if spec.action in deprecated_actions
+    )
+    assert expected, "no deprecated fields to check; the policy shape changed"
+
+    for name in expected:
+        assert name in blocks, f"{name} missing from the Options reference"
+        directives = [line for line in blocks[name] if ".. deprecated::" in line]
+        assert directives, f"{name} has no .. deprecated:: directive"
+        for line in directives:
+            version = line.split(".. deprecated::", 1)[1].strip()
+            assert version, f"{name} has a directive with no version"
+            # Sphinx reads everything after the directive name as the version, so the
+            # note has to be on its own indented line rather than folded onto this one.
+            assert " " not in version, (
+                f"{name} folded its note onto the directive line, which Sphinx would "
+                f"render as the version: {version!r}"
+            )
+
+
 def test_unknown_flag_fails_loud():
     overrides = copy.deepcopy(OVERRIDES)
     overrides["policy"]["parameters"]["--not-a-flag"] = {

--- a/test/python/test_parameter_policy.py
+++ b/test/python/test_parameter_policy.py
@@ -206,6 +206,14 @@ def test_every_deprecated_option_field_carries_a_versioned_directive():
                 f"{name} folded its note onto the directive line, which Sphinx would "
                 f"render as the version: {version!r}"
             )
+            # The exact release, not merely "some token": RELEASING.md fixes this
+            # deprecation wave at 2.15, and a nonempty-check accepted 2.14 or any
+            # other string while claiming to protect that. Written literally rather
+            # than imported from the generator so the two cannot drift together --
+            # a future wave should have to change this line deliberately.
+            assert version == "2.15", (
+                f"{name} carries version {version!r}; this deprecation wave is 2.15"
+            )
 
 
 def test_unknown_flag_fails_loud():

--- a/test/python/test_parameter_policy.py
+++ b/test/python/test_parameter_policy.py
@@ -183,15 +183,25 @@ def test_every_deprecated_option_field_carries_a_versioned_directive():
     assert "include_self_links" in expected
     assert expected, "no deprecated fields to check; the policy shape changed"
 
+    # Anchored to the start of an indented line, not a substring search: Sphinx only
+    # parses a directive that opens its own line, so prose like "See .. deprecated::
+    # 2.15" reads as a directive to `in` while rendering as plain text. The version
+    # is captured from the rest of that line, which is also what catches a note
+    # folded onto it -- Sphinx reads everything after the directive name as the
+    # version, so a folded sentence renders as the version string.
+    directive_pattern = _re.compile(r"^\s+\.\. deprecated::(?P<version>.*)$")
+
     for name in expected:
         assert name in blocks, f"{name} missing from the Options reference"
-        directives = [line for line in blocks[name] if ".. deprecated::" in line]
+        directives = [
+            match
+            for match in (directive_pattern.match(line) for line in blocks[name])
+            if match
+        ]
         assert directives, f"{name} has no .. deprecated:: directive"
-        for line in directives:
-            version = line.split(".. deprecated::", 1)[1].strip()
+        for match in directives:
+            version = match.group("version").strip()
             assert version, f"{name} has a directive with no version"
-            # Sphinx reads everything after the directive name as the version, so the
-            # note has to be on its own indented line rather than folded onto this one.
             assert " " not in version, (
                 f"{name} folded its note onto the directive line, which Sphinx would "
                 f"render as the version: {version!r}"

--- a/test/python/test_parameter_policy.py
+++ b/test/python/test_parameter_policy.py
@@ -168,11 +168,19 @@ def test_every_deprecated_option_field_carries_a_versioned_directive():
             blocks[current].append(line)
 
     deprecated_actions = {"remove", "args-only", "deprecate"}
+    # _OPTION_TABLE is catalog-driven, so it excludes include_self_links: that field
+    # is a binding-only compatibility alias handled separately. It is also the one
+    # deprecated field on this surface whose directive is emitted by hand, so leaving
+    # it out let the only case that could regress pass unchecked (#915).
     expected = sorted(
-        name
-        for name, spec in _OPTION_TABLE.items()
-        if spec.action in deprecated_actions
+        [
+            name
+            for name, spec in _OPTION_TABLE.items()
+            if spec.action in deprecated_actions
+        ]
+        + ["include_self_links"]
     )
+    assert "include_self_links" in expected
     assert expected, "no deprecated fields to check; the policy shape changed"
 
     for name in expected:


### PR DESCRIPTION
## Summary

Refs #915 — its **second checklist item**, the `.. deprecated::` directives. Non-breaking: pure documentation, no behaviour change, nothing removed. The issue stays open.

RELEASING.md's Python API deprecation policy requires a `.. deprecated:: <version>` note on every deprecated member, and the published `Options` reference — which the package docstring points at as the parameter reference — carried none for any field. `inspect.getdoc(Options).count("deprecated")` was **0**.

The generator now emits one for every field classified `remove`, `args-only` or `deprecate` — 14 in all — at version **2.15**, the release RELEASING.md fixes for this wave (2.14.0 shipped the redesign but no versioned markers).

```
print_config_fingerprint : bool, optional
    Print the canonical configuration fingerprint and exit.

    .. deprecated:: 2.15
       Not a Python library option; it leaves the surface in 3.0. A print-and-exit
       CLI diagnostic; run the infomap binary.
```

The directive sits on its own line with the note indented beneath. Folding the note onto the directive line makes Sphinx read the whole sentence as the version — the same trap RELEASING.md warns about from the other direction, and my first attempt produced exactly that.

Generated output, so the edit is in `scripts/generate_binding_options.py`; `_options.py` is regenerated. `make test-binding-options-freshness` reports fresh.

## Why not the rest of the issue

I went in intending items 1, 3 and 5 as well, and item 3 turned out to be a policy change wearing a gap's clothes. **All four fields it names are advanced-tier keywords**:

```
threads                    action=remove   advanced_kwarg=True
silent                     action=remove   advanced_kwarg=True
verbosity_level            action=remove   advanced_kwarg=True
print_config_fingerprint   action=remove   advanced_kwarg=True
```

and RELEASING.md puts advanced-tier keywords in the **silent-by-default `PendingDeprecationWarning`** tier. So "make them warn at all" cannot be answered without first answering item 1, which class. I implemented the loud version to see what it cost: `test_deprecations.py` and `test_run_functional.py` fail in four places, all pinning that `silent=` stays quiet. Those pins are the written policy, not an oversight.

**One thing I found while trying, worth having before anyone does item 1.** A warning raised from `Options.__post_init__` is invisible even in `__main__`, whatever its class. `_external_stacklevel()` walks out of frames whose filename starts with the package prefix, but the `__init__` dataclasses synthesizes for `Options` has `co_filename == "<string>"`, so the walk stops there and the warning is attributed to `<string>` — which the PEP 565 filter `('default', None, DeprecationWarning, '__main__', 0)` does not match. Measured: `Options(threads=4)` in a script printed nothing under default filters and `<string>:79: DeprecationWarning` under `-W default`. Skipping `<string>` frames in that walk fixes it and moves the attribution to the user's own line. Not in this PR, since nothing warns from there yet.

## Verification

- `make test-python-unit`: 851 passed, 2 skipped, 1 xfailed.
- `make test-binding-options-freshness`: fresh.
- New case in `test_parameter_policy.py`, asserted on the rendered docstring rather than on the generator, since `getdoc` is what a user reads. It also rejects a directive with no version and one with its note folded onto the same line. **Fails on the unfixed generator** with `clu has no .. deprecated:: directive`.
- Pre-commit hooks on the changed files: clean.
