### PR TITLE
fix: read a bare top-level tree row as a module of one node

### DIFF
--- a/src/core/InfomapBase.cpp
+++ b/src/core/InfomapBase.cpp
@@ -212,6 +212,34 @@ namespace {
     unsigned long m_previous;
   };
 
+  // A one-level tree path -- `2 0.15 "A" 1` -- names a top-level slot without saying
+  // what sits in it, and its two readings are different partitions: "the root's second
+  // child IS the leaf A", so A is in no module, or "module 2, with the child index left
+  // off". Read it as the module.
+  //
+  // That is already what the rest of the reader does with the same spelling. A file
+  // whose rows are ALL one level deep never reaches this ambiguity -- initTree's
+  // `maxDepth == 2` shortcut routes it through initPartition, which gives every
+  // top-level id a real module -- and neither does --two-level, which keeps path[0] as
+  // the module id. Only a file that mixes a bare row with a deeper one took the other
+  // reading, and it took it silently and inconsistently: whether it did depended on
+  // which row sorted first, because haveModules() tests the root's first child alone
+  // (#1067). The leaf-under-the-root shape it produced is also one the search never
+  // builds and one Infomap will not accept a level down, where a parent holding a leaf
+  // and a sub-module side by side is rejected outright (#898).
+  //
+  // Only the DEPTH of the path matters here: initTree builds the module chain from
+  // path[0..n-2] and never looks at the last index, so appending 1 says "in module k"
+  // and nothing more. Two bare rows sharing a top-level id therefore land in the same
+  // module, which is what the file says they do.
+  void completeTopLevelLeafPaths(NodePaths& tree)
+  {
+    for (auto& nodePath : tree) {
+      if (nodePath.second.size() == 1)
+        nodePath.second.push_back(1);
+    }
+  }
+
 } // namespace
 
 class InfomapBase::RunSession {
@@ -1567,6 +1595,7 @@ NodePaths InfomapBase::normalizeTreePaths(const TreePaths& tree, unsigned int& n
   if (allState) {
     for (const auto& tp : tree)
       normalized.emplace_back(tp.nodeId, tp.path);
+    completeTopLevelLeafPaths(normalized);
     return normalized;
   }
 
@@ -1640,6 +1669,7 @@ NodePaths InfomapBase::normalizeTreePaths(const TreePaths& tree, unsigned int& n
                   numSplitPhysicalNodes == 1 ? "physical node has its" : "physical nodes have their");
   }
 
+  completeTopLevelLeafPaths(normalized);
   return normalized;
 }
 

--- a/test/cpp/test_partition.cpp
+++ b/test/cpp/test_partition.cpp
@@ -493,6 +493,89 @@ TEST_CASE("Mixed-depth cluster data is rejected instead of crashing [fast][core]
   }
 }
 
