### PR TITLE
ci: keep an unreachable intersphinx inventory from failing the docs build

### DIFF
--- a/interfaces/python/source/_ext/intersphinx_offline.py
+++ b/interfaces/python/source/_ext/intersphinx_offline.py
@@ -17,7 +17,7 @@ else's uptime.
 ``suppress_warnings`` cannot reach it: Sphinx 9.1 logs this one through
 ``LOGGER.warning`` with no type or subtype (``sphinx/ext/intersphinx/_load.py``),
 and only typed warnings can be suppressed by name. The record is intercepted here
-instead, on the intersphinx logger alone, and demoted to INFO -- still in the
+instead, on the intersphinx loggers alone, and demoted to INFO -- still in the
 log, no longer fatal.
 
 The alternative was a committed ``objects.inv`` per project as a fallback
@@ -41,12 +41,21 @@ from sphinx.util import logging as sphinx_logging
 
 __all__ = ["setup"]
 
-# The logger intersphinx warns on. Resolved through Sphinx's own getLogger so the
-# "sphinx." namespace prefix it adds cannot drift out from under us; the module
-# path is the part that would have to be updated if upstream moved the logger,
-# and if it ever does this filter stops matching and the build goes back to
-# failing on the warning -- loud, not silent.
-_INTERSPHINX_LOGGER = "sphinx.ext.intersphinx"
+# The loggers intersphinx may warn on, each resolved through Sphinx's own
+# getLogger so the "sphinx." namespace prefix it adds cannot drift out from under
+# us. Python does not run an ancestor's filters for a child logger's records, so
+# every candidate is filtered by name rather than relying on propagation.
+#
+# In Sphinx 9.1 the emitting logger is the first one: `_load.py` imports LOGGER
+# from `_shared.py`, which declares getLogger('sphinx.ext.intersphinx') with an
+# explicit string. The second covers the `getLogger(__name__)` layout, where the
+# emitting module owns its own child logger -- so an upstream move to that shape
+# does not quietly put the warning back in front of the fatal handler. Filtering
+# a logger that never emits costs nothing.
+_INTERSPHINX_LOGGERS = (
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.intersphinx._load",
+)
 
 # The message as passed to LOGGER.warning, before %-interpolation. Matched on the
 # format string so the URL, the exception class, and which site happened to be
@@ -77,9 +86,8 @@ class _DemoteUnreachableInventories(logging.Filter):
 def setup(app):
     # Installed at extension-load time, which is before intersphinx fetches
     # anything (it does that on builder-inited), so no ordering hazard.
