### PR TITLE
feat: dissolve intermediate modules that no longer pay for their codebook

### DIFF
--- a/interfaces/python/source/concepts/hierarchy-and-the-multilevel-map.md
+++ b/interfaces/python/source/concepts/hierarchy-and-the-multilevel-map.md
@@ -194,7 +194,8 @@ print(f"Top-level modules:       {result.num_top_modules}")
 print(f"Map equation codelength: {result.codelength:.4f} bits/step")
 
 # The text below reads these exact counts; assert so the build catches drift.
-assert result.num_top_modules == 3
+assert result.num_levels == 3
+assert result.num_top_modules == 5
 
 # The bundled copy is the same network; the two must agree exactly.
 result_pkg = infomap.run(infomap.datasets.nine_triangles(),
@@ -202,19 +203,27 @@ result_pkg = infomap.run(infomap.datasets.nine_triangles(),
 assert result.codelength == result_pkg.codelength
 ```
 
-As `num_levels` shows, the tree runs from a root through three coarse
-super-groups down to the nine fine triangles.
+As `num_levels` shows, the tree is three levels deep — but not everywhere,
+and `num_top_modules` is five, not three. Two of the super-groups are kept as
+intermediate modules that nest their three triangles; the third super-group's
+triangles sit directly under the root. The reason is the map equation itself:
+an intermediate module is only worth having if the index codebook it adds
+costs less than the description it saves. Once two super-groups are in place,
+the third no longer pays for its own codebook — listing its three triangles at
+the top level is cheaper — so the optimal tree of this perfectly symmetric
+network is ragged. (Dropping all three super-groups at once would cost 0.13
+bits; dropping exactly one saves 0.014 bits.)
 
 ### Read module assignments at each level
 
 ```{code-cell} python
-# Coarsest level (depth 1): the three super-groups
+# Coarsest level (depth 1): two super-groups plus the three triangles of the third
 modules_l1 = result.modules(depth=1)
 
 # Finer level (depth 2): the nine individual triangles
 modules_l2 = result.modules(depth=2)
 
-print("Level-1 assignment (super-groups):")
+print("Level-1 assignment (top modules):")
 print(modules_l1)
 
 print("\nLevel-2 assignment (triangles):")
@@ -239,7 +248,7 @@ fig, axes = plt.subplots(1, 2, figsize=(9, 4), layout="constrained")
 flow = {n.node_id: n.flow for n in result.nodes()}
 
 draw_partition(G, modules_l1, ax=axes[0], flow=flow)
-axes[0].set_title("Level 1: super-groups", fontsize=11)
+axes[0].set_title("Level 1: top modules", fontsize=11)
 
 draw_partition(G, modules_l2, ax=axes[1], flow=flow)
 axes[1].set_title("Level 2: triangles", fontsize=11)
@@ -251,19 +260,21 @@ plt.close(fig)
 
 ```{glue:figure} fig-hierarchy-and-the-multilevel-map
 The same nested network at two levels of the hierarchy Infomap discovers.
-Left: the three coarse super-groups. Right: the nine fine triangles nested
-inside them. Both panels share one layout, so the levels read against each
+Left: the five top-level modules — two super-groups, and the three triangles
+of the third super-group listed directly under the root. Right: the nine fine
+triangles. Both panels share one layout, so the levels read against each
 other.
 ```
 
 This matches the theoretical picture {cite:p}`rosvall2011multilevel`. The
 network has dense intra-triangle flow, moderately dense intra-super-group flow
 (the unit-weight links joining a super-group's triangles), and weak
-inter-super-group flow (the three 0.8 links). Three nested levels of codebooks
-capture exactly those three scales (two levels of index codebooks over the
-module codebooks). The hierarchical map equation confirms that the
-three-level description is more compressed than either a flat two-level
-partition or a one-level description.
+inter-super-group flow (the three 0.8 links). Nested codebooks capture those
+scales, but only where a codebook pays for itself: two super-groups earn an
+index codebook of their own, the third does not, and the hierarchical map
+equation lands on that ragged three-level tree because it is more compressed
+than a uniform three-level tree, a flat two-level partition, or a one-level
+description.
 
 ## API pointers
 

--- a/interfaces/python/src/infomap/_results.py
+++ b/interfaces/python/src/infomap/_results.py
@@ -480,12 +480,12 @@ class _InfomapResultsMixin:
         (3, 7)
         (3, 7)
         (3, 7)
-        (3, 8)
-        (3, 8)
-        (3, 8)
-        (3, 9)
-        (3, 9)
-        (3, 9)
+        (4, 8)
+        (4, 8)
+        (4, 8)
+        (5, 9)
+        (5, 9)
+        (5, 9)
 
         >>> from infomap import Infomap
         >>> im = Infomap()

--- a/interfaces/python/src/infomap/datasets/__init__.py
+++ b/interfaces/python/src/infomap/datasets/__init__.py
@@ -97,7 +97,7 @@ def nine_triangles() -> _Network:
     >>> net.num_nodes, net.num_links
     (27, 39)
     >>> net.run(options={"seed": 123, "num_trials": 10}).num_top_modules
-    3
+    5
     """
     return _load("ninetriangles.net")
 

--- a/src/core/InfoNode.cpp
+++ b/src/core/InfoNode.cpp
@@ -266,6 +266,65 @@ unsigned int InfoNode::replaceWithChildren() noexcept
   return 1;
 }
 
+bool InfoNode::liftChildrenIntoParent() noexcept
+{
+  if (isLeaf() || isRoot())
+    return false;
+
+  unsigned int numChildren = 0;
+  for (InfoNode* child = firstChild; child != nullptr; child = child->next) {
+    child->parent = parent;
+    ++numChildren;
+  }
+  parent->m_childDegree += numChildren - 1;
+
+  firstChild->previous = previous;
+  lastChild->next = next;
+  if (previous != nullptr)
+    previous->next = firstChild;
+  else
+    parent->firstChild = firstChild;
+  if (next != nullptr)
+    next->previous = lastChild;
+  else
+    parent->lastChild = lastChild;
+  return true;
+}
+
+void InfoNode::restoreLiftedChildren() noexcept
+{
+  // The lifted chain runs from firstChild up to (excluding) this node's old next sibling.
+  unsigned int numChildren = 0;
+  for (InfoNode* child = firstChild; child != next; child = child->next) {
+    child->parent = this;
+    ++numChildren;
+  }
+  parent->m_childDegree -= numChildren - 1;
+
+  if (previous != nullptr)
+    previous->next = this;
+  else
+    parent->firstChild = this;
+  if (next != nullptr)
+    next->previous = this;
+  else
+    parent->lastChild = this;
+  firstChild->previous = nullptr;
+  lastChild->next = nullptr;
+}
+
+void InfoNode::destroyLifted() noexcept
+{
+  // Same release as replaceWithChildren(): a null child chain keeps the destructor
+  // from deleting the lifted children, and null siblings keep it from relinking them.
+  firstChild = nullptr;
+  lastChild = nullptr;
+  next = nullptr;
+  previous = nullptr;
+  parent = nullptr;
+  destroyNode(this);
+}
+
 void InfoNode::replaceChildrenWithGrandChildrenDebug() noexcept
 {
   if (firstChild == nullptr)

--- a/src/core/InfoNode.h
+++ b/src/core/InfoNode.h
@@ -466,6 +466,22 @@ public:
    */
   unsigned int replaceWithChildren() noexcept;
 
+  /**
+   * Reversibly take this node out of its parent's child chain and put its own
+   * children there in its place. Unlike replaceWithChildren() the node stays
+   * alive with its parent, sibling and child pointers intact, so
+   * restoreLiftedChildren() undoes the move exactly and destroyLifted() commits
+   * it. Nothing else may touch the parent's chain in between.
+   * @return false, and no change, on a root or a leaf
+   */
+  bool liftChildrenIntoParent() noexcept;
+
+  //! Undo liftChildrenIntoParent(): take the children back and re-link this node.
+  void restoreLiftedChildren() noexcept;
+
+  //! Commit liftChildrenIntoParent(): the children stay with the parent, this node is deleted.
+  void destroyLifted() noexcept;
+
   void replaceWithChildrenDebug() noexcept;
 
   /**

--- a/src/core/InfoNode.h
+++ b/src/core/InfoNode.h
@@ -466,6 +466,8 @@ public:
    */
   unsigned int replaceWithChildren() noexcept;
 
+#ifndef SWIG
+  // Tree surgery for the search, not binding API; kept out of the SWIG wrappers.
   /**
    * Reversibly take this node out of its parent's child chain and put its own
    * children there in its place. Unlike replaceWithChildren() the node stays
@@ -481,6 +483,7 @@ public:
 
   //! Commit liftChildrenIntoParent(): the children stay with the parent, this node is deleted.
   void destroyLifted() noexcept;
+#endif
 
   void replaceWithChildrenDebug() noexcept;
 

--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -44,6 +44,7 @@
 #include <iomanip>
 #include <limits>
 #include <map>
+#include <queue>
 #include <set>
 #include <unordered_map>
 #include <cstdlib>
@@ -2361,6 +2362,7 @@ void InfomapBase::hierarchicalPartition()
     }
 
     recursivePartition();
+    dissolveUnprofitableModules();
     return;
   }
 
@@ -2392,6 +2394,7 @@ void InfomapBase::hierarchicalPartition()
   }
 
   recursivePartition();
+  dissolveUnprofitableModules();
 }
 
 void InfomapBase::partition()
@@ -3326,6 +3329,115 @@ unsigned int InfomapBase::recursivePartition()
   progress.finish(fmt::format(FMT_STRING("{} {} {} levels, codelength {}"), compressionSummary(prettyCompression), Console::arrow(), level, io::toPrecision(hierarchicalCodelength)));
 
   return level;
+}
+
+// Every level in the tree was accepted by one of two tests, and neither asks whether
+// a module still earns its codebook once its children exist. findHierarchicalSuperModules
+// accepts a super level as a whole -- its super modules stand or fall together -- and
+// partitionModuleRecursively accepts a module's sub-partition against that module
+// flat, which is sound but leaves the level it sits in unexamined. Nothing compares
+// p -> m -> {c} with p -> {c, siblings}. On ninetriangles the super level saves 0.13 bits
+// and is rightly kept, while dissolving any one of its three identical super modules
+// saves 0.014 bits -- and only one may go, since after the first the other two stop
+// paying (#1074). Hence best-first: the gains interact along sibling and ancestor
+// chains, and creation order banks a sixth of the gain on science2001.
+//
+// Runs after the recursion has joined rather than inside its tasks: dissolving m does
+// not change what the recursion finds below it, the task graph relies on per-module
+// independence, and the depth-1 candidates come from the super-level build anyway.
+unsigned int InfomapBase::dissolveUnprofitableModules()
+{
+  // Both biases charge tree-level costs -- |K - K_pref| on the number of top modules,
+  // the depth bias per level created -- that a local gain cannot see. A depth
+  // preference with zero strength is a no-op everywhere else and has to be one here.
+  const bool depthBiasActive = preferredNumberOfLevels > 0 && preferredNumberOfLevelsStrength > 0.0;
+  if (preferredNumberOfModules > 0 || depthBiasActive)
+    return 0;
+
+  // Lifting a module's children into its parent must not put leaves beside modules
+  // there, so only a module of modules qualifies -- unless it is the parent's only
+  // child, in which case the parent simply becomes a leaf module.
+  auto isCandidate = [](const InfoNode& m) {
+    return !m.isRoot() && !m.isLeaf() && (!m.firstChild->isLeaf() || m.parent->childDegree() == 1);
+  };
+
+  // The parent's term with m's children in m's place, priced by the objective on the
+  // spliced tree so composed objectives are exact; m's own term disappears.
+  auto dissolveGain = [this](InfoNode& m) {
+    InfoNode& parent = *m.parent;
+    const double before = parent.codelength + m.codelength;
+    m.liftChildrenIntoParent();
+    const double after = calcCodelength(parent);
+    m.restoreLiftedChildren();
+    return before - after;
+  };
+
+  struct Candidate {
+    double gain;
+    unsigned int order; // ties go to the earlier offer, so the result is deterministic
+    unsigned int version;
+    InfoNode* node;
+    bool operator<(const Candidate& other) const noexcept
+    {
+      return gain < other.gain || (gain == other.gain && order > other.order);
+    }
+  };
+  std::priority_queue<Candidate> queue;
+  // A node's live entry is the one carrying its current version; older entries are
+  // skipped when popped. Erased once the node is destroyed, and nothing allocates an
+  // InfoNode during the pass, so a dead pointer can never denote a live node.
+  std::unordered_map<InfoNode*, unsigned int> versions;
+  unsigned int nextOrder = 0;
+  auto offer = [&](InfoNode& m) {
+    const unsigned int version = ++versions[&m];
+    if (!isCandidate(m))
+      return;
+    const double gain = dissolveGain(m);
+    if (gain > minimumCodelengthImprovement)
+      queue.push({ gain, nextOrder++, version, &m });
+  };
+
+  // Every module term current, root included: the gains read node.codelength.
+  const double codelengthBefore = calcCodelengthOnTree(root(), true);
+  std::vector<InfoNode*> modules;
+  for (auto& node : m_root.infomapTree()) {
+    if (!node.isLeaf() && !node.isRoot())
+      modules.push_back(&node);
+  }
+  // Collected first: offer() splices the chain the tree iterator is walking.
+  for (InfoNode* module : modules)
+    offer(*module);
+
+  unsigned int numDissolved = 0;
+  while (!queue.empty()) {
+    const Candidate top = queue.top();
+    queue.pop();
+    auto live = versions.find(top.node);
+    if (live == versions.end() || live->second != top.version)
+      continue;
+    InfoNode& parent = *top.node->parent;
+    top.node->liftChildrenIntoParent();
+    top.node->destroyLifted();
+    versions.erase(live);
+    parent.codelength = calcCodelength(parent);
+    ++numDissolved;
+
+    // The parent's gain reads its new child set; its children's gains read its new term.
+    offer(parent);
+    std::vector<InfoNode*> children;
+    for (auto& child : parent) {
+      if (!child.isLeaf())
+        children.push_back(&child);
+    }
+    for (InfoNode* child : children)
+      offer(*child);
+  }
+
+  if (numDissolved > 0) {
+    m_hierarchicalCodelength = calcCodelengthOnTree(root(), true);
+    Console::detail(1, "prune: dissolved {} modules, codelength {} {} {}", numDissolved, io::toPrecision(codelengthBefore), Console::arrow(), io::toPrecision(m_hierarchicalCodelength));
+  }
+  return numDissolved;
 }
 
 void InfomapBase::queueTopModules(PartitionQueue& partitionQueue)

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -606,6 +606,14 @@ private:
 
   unsigned int recursivePartition();
 
+  /**
+   * Dissolve every intermediate module whose index codebook no longer pays for
+   * itself: its children move into its parent, one level up. Best-first over the
+   * whole tree; each gain is priced through the objective on the spliced tree.
+   * @return the number of modules dissolved
+   */
+  unsigned int dissolveUnprofitableModules();
+
   void queueTopModules(PartitionQueue& partitionQueue);
 
   void queueLeafModules(PartitionQueue& partitionQueue);

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -969,6 +969,160 @@ TEST_CASE("InfoNode replaceWithChildren reparents a middle child chain before de
   CHECK(after->previous->stateId == 2);
 }
 
+TEST_CASE("InfoNode liftChildrenIntoParent is exactly reversible and commits like replaceWithChildren [fast][core][partition][tree][ownership]")
+{
+  InfoNode root;
+  auto* before = new InfoNode({}, 10);
+  auto* module = new InfoNode({}, 20);
+  auto* after = new InfoNode({}, 30);
+  root.addChild(before);
+  root.addChild(module);
+  root.addChild(after);
+  auto* first = new InfoNode({}, 1);
+  auto* second = new InfoNode({}, 2);
+  module->addChild(first);
+  module->addChild(second);
+
+  REQUIRE(module->liftChildrenIntoParent());
+  CHECK(root.childDegree() == 4);
+  CHECK(childStateIds(root) == std::vector<unsigned int> { 10, 1, 2, 30 });
+  CHECK(first->parent == &root);
+  CHECK(second->parent == &root);
+  CHECK(before->next == first);
+  CHECK(after->previous == second);
+  // The lifted node keeps everything it needs to undo the move.
+  CHECK(module->parent == &root);
+  CHECK(module->firstChild == first);
+  CHECK(module->lastChild == second);
+
+  module->restoreLiftedChildren();
+  CHECK(root.childDegree() == 3);
+  CHECK(childStateIds(root) == std::vector<unsigned int> { 10, 20, 30 });
+  CHECK(module->childDegree() == 2);
+  CHECK(first->parent == module);
+  CHECK(second->parent == module);
+  CHECK(first->previous == nullptr);
+  CHECK(second->next == nullptr);
+  CHECK(before->next == module);
+  CHECK(after->previous == module);
+  CHECK(root.firstChild == before);
+  CHECK(root.lastChild == after);
+
+  // Lift and commit: the same end state replaceWithChildren() produces.
+  REQUIRE(module->liftChildrenIntoParent());
+  module->destroyLifted();
+  CHECK(root.childDegree() == 4);
+  CHECK(childStateIds(root) == std::vector<unsigned int> { 10, 1, 2, 30 });
+  CHECK(first->parent == &root);
+  CHECK(second->next == after);
+
+  // Roots and leaves refuse.
+  CHECK_FALSE(root.liftChildrenIntoParent());
+  CHECK_FALSE(first->liftChildrenIntoParent());
+}
+
+TEST_CASE("InfoNode liftChildrenIntoParent handles first, last and only children [fast][core][partition][tree][ownership]")
+{
+  {
+    InfoNode root;
+    auto* module = new InfoNode({}, 20);
+    auto* after = new InfoNode({}, 30);
+    root.addChild(module);
+    root.addChild(after);
+    module->addChild(new InfoNode({}, 1));
+
+    REQUIRE(module->liftChildrenIntoParent());
+    CHECK(childStateIds(root) == std::vector<unsigned int> { 1, 30 });
+    CHECK(root.firstChild->stateId == 1);
+    module->restoreLiftedChildren();
+    CHECK(childStateIds(root) == std::vector<unsigned int> { 20, 30 });
+    CHECK(root.firstChild == module);
+  }
+  {
+    InfoNode root;
+    auto* before = new InfoNode({}, 10);
+    auto* module = new InfoNode({}, 20);
+    root.addChild(before);
+    root.addChild(module);
+    module->addChild(new InfoNode({}, 1));
+    module->addChild(new InfoNode({}, 2));
+
+    REQUIRE(module->liftChildrenIntoParent());
+    CHECK(childStateIds(root) == std::vector<unsigned int> { 10, 1, 2 });
+    CHECK(root.lastChild->stateId == 2);
+    module->restoreLiftedChildren();
+    CHECK(childStateIds(root) == std::vector<unsigned int> { 10, 20 });
+    CHECK(root.lastChild == module);
+  }
+  {
+    // An only child: the parent becomes a leaf module.
+    InfoNode root;
+    auto* module = new InfoNode({}, 20);
+    root.addChild(module);
+    module->addChild(new InfoNode({}, 1));
+    module->addChild(new InfoNode({}, 2));
+
+    REQUIRE(module->liftChildrenIntoParent());
+    CHECK(root.childDegree() == 2);
+    CHECK(root.isLeafModule());
+    module->restoreLiftedChildren();
+    CHECK(root.childDegree() == 1);
+    CHECK(root.firstChild == module);
+    CHECK(root.lastChild == module);
+    CHECK(module->childDegree() == 2);
+  }
+}
+
+TEST_CASE("Hierarchical search dissolves a super module that no longer pays for its codebook [fast][core][partition][tree]")
+{
+  // ninetriangles: nine triangles in three groups of three. The super level as a whole
+  // saves 0.13 bits over nine top modules, so the level-wide test keeps it -- yet each
+  // of the three identical super modules gains 0.014 bits when dissolved alone, and only
+  // one may go, because after the first the other two stop paying. A symmetric network
+  // whose optimum is a ragged tree; neither level test could see it (#1074).
+  std::ostringstream captured;
+  InfomapWrapper im("--seed 123 --num-trials 1 --no-file-output --verbose");
+  {
+    infomap::test::ScopedLogCapture capture(captured);
+    im.readInputData(infomap::test::repoPath("examples/networks/ninetriangles.net"));
+    im.run();
+  }
+  infomap::test::checkRunSanity(im);
+
+  CHECK(im.codelength() == doctest::Approx(3.371875026).epsilon(1e-8));
+  CHECK(im.numTopModules() == 5);
+  CHECK(im.maxTreeDepth() == 3);
+  unsigned int leafModuleTops = 0;
+  unsigned int nestedTops = 0;
+  for (const auto& module : im.root()) {
+    if (module.isLeafModule())
+      ++leafModuleTops;
+    else
+      ++nestedTops;
+  }
+  CHECK(leafModuleTops == 3);
+  CHECK(nestedTops == 2);
+  CHECK(captured.str().find("prune: dissolved 1 modules, codelength 3.38583082 -> 3.371875026") != std::string::npos);
+  // The reported total is the tree's, recomputed after the dissolve.
+  CHECK(sumModuleCodelengths(im.root()) == doctest::Approx(im.codelength()));
+}
+
+TEST_CASE("Dissolving intermediate modules never mixes leaves with modules under one parent [fast][core][partition][tree]")
+{
+  for (const char* network : { "examples/networks/ninetriangles.net", "test/fixtures/networks/unbalanced_hierarchy.net" }) {
+    InfomapWrapper im("--seed 123 --num-trials 2 --silent --no-file-output");
+    im.readInputData(infomap::test::repoPath(network));
+    im.run();
+    for (auto it = im.root().begin_tree(); !it.isEnd(); ++it) {
+      if (it->isLeaf())
+        continue;
+      const bool firstIsLeaf = it->firstChild->isLeaf();
+      for (const auto& child : *it)
+        CHECK(child.isLeaf() == firstIsLeaf);
+    }
+  }
+}
+
 TEST_CASE("InfoNode remove documents current child-chain ownership semantics [fast][core][partition][tree][ownership]")
 {
   InfoNode deleteRoot;

--- a/test/python/test_multilevel_modules.py
+++ b/test/python/test_multilevel_modules.py
@@ -42,7 +42,9 @@ def test_multilevel_modules(make_infomap, example_network_path):
     im.read_file(str(example_network_path("ninetriangles.net")))
     im.run()
 
-    assert im.num_top_modules == 3
+    # Two groups of three triangles plus the three triangles of the dissolved
+    # third group: a ragged three-level tree (#1074).
+    assert im.num_top_modules == 5
     assert im.num_levels == 3
     assert sorted(im.get_multilevel_modules(states=False).values()) == sorted(
         multilevel_modules(im, states=False).values()

--- a/test/python/test_run_functional.py
+++ b/test/python/test_run_functional.py
@@ -178,7 +178,9 @@ def test_run_file_matches_oo(example_network_path):
 
     expected = _oo_codelength(lambda im: im.read_file(str(path)), **settings)
     assert result.codelength == pytest.approx(expected)
-    assert result.codelength == pytest.approx(3.385830820341408, abs=1e-4)
+    # Three top groups of three triangles, with one group dissolved into its
+    # triangles: the ragged optimum a level-wide test cannot see (#1074).
+    assert result.codelength == pytest.approx(3.371875026, abs=1e-4)
 
 
 class _FsPathOnly:


### PR DESCRIPTION
Part of #1074 (the object-oriented engine's half; the columnar engine gets its own pruning on its own structures, see the issue).

## What

After the recursive partition has joined, walk the tree once more and **dissolve every intermediate module whose index codebook no longer pays for itself**: its children move into its parent, one level up. Best-first over the whole tree; each candidate is priced through the objective on a reversibly spliced tree.

Best codelength at `-N10 --seed 123`, single-thread, base = master tip `429bc935`:

| network | trials | base bits | new bits | Δbits | base s | new s | Δt | base instr | new instr | Δinstr | top | lvls |
|---|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|---|---|
| ninetriangles | 10 | 3.38583082 | 3.37187503 | −0.412% | 0.010 | 0.010 | = | 0.11G | 0.11G | +1.27% | 3 → 5 | 3 → 3 |
| netscicoauthor2010 | 10 | 4.04354934 | 4.02655712 | −0.420% | 0.120 | 0.120 | = | 1.29G | 1.30G | +0.22% | 2 → 12 | 5 → 5 |
| powergrid | 10 | 4.75872920 | 4.73641260 | −0.469% | 1.880 | 1.900 | +1.1% | 19.70G | 19.73G | +0.15% | 5 → 11 | 7 → 6 |
| science2001 `-d` | 10 | 7.83638921 | 7.80546577 | −0.395% | 8.190 | 8.160 | −0.4% | 62.86G | 62.89G | +0.05% | 11 → 220 | 4 → 4 |
| web-NotreDame `-d` | 10 | 5.56592477 | 5.55442136 | −0.207% | 153.33 | 149.87 | −2.3% | 1098.2G | 1101.5G | +0.30% | 17 → 766 | 13 → 9 |
| netscicoauthor2010 | 1 | 4.05610725 | 4.03759030 | −0.457% | 0.020 | 0.020 | = | 0.18G | 0.18G | +0.07% | 2 → 12 | 5 → 5 |
| powergrid | 1 | 4.77185708 | 4.75017724 | −0.454% | 0.190 | 0.190 | = | 2.02G | 2.02G | +0.18% | 6 → 10 | 6 → 6 |
| science2001 `-d` | 1 | 7.84901608 | 7.81916136 | −0.380% | 1.120 | 1.110 | −0.9% | 9.25G | 9.26G | +0.07% | 11 → 240 | 4 → 4 |
| web-NotreDame `-d` | 1 | 5.56693732 | 5.55758112 | −0.168% | 14.37 | 14.36 | −0.1% | 105.9G | 106.5G | +0.56% | 21 → 21 | 12 → 12 |

Wall time is `/usr/bin/time` at 10 ms resolution, min of 3 interleaved rounds (`-N10` web-NotreDame: one round); `instr` is instructions retired from the same execution and is the load-independent column — the pass costs **+0.05…+0.56% in instructions**, wall within noise, for **−0.17…−0.47% in bits** on every hierarchical row. Two-level runs (`-2`, jazz, politicalblogs) have no candidates and are untouched by construction. At `-N10` the pass runs per trial before the best trial is picked, which is why science2001 lands below what pruning the base winner alone gives (7.8055 against 7.8152).

## Why the search leaves this on the table

Every level in a tree is accepted by one of two tests, and neither asks whether a module still earns its codebook once its children exist:

- `findHierarchicalSuperModules` accepts a super level **as a whole**: `superCodelength < oldIndexLength - minimumCodelengthImprovement`. Super modules stand or fall together; none is asked whether it earns its own codebook.
- `partitionModuleRecursively` accepts a module's sub-partition against that module flat. Sound — undoing a sub-partition never pays, and no `flatten`-type gain exists on any tree probed — but the level the module *sits in* is never re-examined, and the sub-Infomap's `setOnlySuperModules(true)` builds levels inside a module level-wide again.
- Nothing compares p → m → {c} with p → {c, siblings}.

`examples/networks/ninetriangles.net` is the whole argument in 27 nodes: removing the super level costs **+0.132 bits**, so the level test rightly keeps it — yet each of the three identical super modules gains **+0.014 bits** when dissolved alone, and only *one* may go, because after the first the other two stop paying. A symmetric network whose optimum is a ragged tree; no all-or-nothing test finds it.

## How

- `InfoNode::liftChildrenIntoParent()` / `restoreLiftedChildren()` / `destroyLifted()`: a reversible form of `replaceWithChildren()`. The candidate is spliced out, its parent re-priced with the objective's own `calcCodelength(parent)`, and the splice undone — so Mem/Meta/Biased/Lossy/Regularized are priced exactly without duplicating any formula.
- `InfomapBase::dissolveUnprofitableModules()`, called at the end of `hierarchicalPartition()` after `recursivePartition()`: a max-heap of candidates with per-node version stamps; applying a dissolve re-offers the parent (its child set changed) and the parent's children (their gain reads the parent's term). Ties go to the earlier offer, so the result is deterministic. Accepts a gain above `minimumCodelengthImprovement`, like the two existing tests.
- Only a module of modules qualifies (a leaf module could only dissolve into a parent that keeps other module children, which mixes leaves with modules — the shape #990 rejects), unless it is the parent's only child, in which case the parent simply becomes a leaf module.
- After the recursion has joined rather than inside its tasks: dissolving m does not change what the recursion finds below it, the task graph's correctness rests on per-module independence, and the depth-1 candidates come from the super-level build, not the recursion.
- Skipped under `--preferred-number-of-modules` and an *active* `--preferred-number-of-levels` (strength > 0): both charge tree-level costs a local gain cannot see. A depth preference with zero strength stays the no-op it is everywhere else (`preferred_levels` tests).

Known cost corner: re-offering a parent's children after each dissolve is O(children) per child, so a root that ends with hundreds of top modules (web-NotreDame: 766) pays the +0.3–0.6% in instructions above. An incremental parent term would remove it; not done here since wall stays within noise.

## Tests

- New: InfoNode lift/restore/commit round trips (middle, first, last and only child); the ninetriangles end-to-end shape (5 top modules, three of them leaf modules, 3.371875026, and the `prune:` detail line); a homogeneity sweep asserting no module ever mixes leaves and modules, on ninetriangles and `test/fixtures/networks/unbalanced_hierarchy.net`.
- Moved pins: `test/python/test_run_functional.py` (ninetriangles 3.385830820 → 3.371875026) and `test/python/test_multilevel_modules.py` (`num_top_modules` 3 → 5).
- `make test-native MODE=release` with `OPENMP=1`, `OPENMP=0` and `OPENMP=1 FEATURES="lossy-map-equation regularized-multilayer"`: 27/27 each. `pytest test/python`: 854 passed, 2 skipped, 1 xfailed.