+namespace {
+
+double scoreTreeFixture(const std::string& cluster)
+{
+  InfomapWrapper im(infomap::test::defaultFlags("--no-infomap --cluster-data " + infomap::test::clusterFixturePath(cluster)));
+  im.readInputData(infomap::test::networkFixturePath("twotriangles_flow.net"));
+  im.run();
+  return im.codelength();
+}
+
+} // namespace
+
+TEST_CASE("A bare top-level tree row is a module of one node [fast][core][partition][parser]")
+{
+  // `2 0.15 "A" 1` names a top-level slot without saying what is in it, and its two
+  // readings are different partitions: the root's second child IS the leaf A, or module 2
+  // with the child index left off. The reader completes it to `2:1`, so every spelling of
+  // the partition scores alike and row order cannot matter (#1067).
+  //
+  // Both numbers are the object-oriented scorer's, and their difference is one codebook:
+  // A's flow is 0.15 and all of it crosses the module boundary, so the module of one node
+  // costs (0.15 + 0.15) * H(1/2, 1/2) = 0.3 bits. The root's own codebook is 0.3 bits
+  // either way -- it codes A's slot at rate 0.15 whether that slot is a node visit or a
+  // module entry -- which is why the old leaf-under-the-root reading came out exactly one
+  // codebook cheap at 2.714170945.
+  const double explicitModule = scoreTreeFixture("twotriangles_top_level_leaf_module.tree");
+  CHECK(explicitModule == doctest::Approx(3.014170945).epsilon(1e-9));
+  CHECK(scoreTreeFixture("twotriangles_top_level_leaf.tree") == doctest::Approx(explicitModule).epsilon(1e-12));
+  CHECK(scoreTreeFixture("twotriangles_top_level_leaf_first.tree") == doctest::Approx(explicitModule).epsilon(1e-12));
+
+  // The shape behind the number: the root's children are all modules, whichever row came
+  // first. haveModules() tests the root's FIRST child alone, so a bare row sorting first
+  // used to answer "no modules" for the whole file and score the leaf network instead.
+  for (const auto* fixture : { "twotriangles_top_level_leaf.tree", "twotriangles_top_level_leaf_first.tree" }) {
+    InfomapWrapper im(infomap::test::defaultFlags());
+    im.readInputData(infomap::test::networkFixturePath("twotriangles_flow.net"));
+    im.initNetwork(im.network());
+    im.initPartition(infomap::test::clusterFixturePath(fixture), false, &im.network());
+
+    CHECK(im.numTopModules() == 2);
+    CHECK(im.maxTreeDepth() == 3);
+    for (const auto& child : im.root()) {
+      CHECK_FALSE(child.isLeaf());
+    }
+  }
+}
+
+TEST_CASE("A tree of bare rows only keeps its one module per node [fast][core][partition][parser]")
+{
+  // Completing the paths must not disturb a file that is flat to begin with: initTree
+  // takes its `maxDepth == 2` shortcut for both spellings and reads the top-level id as
+  // the module, so the six one-node modules are the same six either way.
+  CHECK(scoreTreeFixture("twotriangles_all_bare.tree") == doctest::Approx(4.470950594).epsilon(1e-9));
+
+  InfomapWrapper im(infomap::test::defaultFlags());
+  im.readInputData(infomap::test::networkFixturePath("twotriangles_flow.net"));
+  im.initNetwork(im.network());
+  im.initPartition(infomap::test::clusterFixturePath("twotriangles_all_bare.tree"), false, &im.network());
+
+  CHECK(im.numTopModules() == 6);
+  CHECK(im.maxTreeDepth() == 2);
+}
+
+TEST_CASE("A bare top-level row colliding with a sub-module is rejected [fast][core][partition][parser]")
+{
+  // Completing `2` to `2:1` puts a leaf and a sub-module side by side under module 2,
+  // which is the shape that has no defined codelength and is refused (#898). The bare
+  // spelling used to slip past that check by being in no module at all.
+  InfomapWrapper im(infomap::test::defaultFlags());
+  im.readInputData(infomap::test::networkFixturePath("twotriangles_flow.net"));
+  im.initNetwork(im.network());
+
+  try {
+    im.initPartition(infomap::test::clusterFixturePath("twotriangles_top_level_leaf_conflict.tree"), false, &im.network());
+    FAIL("expected a bare row under a module with sub-modules to be rejected");
+  } catch (const infomap::InfomapError& e) {
+    CHECK(e.code() == infomap::ExitCode::InputError);
+    const std::string message(e.what());
+    CHECK(message.find("mixes depths") != std::string::npos);
+    CHECK(message.find("module 2") != std::string::npos);
+  }
+}
+
 TEST_CASE("A two-level search from a deeper tree keeps its top level [fast][core][partition]")
 {
   // --two-level with a deeper cluster tree reported codelength 0 on a tree that still

--- a/test/fixtures/clusters/twotriangles_all_bare.tree
+++ b/test/fixtures/clusters/twotriangles_all_bare.tree
@@ -1,0 +1,10 @@
+# path flow name node_id
+# Every row one level deep: six top-level slots, one node each. Nothing here is ragged,
+# so completing the paths to `k:1` must leave the partition exactly as it was -- initTree
+# takes its `maxDepth == 2` shortcut and reads the top-level id as the module either way.
+1 0.3 "C" 3
+2 0.2 "B" 2
+3 0.15 "D" 4
+4 0.1 "E" 5
+5 0.1 "F" 6
+6 0.15 "A" 1

--- a/test/fixtures/clusters/twotriangles_top_level_leaf.tree
+++ b/test/fixtures/clusters/twotriangles_top_level_leaf.tree
@@ -1,0 +1,14 @@
+# path flow name node_id
+# A BARE top-level row (`2 0.15 "A" 1`) next to three-level branches. The row names a
+# top-level slot without saying what is in it; the reader completes it to `2:1`, so node
+# A is alone in top module 2. See completeTopLevelLeafPaths (#1067).
+#
+# NOT a shape Infomap writes -- its writer gives a one-node top module a full path, and
+# the one-level fallback puts every leaf at depth 1 -- so this arises only from
+# hand-written or third-party cluster files, which is what the fixture pins.
+1:1:1 0.3 "C" 3
+1:1:2 0.2 "B" 2
+1:2:1 0.15 "D" 4
+1:2:2 0.1 "E" 5
+1:2:3 0.1 "F" 6
+2 0.15 "A" 1

--- a/test/fixtures/clusters/twotriangles_top_level_leaf_conflict.tree
+++ b/test/fixtures/clusters/twotriangles_top_level_leaf_conflict.tree
@@ -1,0 +1,11 @@
+# path flow name node_id
+# A bare top-level row whose module ALSO has a sub-module (`2` and `2:1:1` share top-level
+# id 2). Completing the bare row to `2:1` puts a leaf and a sub-module under module 2,
+# which is the shape validateClusterDataTreeShape rejects (#898). Before #1067 the bare
+# row was invisible to that check.
+1:1:1 0.3 "C" 3
+1:1:2 0.2 "B" 2
+2 0.15 "A" 1
+2:1:1 0.15 "D" 4
+2:1:2 0.1 "E" 5
+2:1:3 0.1 "F" 6

--- a/test/fixtures/clusters/twotriangles_top_level_leaf_first.tree
+++ b/test/fixtures/clusters/twotriangles_top_level_leaf_first.tree
@@ -1,0 +1,11 @@
+# path flow name node_id
+# twotriangles_top_level_leaf.tree with the bare row FIRST. Row order carries no meaning
+# in a tree file, so this must score exactly like the other two spellings -- it did not
+# before #1067, because haveModules() tests only the root's first child and answered
+# "no modules" for the whole file when a leaf sorted first.
+2 0.15 "A" 1
+1:1:1 0.3 "C" 3
+1:1:2 0.2 "B" 2
+1:2:1 0.15 "D" 4
+1:2:2 0.1 "E" 5
+1:2:3 0.1 "F" 6

--- a/test/fixtures/clusters/twotriangles_top_level_leaf_module.tree
+++ b/test/fixtures/clusters/twotriangles_top_level_leaf_module.tree
@@ -1,0 +1,10 @@
+# path flow name node_id
+# The same partition as twotriangles_top_level_leaf.tree with A's module written out
+# explicitly (`2:1` instead of a bare `2`). Still ragged -- A's branch is one level
+# shallower than the others -- so the two files must agree bit for bit.
+1:1:1 0.3 "C" 3
+1:1:2 0.2 "B" 2
+1:2:1 0.15 "D" 4
+1:2:2 0.1 "E" 5
+1:2:3 0.1 "F" 6
+2:1 0.15 "A" 1


### PR DESCRIPTION
## The bug

A one-level path in a `--cluster-data` tree — `2 0.15 "A" 1` — names a top-level slot without saying what sits in it. Its two readings are different partitions:

- **the root's second child IS the leaf A**, so A is in no module at all, or
- **module 2**, with the child index left off.

Infomap took both, depending on the file:

| file | reading before this PR | L |
|---|---|--:|
| all rows one level deep | module k → six one-node modules | 4.470950594 |
| any tree under `--two-level` | module k | 3.070950594 |
| a bare row mixed with deeper rows | leaf the root owns → A in no module | 2.714170945, or **3.02401125** if the bare row sorts first |

The first two go through `initTree`'s `maxDepth == 2` shortcut, which routes them to `initPartition` and gives every top-level id a real module. Only the third took the other reading — silently, and by accident: whether it did depended on which row happened to sort first in the file, because `haveModules()` (`src/core/InfomapBase.h`) tests the root's *first* child alone. Same tree, same partition, 11% apart in bits, and the summary reports 2 top modules and 3 levels either way. Closes #1067.

## The fix

Complete a one-level path to `k:1` in `normalizeTreePaths`, the single choke point for external tree paths — the `-c` file reader and the `NetworkBuilder` API both pass through it. Only the *depth* matters: `initTree` builds the module chain from `path[0..n-2]` and never looks at the last index, so appending `1` says "in module k" and nothing more (two bare rows sharing a top-level id therefore land in the same module, which is what the file says).

The leaf-under-the-root shape this removes is one the search never builds, one the writer never emits on its own, and one Infomap already refuses a level down, where a parent holding a leaf and a sub-module side by side is rejected outright (#898). The root was simply exempt from that check, since `validateClusterDataTreeShape` only examines prefixes from `path[0]` onward.

## What moves

On `test/fixtures/networks/twotriangles_flow.net` with `--no-infomap -c`, bare row moved through every position:

| cluster file | before | after |
|---|--:|--:|
| bare row first | 3.02401125 | **3.014170945** |
| bare row 2nd … last | 2.714170945 | **3.014170945** |
| same partition spelled `2:1` | 3.014170945 | 3.014170945 |
| flat tree of bare rows | 4.470950594 | 4.470950594 |
| any tree with `--two-level` | 3.070950594 | 3.070950594 |

The 0.3 bits between the two spellings of the mixed file is exactly one codebook. A's flow is 0.15 and all of it crosses the module boundary, so a module of one node costs `(0.15 + 0.15) * H(1/2, 1/2) = 0.3` bits. The root's own codebook is 0.3 bits either way — it codes A's slot at rate 0.15 whether that slot is a node visit or a module entry — which is why the old reading came out exactly one codebook cheap. Confirmed by the `-vv` split, which reports index `0.3` for `2`, `2:1` and `2:1:1` alike while the module term climbs 2.41417 → 2.71417 → 3.01417.

One shape becomes an error: a bare row whose top-level id also carries a sub-module (`2` next to `2:1:1`) now completes to a leaf beside a sub-module under module 2, which is what #898 refuses. It used to slip past that check by being in no module at all.

## Tests

Three cases in `test/cpp/test_partition.cpp`: the three spellings score alike and row order does not matter (plus the shape behind the number — every root child is a module, whichever row came first); a flat tree of bare rows is untouched; the colliding file is rejected naming module 2. Five fixtures added under `test/fixtures/clusters/`.

`make test-native MODE=release` green in all three CI configurations — `OPENMP=1`, `OPENMP=0`, and `OPENMP=1 FEATURES="lossy-map-equation regularized-multilayer"` — 27/27 each.