-    sphinx_logging.getLogger(_INTERSPHINX_LOGGER).logger.addFilter(
-        _DemoteUnreachableInventories()
-    )
+    for name in _INTERSPHINX_LOGGERS:
+        sphinx_logging.getLogger(name).logger.addFilter(_DemoteUnreachableInventories())
     # Only a log filter: no doctree read or write, so parallel builds are fine.
     return {
         "version": "1.0",

--- a/interfaces/python/source/_ext/intersphinx_offline.py
+++ b/interfaces/python/source/_ext/intersphinx_offline.py
@@ -1,0 +1,88 @@
+"""Keep an unreachable intersphinx inventory from failing the docs build.
+
+``make build-docs`` passes ``-W``, so every Sphinx warning is an error -- which is
+what we want for a broken reference or a stale toctree, and not what we want for
+six external documentation sites that have to answer over the network on every
+build. When one of them times out, intersphinx logs
+
+    WARNING: failed to reach any of the inventories with the following issues:
+    intersphinx inventory 'https://docs.scipy.org/doc/scipy/objects.inv' not
+    fetchable due to <class 'requests.exceptions.ConnectTimeout'>
+
+and that one warning ends the build. It reddened two unrelated pull requests
+inside the same half hour (#1055, #1060), where it reads as a docs regression in
+the branch until someone opens the log, and re-running is a coin flip on someone
+else's uptime.
+
+``suppress_warnings`` cannot reach it: Sphinx 9.1 logs this one through
+``LOGGER.warning`` with no type or subtype (``sphinx/ext/intersphinx/_load.py``),
+and only typed warnings can be suppressed by name. The record is intercepted here
+instead, on the intersphinx logger alone, and demoted to INFO -- still in the
+log, no longer fatal.
+
+The alternative was a committed ``objects.inv`` per project as a fallback
+location, which is intersphinx's own mechanism for this (a failure with a working
+alternative logs at INFO). That was 612 KiB of binaries with a refresh chore
+attached, and a stale inventory resolves references to URLs that no longer exist
+-- silently wrong links, where this degrades to no link at all.
+
+Losing an inventory costs only link resolution: with ``nitpicky`` off (the
+default, and unset in ``conf.py``), an unresolved cross-reference renders as
+plain text without a warning of its own. A build that hits this therefore leaves
+``:class:`scipy.sparse.csr_matrix`` as unlinked code text and stays green, while
+every other warning class remains an error.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sphinx.util import logging as sphinx_logging
+
+__all__ = ["setup"]
+
+# The logger intersphinx warns on. Resolved through Sphinx's own getLogger so the
+# "sphinx." namespace prefix it adds cannot drift out from under us; the module
+# path is the part that would have to be updated if upstream moved the logger,
+# and if it ever does this filter stops matching and the build goes back to
+# failing on the warning -- loud, not silent.
+_INTERSPHINX_LOGGER = "sphinx.ext.intersphinx"
+
+# The message as passed to LOGGER.warning, before %-interpolation. Matched on the
+# format string so the URL, the exception class, and which site happened to be
+# down do not enter into it. Sphinx runs it through gettext, so a translated
+# docs build would not match and would keep failing as it does today; this build
+# is English (no `language` set in conf.py).
+_UNREACHABLE_INVENTORIES = "failed to reach any of the inventories"
+
+
+class _DemoteUnreachableInventories(logging.Filter):
+    """Demote the unreachable-inventory warning to INFO, leaving the rest alone.
+
+    A filter on the logger rather than on the handler: Sphinx's
+    ``WarningIsErrorFilter`` lives on the warning handler and raises from inside
+    its own ``filter()``, so a handler filter added later would never get to run.
+    Logger filters all run before any handler sees the record.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.levelno == logging.WARNING and _UNREACHABLE_INVENTORIES in str(
+            record.msg
+        ):
+            record.levelno = logging.INFO
+            record.levelname = "INFO"
+        return True
+
+
+def setup(app):
+    # Installed at extension-load time, which is before intersphinx fetches
+    # anything (it does that on builder-inited), so no ordering hazard.
+    sphinx_logging.getLogger(_INTERSPHINX_LOGGER).logger.addFilter(
+        _DemoteUnreachableInventories()
+    )
+    # Only a log filter: no doctree read or write, so parallel builds are fine.
+    return {
+        "version": "1.0",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/interfaces/python/source/conf.py
+++ b/interfaces/python/source/conf.py
@@ -42,6 +42,9 @@ extensions = [
     "myst_nb",
     "sphinx_reredirects",
     "sphinxcontrib.bibtex",
+    # Local, in _ext/: keeps an unreachable external inventory from ending a -W
+    # build. See the module docstring for why suppress_warnings cannot.
+    "intersphinx_offline",
 ]
 
 # Consolidated bibliography (see references.bib and the References page).
@@ -144,6 +147,13 @@ intersphinx_mapping = {
     "networkx": ("https://networkx.org/documentation/stable/", None),
     "igraph": ("https://python.igraph.org/en/main/", None),
 }
+
+# Bound the per-inventory fetch. The default is None, i.e. the socket's own
+# connect timeout, which is how a single unresponsive site cost the docs job six
+# minutes before failing it. Six inventories at 15 s each is the worst case, and
+# the outcome of a timeout is now a demoted warning (see the intersphinx_offline
+# extension) rather than a red build.
+intersphinx_timeout = 15
 
 # -- Copy button -------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

The `docs` job builds with `-W`, so the one warning intersphinx logs when it cannot fetch an inventory ends the build:

```
WARNING: failed to reach any of the inventories with the following issues:
intersphinx inventory 'https://docs.scipy.org/doc/scipy/objects.inv' not fetchable
due to <class 'requests.exceptions.ConnectTimeout'>
build finished with problems, 1 warning (with warnings treated as errors).
```

`docs.scipy.org` timed out on 2026-09-03 and reddened two unrelated PRs (#1055, #1060) inside half an hour — twice on #1060, since re-running is a coin flip on someone else's uptime. Six external sites are consulted on every build, so any one of them can do this, and it looks like a docs regression in the branch until you open the log.

## Fix

`suppress_warnings` cannot reach that warning: Sphinx 9.1 logs it through `LOGGER.warning` with no type or subtype (`sphinx/ext/intersphinx/_load.py`), and only typed warnings can be suppressed by name.

So a small local extension (`source/_ext/intersphinx_offline.py`) demotes that one record to INFO, filtered on the intersphinx logger before any handler sees it — Sphinx's `WarningIsErrorFilter` raises from inside its own `filter()` on the warning handler, so a handler filter would never get to run. The message stays in the log; it just stops being fatal.

`intersphinx_timeout = 15` bounds the fetch as well. The failing job spent six minutes on a connect timeout that defaults to the socket's own (`connect timeout=None` in the log above).

Losing an inventory costs only link resolution: with `nitpicky` off (the default, unset here) an unresolved cross-reference renders as plain text without a warning of its own. The degraded build is unlinked `scipy` references and nothing else.

### Why not committed inventories

A committed `objects.inv` per project as a fallback location is intersphinx's own mechanism for this — a failure with a working alternative logs at INFO rather than WARNING. It is also 612 KiB of binaries with a refresh chore attached, and a stale inventory resolves references to URLs that no longer exist: silently wrong links, against no link at all here.

## Verification

- scipy pointed at an unroutable address (`192.0.2.1`): the `-W` build exits 0 and reports `build succeeded`.
- An undefined label (`{ref}` to a nonexistent target) still fails the build — `WARNING: undefined label ... [ref.ref]`, exit 1 — so the `-W` guarantee is intact.
- The final build on the real URLs hit the actual `docs.scipy.org` timeout and stayed green.

Unblocks the `docs` check on #1060, which is red for this reason alone.
