### PR TITLE
fix: plan a shard's per-trial output paths with the writer's trial numbers

### DIFF
--- a/src/io/OutputPlan.cpp
+++ b/src/io/OutputPlan.cpp
@@ -379,10 +379,19 @@ std::vector<std::string> planAllOutputPaths(const Config& config, HigherOrderInp
 
   // The final modular result is written once with the canonical basename, and
   // additionally per trial when --print-all-trials uses separate files.
+  //
+  // The trial numbers are the writer's global ones -- `trialOffset + i + 1`, the
+  // same expression both writeResult call sites use -- not a local 1..numTrials.
+  // A shard planned `_trial_1.._trial_4` while writing `_trial_11.._trial_14`,
+  // which left both consumers of this plan looking at files that never exist:
+  // --no-overwrite could only discover a real collision by hitting it mid-run,
+  // after earlier artifacts were already on disk, and the input-overwrite check
+  // above could not see that a run was about to destroy an input named like one
+  // of its own per-trial outputs.
   collectPhase(OutputPhase::AfterPartition, -1);
   if (config.printAllTrials && config.numTrials > 1) {
-    for (unsigned int trial = 1; trial <= config.numTrials; ++trial)
-      collectPhase(OutputPhase::AfterPartition, static_cast<int>(trial));
+    for (unsigned int i = 0; i < config.numTrials; ++i)
+      collectPhase(OutputPhase::AfterPartition, static_cast<int>(config.trialOffset + i + 1));
   }
 
   for (const auto& report : planReportArtifacts(config))

--- a/test/scripts/check_run_metadata_cli.py
+++ b/test/scripts/check_run_metadata_cli.py
@@ -93,6 +93,84 @@ def test_no_overwrite_preflight_writes_no_files_when_one_target_exists(
     assert not (out_dir / "network.clu").exists()
 
 
+def test_no_overwrite_preflight_sees_a_shards_own_trial_paths(infomap_bin, work):
+    # The plan enumerated `_trial_1..N` while the writers use the global
+    # `trialOffset + i + 1`, so on a shard the two disagreed about every per-trial
+    # filename. --no-overwrite then had nothing real to check and could only meet
+    # the collision by running into it, after earlier artifacts were already
+    # written -- which is the one thing the pre-flight exists to prevent.
+    #
+    # The *last* trial of the shard is the pre-existing file on purpose. With the
+    # first one, the writer collides on its very first write and nothing has
+    # reached disk yet, so the bug is invisible: the run exits 3 either way. At
+    # trial 14 the buggy plan let the aggregate and trials 11 through 13 be
+    # written before the refusal -- four files, under --no-overwrite.
+    make_workdir(work)
+    out_dir = work / "out"
+    out_dir.mkdir()
+    (out_dir / "network_trial_14.tree").write_text("existing\n", encoding="utf-8")
+
+    result = run(
+        infomap_bin,
+        "network.net",
+        "out",
+        "--silent",
+        "--seed",
+        "42",
+        "--trial-offset",
+        "10",
+        "-N4",
+        "--print-all-trials",
+        "-o",
+        "tree",
+        "--no-overwrite",
+        cwd=work,
+    )
+
+    assert result.returncode == 3, result.stderr
+    assert "Output file already exists" in result.stderr
+    assert (out_dir / "network_trial_14.tree").read_text(
+        encoding="utf-8"
+    ) == "existing\n"
+    # Nothing else reached disk, including the aggregate and the earlier trials.
+    assert sorted(path.name for path in out_dir.iterdir()) == [
+        "network_trial_14.tree"
+    ], sorted(path.name for path in out_dir.iterdir())
+
+
+def test_shard_trial_output_does_not_overwrite_its_own_cluster_input(infomap_bin, work):
+    # The mirror consumer of the same plan: feeding a previous run's per-trial clu
+    # back in as the initial partition, into the directory it came from. The
+    # refusal is not subject to the overwrite policy, so a plan blind to the
+    # offset meant this run destroyed its own input and exited 0.
+    make_workdir(work)
+    partition = work / "network_trial_11.clu"
+    partition.write_text("1 1\n2 1\n", encoding="utf-8")
+    original = partition.read_text(encoding="utf-8")
+
+    result = run(
+        infomap_bin,
+        "network.net",
+        ".",
+        "--silent",
+        "--seed",
+        "42",
+        "--cluster-data",
+        "network_trial_11.clu",
+        "--trial-offset",
+        "10",
+        "-N4",
+        "--print-all-trials",
+        "-o",
+        "clu",
+        cwd=work,
+    )
+
+    assert result.returncode == 3, result.stderr
+    assert "Refusing to write output" in result.stderr
+    assert partition.read_text(encoding="utf-8") == original
+
+
 def make_state_workdir(path: Path) -> Path:
     # A higher-order input, so the run writes both `<name>.tree` and
     # `<name>_states.tree`. The file is named after the state half on purpose.
@@ -421,6 +499,8 @@ def main(argv):
             test_missing_input_returns_input_exit_code,
             test_no_overwrite_returns_output_exit_code,
             test_no_overwrite_preflight_writes_no_files_when_one_target_exists,
+            test_no_overwrite_preflight_sees_a_shards_own_trial_paths,
+            test_shard_trial_output_does_not_overwrite_its_own_cluster_input,
             test_state_output_does_not_overwrite_its_own_input,
             test_first_order_run_may_write_beside_a_states_named_input,
             test_pajek_dump_of_a_higher_order_network_is_named_and_labelled_for_it,


### PR DESCRIPTION
## Summary

Found by review on #1055 after it merged.

`planAllOutputPaths` enumerated `_trial_1..numTrials`, while both `writeResult` call sites name the file from `trialOffset + i + 1`. On a shard the two never agreed — `--trial-offset 10 -N4` planned `_trial_1.._trial_4` and wrote `_trial_11.._trial_14` — so the pre-flight was checking files that never exist.

Both consumers of that plan were blind as a result.

**`--no-overwrite` could only discover a collision by running into it.** With `out/network_trial_14.tree` already present:

```
$ Infomap network.net out --trial-offset 10 -N4 --print-all-trials -o tree --no-overwrite
Error: Output file already exists: 'out/network_trial_14.tree'
$ ls out
network.tree  network_trial_11.tree  network_trial_12.tree  network_trial_13.tree  network_trial_14.tree
```

Four files written under the flag whose entire purpose is that none are. The pre-flight exists to catch this before anything reaches disk.

**The input-overwrite refusal could not see a per-trial path at all.** That check is deliberately not subject to the overwrite policy, because writing a result over the run's own input destroys the input and `--no-overwrite` is not a usable mitigation (it rejects every ordinary re-run too). Feeding a previous shard's `network_trial_11.clu` back in as `--cluster-data` and writing clu output to the same directory destroyed that input and exited 0.

## Scope

One expression in `OutputPlan.cpp`: the plan now uses the writer's global trial numbers. No output filename changes for any run that does not use `--trial-offset`, since the offset is 0 there and `trialOffset + i + 1` reduces to `i + 1`.

The defect is as old as sharding on the serial path. It became reachable for per-trial artifacts under `--parallel-trials` only in #1055, which is what surfaced it.

## Verification

- Two cases in `check_run_metadata_cli.py`, one per consumer of the plan. Both fail on a binary built without this change.
- The `--no-overwrite` case pre-creates the shard's **last** trial on purpose. With the first trial, the writer collides on its very first write and the run exits 3 either way, so the bug leaves no trace and the test would pass unfixed — I checked that before settling on trial 14.
- `ctest`: 21/26 locally, with the same 5 CLI script tests failing only because the cmake-detected Python lacks `jsonschema`; all 5 pass when it is available.
- `make test-python-unit`: 854 passed, 2 skipped, 1 xfailed.
- Pre-commit hooks, including clang-format: clean.