### PR TITLE
ci: reject unsanctioned commit scopes before they reach master

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,81 @@
+name: PR title
+
+# The pull request title is what GitHub puts in the squash commit subject, and
+# that subject is what release-please turns into a changelog line. v2.16.0 shipped
+# three `fix(core):` entries that way, and undoing them meant a
+# BEGIN_COMMIT_OVERRIDE block in each merged PR body -- so reject an unsanctioned
+# type or scope here, before it can reach master.
+#
+# Deliberately its own workflow rather than a job in ci.yml: it needs the `edited`
+# event (a title changed after opening must be re-checked -- the merge box reads
+# the title as it stands at merge time), and adding `edited` to ci.yml's trigger
+# would re-run sanitizers, clang-tidy and the Docker lanes on every title or body
+# edit. This job needs no checkout and finishes in seconds.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions: {}
+
+concurrency:
+  group: pr-title-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  commit-scope:
+    name: Commit scope
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Check the title's type and scope
+        env:
+          # Via env, never inline in the script: these are attacker-controlled
+          # text and `${{ }}` interpolation would splice them into the shell.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+
+          # Release Please titles its own PR `chore(master): release X.Y.Z`,
+          # where `master` is the release branch rather than a component. That
+          # title is generated, not authored, so exempt the branch instead of
+          # allowlisting a scope no subproject answers to.
+          if [[ "$HEAD_REF" == release-please--* ]]; then
+            echo "Release Please's own pull request ($HEAD_REF); title is generated. Skipping."
+            exit 0
+          fi
+
+          # Conventional Commits types. release-please maps feat/fix/perf to
+          # changelog sections and ignores the rest, but all of them are valid.
+          types=(build chore ci docs feat fix perf refactor revert style test)
+
+          # Sanctioned scopes -- subprojects that exist, plus `deps`/`deps-dev`
+          # for Dependabot's `build(deps): bump ...`.
+          # Keep in sync with --scopes in .pre-commit-config.yaml.
+          scopes=(R build deps deps-dev docker docs js notebooks python scripts skills)
+
+          if [[ ! "$PR_TITLE" =~ ^([a-zA-Z]+)(\(([^\)]*)\))?(!)?:[[:space:]]+(.+)$ ]]; then
+            echo "::error::Not a Conventional Commits title: '$PR_TITLE'"
+            echo "Expected '<type>: <subject>' or '<type>(<scope>): <subject>'."
+            exit 1
+          fi
+
+          type="${BASH_REMATCH[1]}"
+          scope="${BASH_REMATCH[3]}"
+
+          if ! printf '%s\n' "${types[@]}" | grep -qxF -- "$type"; then
+            echo "::error::'$type' is not a Conventional Commits type (title: '$PR_TITLE')"
+            echo "Sanctioned types: ${types[*]}"
+            exit 1
+          fi
+
+          if [ -n "$scope" ] && ! printf '%s\n' "${scopes[@]}" | grep -qxF -- "$scope"; then
+            echo "::error::'$scope' is not a sanctioned commit scope (title: '$PR_TITLE')"
+            echo "Sanctioned scopes: ${scopes[*]}"
+            echo "Drop the scope, or -- if it names a real subproject -- add it here and to .pre-commit-config.yaml."
+            exit 1
+          fi
+
+          echo "OK: type='$type' scope='${scope:-<none>}'"

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -35,15 +35,29 @@ jobs:
           # text and `${{ }}` interpolation would splice them into the shell.
           PR_TITLE: ${{ github.event.pull_request.title }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          THIS_REPO: ${{ github.repository }}
+          # The GitHub App in release-please.yml, as it appears as a PR author.
+          RELEASE_BOT: infomap-release-bot[bot]
         run: |
           set -euo pipefail
 
           # Release Please titles its own PR `chore(master): release X.Y.Z`,
           # where `master` is the release branch rather than a component. That
-          # title is generated, not authored, so exempt the branch instead of
-          # allowlisting a scope no subproject answers to.
-          if [[ "$HEAD_REF" == release-please--* ]]; then
-            echo "Release Please's own pull request ($HEAD_REF); title is generated. Skipping."
+          # title is generated, not authored, so exempt that one pull request
+          # instead of allowlisting a scope no subproject answers to.
+          #
+          # All three conditions are load-bearing, and the branch prefix is the
+          # weakest: a branch name is chosen by whoever pushes it, so on its own
+          # `release-please--anything` would wave any title past a required
+          # check. Authorship is the part that cannot be forged, and the head
+          # repository keeps a fork out. Fails closed -- rename the app and the
+          # release PR starts failing this check rather than skipping it.
+          if [[ "$HEAD_REF" == release-please--* ]] \
+            && [[ "$PR_AUTHOR" == "$RELEASE_BOT" ]] \
+            && [[ "$HEAD_REPO" == "$THIS_REPO" ]]; then
+            echo "Release Please's own pull request ($HEAD_REF by $PR_AUTHOR); title is generated. Skipping."
             exit 0
           fi
 
@@ -56,7 +70,10 @@ jobs:
           # Keep in sync with --scopes in .pre-commit-config.yaml.
           scopes=(R build deps deps-dev docker docs js notebooks python scripts skills)
 
-          if [[ ! "$PR_TITLE" =~ ^([a-zA-Z]+)(\(([^\)]*)\))?(!)?:[[:space:]]+(.+)$ ]]; then
+          # `[^)]+`, not `[^)]*`: an empty `fix(): subject` is not Conventional
+          # Commits, and matching it here would leave $scope empty and skip the
+          # scope check below.
+          if [[ ! "$PR_TITLE" =~ ^([a-zA-Z]+)(\(([^\)]+)\))?(!)?:[[:space:]]+(.+)$ ]]; then
             echo "::error::Not a Conventional Commits title: '$PR_TITLE'"
             echo "Expected '<type>: <subject>' or '<type>(<scope>): <subject>'."
             exit 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,14 @@ ci:
   autoupdate_schedule: monthly
   autoupdate_commit_msg: "build(deps): pre-commit autoupdate"
 
