### PR TITLE
perf: parse --cluster-data once per run instead of once per trial plus once to warn

### DIFF
--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -283,7 +283,7 @@ public:
     m_runParallelTrials = selectParallelTrialMode();
     m_threadsUsed = m_runParallelTrials ? parallelTrialWorkers() : 1;
     releaseInputLinksIfCli();
-    reportClusterDataIssues();
+    readClusterData();
     logRunPartitionStart();
     Result result;
     {
@@ -646,33 +646,42 @@ private:
     return stateOutput ? HigherOrderInput::Yes : HigherOrderInput::No;
   }
 
-  // Report what is wrong with the --cluster-data file, once per run and on the
-  // main instance, where nothing is muted. Doing this from initPartition instead
-  // put it inside the trial loop: ten warnings on a serial -N10, and none at all
-  // under --parallel-trials, because every worker's initTrialPartition is wrapped
-  // in Log::ScopedMute. The cost is one extra parse of the cluster file, which is
-  // a validation pass and not the partition the trials build.
-  void reportClusterDataIssues()
+  // Parse the --cluster-data file once, on the main instance before any trial, and
+  // keep the result: every trial applies this parse (initTrialPartition), and the
+  // duplicate-id report below reads it too. Parsing from initPartition per trial
+  // read the file once per trial, and the report used to re-read it a further time
+  // to warn outside the trial loop -- ~7% of a --no-infomap -c scoring run (#1072).
+  void readClusterData()
   {
     if (!m_infomap.isMainInfomap() || m_infomap.clusterDataFile.empty()) {
       return;
     }
 
-    ClusterMap clusterMap;
     if (m_network.isMultilayerNetwork()) {
       const auto& map = m_network.layerNodeToStateId();
-      clusterMap.readClusterData(m_infomap.clusterDataFile, false, &map);
+      m_clusterData.readClusterData(m_infomap.clusterDataFile, false, &map);
     } else {
-      clusterMap.readClusterData(m_infomap.clusterDataFile);
+      m_clusterData.readClusterData(m_infomap.clusterDataFile);
     }
+    m_haveClusterData = true;
 
-    if (clusterMap.extension() != "clu") {
+    reportClusterDataIssues();
+  }
+
+  // Report what is wrong with the --cluster-data file, once per run and on the
+  // main instance, where nothing is muted. Doing this from initPartition instead
+  // put it inside the trial loop: ten warnings on a serial -N10, and none at all
+  // under --parallel-trials, because every worker's initTrialPartition is wrapped
+  // in Log::ScopedMute.
+  void reportClusterDataIssues()
+  {
+    if (m_clusterData.extension() != "clu") {
       // A tree carries a path per row, so a repeated id there is a different
       // situation with its own report in normalizeTreePaths (#908).
       return;
     }
 
-    const auto& duplicates = clusterMap.duplicateClusterIds();
+    const auto& duplicates = m_clusterData.duplicateClusterIds();
     if (!duplicates.any()) {
       return;
     }
@@ -1067,9 +1076,14 @@ private:
     if (!infomap.clusterDataFile.empty() && !m_network.initialPartitionPaths().empty())
       Console::note(0, "--cluster-data overrides embedded JSON initial-partition paths.");
 
-    if (!infomap.clusterDataFile.empty())
-      infomap.initPartition(infomap.clusterDataFile, infomap.clusterDataIsHard, &m_network);
-    else if (!infomap.m_multilayerInitialPartition.empty()) {
+    if (!infomap.clusterDataFile.empty()) {
+      // The parse readClusterData() did before the trials; shared read-only by the
+      // parallel-trial workers. The fallback only serves a caller that skipped run().
+      if (m_haveClusterData)
+        infomap.initPartition(m_clusterData, infomap.clusterDataIsHard);
+      else
+        infomap.initPartition(infomap.clusterDataFile, infomap.clusterDataIsHard, &m_network);
+    } else if (!infomap.m_multilayerInitialPartition.empty()) {
       // Resolve the physical (layer_id, node_id) keys to the generated state
       // ids now that the network is built, then init as a normal partition.
       const auto& layerNodeToStateId = m_network.layerNodeToStateId();
@@ -1315,6 +1329,9 @@ private:
   unsigned int m_threadsUsed = 1;
   ThreadBudget m_threadBudget;
   unsigned int m_cpusetCount = 0;
+  // --cluster-data, parsed once by readClusterData() and applied in every trial.
+  ClusterMap m_clusterData;
+  bool m_haveClusterData = false;
 };
 
 std::map<unsigned int, std::vector<unsigned int>> InfomapBase::getMultilevelModules(bool states)
@@ -1503,9 +1520,13 @@ InfomapBase& InfomapBase::initPartition(const std::string& clusterDataFile, bool
   } else {
     clusterMap.readClusterData(clusterDataFile);
   }
+  return initPartition(clusterMap, hard);
+}
 
-  Console().status("Initial", fmt::format(FMT_STRING("reading {}"), clusterDataFile));
-  Console::detail(1, "init partition from file '{}'", clusterDataFile);
+InfomapBase& InfomapBase::initPartition(const ClusterMap& clusterMap, bool hard)
+{
+  Console().status("Initial", fmt::format(FMT_STRING("reading {}"), clusterMap.filename()));
+  Console::detail(1, "init partition from file '{}'", clusterMap.filename());
 
   const auto& ext = clusterMap.extension();
 

--- a/src/core/InfomapBase.h
+++ b/src/core/InfomapBase.h
@@ -432,6 +432,16 @@ private:
    */
   InfomapBase& initPartition(const std::string& clusterDataFile, bool hard = false, const Network* network = nullptr);
 
+#ifndef SWIG
+  /**
+   * Apply cluster data that has already been parsed. A run parses --cluster-data
+   * once and applies it from here in every trial, so the file is read exactly
+   * once however many trials there are (#1072). Not binding API: the bindings
+   * set clusterDataFile and let the run do this.
+   */
+  InfomapBase& initPartition(const ClusterMap& clusterData, bool hard = false);
+#endif
+
   /**
    * Provide an initial partition of the network.
    *

--- a/src/io/ClusterMap.cpp
+++ b/src/io/ClusterMap.cpp
@@ -24,6 +24,7 @@ void ClusterMap::readClusterData(const std::string& filename, bool includeFlow, 
   m_flowData.clear();
   m_treePaths.clear();
   m_extension.clear();
+  m_filename = filename;
   m_duplicateClusterIds = {};
   m_isHigherOrder = false;
   m_hasTreeLeafIdType = false;

--- a/src/io/ClusterMap.h
+++ b/src/io/ClusterMap.h
@@ -72,6 +72,9 @@ public:
 
   const std::string& extension() const noexcept { return m_extension; }
 
+  //! The file the last readClusterData() call parsed; empty before any read.
+  const std::string& filename() const noexcept { return m_filename; }
+
   TreeLeafIdType treeLeafIdType() const noexcept { return m_treeLeafIdType; }
 
   // Only ever non-empty for a clu file. The tree reader has its own report for the
@@ -87,6 +90,7 @@ private:
   std::map<unsigned int, double> m_flowData;
   TreePaths m_treePaths;
   std::string m_extension;
+  std::string m_filename;
   DuplicateClusterIds m_duplicateClusterIds;
   bool m_isHigherOrder = false;
   bool m_hasTreeLeafIdType = false;


### PR DESCRIPTION
Fixes #1072.

## What

`--cluster-data` is now parsed **once per run**. `RunSession` reads the file on the main instance before the trials (`readClusterData()`), reports duplicate ids from that parse, and every trial — serial or a parallel worker — applies the parsed `ClusterMap` through a new SWIG-hidden `InfomapBase::initPartition(const ClusterMap&, bool hard)`. The file overload `initPartition(const std::string&, …)` is unchanged for callers and now delegates to it.

Before, the file was parsed once per trial in `initPartition` and then a further time by `reportClusterDataIssues` purely to warn outside the trial loop (#1051) — the extra pass #1072 measured at ~7% of a scoring run, and one that a `.tree`/`.ftree` seed paid in full only to learn the warning does not apply to it.

## Measured

Single-threaded `MODE=release OPENMP=0`, `--seed 123`, instructions retired from `/usr/bin/time -l` on the same execution, interleaved min of 3, base = master `d82d8147`. Codelength is bit-identical in every row.

| case | codelength | base instr | new instr | Δinstr |
|---|--:|--:|--:|--:|
| om2 planted `.clu` (28 203 rows), `-2d --no-infomap -c` | 6.789039995 | 616M | 553M | **−10.2%** (−63M) |
| om4 (45 394 rows) | 6.880650147 | 1049M | 954M | −9.0% (−95M) |
| om5 (50 133 rows) | 6.902222527 | 1125M | 1020M | −9.3% (−105M) |
| om6 (53 860 rows) | 6.930934993 | 1181M | 1049M | −11.2% (−132M) |
| om8 (58 505 rows) | 6.981034760 | 1245M | 1110M | −10.9% (−136M) |
| web-NotreDame ragged `.tree` seed (325 729 rows), `-d --no-infomap -c` | 5.55442136 | 20 367M | 16 505M | **−19.0%** (−3 862M) |
| om2 seeded search, `-2d -N10 -c` | 6.750463729 | 56 045M | 55 445M | −1.07% (−600M) |

The savings are the parses removed, to the row: the clu rows give back the one extra pass #1072 measured (+61M…+130M there, −63M…−136M here); the tree seed gives back a full re-parse of a 325k-row file; the `-N10` search gives back ten per-trial parses (10 × ~60M).

## Behaviour kept

- The duplicate-id warning is still emitted once, on the main instance, before the first trial — serial, `-N10`, and `--parallel-trials` alike (the existing #1051 tests pin this). It now comes from the same parse the trials use.
- Tree seeds skip the clu-only report without being read a second time.
- Per-trial console lines (`Initial reading <file>`, `generated N levels`) are unchanged; the parsed map now carries its `filename()`.
- Parallel-trial workers read the shared parse concurrently; it is `const` for them and nothing writes it after the pre-trial read.

## Tests

`make test-native MODE=release` with `OPENMP=1`, `OPENMP=0` and `OPENMP=1 FEATURES="lossy-map-equation regularized-multilayer"`: 27/27 each. `pytest test/python`: 855 passed, 2 skipped, 1 xfailed; doctests 40/40. Both SWIG freshness checks pass (no binding surface added).
