### PR TITLE
fix(columnar): score ragged --cluster-data natively, and make the ragged-tree guard order-independent

### DIFF
--- a/columnar_wip/columnar-rethink-notes.md
+++ b/columnar_wip/columnar-rethink-notes.md
@@ -4004,3 +4004,74 @@ order-dependent in principle (bottom-up, dissolve preferred on ties); no attempt
 Cosmetic defect found on the way: scoring a ragged input of max depth 9 prints `Initial generated 4
 levels` on the console while the written tree header correctly says 9 levels and L is exact — readout
 only, filed here rather than fixed.
+
+> **Renumbered on port (2026-09-05).** Written on 2026-08-19 as F42 on the unmerged local branch
+> `columnar-native-ragged-eval`, which was never pushed and sat 30 commits behind. F42 has since been
+> taken by another finding, so it is F52 here; the text is otherwise unchanged. The order-dependence
+> it describes in `columnarSeedPathsFromTree` turned out to have a twin in the shared scoring path —
+> see [#1067](https://github.com/mapequation/infomap/issues/1067).
+### F52 — The ragged-tree fallback was one gate, not a missing feature (#824 follow-up, 2026-08-19; logged 2026-09-05)
+
+`evaluateColumnarPartition` handed every ragged tree to the object-oriented scorer unless
+`--non-redundant` was set. That fallback is what made `-C -c`'s guard compare **two different
+objectives**: the search's value came from the columnar core, the input partition's from
+`calcCodelengthOnTree`. On any objective the object-oriented side cannot express — L\*, or
+`--meta-data` on higher-order input, where the columnar core composes two codebooks the OO side
+composes neither of — the comparison prices different things.
+
+**The machinery to score a ragged tree natively was already there, in full generality.**
+`stampColumnarCodelengths` sums the phantom pass-through levels' complete breakdown entries into
+`padCharge`, and the evaluation returns `L - padCharge`. Only the gate was missing:
+`padDepth = nonRedundant ? padLeafPathsToUniformDepth(paths) : std::vector<int>()`. The comment
+justifying that gate — a pass-through level costs 0 under L\* and real bits under L — is true and
+beside the point, because the charge it names *is* the breakdown entry being subtracted.
+
+**Why the subtraction is exact, and the one thing that makes it so.** A phantom `p` inserted
+between module `x` and its real parent `P` is an exact copy of `x`'s flow / enter / exit / teleport
+aggregates (`aggregateLevel` over a singleton assignment skips intra-group edges, so `p`'s edge set
+is `x`'s). Every per-module term in the scorer reads only that module's own exit and its children's
+enter — never a depth, a level count or a grandparent — so `P`'s term is unchanged (its child `p`
+contributes the enter `x` did) and `x`'s term is unchanged. `p`'s whole cost is therefore its own
+entry: `plogp(a+b) - plogp(a) - plogp(b)`, which on undirected input is exactly `2a`.
+
+The load-bearing detail is that the duplicate is **appended**, and paths are coarsest-first, so `x`
+keeps the level-1 leaf-codebook role. Prepending it would re-price `x` as a module-of-modules and
+the cancellation would fail. Verified across all five corrections: four read level-1 quantities
+only and are untouched; `BiasedEntropy` counts nodes and moves by exactly the phantom's own entry.
+
+**Measured**: on `twotriangles_ragged_branches.tree` the native value reproduces the
+object-oriented value to the digit for base, `-d`, `--entropy-corrected`, `--markov-time 0.8`,
+`--preferred-number-of-modules 3` and `--non-redundant`; same on `states_ragged_branches.tree`. The
+pass-through charge on that fixture is exactly 1/7 under base and 0 under L\*.
+
+**A precondition that is enforced but was never written down.** The phantom is a single-child
+pass-through only because no module has both a leaf child and a sub-module child. Under that shape
+the padding is not an insertion at all — `P`'s direct leaf children get grouped into a genuinely new
+module and the stamping would mark the **real** module `P` as phantom and subtract its term.
+`validateClusterDataTreeShape` rejects such input (#898) and the search never builds it, but the
+public `initTree(const NodePaths&)` does not validate, so a library caller can still reach it. Now
+stated in the code.
+
+**Two things ungating exposed that padding had been hiding.**
+
+1. **A module-less tree is not a partition.** With every leaf path empty, padding hands each leaf a
+   synthetic module of its own and scores the **singleton** partition. Under L\* that has been
+   happening since the padding shipped: `-C --non-redundant --no-infomap` with no `--cluster-data`
+   reports 3.220279696 on `twotriangles_flow` — the singleton L\*, not the module-less codelength.
+   The base objective was shielded by the fallback. The guard is `haveModules()`, and it belongs
+   there for both objectives; what L\* assigns to a module-less tree, and which engine computes it,
+   is a separate question, since the stack needs at least one module level and the OO side has no
+   L\* at all.
+
+2. **The two objectives disagree about what a file means.** For a bare top-level leaf
+   (`2 0.15 "A" 1`, which is how Infomap's own writer emits a one-node top module) the repo pins two
+   incompatible readings, each with a reasoned comment: under L\* the bare, explicit-module and
+   rectangular spellings are one partition and score alike (2.187131226); under base the bare
+   spelling is addressed in the **root's** codebook and gets no module codebook (2.714170945 against
+   the explicit 3.014170945), with the note that base "must not move". Both are now implemented
+   without an OO call — the synthetic module's charge is kept under L\* and subtracted under base —
+   but the same file denoting different partitions depending on the objective is a modelling
+   question, not an implementation detail. Related: `BiasedEntropy` over-charges that synthetic
+   module under L\* by one per-node term, and `PreferredModulesCorrection`'s leaf-module count
+   disagrees with the OO one by `max(0, #bare-top-level-leaves - 1)` and sits on `rootTerm`, which
+   `padCharge` structurally never reaches.

--- a/columnar_wip/columnar-rethink-notes.md
+++ b/columnar_wip/columnar-rethink-notes.md
@@ -4064,7 +4064,8 @@ stated in the code.
    L\* at all.
 
 2. **The two objectives disagree about what a file means.** For a bare top-level leaf
-   (`2 0.15 "A" 1`, which is how Infomap's own writer emits a one-node top module) the repo pins two
+   (`2 0.15 "A" 1` — a node in no module at all, which only hand-written or third-party cluster files
+   contain: Infomap's own writer gives a one-node top module a full path, `3:1`) the repo pins two
    incompatible readings, each with a reasoned comment: under L\* the bare, explicit-module and
    rectangular spellings are one partition and score alike (2.187131226); under base the bare
    spelling is addressed in the **root's** codebook and gets no module codebook (2.714170945 against
@@ -4075,3 +4076,74 @@ stated in the code.
    module under L\* by one per-node term, and `PreferredModulesCorrection`'s leaf-module count
    disagrees with the OO one by `max(0, #bare-top-level-leaves - 1)` and sits on `rootTerm`, which
    `padCharge` structurally never reaches.
+#### F52 addendum — what the port actually changes, measured commit by commit (2026-09-05)
+
+Ported onto the tip (`090d9ab9`) and measured against a tip-equivalent binary. Two things came out
+differently from the original write-up.
+
+**Commit 1 (score a ragged tree natively) changes no number I can construct.** On both ragged
+fixtures the native value already equalled the object-oriented one on the tip, for every objective
+tried — base, `-d`, `--entropy-corrected`, `--markov-time 0.8`, `--preferred-number-of-modules 3`,
+`--non-redundant`, and `--meta-data` on the higher-order fixture. That is the *expected* outcome for
+objectives OO can express, and the F52 argument was always about the ones it cannot; but no fixture in
+the repo exercises that case, so the benefit stays structural — the columnar path stops depending on
+the OO scorer at all (#832) — and is **not** demonstrated by a moved number. Stated plainly rather
+than implied.
+
+**Commit 2 (order-independent guard) fixes a silent wrong answer, and it is the whole measurable
+win.** Three distinct binaries, `-C --no-infomap -c` on a tree whose one-node top module is written
+as a bare top-level leaf:
+
+| binary | bare row FIRST | bare row LAST | |
+|---|--:|--:|---|
+| tip (md5 4b63cea2…) | 3.02401125 | 2.714170945 | order-dependent |
+| commit 1 only (baf353bd…) | 3.02401125 | 2.714170945 | order-dependent |
+| commit 1+2 (02a498e8…) | **2.714170945** | 2.714170945 | order-independent |
+
+So ungating rectangularization is *not* what sidesteps the defect — reading the guard off the paths
+is. Worth recording because the opposite was inferred first, from the two-arm comparison alone, and
+only the three-binary split showed it.
+
+**The shared half is untouched and is now #1067.** `haveModules()` tests `m_root.firstChild` only, so
+the same file still scores 3.02401125 vs 2.714170945 through the OO path in both arms. That is master
+code and is not this branch's to fix.
+
+**Cost: none.** Every benchmark row bit-identical — the five overlapping `-2d -c` planted seeds, the
+five `-2d` free runs, air30k `-C -2` and `-C -d --regularized`, science2001, malaria — with
+instructions retired within ±0.3%, which on this machine is noise. Expected by construction: the
+`.clu` files in the set are rectangular, so the ragged path never fires.
+
+#### F52 addendum 2 — Infomap never writes a bare top-level leaf (2026-09-07)
+
+The original F42 text asserted, in passing, that a bare top-level leaf is "how Infomap's own writer
+emits a one-node top module", and the comment on
+`test/fixtures/clusters/twotriangles_top_level_leaf.tree` said the same. **Both are wrong**; both are
+corrected in this commit rather than carried in and annotated, since neither had ever been committed
+to this branch. Daniel caught it by reasoning rather than measurement: a one-node top module is still a module, so the writer has a
+path to write; and if there were no modules at all, *every* row would be bare and uniform, so row
+order could not matter. Both halves check out.
+
+Measured. Seeding node A alone into module 3 and writing the tree gives
+
+```
+1:1 0.3  "C" 3      2:1 0.15 "D" 4      3:1 0.15 "A" 1   <- full path, not `3 0.15 "A" 1`
+```
+
+and the one-level fallback writes `1:1` … `1:6`, every leaf at depth 1. Swept the tree section of
+every output mode for a bare top-level leaf — `.tree` and `.ftree`, base / `-d` / hierarchical, `-N1`
+to `-N10`, on twotriangles_flow, ninetriangles, politicalblogs, science2001, air30k (+`_states`),
+malaria (+`_states`): **zero in every one**. Infomap does write genuinely ragged trees — air30k's
+output carries path depths 1, 2 and 3 at once — but every leaf it writes sits inside at least one
+module. A bare top-level leaf means "in no module at all", which the search never produces.
+
+An earlier sweep of mine appeared to find bare leaves in `.ftree` files; those were `*Links root` /
+`*Links 1:2` header rows, which also have four-plus fields and no colon in field 1. The detector was
+wrong, not the writer — worth recording as the second time in this session a plausible-looking
+positive came from the instrument rather than the subject (cf. F48).
+
+**Consequence.** The order dependence in F52's guard is real and reproduces, but only for input that
+*mixes* bare top-level leaves with module paths, which is hand-written or third-party. It is not
+reachable by a write-then-read round trip, so it is a robustness gap on external `--cluster-data`, not
+a round-trip defect. #1067 has been corrected accordingly, and the likely right fix moved with it:
+rejecting or warning on a mixed root (next to `validateClusterDataTreeShape`, #898) rather than making
+`haveModules()` scan and silently picking one of the two pinned readings.

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -2980,10 +2980,18 @@ bool InfomapBase::columnarSeedPathsFromTree(std::vector<std::vector<int>>& paths
   squared = false;
   // A hard --cluster-data partition is already collapsed into the leaf network the
   // search optimizes (see setupColumnarOptimizer), so there is nothing to seed.
-  if (m_leafNodes.empty() || haveHardPartition() || !haveModules())
+  if (m_leafNodes.empty() || haveHardPartition())
     return false;
 
   paths = leafModulePathsFromTree();
+  // Nothing to seed from only when NO leaf has a module. Read off the paths rather than from
+  // haveModules(), which tests m_root.firstChild alone and so answers false for a tree whose
+  // first row happens to be a bare top-level leaf -- which would make the warm start depend on
+  // the order of the rows in the cluster file.
+  if (std::none_of(paths.begin(), paths.end(), [](const std::vector<int>& p) { return !p.empty(); })) {
+    paths.clear();
+    return false;
+  }
 
   // A top-level leaf gets an EMPTY path (leafModulePathsFromTree stops below the
   // root), but it IS a module of one node, so give it a synthetic id past every real
@@ -3135,7 +3143,16 @@ double InfomapBase::evaluateColumnarPartition()
   // path is empty, so padding would hand each leaf a synthetic module of its own and score
   // a SINGLETON partition instead of the module-less one asked about. That is not this
   // function's question to answer, so it drops through to the fallback below.
-  const std::vector<int> padDepth = haveModules() ? padLeafPathsToUniformDepth(paths) : std::vector<int>();
+  //
+  // The test is "does SOME leaf have a module", read off the paths, and deliberately not
+  // haveModules(): that predicate looks at m_root.firstChild alone, so it answers false for a
+  // tree whose first child happens to be a bare top-level leaf even though the rest of the
+  // tree is fully modular. Gating on it made the result depend on the ORDER of the rows in
+  // the cluster file -- moving the bare leaf to the top of
+  // twotriangles_top_level_leaf.tree took L* from 2.187131226 to 3.02401125, the base L,
+  // because the fallback below reports an objective the object-oriented side cannot express.
+  const bool haveAnyModule = std::any_of(paths.begin(), paths.end(), [](const std::vector<int>& p) { return !p.empty(); });
+  const std::vector<int> padDepth = haveAnyModule ? padLeafPathsToUniformDepth(paths) : std::vector<int>();
   if (!opt.seedHierarchyFromLeafPaths(paths)) {
     // Only one shape reaches this now: a tree with no module structure at all, whose leaf
     // paths are all empty and which the padding above deliberately leaves alone. There is

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -2954,10 +2954,16 @@ std::vector<int> InfomapBase::padLeafPathsToUniformDepth(std::vector<std::vector
   // an appended duplicate becomes a single-child module ABOVE the leaf module,
   // between it and its real parent. That level costs exactly 0 under L* (the
   // parent's enter codebook is e*(plogp(e)-plogp(e))/e == 0 and the child's exit
-  // term has numerator plogp(x)-0-plogp(x) == 0), which is why this is gated on
-  // --non-redundant: the base map equation charges plogp(x+e)-plogp(e)-plogp(x)
-  // for the same node (ninetriangles rect 3.38583082 -> 3.97958082 with one such
-  // level above every leaf module, against L* bit-identical at 3.078067323).
+  // term has numerator plogp(x)-0-plogp(x) == 0) and costs
+  // plogp(x+e)-plogp(e)-plogp(x) under the base map equation (ninetriangles rect
+  // 3.38583082 -> 3.97958082 with one such level above every leaf module, against L*
+  // bit-identical at 3.078067323).
+  //
+  // That base cost is why this helper was once used only under --non-redundant. It no
+  // longer needs to be: the charge is a per-module breakdown entry and the caller takes
+  // it back off the total (padCharge), so padding now serves every objective. See
+  // evaluateColumnarPartition for why the subtraction is exact and for the one tree
+  // shape that would break it.
   for (std::size_t i = 0; i < paths.size(); ++i) {
     padDepth[i] = static_cast<int>(maxDepth - paths[i].size());
     // Copy the id out first: resize's fill value must not alias an element of the
@@ -3101,11 +3107,42 @@ double InfomapBase::evaluateColumnarPartition()
   // reported base L for L* runs -- ninetriangles ragged 3.458078031 for both
   // objectives, against a true L* of 3.237864808. Under L* the tree can be made
   // rectangular for free instead; see padLeafPathsToUniformDepth.
-  const std::vector<int> padDepth = nonRedundant ? padLeafPathsToUniformDepth(paths) : std::vector<int>();
+  // Rectangularize whenever the tree HAS a module structure. The padding used to be
+  // gated on --non-redundant, on the argument that a pass-through level is free under L*
+  // and costs real bits under the base map equation -- true, but beside the point: the
+  // stamping below already takes the phantom levels' charge back off the total in full
+  // generality (padCharge), so the base objective is priced exactly too, and the ragged
+  // tree no longer has to be handed to the object-oriented scorer.
+  //
+  // Why the subtraction is exact, for every objective: a phantom p inserted between a
+  // module x and its real parent P is an exact copy of x's flow / enter / exit / teleport
+  // aggregates (aggregateLevel over a singleton assignment), and every per-module term in
+  // the scorer reads only that module's own exit and its children's enter -- never a
+  // depth, a level count or a grandparent. So P's term is unchanged (its child p
+  // contributes the same enter x did), x's term is unchanged, and p's whole cost is its
+  // own breakdown entry: for the base objective plogp(a+b)-plogp(a)-plogp(b), which is
+  // exactly 2a on undirected input. Because the duplicate is APPENDED and paths are
+  // coarsest-first, x keeps the level-1 leaf-codebook role; prepending it would re-price x
+  // as a module-of-modules and the cancellation would fail.
+  //
+  // PRECONDITION, enforced elsewhere: no module has both a leaf child and a sub-module
+  // child. Under that shape the padding is not a pass-through insertion -- P's direct leaf
+  // children would be grouped into a genuinely new module and the stamping would mark the
+  // REAL module P as phantom and subtract its term. validateClusterDataTreeShape rejects
+  // such input (#898) and the search never builds it, which is what makes this safe.
+  //
+  // A tree with NO modules at all is a different matter and is excluded here: every leaf
+  // path is empty, so padding would hand each leaf a synthetic module of its own and score
+  // a SINGLETON partition instead of the module-less one asked about. That is not this
+  // function's question to answer, so it drops through to the fallback below.
+  const std::vector<int> padDepth = haveModules() ? padLeafPathsToUniformDepth(paths) : std::vector<int>();
   if (!opt.seedHierarchyFromLeafPaths(paths)) {
-    // Ragged tree the padding could not rescue (a base-objective run, or leaves at
-    // differing depths with no leaf level to repeat): score the object-oriented tree.
-    Console::detail(1, "columnar eval: ragged tree, using object-oriented codelength");
+    // Only one shape reaches this now: a tree with no module structure at all, whose leaf
+    // paths are all empty and which the padding above deliberately leaves alone. There is
+    // no partition for the stack to hold, so the module-less codelength is what the
+    // object-oriented scorer is still asked for. Every ragged tree that DOES carry a
+    // partition is now scored on the columnar stack.
+    Console::detail(1, "columnar eval: no module structure to score on the stack, using object-oriented codelength");
     return objectOrientedTreeCodelength();
   }
   columnar::StackBreakdown breakdown;
@@ -3218,7 +3255,26 @@ bool InfomapBase::stampColumnarCodelengths(const ColumnarTwoLevel& opt,
       if (isPad[static_cast<std::size_t>(k)][m] != 0)
         padCharge += breakdown.moduleTerm[static_cast<std::size_t>(k)][m];
 
-  m_root.codelength = breakdown.rootTerm + rootLeafCharge;
+  // The synthetic module a bare top-level leaf was given is where the two objectives
+  // genuinely disagree about what the FILE MEANS, so it is charged per objective rather
+  // than uniformly.
+  //
+  // Under L* the three spellings of that partition -- bare `2 "A"`, explicit `2:1 "A"`,
+  // and `2:1:1 "A"` -- are one partition and must score alike, which is what keeping this
+  // charge in the total achieves (it is not zero: dropping it moves the bare spelling from
+  // 2.187131226 to 2.037131226 on twotriangles_flow, breaking the equality the L* tests
+  // pin). Under the base map equation a bare top-level leaf is addressed in the ROOT's own
+  // codebook and gets no module codebook of its own -- bare 2.714170945 against explicit
+  // 3.014170945, pinned with the note that base "must not move" -- so there the synthetic
+  // module's charge is one the tree does not contain, and it comes off.
+  //
+  // Both readings predate this function being able to score a ragged tree natively; the
+  // inconsistency between them is a modelling question, not something to settle here. What
+  // matters is that neither value moves now that the object-oriented scorer is out of the
+  // path.
+  if (!nonRedundant)
+    padCharge += rootLeafCharge;
+  m_root.codelength = breakdown.rootTerm + (nonRedundant ? rootLeafCharge : 0.0);
   return true;
 }
 

--- a/test/fixtures/clusters/twotriangles_top_level_leaf.tree
+++ b/test/fixtures/clusters/twotriangles_top_level_leaf.tree
@@ -1,8 +1,14 @@
 # path flow name node_id
-# The ragged shape Infomap's own .tree format produces and reads back: node A is a
-# module of one node, written as a BARE top-level leaf (no trailing module level) next
-# to a three-level branch. leafModulePathsFromTree gives it an EMPTY path, since it
-# walks parents up to but not including the root.
+# A BARE top-level leaf (node A, no trailing module level) next to a three-level
+# branch: node A is in no module at all. leafModulePathsFromTree gives it an EMPTY
+# path, since it walks parents up to but not including the root.
+#
+# NOT a shape Infomap writes. Its writer gives a one-node top module a full path
+# (`3:1 0.15 "A" 1`), and the one-level fallback puts every leaf at depth 1, so no
+# output mode -- .tree or .ftree, base/-d/hierarchical, first-order or higher-order --
+# emits a leaf outside every module. Checked across the benchmark set; see F52
+# addendum 2. This fixture exists to pin how the READER treats hand-written or
+# third-party input of that shape, which is the only way it arises.
 1:1:1 0.3 "C" 3
 1:1:2 0.2 "B" 2
 1:2:1 0.15 "D" 4


### PR DESCRIPTION
Revives two commits from `columnar-native-ragged-eval` (2026-08-19/20) — a local branch that was never
pushed, has no PR or issue, and sat 30 commits behind. Both code sites it changes are still present
unchanged on the tip, so it is still relevant; ported here onto `090d9ab9` with its finding renumbered
F42 → F52 (F42 has since been taken).

## What the two commits do

**1. Score a ragged `--cluster-data` tree on the columnar stack, not the OO one.** Rectangularization
was gated on `--non-redundant`, on the argument that a pass-through level is free under L\* and costs
real bits under the base map equation. True, and beside the point: `stampColumnarCodelengths` already
subtracts the phantom levels' complete breakdown entries (`padCharge`) in full generality, so the base
objective is priced exactly too. Ungating it means the columnar path no longer hands ragged input to
the object-oriented scorer at all (#832).

**2. Make the ragged-tree guard order-independent.** `columnarSeedPathsFromTree` tested
`haveModules()`, which inspects `m_root.firstChild` alone — so a tree whose first row happens to be a
bare top-level leaf answered "no modules". It now reads the condition off the paths.

## Per-feature attribution, measured

**Commit 1 moves no number I can construct.** On both ragged fixtures the native value already
equalled the OO value on the tip, for every objective tried — base, `-d`, `--entropy-corrected`,
`--markov-time 0.8`, `--preferred-number-of-modules 3`, `--non-redundant`, and `--meta-data` on the
higher-order fixture. That is the expected outcome for objectives OO *can* express, and the argument
was always about the ones it cannot — but no fixture here exercises that case. So its benefit is
structural, and I am **not** claiming a measured one.

**Commit 2 fixes a silent wrong answer, and is the whole measurable win.** `-C --no-infomap -c` on a
tree whose one-node top module is written as a bare top-level leaf — a node in no module at all, which
only hand-written or third-party cluster files contain (Infomap's own writer gives it the full path
`3:1`; see the correction on #1067):

| binary | bare row FIRST | bare row LAST | |
|---|--:|--:|---|
| tip (`4b63cea2…`) | 3.02401125 | 2.714170945 | order-dependent |
| commit 1 only (`baf353bd…`) | 3.02401125 | 2.714170945 | order-dependent |
| **commit 1+2 (`02a498e8…`)** | **2.714170945** | 2.714170945 | **order-independent** |

0.31 bits, 11%, on a file whose row order carries no meaning. **Scope, corrected during review:** this
is reachable only from external `--cluster-data`, not from Infomap's own output — no writer mode emits
a leaf outside every module, checked across `.tree`/`.ftree`, base/`-d`/hierarchical, first-order and
higher-order. So it is a robustness gap on input we do not produce, not a round-trip defect. This
commit also fixes the fixture comment and the ported F42 text that both claimed otherwise. Three distinct binaries, so the
attribution is not inferred: ungating rectangularization is *not* what fixes it — reading the guard
off the paths is.

**The shared half stays broken and is filed as [#1067](https://github.com/mapequation/infomap/issues/1067).**
`haveModules()` is master code; the same file still scores 3.02401125 vs 2.714170945 through the OO
path in both arms of this PR.

## Cost: none

Every benchmark row bit-identical — the five overlapping `-2d -c` planted seeds, the five `-2d` free
runs, air30k `-C -2` and `-C -d --regularized`, science2001, malaria — with instructions retired within
±0.3%, which is noise on this machine. **Expected by construction:** the `.clu` files in the benchmark
set are rectangular, so the ragged path never fires. I did not re-run the full 121-configuration sweep
to reproduce numbers the change cannot reach; the tip's tables are in #1043, and this PR's "old" arm
*is* that tip.

Timings are omitted deliberately: the machine was at load 23 throughout, where wall time cannot resolve
anything this small. Instructions retired are load-independent and are reported instead.

## Verification

`make test-native` green in all three configurations (`OPENMP=1`, `OPENMP=0`,
`FEATURES="lossy-map-equation regularized-multilayer"`), 31/31 each.