+# Which git hooks `pre-commit install` writes. Declared here rather than as
+# --hook-type flags in `make hooks`, so the two agree and adding a stage below
+# takes effect without touching the Makefile.
+default_install_hook_types:
+  - pre-commit
+  - pre-push
+  - commit-msg
+
 repos:
   # Python lint. CI already runs `ruff check` on the package + examples/python
   # (via `make test-python-doctest`); this runs it repo-wide with autofix.
@@ -137,3 +145,23 @@ repos:
         pass_filenames: false
         files: \.py$
         stages: [pre-push]
+
+  # Conventional Commits on the commit message itself. The scope a branch commit
+  # carries is what GitHub offers as the squash subject on a single-commit PR --
+  # which is how v2.16.0 picked up three `fix(core):` changelog entries despite
+  # the PR titles being clean. The same allowlist is enforced on PR titles by
+  # .github/workflows/pr-title.yml; keep the two in sync.
+  #
+  # commit-msg stage, so `pre-commit run --all-files` (what CI runs) does not
+  # touch it -- CI's gate on this is the PR title check.
+  #
+  # No --strict: fixup! commits are how a branch answers review, and they are
+  # squashed away before the message that matters is written.
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.4.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args:
+          - --scopes
+          - R,build,deps,deps-dev,docker,docs,js,notebooks,python,scripts,skills

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -297,15 +297,19 @@ dev-bootstrap:
 		"  make build-python dev-python-install" \
 		"  make test-fast"
 
-# Install the pre-commit git hook. Idempotent; safe to re-run. Never fails the
+# Install the pre-commit git hooks. Idempotent; safe to re-run. Never fails the
 # build: a native-only checkout may not have pre-commit yet, and a repo with
 # core.hooksPath set (pre-commit refuses to auto-install there) can still lint
 # via `pre-commit run --all-files` or CI.
+#
+# Which hooks get written is `default_install_hook_types` in
+# .pre-commit-config.yaml, not flags here -- an explicit --hook-type overrides
+# that list, so the two would silently drift apart.
 hooks:
 	@if ! $(PRECOMMIT) --version >/dev/null 2>&1; then \
 		printf "pre-commit not installed; run 'make dev-bootstrap' or 'pip install pre-commit'.\n"; \
-	elif $(PRECOMMIT) install --hook-type pre-commit --hook-type pre-push >/dev/null 2>&1; then \
-		printf "pre-commit and pre-push git hooks installed.\n"; \
+	elif $(PRECOMMIT) install >/dev/null 2>&1; then \
+		printf "git hooks installed (pre-commit, pre-push, commit-msg).\n"; \
 	else \
 		printf "pre-commit is installed but the git hook was not auto-installed:\n"; \
 		printf "  core.hooksPath is set (%s), so pre-commit refuses to manage it.\n" "$$(git config core.hooksPath)"; \


### PR DESCRIPTION
`core` is not a sanctioned commit scope, but v2.16.0's changelog carried three
`fix(core):` entries anyway ([#1033], [#1014], [#998]). Undoing them took a
`BEGIN_COMMIT_OVERRIDE` block in each merged PR body. This makes the next one
impossible instead.

## How the scope got in

All three pull request **titles** were clean at merge time, so a title check
alone would have caught none of them. Two different routes put `(core)` in the
squash subject:

| PR | commits | route |
|---|---|---|
| [#1033], [#998] | 1 | `squash_merge_commit_title` is `COMMIT_OR_PR_TITLE`, which on a single-commit PR offers the **branch commit's** subject, not the PR title |
| [#1014] | 3 | the PR title was offered, and the scope was typed into the merge dialog by hand |

On [#998] the title was renamed to drop `(core)` **two seconds** before the
merge (timeline: rename `07:09:13Z`, merge `07:09:15Z`) and the rename made no
difference — the single-commit rule ignored it.

## What this adds

**1. `conventional-pre-commit` at the `commit-msg` stage.** Rejects an
unsanctioned scope where it is written, on the branch, before any of this can
happen. No `--strict`: `fixup!` commits are how a branch answers review and get
squashed away before the message that matters exists. It runs at `commit-msg`,
which `pre-commit run --all-files` (what CI runs) does not touch, so the CI
pre-commit job is unaffected.

**2. `.github/workflows/pr-title.yml`.** Checks the title on
`opened`/`edited`/`synchronize`/`reopened`. Deliberately its own workflow rather
than a job in `ci.yml`: `edited` is required, because the merge box reads the
title as it stands at merge time, and adding that event to `ci.yml`'s trigger
would re-run sanitizers, clang-tidy and the Docker lanes on every title or body
edit. This job needs no checkout and finishes in seconds.

**3. `make hooks` follows `default_install_hook_types`.** An explicit
`--hook-type` flag overrides that list, so the Makefile and the config would
drift apart. This adds `commit-msg` to the `pre-commit` and `pre-push` hooks it
already installed — same set, one source of truth.

Alongside this PR, `squash_merge_commit_title` is being set to `PR_TITLE`, which
closes the single-commit route at the source.

## Release Please

Release Please titles its own PR `chore(master): release X.Y.Z`, where `master`
is the release branch, not a component. Its branch is exempted **by name**
(`release-please--*`) rather than admitting a scope no subproject answers to —
so `chore(master):` still fails on any human branch.

## Sanctioned scopes

`R`, `build`, `deps`, `deps-dev`, `docker`, `docs`, `js`, `notebooks`, `python`,
`scripts`, `skills` — every scope in current use on master, plus `deps`/`deps-dev`
for Dependabot. The list is duplicated between the workflow and the hook config
with a comment in each pointing at the other; sharing one file would mean adding
a checkout to the workflow to read it.

## Testing

The check's script was extracted from the workflow and run against **23 real
titles**, and the hook against **10 real commit messages**. All pass:

- blocked: the three `fix(core):` titles that shipped, `refactor(config):` (a
  real branch commit from #1014), `chore(master):` on a human branch,
  `feet(python):`, a title with no prefix, and `fix:` with no space after the
  colon
- allowed: `fix:` / `perf:` / `ci:` with no scope, `feat(python):`, `fix(R):`,
  `fix(js):`, `docs(python):`, Dependabot's `build(deps):` and
  `build(deps-dev):`, `feat!:` and `feat(python)!:`, `fixup!` commits, and
  `chore(master): release 2.16.0` **on the `release-please--…` branch**

This PR's own title exercises the workflow, and the `actionlint` hook in CI's
pre-commit job lints the new file.

## What this does not stop

A squash subject hand-edited in the merge dialog ([#1014]'s route) is not
visible to any pre-merge check. Catching that needs a check on the master commit
subject after the push — which would turn a scope typo into a red `CI Summary`
and a `verify-master-ci` refusal to publish the release. Not worth it; with
`PR_TITLE` set, the dialog is prefilled from a title this workflow has already
approved.

[#1033]: https://github.com/mapequation/infomap/pull/1033
[#1014]: https://github.com/mapequation/infomap/pull/1014
[#998]: https://github.com/mapequation/infomap/pull/998
